### PR TITLE
feat: unify component granularity across React, Vue, and Svelte

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
       "dependencies": {
         "@tiptap/core": "^3.14.0",
         "@tiptap/extension-bubble-menu": "^3.14.0",
+        "@tiptap/suggestion": "^3.14.0",
         "@vizel/core": "workspace:*",
         "tippy.js": "^6.3.7",
       },
@@ -116,6 +117,7 @@
       "dependencies": {
         "@tiptap/core": "^3.14.0",
         "@tiptap/extension-bubble-menu": "^3.14.0",
+        "@tiptap/suggestion": "^3.14.0",
         "@tiptap/vue-3": "^3.14.0",
         "@vizel/core": "workspace:*",
         "tippy.js": "^6.3.7",

--- a/packages/react/src/components/BubbleMenu.tsx
+++ b/packages/react/src/components/BubbleMenu.tsx
@@ -1,6 +1,7 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
 import { useEditorContextSafe } from "./EditorContext.tsx";
+import { BubbleMenuToolbar } from "./BubbleMenuToolbar.tsx";
 import type { Editor } from "@vizel/core";
 import type { ReactNode } from "react";
 
@@ -25,143 +26,30 @@ export interface BubbleMenuProps {
   }) => boolean;
 }
 
-interface ToolbarButtonProps {
-  onClick: () => void;
-  isActive: boolean;
-  children: ReactNode;
-  title: string;
-}
-
-function ToolbarButton({ onClick, isActive, children, title }: ToolbarButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`vizel-bubble-menu-button ${isActive ? "is-active" : ""}`}
-      title={title}
-      data-active={isActive || undefined}
-    >
-      {children}
-    </button>
-  );
-}
-
-interface LinkEditorProps {
-  editor: Editor;
-  onClose: () => void;
-}
-
-function LinkEditor({ editor, onClose }: LinkEditorProps) {
-  const currentHref = editor.getAttributes("link").href || "";
-  const [url, setUrl] = useState(currentHref);
-
-  const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-      if (url.trim()) {
-        editor.chain().focus().setLink({ href: url.trim() }).run();
-      } else {
-        editor.chain().focus().unsetLink().run();
-      }
-      onClose();
-    },
-    [editor, url, onClose]
-  );
-
-  const handleRemove = useCallback(() => {
-    editor.chain().focus().unsetLink().run();
-    onClose();
-  }, [editor, onClose]);
-
-  return (
-    <form onSubmit={handleSubmit} className="vizel-link-editor">
-      <input
-        type="url"
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-        placeholder="Enter URL..."
-        className="vizel-link-input"
-        autoFocus
-      />
-      <button type="submit" className="vizel-link-button" title="Apply">
-        OK
-      </button>
-      {currentHref && (
-        <button
-          type="button"
-          onClick={handleRemove}
-          className="vizel-link-button vizel-link-remove"
-          title="Remove link"
-        >
-          X
-        </button>
-      )}
-    </form>
-  );
-}
-
-function DefaultToolbar({ editor }: { editor: Editor }) {
-  const [showLinkEditor, setShowLinkEditor] = useState(false);
-
-  if (showLinkEditor) {
-    return <LinkEditor editor={editor} onClose={() => setShowLinkEditor(false)} />;
-  }
-
-  return (
-    <>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        isActive={editor.isActive("bold")}
-        title="Bold (Cmd+B)"
-      >
-        <strong>B</strong>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        isActive={editor.isActive("italic")}
-        title="Italic (Cmd+I)"
-      >
-        <em>I</em>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        isActive={editor.isActive("strike")}
-        title="Strikethrough"
-      >
-        <s>S</s>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleCode().run()}
-        isActive={editor.isActive("code")}
-        title="Code (Cmd+E)"
-      >
-        <code>&lt;/&gt;</code>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => setShowLinkEditor(true)}
-        isActive={editor.isActive("link")}
-        title="Link (Cmd+K)"
-      >
-        <span>L</span>
-      </ToolbarButton>
-    </>
-  );
-}
-
 /**
  * A floating menu that appears when text is selected.
  * Provides formatting options like bold, italic, strike, code, and link.
  *
  * @example
  * ```tsx
+ * // Basic usage with default toolbar
  * <EditorRoot editor={editor}>
  *   <EditorContent />
  *   <BubbleMenu />
  * </EditorRoot>
  *
- * // With custom items
+ * // With custom items using sub-components
  * <BubbleMenu>
- *   <button onClick={() => editor.chain().toggleBold().run()}>Bold</button>
+ *   <BubbleMenuButton
+ *     onClick={() => editor.chain().toggleBold().run()}
+ *     isActive={editor.isActive("bold")}
+ *   >
+ *     Bold
+ *   </BubbleMenuButton>
+ *   <BubbleMenuDivider />
+ *   <BubbleMenuButton onClick={() => setShowLinkEditor(true)}>
+ *     Link
+ *   </BubbleMenuButton>
  * </BubbleMenu>
  * ```
  */
@@ -214,7 +102,7 @@ export function BubbleMenu({
       data-vizel-bubble-menu=""
       style={{ visibility: "hidden" }}
     >
-      {children ?? (showDefaultToolbar && <DefaultToolbar editor={editor} />)}
+      {children ?? (showDefaultToolbar && <BubbleMenuToolbar editor={editor} />)}
     </div>
   );
 }

--- a/packages/react/src/components/BubbleMenuButton.tsx
+++ b/packages/react/src/components/BubbleMenuButton.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+export interface BubbleMenuButtonProps {
+  onClick: () => void;
+  isActive?: boolean;
+  disabled?: boolean;
+  children: ReactNode;
+  title?: string;
+  className?: string;
+}
+
+/**
+ * A button component for use in the BubbleMenu toolbar.
+ *
+ * @example
+ * ```tsx
+ * <BubbleMenuButton
+ *   onClick={() => editor.chain().focus().toggleBold().run()}
+ *   isActive={editor.isActive("bold")}
+ *   title="Bold (Cmd+B)"
+ * >
+ *   <strong>B</strong>
+ * </BubbleMenuButton>
+ * ```
+ */
+export function BubbleMenuButton({
+  onClick,
+  isActive = false,
+  disabled = false,
+  children,
+  title,
+  className,
+}: BubbleMenuButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`vizel-bubble-menu-button ${isActive ? "is-active" : ""} ${className ?? ""}`}
+      title={title}
+      data-active={isActive || undefined}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/react/src/components/BubbleMenuDivider.tsx
+++ b/packages/react/src/components/BubbleMenuDivider.tsx
@@ -1,0 +1,22 @@
+export interface BubbleMenuDividerProps {
+  className?: string;
+}
+
+/**
+ * A divider component for separating groups of buttons in the BubbleMenu.
+ *
+ * @example
+ * ```tsx
+ * <BubbleMenu>
+ *   <BubbleMenuButton>B</BubbleMenuButton>
+ *   <BubbleMenuButton>I</BubbleMenuButton>
+ *   <BubbleMenuDivider />
+ *   <BubbleMenuButton>Link</BubbleMenuButton>
+ * </BubbleMenu>
+ * ```
+ */
+export function BubbleMenuDivider({ className }: BubbleMenuDividerProps) {
+  return (
+    <span className={`vizel-bubble-menu-divider ${className ?? ""}`} />
+  );
+}

--- a/packages/react/src/components/BubbleMenuLinkEditor.tsx
+++ b/packages/react/src/components/BubbleMenuLinkEditor.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from "react";
+import type { Editor } from "@vizel/core";
+
+export interface BubbleMenuLinkEditorProps {
+  editor: Editor;
+  onClose: () => void;
+  className?: string;
+}
+
+/**
+ * A link editor component for editing hyperlinks in the BubbleMenu.
+ * Provides an input field for URL entry and buttons to apply or remove the link.
+ *
+ * @example
+ * ```tsx
+ * const [showLinkEditor, setShowLinkEditor] = useState(false);
+ *
+ * {showLinkEditor ? (
+ *   <BubbleMenuLinkEditor
+ *     editor={editor}
+ *     onClose={() => setShowLinkEditor(false)}
+ *   />
+ * ) : (
+ *   <BubbleMenuButton onClick={() => setShowLinkEditor(true)}>
+ *     Link
+ *   </BubbleMenuButton>
+ * )}
+ * ```
+ */
+export function BubbleMenuLinkEditor({
+  editor,
+  onClose,
+  className,
+}: BubbleMenuLinkEditorProps) {
+  const currentHref = editor.getAttributes("link").href || "";
+  const [url, setUrl] = useState(currentHref);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (url.trim()) {
+        editor.chain().focus().setLink({ href: url.trim() }).run();
+      } else {
+        editor.chain().focus().unsetLink().run();
+      }
+      onClose();
+    },
+    [editor, url, onClose]
+  );
+
+  const handleRemove = useCallback(() => {
+    editor.chain().focus().unsetLink().run();
+    onClose();
+  }, [editor, onClose]);
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={`vizel-link-editor ${className ?? ""}`}
+    >
+      <input
+        type="url"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="Enter URL..."
+        className="vizel-link-input"
+        autoFocus
+      />
+      <button type="submit" className="vizel-link-button" title="Apply">
+        OK
+      </button>
+      {currentHref && (
+        <button
+          type="button"
+          onClick={handleRemove}
+          className="vizel-link-button vizel-link-remove"
+          title="Remove link"
+        >
+          X
+        </button>
+      )}
+    </form>
+  );
+}

--- a/packages/react/src/components/BubbleMenuToolbar.tsx
+++ b/packages/react/src/components/BubbleMenuToolbar.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import type { Editor } from "@vizel/core";
+import { BubbleMenuButton } from "./BubbleMenuButton.tsx";
+import { BubbleMenuLinkEditor } from "./BubbleMenuLinkEditor.tsx";
+
+export interface BubbleMenuToolbarProps {
+  editor: Editor;
+  className?: string;
+}
+
+/**
+ * The default toolbar component for the BubbleMenu.
+ * Provides formatting buttons for bold, italic, strikethrough, code, and link.
+ *
+ * @example
+ * ```tsx
+ * <BubbleMenu>
+ *   <BubbleMenuToolbar editor={editor} />
+ * </BubbleMenu>
+ * ```
+ */
+export function BubbleMenuToolbar({ editor, className }: BubbleMenuToolbarProps) {
+  const [showLinkEditor, setShowLinkEditor] = useState(false);
+
+  if (showLinkEditor) {
+    return (
+      <BubbleMenuLinkEditor
+        editor={editor}
+        onClose={() => setShowLinkEditor(false)}
+      />
+    );
+  }
+
+  return (
+    <div className={`vizel-bubble-menu-toolbar ${className ?? ""}`}>
+      <BubbleMenuButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        isActive={editor.isActive("bold")}
+        title="Bold (Cmd+B)"
+      >
+        <strong>B</strong>
+      </BubbleMenuButton>
+      <BubbleMenuButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        isActive={editor.isActive("italic")}
+        title="Italic (Cmd+I)"
+      >
+        <em>I</em>
+      </BubbleMenuButton>
+      <BubbleMenuButton
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        isActive={editor.isActive("strike")}
+        title="Strikethrough"
+      >
+        <s>S</s>
+      </BubbleMenuButton>
+      <BubbleMenuButton
+        onClick={() => editor.chain().focus().toggleCode().run()}
+        isActive={editor.isActive("code")}
+        title="Code (Cmd+E)"
+      >
+        <code>&lt;/&gt;</code>
+      </BubbleMenuButton>
+      <BubbleMenuButton
+        onClick={() => setShowLinkEditor(true)}
+        isActive={editor.isActive("link")}
+        title="Link (Cmd+K)"
+      >
+        <span>L</span>
+      </BubbleMenuButton>
+    </div>
+  );
+}

--- a/packages/react/src/components/SlashMenuEmpty.tsx
+++ b/packages/react/src/components/SlashMenuEmpty.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+export interface SlashMenuEmptyProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * An empty state component for the SlashMenu when no results are found.
+ *
+ * @example
+ * ```tsx
+ * {items.length === 0 && (
+ *   <SlashMenuEmpty>No commands found</SlashMenuEmpty>
+ * )}
+ * ```
+ */
+export function SlashMenuEmpty({ children, className }: SlashMenuEmptyProps) {
+  return (
+    <div className={`vizel-slash-menu-empty ${className ?? ""}`}>
+      {children ?? "No results"}
+    </div>
+  );
+}

--- a/packages/react/src/components/SlashMenuItem.tsx
+++ b/packages/react/src/components/SlashMenuItem.tsx
@@ -1,0 +1,43 @@
+import type { SlashCommandItem } from "@vizel/core";
+
+export interface SlashMenuItemProps {
+  item: SlashCommandItem;
+  isSelected?: boolean;
+  onClick: () => void;
+  className?: string;
+}
+
+/**
+ * A menu item component for the SlashMenu.
+ * Displays the command icon, title, and description.
+ *
+ * @example
+ * ```tsx
+ * <SlashMenuItem
+ *   item={{ title: "Heading 1", icon: "H1", description: "Large heading" }}
+ *   isSelected={selectedIndex === 0}
+ *   onClick={() => command(item)}
+ * />
+ * ```
+ */
+export function SlashMenuItem({
+  item,
+  isSelected = false,
+  onClick,
+  className,
+}: SlashMenuItemProps) {
+  return (
+    <button
+      type="button"
+      className={`vizel-slash-menu-item ${isSelected ? "is-selected" : ""} ${className ?? ""}`}
+      onClick={onClick}
+      data-selected={isSelected || undefined}
+    >
+      <span className="vizel-slash-menu-icon">{item.icon}</span>
+      <div className="vizel-slash-menu-text">
+        <span className="vizel-slash-menu-title">{item.title}</span>
+        <span className="vizel-slash-menu-description">{item.description}</span>
+      </div>
+    </button>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,3 +1,4 @@
+// Editor components
 export { EditorRoot, type EditorRootProps } from "./EditorRoot.tsx";
 export { EditorContent, type EditorContentProps } from "./EditorContent.tsx";
 export {
@@ -6,6 +7,31 @@ export {
   useEditorContextSafe,
   type EditorProviderProps,
 } from "./EditorContext.tsx";
+
+// BubbleMenu components
 export { BubbleMenu, type BubbleMenuProps } from "./BubbleMenu.tsx";
+export {
+  BubbleMenuButton,
+  type BubbleMenuButtonProps,
+} from "./BubbleMenuButton.tsx";
+export {
+  BubbleMenuDivider,
+  type BubbleMenuDividerProps,
+} from "./BubbleMenuDivider.tsx";
+export {
+  BubbleMenuLinkEditor,
+  type BubbleMenuLinkEditorProps,
+} from "./BubbleMenuLinkEditor.tsx";
+export {
+  BubbleMenuToolbar,
+  type BubbleMenuToolbarProps,
+} from "./BubbleMenuToolbar.tsx";
+
+// SlashMenu components
 export { SlashMenu, type SlashMenuProps, type SlashMenuRef } from "./SlashMenu.tsx";
-export { createSlashMenuRenderer, type SlashMenuRendererOptions } from "./SlashMenuRenderer.tsx";
+export { SlashMenuItem, type SlashMenuItemProps } from "./SlashMenuItem.tsx";
+export { SlashMenuEmpty, type SlashMenuEmptyProps } from "./SlashMenuEmpty.tsx";
+export {
+  createSlashMenuRenderer,
+  type SlashMenuRendererOptions,
+} from "./SlashMenuRenderer.tsx";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,22 +7,42 @@
 // Tiptap React re-exports for convenience
 export { useEditor, EditorContent as TiptapEditorContent } from "@tiptap/react";
 
-// Components
+// Editor components
 export {
   EditorRoot,
   EditorContent,
   EditorProvider,
   useEditorContext,
   useEditorContextSafe,
-  BubbleMenu,
-  SlashMenu,
-  createSlashMenuRenderer,
   type EditorRootProps,
   type EditorContentProps,
   type EditorProviderProps,
+} from "./components/index.ts";
+
+// BubbleMenu components
+export {
+  BubbleMenu,
+  BubbleMenuButton,
+  BubbleMenuDivider,
+  BubbleMenuLinkEditor,
+  BubbleMenuToolbar,
   type BubbleMenuProps,
+  type BubbleMenuButtonProps,
+  type BubbleMenuDividerProps,
+  type BubbleMenuLinkEditorProps,
+  type BubbleMenuToolbarProps,
+} from "./components/index.ts";
+
+// SlashMenu components
+export {
+  SlashMenu,
+  SlashMenuItem,
+  SlashMenuEmpty,
+  createSlashMenuRenderer,
   type SlashMenuProps,
   type SlashMenuRef,
+  type SlashMenuItemProps,
+  type SlashMenuEmptyProps,
   type SlashMenuRendererOptions,
 } from "./components/index.ts";
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -19,6 +19,7 @@
     "@vizel/core": "workspace:*",
     "@tiptap/core": "^3.14.0",
     "@tiptap/extension-bubble-menu": "^3.14.0",
+    "@tiptap/suggestion": "^3.14.0",
     "tippy.js": "^6.3.7"
   },
   "peerDependencies": {

--- a/packages/svelte/src/components/BubbleMenu.svelte
+++ b/packages/svelte/src/components/BubbleMenu.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
+  import type { Editor } from "@vizel/core";
+  import type { Snippet } from "svelte";
+  import BubbleMenuToolbar from "./BubbleMenuToolbar.svelte";
+
+  interface Props {
+    editor: Editor | null;
+    class?: string;
+    showDefaultToolbar?: boolean;
+    pluginKey?: string;
+    updateDelay?: number;
+    shouldShow?: (props: { editor: Editor; from: number; to: number }) => boolean;
+    children?: Snippet;
+  }
+
+  let {
+    editor,
+    class: className,
+    showDefaultToolbar = true,
+    pluginKey = "vizelBubbleMenu",
+    updateDelay = 100,
+    shouldShow,
+    children,
+  }: Props = $props();
+
+  let menuElement = $state<HTMLElement | null>(null);
+
+  $effect(() => {
+    if (!editor || !menuElement) return;
+
+    const plugin = BubbleMenuPlugin({
+      pluginKey,
+      editor,
+      element: menuElement,
+      updateDelay,
+      shouldShow: shouldShow
+        ? ({ editor: e, from, to }) =>
+            shouldShow({ editor: e as Editor, from, to })
+        : undefined,
+      options: {
+        placement: "top",
+      },
+    });
+
+    editor.registerPlugin(plugin);
+
+    return () => {
+      editor.unregisterPlugin(pluginKey);
+    };
+  });
+
+  onDestroy(() => {
+    if (editor) {
+      editor.unregisterPlugin(pluginKey);
+    }
+  });
+</script>
+
+{#if editor}
+  <div
+    bind:this={menuElement}
+    class="vizel-bubble-menu {className ?? ''}"
+    data-vizel-bubble-menu
+    style="visibility: hidden"
+  >
+    {#if children}
+      {@render children()}
+    {:else if showDefaultToolbar}
+      <BubbleMenuToolbar {editor} />
+    {/if}
+  </div>
+{/if}

--- a/packages/svelte/src/components/BubbleMenuButton.svelte
+++ b/packages/svelte/src/components/BubbleMenuButton.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    isActive?: boolean;
+    disabled?: boolean;
+    title?: string;
+    class?: string;
+    children: Snippet;
+    onclick?: () => void;
+  }
+
+  let {
+    isActive = false,
+    disabled = false,
+    title,
+    class: className,
+    children,
+    onclick,
+  }: Props = $props();
+</script>
+
+<button
+  type="button"
+  {disabled}
+  class="vizel-bubble-menu-button {isActive ? 'is-active' : ''} {className ?? ''}"
+  {title}
+  data-active={isActive || undefined}
+  {onclick}
+>
+  {@render children()}
+</button>

--- a/packages/svelte/src/components/BubbleMenuDivider.svelte
+++ b/packages/svelte/src/components/BubbleMenuDivider.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className }: Props = $props();
+</script>
+
+<span class="vizel-bubble-menu-divider {className ?? ''}"></span>

--- a/packages/svelte/src/components/BubbleMenuLinkEditor.svelte
+++ b/packages/svelte/src/components/BubbleMenuLinkEditor.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { Editor } from "@vizel/core";
+
+  interface Props {
+    editor: Editor;
+    class?: string;
+    onclose?: () => void;
+  }
+
+  let { editor, class: className, onclose }: Props = $props();
+
+  let inputElement: HTMLInputElement;
+  let currentHref = $derived(editor.getAttributes("link").href || "");
+  let url = $state(editor.getAttributes("link").href || "");
+
+  onMount(() => {
+    inputElement?.focus();
+  });
+
+  function handleSubmit(e: Event) {
+    e.preventDefault();
+    if (url.trim()) {
+      editor.chain().focus().setLink({ href: url.trim() }).run();
+    } else {
+      editor.chain().focus().unsetLink().run();
+    }
+    onclose?.();
+  }
+
+  function handleRemove() {
+    editor.chain().focus().unsetLink().run();
+    onclose?.();
+  }
+</script>
+
+<form class="vizel-link-editor {className ?? ''}" onsubmit={handleSubmit}>
+  <input
+    bind:this={inputElement}
+    bind:value={url}
+    type="url"
+    placeholder="Enter URL..."
+    class="vizel-link-input"
+  />
+  <button type="submit" class="vizel-link-button" title="Apply">
+    OK
+  </button>
+  {#if currentHref}
+    <button
+      type="button"
+      class="vizel-link-button vizel-link-remove"
+      title="Remove link"
+      onclick={handleRemove}
+    >
+      X
+    </button>
+  {/if}
+</form>

--- a/packages/svelte/src/components/BubbleMenuToolbar.svelte
+++ b/packages/svelte/src/components/BubbleMenuToolbar.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { Editor } from "@vizel/core";
+  import BubbleMenuButton from "./BubbleMenuButton.svelte";
+  import BubbleMenuLinkEditor from "./BubbleMenuLinkEditor.svelte";
+
+  interface Props {
+    editor: Editor;
+    class?: string;
+  }
+
+  let { editor, class: className }: Props = $props();
+  let showLinkEditor = $state(false);
+</script>
+
+{#if showLinkEditor}
+  <BubbleMenuLinkEditor {editor} onclose={() => (showLinkEditor = false)} />
+{:else}
+  <div class="vizel-bubble-menu-toolbar {className ?? ''}">
+    <BubbleMenuButton
+      isActive={editor.isActive("bold")}
+      title="Bold (Cmd+B)"
+      onclick={() => editor.chain().focus().toggleBold().run()}
+    >
+      <strong>B</strong>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      isActive={editor.isActive("italic")}
+      title="Italic (Cmd+I)"
+      onclick={() => editor.chain().focus().toggleItalic().run()}
+    >
+      <em>I</em>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      isActive={editor.isActive("strike")}
+      title="Strikethrough"
+      onclick={() => editor.chain().focus().toggleStrike().run()}
+    >
+      <s>S</s>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      isActive={editor.isActive("code")}
+      title="Code (Cmd+E)"
+      onclick={() => editor.chain().focus().toggleCode().run()}
+    >
+      <code>&lt;/&gt;</code>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      isActive={editor.isActive("link")}
+      title="Link (Cmd+K)"
+      onclick={() => (showLinkEditor = true)}
+    >
+      <span>L</span>
+    </BubbleMenuButton>
+  </div>
+{/if}

--- a/packages/svelte/src/components/SlashMenu.svelte
+++ b/packages/svelte/src/components/SlashMenu.svelte
@@ -1,0 +1,88 @@
+<script lang="ts" module>
+  export interface SlashMenuRef {
+    onKeyDown: (event: KeyboardEvent) => boolean;
+  }
+</script>
+
+<script lang="ts">
+  import type { SlashCommandItem } from "@vizel/core";
+  import type { Snippet } from "svelte";
+  import SlashMenuItem from "./SlashMenuItem.svelte";
+  import SlashMenuEmpty from "./SlashMenuEmpty.svelte";
+
+  interface Props {
+    items: SlashCommandItem[];
+    class?: string;
+    oncommand?: (item: SlashCommandItem) => void;
+    renderItem?: Snippet<[{ item: SlashCommandItem; isSelected: boolean; onclick: () => void }]>;
+    renderEmpty?: Snippet;
+  }
+
+  let {
+    items,
+    class: className,
+    oncommand,
+    renderItem,
+    renderEmpty,
+  }: Props = $props();
+
+  let selectedIndex = $state(0);
+
+  // Reset selection when items change
+  $effect(() => {
+    items;
+    selectedIndex = 0;
+  });
+
+  function selectItem(index: number) {
+    const item = items[index];
+    if (item) {
+      oncommand?.(item);
+    }
+  }
+
+  export function onKeyDown(event: KeyboardEvent): boolean {
+    if (event.key === "ArrowUp") {
+      selectedIndex = (selectedIndex + items.length - 1) % items.length;
+      return true;
+    }
+
+    if (event.key === "ArrowDown") {
+      selectedIndex = (selectedIndex + 1) % items.length;
+      return true;
+    }
+
+    if (event.key === "Enter") {
+      selectItem(selectedIndex);
+      return true;
+    }
+
+    return false;
+  }
+</script>
+
+<div class="vizel-slash-menu {className ?? ''}" data-vizel-slash-menu>
+  {#if items.length === 0}
+    {#if renderEmpty}
+      {@render renderEmpty()}
+    {:else}
+      <SlashMenuEmpty />
+    {/if}
+  {:else}
+    {#each items as item, index (item.title)}
+      {#if renderItem}
+        {@render renderItem({
+          item,
+          isSelected: index === selectedIndex,
+          onclick: () => selectItem(index),
+        })}
+      {:else}
+        <SlashMenuItem
+          {item}
+          isSelected={index === selectedIndex}
+          onclick={() => selectItem(index)}
+        />
+      {/if}
+    {/each}
+  {/if}
+</div>

--- a/packages/svelte/src/components/SlashMenuEmpty.svelte
+++ b/packages/svelte/src/components/SlashMenuEmpty.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    class?: string;
+    children?: Snippet;
+  }
+
+  let { class: className, children }: Props = $props();
+</script>
+
+<div class="vizel-slash-menu-empty {className ?? ''}">
+  {#if children}
+    {@render children()}
+  {:else}
+    No results
+  {/if}
+</div>

--- a/packages/svelte/src/components/SlashMenuItem.svelte
+++ b/packages/svelte/src/components/SlashMenuItem.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { SlashCommandItem } from "@vizel/core";
+
+  interface Props {
+    item: SlashCommandItem;
+    isSelected?: boolean;
+    class?: string;
+    onclick?: () => void;
+  }
+
+  let {
+    item,
+    isSelected = false,
+    class: className,
+    onclick,
+  }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class="vizel-slash-menu-item {isSelected ? 'is-selected' : ''} {className ?? ''}"
+  data-selected={isSelected || undefined}
+  {onclick}
+>
+  <span class="vizel-slash-menu-icon">{item.icon}</span>
+  <div class="vizel-slash-menu-text">
+    <span class="vizel-slash-menu-title">{item.title}</span>
+    <span class="vizel-slash-menu-description">{item.description}</span>
+  </div>
+</button>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -1,3 +1,4 @@
+// Editor components
 export { default as EditorRoot } from "./EditorRoot.svelte";
 export { default as EditorContent } from "./EditorContent.svelte";
 export {
@@ -5,3 +6,15 @@ export {
   getEditorContextSafe,
   EDITOR_CONTEXT_KEY,
 } from "./EditorContext.ts";
+
+// BubbleMenu components
+export { default as BubbleMenu } from "./BubbleMenu.svelte";
+export { default as BubbleMenuButton } from "./BubbleMenuButton.svelte";
+export { default as BubbleMenuDivider } from "./BubbleMenuDivider.svelte";
+export { default as BubbleMenuLinkEditor } from "./BubbleMenuLinkEditor.svelte";
+export { default as BubbleMenuToolbar } from "./BubbleMenuToolbar.svelte";
+
+// SlashMenu components
+export { default as SlashMenu, type SlashMenuRef } from "./SlashMenu.svelte";
+export { default as SlashMenuItem } from "./SlashMenuItem.svelte";
+export { default as SlashMenuEmpty } from "./SlashMenuEmpty.svelte";

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -8,13 +8,30 @@
 export { Editor } from "@tiptap/core";
 export { default as BubbleMenuExtension } from "@tiptap/extension-bubble-menu";
 
-// Components
+// Editor components
 export {
   EditorRoot,
   EditorContent,
   getEditorContext,
   getEditorContextSafe,
   EDITOR_CONTEXT_KEY,
+} from "./components/index.ts";
+
+// BubbleMenu components
+export {
+  BubbleMenu,
+  BubbleMenuButton,
+  BubbleMenuDivider,
+  BubbleMenuLinkEditor,
+  BubbleMenuToolbar,
+} from "./components/index.ts";
+
+// SlashMenu components
+export {
+  SlashMenu,
+  SlashMenuItem,
+  SlashMenuEmpty,
+  type SlashMenuRef,
 } from "./components/index.ts";
 
 // Editor factory
@@ -25,6 +42,10 @@ export {
 
 // Utilities
 export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
+export {
+  createSlashMenuRenderer,
+  type SlashMenuRendererOptions,
+} from "./utils/createSlashMenuRenderer.ts";
 
 // Re-export core types for convenience
 export type {

--- a/packages/svelte/src/utils/createSlashMenuRenderer.ts
+++ b/packages/svelte/src/utils/createSlashMenuRenderer.ts
@@ -1,0 +1,122 @@
+import { mount, unmount } from "svelte";
+import tippy, { type Instance as TippyInstance } from "tippy.js";
+import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
+import type { SlashCommandItem } from "@vizel/core";
+import SlashMenu from "../components/SlashMenu.svelte";
+
+export interface SlashMenuRendererOptions {
+  /** Custom class name for the menu */
+  className?: string;
+}
+
+interface SlashMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Creates a suggestion render configuration for the SlashCommand extension.
+ * This handles the popup positioning and Svelte component lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { SlashCommand, createSlashMenuRenderer } from '@vizel/svelte';
+ *
+ * const editor = new Editor({
+ *   extensions: [
+ *     SlashCommand.configure({
+ *       suggestion: createSlashMenuRenderer(),
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function createSlashMenuRenderer(
+  options: SlashMenuRendererOptions = {}
+): Partial<SuggestionOptions<SlashCommandItem>> {
+  return {
+    render: () => {
+      let component: ReturnType<typeof mount> | null = null;
+      let popup: TippyInstance[] | null = null;
+      let container: HTMLElement | null = null;
+      let items: SlashCommandItem[] = [];
+      let commandFn: ((item: SlashCommandItem) => void) | null = null;
+
+      return {
+        onStart: (props: SuggestionProps<SlashCommandItem>) => {
+          items = props.items;
+          commandFn = props.command;
+
+          container = document.createElement("div");
+
+          component = mount(SlashMenu, {
+            target: container,
+            props: {
+              items,
+              class: options.className,
+              oncommand: (item: SlashCommandItem) => {
+                commandFn?.(item);
+              },
+            },
+          });
+
+          if (!props.clientRect) {
+            return;
+          }
+
+          popup = tippy("body", {
+            getReferenceClientRect: props.clientRect as () => DOMRect,
+            appendTo: () => document.body,
+            content: container,
+            showOnCreate: true,
+            interactive: true,
+            trigger: "manual",
+            placement: "bottom-start",
+          });
+        },
+
+        onUpdate: (props: SuggestionProps<SlashCommandItem>) => {
+          items = props.items;
+          commandFn = props.command;
+
+          // Update component props
+          if (component) {
+            // Svelte 5 mount returns the component instance
+            // We need to update props through the returned object
+            (component as unknown as { items: SlashCommandItem[] }).items = items;
+          }
+
+          if (!props.clientRect) {
+            return;
+          }
+
+          popup?.[0]?.setProps({
+            getReferenceClientRect: props.clientRect as () => DOMRect,
+          });
+        },
+
+        onKeyDown: (props: { event: KeyboardEvent }) => {
+          if (props.event.key === "Escape") {
+            popup?.[0]?.hide();
+            return true;
+          }
+
+          if (component) {
+            const ref = component as unknown as SlashMenuRef;
+            return ref.onKeyDown?.(props.event) ?? false;
+          }
+          return false;
+        },
+
+        onExit: () => {
+          popup?.[0]?.destroy();
+          if (component) {
+            unmount(component);
+          }
+          container?.remove();
+          component = null;
+          container = null;
+        },
+      };
+    },
+  };
+}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -17,6 +17,7 @@
     "@vizel/core": "workspace:*",
     "@tiptap/core": "^3.14.0",
     "@tiptap/extension-bubble-menu": "^3.14.0",
+    "@tiptap/suggestion": "^3.14.0",
     "@tiptap/vue-3": "^3.14.0",
     "tippy.js": "^6.3.7"
   },

--- a/packages/vue/src/components/BubbleMenu.vue
+++ b/packages/vue/src/components/BubbleMenu.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, useSlots } from "vue";
+import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
+import type { Editor } from "@tiptap/vue-3";
+import BubbleMenuToolbar from "./BubbleMenuToolbar.vue";
+
+const props = withDefaults(
+  defineProps<{
+    editor: Editor | undefined;
+    class?: string;
+    showDefaultToolbar?: boolean;
+    pluginKey?: string;
+    updateDelay?: number;
+    shouldShow?: (props: { editor: Editor; from: number; to: number }) => boolean;
+  }>(),
+  {
+    showDefaultToolbar: true,
+    pluginKey: "vizelBubbleMenu",
+    updateDelay: 100,
+  }
+);
+
+const slots = useSlots();
+const menuRef = ref<HTMLElement | null>(null);
+
+watch(
+  [() => props.editor, menuRef],
+  ([editor, element], [, oldElement]) => {
+    if (!editor || !element) return;
+
+    // Unregister old plugin if element changed
+    if (oldElement) {
+      editor.unregisterPlugin(props.pluginKey);
+    }
+
+    const plugin = BubbleMenuPlugin({
+      pluginKey: props.pluginKey,
+      editor,
+      element,
+      updateDelay: props.updateDelay,
+      shouldShow: props.shouldShow
+        ? ({ editor: e, from, to }) =>
+            props.shouldShow!({ editor: e as Editor, from, to })
+        : undefined,
+      options: {
+        placement: "top",
+      },
+    });
+
+    editor.registerPlugin(plugin);
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  if (props.editor) {
+    props.editor.unregisterPlugin(props.pluginKey);
+  }
+});
+</script>
+
+<template>
+  <div
+    v-if="editor"
+    ref="menuRef"
+    :class="['vizel-bubble-menu', $props.class]"
+    data-vizel-bubble-menu
+    style="visibility: hidden"
+  >
+    <slot v-if="slots.default" />
+    <BubbleMenuToolbar v-else-if="showDefaultToolbar" :editor="editor" />
+  </div>
+</template>

--- a/packages/vue/src/components/BubbleMenuButton.vue
+++ b/packages/vue/src/components/BubbleMenuButton.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+defineProps<{
+  isActive?: boolean;
+  disabled?: boolean;
+  title?: string;
+  class?: string;
+}>();
+
+const emit = defineEmits<{
+  click: [];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :disabled="disabled"
+    :class="[
+      'vizel-bubble-menu-button',
+      { 'is-active': isActive },
+      $props.class,
+    ]"
+    :title="title"
+    :data-active="isActive || undefined"
+    @click="emit('click')"
+  >
+    <slot />
+  </button>
+</template>

--- a/packages/vue/src/components/BubbleMenuDivider.vue
+++ b/packages/vue/src/components/BubbleMenuDivider.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  class?: string;
+}>();
+</script>
+
+<template>
+  <span :class="['vizel-bubble-menu-divider', $props.class]" />
+</template>

--- a/packages/vue/src/components/BubbleMenuLinkEditor.vue
+++ b/packages/vue/src/components/BubbleMenuLinkEditor.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import type { Editor } from "@tiptap/vue-3";
+
+const props = defineProps<{
+  editor: Editor;
+  class?: string;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const currentHref = computed(() => props.editor.getAttributes("link").href || "");
+const url = ref(currentHref.value);
+
+onMounted(() => {
+  inputRef.value?.focus();
+});
+
+function handleSubmit(e: Event) {
+  e.preventDefault();
+  if (url.value.trim()) {
+    props.editor.chain().focus().setLink({ href: url.value.trim() }).run();
+  } else {
+    props.editor.chain().focus().unsetLink().run();
+  }
+  emit("close");
+}
+
+function handleRemove() {
+  props.editor.chain().focus().unsetLink().run();
+  emit("close");
+}
+</script>
+
+<template>
+  <form
+    :class="['vizel-link-editor', $props.class]"
+    @submit="handleSubmit"
+  >
+    <input
+      ref="inputRef"
+      v-model="url"
+      type="url"
+      placeholder="Enter URL..."
+      class="vizel-link-input"
+    />
+    <button type="submit" class="vizel-link-button" title="Apply">
+      OK
+    </button>
+    <button
+      v-if="currentHref"
+      type="button"
+      class="vizel-link-button vizel-link-remove"
+      title="Remove link"
+      @click="handleRemove"
+    >
+      X
+    </button>
+  </form>
+</template>

--- a/packages/vue/src/components/BubbleMenuToolbar.vue
+++ b/packages/vue/src/components/BubbleMenuToolbar.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import type { Editor } from "@tiptap/vue-3";
+import BubbleMenuButton from "./BubbleMenuButton.vue";
+import BubbleMenuLinkEditor from "./BubbleMenuLinkEditor.vue";
+
+const props = defineProps<{
+  editor: Editor;
+  class?: string;
+}>();
+
+const showLinkEditor = ref(false);
+</script>
+
+<template>
+  <BubbleMenuLinkEditor
+    v-if="showLinkEditor"
+    :editor="props.editor"
+    @close="showLinkEditor = false"
+  />
+  <div v-else :class="['vizel-bubble-menu-toolbar', $props.class]">
+    <BubbleMenuButton
+      :is-active="props.editor.isActive('bold')"
+      title="Bold (Cmd+B)"
+      @click="props.editor.chain().focus().toggleBold().run()"
+    >
+      <strong>B</strong>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      :is-active="props.editor.isActive('italic')"
+      title="Italic (Cmd+I)"
+      @click="props.editor.chain().focus().toggleItalic().run()"
+    >
+      <em>I</em>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      :is-active="props.editor.isActive('strike')"
+      title="Strikethrough"
+      @click="props.editor.chain().focus().toggleStrike().run()"
+    >
+      <s>S</s>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      :is-active="props.editor.isActive('code')"
+      title="Code (Cmd+E)"
+      @click="props.editor.chain().focus().toggleCode().run()"
+    >
+      <code>&lt;/&gt;</code>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      :is-active="props.editor.isActive('link')"
+      title="Link (Cmd+K)"
+      @click="showLinkEditor = true"
+    >
+      <span>L</span>
+    </BubbleMenuButton>
+  </div>
+</template>

--- a/packages/vue/src/components/SlashMenu.vue
+++ b/packages/vue/src/components/SlashMenu.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { ref, watch, useSlots } from "vue";
+import type { SlashCommandItem } from "@vizel/core";
+import SlashMenuItem from "./SlashMenuItem.vue";
+import SlashMenuEmpty from "./SlashMenuEmpty.vue";
+
+const props = defineProps<{
+  items: SlashCommandItem[];
+  class?: string;
+}>();
+
+const emit = defineEmits<{
+  command: [item: SlashCommandItem];
+}>();
+
+const slots = useSlots();
+const selectedIndex = ref(0);
+
+// Reset selection when items change
+watch(
+  () => props.items,
+  () => {
+    selectedIndex.value = 0;
+  }
+);
+
+function selectItem(index: number) {
+  const item = props.items[index];
+  if (item) {
+    emit("command", item);
+  }
+}
+
+function handleKeyDown(event: KeyboardEvent): boolean {
+  if (event.key === "ArrowUp") {
+    selectedIndex.value =
+      (selectedIndex.value + props.items.length - 1) % props.items.length;
+    return true;
+  }
+
+  if (event.key === "ArrowDown") {
+    selectedIndex.value = (selectedIndex.value + 1) % props.items.length;
+    return true;
+  }
+
+  if (event.key === "Enter") {
+    selectItem(selectedIndex.value);
+    return true;
+  }
+
+  return false;
+}
+
+// Expose handleKeyDown for parent components
+defineExpose({
+  onKeyDown: handleKeyDown,
+});
+</script>
+
+<template>
+  <div
+    :class="['vizel-slash-menu', $props.class]"
+    data-vizel-slash-menu
+  >
+    <template v-if="items.length === 0">
+      <slot v-if="slots.empty" name="empty" />
+      <SlashMenuEmpty v-else />
+    </template>
+    <template v-else>
+      <template v-for="(item, index) in items" :key="item.title">
+        <slot
+          v-if="slots.item"
+          name="item"
+          :item="item"
+          :is-selected="index === selectedIndex"
+          :on-click="() => selectItem(index)"
+        />
+        <SlashMenuItem
+          v-else
+          :item="item"
+          :is-selected="index === selectedIndex"
+          @click="selectItem(index)"
+        />
+      </template>
+    </template>
+  </div>
+</template>

--- a/packages/vue/src/components/SlashMenuEmpty.vue
+++ b/packages/vue/src/components/SlashMenuEmpty.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useSlots } from "vue";
+
+defineProps<{
+  class?: string;
+}>();
+
+const slots = useSlots();
+</script>
+
+<template>
+  <div :class="['vizel-slash-menu-empty', $props.class]">
+    <slot v-if="slots.default" />
+    <template v-else>No results</template>
+  </div>
+</template>

--- a/packages/vue/src/components/SlashMenuItem.vue
+++ b/packages/vue/src/components/SlashMenuItem.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import type { SlashCommandItem } from "@vizel/core";
+
+defineProps<{
+  item: SlashCommandItem;
+  isSelected?: boolean;
+  class?: string;
+}>();
+
+const emit = defineEmits<{
+  click: [];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="[
+      'vizel-slash-menu-item',
+      { 'is-selected': isSelected },
+      $props.class,
+    ]"
+    :data-selected="isSelected || undefined"
+    @click="emit('click')"
+  >
+    <span class="vizel-slash-menu-icon">{{ item.icon }}</span>
+    <div class="vizel-slash-menu-text">
+      <span class="vizel-slash-menu-title">{{ item.title }}</span>
+      <span class="vizel-slash-menu-description">{{ item.description }}</span>
+    </div>
+  </button>
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -1,3 +1,4 @@
+// Editor components
 export { default as EditorRoot } from "./EditorRoot.vue";
 export { default as EditorContent } from "./EditorContent.vue";
 export {
@@ -5,3 +6,15 @@ export {
   useEditorContextSafe,
   EDITOR_INJECTION_KEY,
 } from "./EditorContext.ts";
+
+// BubbleMenu components
+export { default as BubbleMenu } from "./BubbleMenu.vue";
+export { default as BubbleMenuButton } from "./BubbleMenuButton.vue";
+export { default as BubbleMenuDivider } from "./BubbleMenuDivider.vue";
+export { default as BubbleMenuLinkEditor } from "./BubbleMenuLinkEditor.vue";
+export { default as BubbleMenuToolbar } from "./BubbleMenuToolbar.vue";
+
+// SlashMenu components
+export { default as SlashMenu } from "./SlashMenu.vue";
+export { default as SlashMenuItem } from "./SlashMenuItem.vue";
+export { default as SlashMenuEmpty } from "./SlashMenuEmpty.vue";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -8,7 +8,7 @@
 export { Editor } from "@tiptap/core";
 export { default as BubbleMenuExtension } from "@tiptap/extension-bubble-menu";
 
-// Components
+// Editor components
 export {
   EditorRoot,
   EditorContent,
@@ -17,11 +17,31 @@ export {
   EDITOR_INJECTION_KEY,
 } from "./components/index.ts";
 
+// BubbleMenu components
+export {
+  BubbleMenu,
+  BubbleMenuButton,
+  BubbleMenuDivider,
+  BubbleMenuLinkEditor,
+  BubbleMenuToolbar,
+} from "./components/index.ts";
+
+// SlashMenu components
+export {
+  SlashMenu,
+  SlashMenuItem,
+  SlashMenuEmpty,
+} from "./components/index.ts";
+
 // Composables
 export { useVizelEditor, type UseVizelEditorOptions } from "./composables/index.ts";
 
 // Utilities
 export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
+export {
+  createSlashMenuRenderer,
+  type SlashMenuRendererOptions,
+} from "./utils/createSlashMenuRenderer.ts";
 
 // Re-export core types for convenience
 export type {

--- a/packages/vue/src/utils/createSlashMenuRenderer.ts
+++ b/packages/vue/src/utils/createSlashMenuRenderer.ts
@@ -1,0 +1,115 @@
+import { createApp, h, ref, type App } from "vue";
+import tippy, { type Instance as TippyInstance } from "tippy.js";
+import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
+import type { SlashCommandItem } from "@vizel/core";
+import SlashMenu from "../components/SlashMenu.vue";
+
+export interface SlashMenuRendererOptions {
+  /** Custom class name for the menu */
+  className?: string;
+}
+
+interface SlashMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Creates a suggestion render configuration for the SlashCommand extension.
+ * This handles the popup positioning and Vue component lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { SlashCommand, createSlashMenuRenderer } from '@vizel/vue';
+ *
+ * const editor = new Editor({
+ *   extensions: [
+ *     SlashCommand.configure({
+ *       suggestion: createSlashMenuRenderer(),
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function createSlashMenuRenderer(
+  options: SlashMenuRendererOptions = {}
+): Partial<SuggestionOptions<SlashCommandItem>> {
+  return {
+    render: () => {
+      let app: App | null = null;
+      let popup: TippyInstance[] | null = null;
+      let container: HTMLElement | null = null;
+      let componentRef = ref<SlashMenuRef | null>(null);
+      const items = ref<SlashCommandItem[]>([]);
+      const commandFn = ref<((item: SlashCommandItem) => void) | null>(null);
+
+      return {
+        onStart: (props: SuggestionProps<SlashCommandItem>) => {
+          items.value = props.items;
+          commandFn.value = props.command;
+
+          container = document.createElement("div");
+
+          app = createApp({
+            setup() {
+              return () =>
+                h(SlashMenu, {
+                  items: items.value,
+                  class: options.className,
+                  ref: componentRef,
+                  onCommand: (item: SlashCommandItem) => {
+                    commandFn.value?.(item);
+                  },
+                });
+            },
+          });
+
+          app.mount(container);
+
+          if (!props.clientRect) {
+            return;
+          }
+
+          popup = tippy("body", {
+            getReferenceClientRect: props.clientRect as () => DOMRect,
+            appendTo: () => document.body,
+            content: container,
+            showOnCreate: true,
+            interactive: true,
+            trigger: "manual",
+            placement: "bottom-start",
+          });
+        },
+
+        onUpdate: (props: SuggestionProps<SlashCommandItem>) => {
+          items.value = props.items;
+          commandFn.value = props.command;
+
+          if (!props.clientRect) {
+            return;
+          }
+
+          popup?.[0]?.setProps({
+            getReferenceClientRect: props.clientRect as () => DOMRect,
+          });
+        },
+
+        onKeyDown: (props: { event: KeyboardEvent }) => {
+          if (props.event.key === "Escape") {
+            popup?.[0]?.hide();
+            return true;
+          }
+
+          return componentRef.value?.onKeyDown(props.event) ?? false;
+        },
+
+        onExit: () => {
+          popup?.[0]?.destroy();
+          app?.unmount();
+          container?.remove();
+          app = null;
+          container = null;
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

React/Vue/Svelteのコンポーネント粒度を統一し、可能な限り細分化しました。

### 変更内容

#### React (@vizel/react)
- `BubbleMenu` を細分化:
  - `BubbleMenuButton` - 個別のボタンコンポーネント
  - `BubbleMenuDivider` - ボタン間の区切り線
  - `BubbleMenuLinkEditor` - リンク編集フォーム
  - `BubbleMenuToolbar` - デフォルトツールバー

- `SlashMenu` を細分化:
  - `SlashMenuItem` - 個別のメニューアイテム
  - `SlashMenuEmpty` - 空状態の表示

#### Vue (@vizel/vue)
- `BubbleMenu.vue` コンポーネント追加（React版と同等の機能）
- `SlashMenu.vue` コンポーネント追加（React版と同等の機能）
- `createSlashMenuRenderer` - Vue ネイティブコンポーネントを使用するレンダラー
- 各サブコンポーネントも同様に追加

#### Svelte (@vizel/svelte)
- `BubbleMenu.svelte` コンポーネント追加（React版と同等の機能）
- `SlashMenu.svelte` コンポーネント追加（React版と同等の機能）
- `createSlashMenuRenderer` - Svelte ネイティブコンポーネントを使用するレンダラー
- 各サブコンポーネントも同様に追加

### API の統一

各パッケージから以下のコンポーネントが統一的にエクスポートされます:

| Component | React | Vue | Svelte |
|-----------|-------|-----|--------|
| BubbleMenu | ✅ | ✅ | ✅ |
| BubbleMenuButton | ✅ | ✅ | ✅ |
| BubbleMenuDivider | ✅ | ✅ | ✅ |
| BubbleMenuLinkEditor | ✅ | ✅ | ✅ |
| BubbleMenuToolbar | ✅ | ✅ | ✅ |
| SlashMenu | ✅ | ✅ | ✅ |
| SlashMenuItem | ✅ | ✅ | ✅ |
| SlashMenuEmpty | ✅ | ✅ | ✅ |
| createSlashMenuRenderer | ✅ | ✅ | ✅ |