### PR TITLE
refactor: migrate utils to composables (Vue) and runes (Svelte)

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -49,6 +49,9 @@ export {
 // Hooks
 export { useVizelEditor, type UseVizelEditorOptions } from "./hooks/index.ts";
 
+// Utilities (framework-agnostic)
+export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
+
 // Re-export core types for convenience
 export type {
   VizelEditorOptions,

--- a/packages/react/src/utils/slashMenuRenderer.ts
+++ b/packages/react/src/utils/slashMenuRenderer.ts
@@ -1,0 +1,150 @@
+import tippy, { type Instance as TippyInstance } from "tippy.js";
+import type { SlashCommandItem } from "@vizel/core";
+
+interface SlashMenuState {
+  popup: TippyInstance[] | null;
+  menuElement: HTMLElement | null;
+  selectedIndex: number;
+  items: SlashCommandItem[];
+  commandFn: ((item: SlashCommandItem) => void) | null;
+}
+
+/**
+ * Creates a vanilla JS slash menu renderer for React apps.
+ * This is a framework-agnostic implementation using tippy.js.
+ *
+ * @example
+ * ```ts
+ * import { SlashCommand, defaultSlashCommands, createVanillaSlashMenuRenderer } from "@vizel/react";
+ *
+ * const editor = useEditor({
+ *   extensions: [
+ *     SlashCommand.configure({
+ *       items: defaultSlashCommands,
+ *       suggestion: createVanillaSlashMenuRenderer(),
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function createVanillaSlashMenuRenderer() {
+  const state: SlashMenuState = {
+    popup: null,
+    menuElement: null,
+    selectedIndex: 0,
+    items: [],
+    commandFn: null,
+  };
+
+  function renderMenu() {
+    if (!state.menuElement) return;
+
+    if (state.items.length === 0) {
+      state.menuElement.innerHTML = `
+        <div class="vizel-slash-menu-empty">No results</div>
+      `;
+      return;
+    }
+
+    state.menuElement.innerHTML = state.items
+      .map(
+        (item, index) => `
+        <button class="vizel-slash-menu-item ${index === state.selectedIndex ? "is-selected" : ""}" data-index="${index}">
+          <span class="vizel-slash-menu-icon">${item.icon}</span>
+          <div class="vizel-slash-menu-text">
+            <span class="vizel-slash-menu-title">${item.title}</span>
+            <span class="vizel-slash-menu-description">${item.description}</span>
+          </div>
+        </button>
+      `
+      )
+      .join("");
+
+    state.menuElement.querySelectorAll(".vizel-slash-menu-item").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const index = parseInt(btn.getAttribute("data-index") || "0");
+        if (state.commandFn && state.items[index]) {
+          state.commandFn(state.items[index]);
+        }
+      });
+    });
+  }
+
+  return {
+    render: () => ({
+      onStart: (props: {
+        items: SlashCommandItem[];
+        command: (item: SlashCommandItem) => void;
+        clientRect?: (() => DOMRect) | null;
+      }) => {
+        state.items = props.items;
+        state.commandFn = props.command;
+        state.selectedIndex = 0;
+
+        state.menuElement = document.createElement("div");
+        state.menuElement.className = "vizel-slash-menu";
+        renderMenu();
+
+        if (!props.clientRect) return;
+
+        state.popup = tippy("body", {
+          getReferenceClientRect: props.clientRect,
+          appendTo: () => document.body,
+          content: state.menuElement,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "bottom-start",
+        });
+      },
+
+      onUpdate: (props: {
+        items: SlashCommandItem[];
+        command: (item: SlashCommandItem) => void;
+        clientRect?: (() => DOMRect) | null;
+      }) => {
+        state.items = props.items;
+        state.commandFn = props.command;
+        state.selectedIndex = 0;
+        renderMenu();
+
+        if (props.clientRect) {
+          state.popup?.[0]?.setProps({
+            getReferenceClientRect: props.clientRect,
+          });
+        }
+      },
+
+      onKeyDown: (props: { event: KeyboardEvent }) => {
+        if (props.event.key === "ArrowUp") {
+          state.selectedIndex =
+            (state.selectedIndex + state.items.length - 1) % state.items.length;
+          renderMenu();
+          return true;
+        }
+        if (props.event.key === "ArrowDown") {
+          state.selectedIndex = (state.selectedIndex + 1) % state.items.length;
+          renderMenu();
+          return true;
+        }
+        if (props.event.key === "Enter") {
+          const item = state.items[state.selectedIndex];
+          if (state.commandFn && item) {
+            state.commandFn(item);
+          }
+          return true;
+        }
+        if (props.event.key === "Escape") {
+          state.popup?.[0]?.hide();
+          return true;
+        }
+        return false;
+      },
+
+      onExit: () => {
+        state.popup?.[0]?.destroy();
+        state.menuElement = null;
+      },
+    }),
+  };
+}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -40,12 +40,23 @@ export {
   type CreateVizelEditorOptions,
 } from "./createVizelEditor.ts";
 
-// Utilities
-export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
+// Runes (Svelte 5 reactive state)
+export {
+  createBubbleMenu,
+  createSlashMenu,
+  type CreateBubbleMenuOptions,
+  type BubbleMenuState,
+  type SlashMenuState,
+} from "./runes/index.ts";
+
+// Renderers
 export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
 } from "./utils/createSlashMenuRenderer.ts";
+
+// Utilities (framework-agnostic)
+export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
 
 // Re-export core types for convenience
 export type {

--- a/packages/svelte/src/runes/bubbleMenu.svelte.ts
+++ b/packages/svelte/src/runes/bubbleMenu.svelte.ts
@@ -1,0 +1,101 @@
+import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
+import type { Editor } from "@vizel/core";
+
+export interface CreateBubbleMenuOptions {
+  /** Plugin key for the bubble menu */
+  pluginKey?: string;
+  /** Delay in ms before updating the menu position */
+  updateDelay?: number;
+  /** Custom shouldShow function */
+  shouldShow?: (props: { editor: Editor; from: number; to: number }) => boolean;
+}
+
+export interface BubbleMenuState {
+  /** The menu element - bind to this */
+  element: HTMLElement | null;
+  /** Whether the plugin is registered */
+  isRegistered: boolean;
+  /** Register the plugin with the editor */
+  register: (editor: Editor, element: HTMLElement) => void;
+  /** Unregister the plugin from the editor */
+  unregister: (editor: Editor) => void;
+}
+
+/**
+ * Creates a reactive BubbleMenu state using Svelte 5 runes.
+ * Manages plugin registration and provides element binding.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import { createBubbleMenu, BubbleMenuToolbar } from '@vizel/svelte';
+ *
+ * let { editor } = $props();
+ * const bubbleMenu = createBubbleMenu();
+ *
+ * $effect(() => {
+ *   if (editor && bubbleMenu.element) {
+ *     bubbleMenu.register(editor, bubbleMenu.element);
+ *     return () => bubbleMenu.unregister(editor);
+ *   }
+ * });
+ * </script>
+ *
+ * <div bind:this={bubbleMenu.element} class="vizel-bubble-menu">
+ *   <BubbleMenuToolbar {editor} />
+ * </div>
+ * ```
+ */
+export function createBubbleMenu(
+  options: CreateBubbleMenuOptions = {}
+): BubbleMenuState {
+  const {
+    pluginKey = "vizelBubbleMenu",
+    updateDelay = 100,
+    shouldShow,
+  } = options;
+
+  let element = $state<HTMLElement | null>(null);
+  let isRegistered = $state(false);
+
+  function register(editor: Editor, el: HTMLElement) {
+    if (isRegistered) return;
+
+    const plugin = BubbleMenuPlugin({
+      pluginKey,
+      editor,
+      element: el,
+      updateDelay,
+      shouldShow: shouldShow
+        ? ({ editor: e, from, to }) =>
+            shouldShow({ editor: e as Editor, from, to })
+        : undefined,
+      options: {
+        placement: "top",
+      },
+    });
+
+    editor.registerPlugin(plugin);
+    isRegistered = true;
+  }
+
+  function unregister(editor: Editor) {
+    if (!isRegistered) return;
+    editor.unregisterPlugin(pluginKey);
+    isRegistered = false;
+  }
+
+  return {
+    get element() {
+      return element;
+    },
+    set element(value: HTMLElement | null) {
+      element = value;
+    },
+    get isRegistered() {
+      return isRegistered;
+    },
+    register,
+    unregister,
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -1,0 +1,10 @@
+export {
+  createBubbleMenu,
+  type CreateBubbleMenuOptions,
+  type BubbleMenuState,
+} from "./bubbleMenu.svelte.ts";
+
+export {
+  createSlashMenu,
+  type SlashMenuState,
+} from "./slashMenu.svelte.ts";

--- a/packages/svelte/src/runes/slashMenu.svelte.ts
+++ b/packages/svelte/src/runes/slashMenu.svelte.ts
@@ -1,0 +1,132 @@
+import type { SlashCommandItem } from "@vizel/core";
+
+export interface SlashMenuState {
+  /** Current items */
+  items: SlashCommandItem[];
+  /** Currently selected index */
+  selectedIndex: number;
+  /** Whether the menu has items */
+  readonly hasItems: boolean;
+  /** Currently selected item */
+  readonly selectedItem: SlashCommandItem | undefined;
+  /** Set items */
+  setItems: (newItems: SlashCommandItem[]) => void;
+  /** Select an item by index */
+  selectItem: (index: number) => SlashCommandItem | undefined;
+  /** Move selection up */
+  moveUp: () => void;
+  /** Move selection down */
+  moveDown: () => void;
+  /** Reset selection to first item */
+  resetSelection: () => void;
+  /** Handle keyboard navigation, returns true if handled */
+  handleKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Creates a reactive SlashMenu state using Svelte 5 runes.
+ * Provides state management and keyboard navigation.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import { createSlashMenu, SlashMenuItem } from '@vizel/svelte';
+ *
+ * const slashMenu = createSlashMenu();
+ *
+ * // Use with SlashCommand suggestion
+ * const suggestionConfig = {
+ *   render: () => ({
+ *     onStart: (props) => slashMenu.setItems(props.items),
+ *     onUpdate: (props) => slashMenu.setItems(props.items),
+ *     onKeyDown: ({ event }) => slashMenu.handleKeyDown(event),
+ *   }),
+ * };
+ * </script>
+ *
+ * {#each slashMenu.items as item, index}
+ *   <SlashMenuItem
+ *     {item}
+ *     isSelected={index === slashMenu.selectedIndex}
+ *     onclick={() => slashMenu.selectItem(index)}
+ *   />
+ * {/each}
+ * ```
+ */
+export function createSlashMenu(
+  initialItems: SlashCommandItem[] = []
+): SlashMenuState {
+  let items = $state<SlashCommandItem[]>(initialItems);
+  let selectedIndex = $state(0);
+
+  const hasItems = $derived(items.length > 0);
+  const selectedItem = $derived(items[selectedIndex]);
+
+  function setItems(newItems: SlashCommandItem[]) {
+    items = newItems;
+    selectedIndex = 0;
+  }
+
+  function selectItem(index: number): SlashCommandItem | undefined {
+    return items[index];
+  }
+
+  function moveUp() {
+    if (items.length === 0) return;
+    selectedIndex = (selectedIndex + items.length - 1) % items.length;
+  }
+
+  function moveDown() {
+    if (items.length === 0) return;
+    selectedIndex = (selectedIndex + 1) % items.length;
+  }
+
+  function resetSelection() {
+    selectedIndex = 0;
+  }
+
+  function handleKeyDown(event: KeyboardEvent): boolean {
+    if (event.key === "ArrowUp") {
+      moveUp();
+      return true;
+    }
+
+    if (event.key === "ArrowDown") {
+      moveDown();
+      return true;
+    }
+
+    if (event.key === "Enter") {
+      return true;
+    }
+
+    return false;
+  }
+
+  return {
+    get items() {
+      return items;
+    },
+    set items(value: SlashCommandItem[]) {
+      items = value;
+    },
+    get selectedIndex() {
+      return selectedIndex;
+    },
+    set selectedIndex(value: number) {
+      selectedIndex = value;
+    },
+    get hasItems() {
+      return hasItems;
+    },
+    get selectedItem() {
+      return selectedItem;
+    },
+    setItems,
+    selectItem,
+    moveUp,
+    moveDown,
+    resetSelection,
+    handleKeyDown,
+  };
+}

--- a/packages/vue/src/composables/createSlashMenuRenderer.ts
+++ b/packages/vue/src/composables/createSlashMenuRenderer.ts
@@ -2,7 +2,7 @@ import { createApp, h, ref, type App } from "vue";
 import tippy, { type Instance as TippyInstance } from "tippy.js";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import type { SlashCommandItem } from "@vizel/core";
-import SlashMenu from "../components/SlashMenu.vue";
+import { SlashMenu } from "../components/index.ts";
 
 export interface SlashMenuRendererOptions {
   /** Custom class name for the menu */

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -1,1 +1,15 @@
 export { useVizelEditor, type UseVizelEditorOptions } from "./useVizelEditor.ts";
+export {
+  useBubbleMenu,
+  type UseBubbleMenuOptions,
+  type UseBubbleMenuReturn,
+} from "./useBubbleMenu.ts";
+export {
+  useSlashMenu,
+  type UseSlashMenuOptions,
+  type UseSlashMenuReturn,
+} from "./useSlashMenu.ts";
+export {
+  createSlashMenuRenderer,
+  type SlashMenuRendererOptions,
+} from "./createSlashMenuRenderer.ts";

--- a/packages/vue/src/composables/useBubbleMenu.ts
+++ b/packages/vue/src/composables/useBubbleMenu.ts
@@ -1,0 +1,89 @@
+import { ref, watch, onBeforeUnmount, type Ref } from "vue";
+import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
+import type { Editor } from "@tiptap/vue-3";
+
+export interface UseBubbleMenuOptions {
+  /** The editor instance */
+  editor: Ref<Editor | undefined>;
+  /** Plugin key for the bubble menu */
+  pluginKey?: string;
+  /** Delay in ms before updating the menu position */
+  updateDelay?: number;
+  /** Custom shouldShow function */
+  shouldShow?: (props: { editor: Editor; from: number; to: number }) => boolean;
+}
+
+export interface UseBubbleMenuReturn {
+  /** Ref for the menu element - bind to the menu container */
+  menuRef: Ref<HTMLElement | null>;
+}
+
+/**
+ * Vue composable for managing a BubbleMenu.
+ * Handles plugin registration and lifecycle automatically.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useVizelEditor, useBubbleMenu, BubbleMenuToolbar } from '@vizel/vue';
+ *
+ * const editor = useVizelEditor({ placeholder: "Start typing..." });
+ * const { menuRef } = useBubbleMenu({ editor });
+ * </script>
+ *
+ * <template>
+ *   <div ref="menuRef" class="vizel-bubble-menu" style="visibility: hidden">
+ *     <BubbleMenuToolbar v-if="editor" :editor="editor" />
+ *   </div>
+ * </template>
+ * ```
+ */
+export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuReturn {
+  const {
+    editor,
+    pluginKey = "vizelBubbleMenu",
+    updateDelay = 100,
+    shouldShow,
+  } = options;
+
+  const menuRef = ref<HTMLElement | null>(null);
+
+  watch(
+    [editor, menuRef],
+    ([editorInstance, element], [oldEditor]) => {
+      if (!editorInstance || !element) return;
+
+      // Unregister old plugin if editor changed
+      if (oldEditor) {
+        oldEditor.unregisterPlugin(pluginKey);
+      }
+
+      const plugin = BubbleMenuPlugin({
+        pluginKey,
+        editor: editorInstance,
+        element,
+        updateDelay,
+        shouldShow: shouldShow
+          ? ({ editor: e, from, to }) =>
+              shouldShow({ editor: e as Editor, from, to })
+          : undefined,
+        options: {
+          placement: "top",
+        },
+      });
+
+      editorInstance.registerPlugin(plugin);
+    },
+    { immediate: true }
+  );
+
+  onBeforeUnmount(() => {
+    if (editor.value) {
+      editor.value.unregisterPlugin(pluginKey);
+    }
+  });
+
+  return {
+    menuRef,
+  };
+}

--- a/packages/vue/src/composables/useSlashMenu.ts
+++ b/packages/vue/src/composables/useSlashMenu.ts
@@ -1,0 +1,126 @@
+import { ref, computed, type Ref, type ComputedRef } from "vue";
+import type { SlashCommandItem } from "@vizel/core";
+
+export interface UseSlashMenuOptions {
+  /** Initial items */
+  initialItems?: SlashCommandItem[];
+}
+
+export interface UseSlashMenuReturn {
+  /** Current items */
+  items: Ref<SlashCommandItem[]>;
+  /** Currently selected index */
+  selectedIndex: Ref<number>;
+  /** Whether the menu has items */
+  hasItems: ComputedRef<boolean>;
+  /** Currently selected item */
+  selectedItem: ComputedRef<SlashCommandItem | undefined>;
+  /** Set items */
+  setItems: (newItems: SlashCommandItem[]) => void;
+  /** Select an item by index */
+  selectItem: (index: number) => SlashCommandItem | undefined;
+  /** Move selection up */
+  moveUp: () => void;
+  /** Move selection down */
+  moveDown: () => void;
+  /** Reset selection to first item */
+  resetSelection: () => void;
+  /** Handle keyboard navigation, returns true if handled */
+  handleKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Vue composable for managing SlashMenu state.
+ * Provides reactive state and keyboard navigation handlers.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useSlashMenu, SlashMenuItem } from '@vizel/vue';
+ *
+ * const {
+ *   items,
+ *   selectedIndex,
+ *   setItems,
+ *   selectItem,
+ *   handleKeyDown,
+ * } = useSlashMenu();
+ *
+ * // Use with SlashCommand suggestion
+ * const suggestionConfig = {
+ *   render: () => ({
+ *     onStart: (props) => setItems(props.items),
+ *     onUpdate: (props) => setItems(props.items),
+ *     onKeyDown: ({ event }) => handleKeyDown(event),
+ *   }),
+ * };
+ * </script>
+ * ```
+ */
+export function useSlashMenu(options: UseSlashMenuOptions = {}): UseSlashMenuReturn {
+  const { initialItems = [] } = options;
+
+  const items = ref<SlashCommandItem[]>(initialItems);
+  const selectedIndex = ref(0);
+
+  const hasItems = computed(() => items.value.length > 0);
+  const selectedItem = computed(() => items.value[selectedIndex.value]);
+
+  function setItems(newItems: SlashCommandItem[]) {
+    items.value = newItems;
+    selectedIndex.value = 0;
+  }
+
+  function selectItem(index: number): SlashCommandItem | undefined {
+    const item = items.value[index];
+    return item;
+  }
+
+  function moveUp() {
+    if (items.value.length === 0) return;
+    selectedIndex.value =
+      (selectedIndex.value + items.value.length - 1) % items.value.length;
+  }
+
+  function moveDown() {
+    if (items.value.length === 0) return;
+    selectedIndex.value = (selectedIndex.value + 1) % items.value.length;
+  }
+
+  function resetSelection() {
+    selectedIndex.value = 0;
+  }
+
+  function handleKeyDown(event: KeyboardEvent): boolean {
+    if (event.key === "ArrowUp") {
+      moveUp();
+      return true;
+    }
+
+    if (event.key === "ArrowDown") {
+      moveDown();
+      return true;
+    }
+
+    if (event.key === "Enter") {
+      // Return true to indicate the event was handled
+      // The caller should use selectedItem.value to get the selected item
+      return true;
+    }
+
+    return false;
+  }
+
+  return {
+    items,
+    selectedIndex,
+    hasItems,
+    selectedItem,
+    setItems,
+    selectItem,
+    moveUp,
+    moveDown,
+    resetSelection,
+    handleKeyDown,
+  };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,14 +34,21 @@ export {
 } from "./components/index.ts";
 
 // Composables
-export { useVizelEditor, type UseVizelEditorOptions } from "./composables/index.ts";
-
-// Utilities
-export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
 export {
+  useVizelEditor,
+  useBubbleMenu,
+  useSlashMenu,
   createSlashMenuRenderer,
+  type UseVizelEditorOptions,
+  type UseBubbleMenuOptions,
+  type UseBubbleMenuReturn,
+  type UseSlashMenuOptions,
+  type UseSlashMenuReturn,
   type SlashMenuRendererOptions,
-} from "./utils/createSlashMenuRenderer.ts";
+} from "./composables/index.ts";
+
+// Utilities (framework-agnostic)
+export { createVanillaSlashMenuRenderer } from "./utils/slashMenuRenderer.ts";
 
 // Re-export core types for convenience
 export type {


### PR DESCRIPTION
## Summary

- **Vue**: Add `useBubbleMenu`, `useSlashMenu` composables using Vue 3 Composition API
- **Vue**: Move `createSlashMenuRenderer` from `utils/` to `composables/`
- **Svelte**: Add `createBubbleMenu`, `createSlashMenu` using Svelte 5 runes (`.svelte.ts` files)
- **React**: Add `createVanillaSlashMenuRenderer` to `utils/` for consistency
- All packages now export framework-agnostic `createVanillaSlashMenuRenderer`

## Structure

| Package | Composables/Runes | Utils |
|---------|-------------------|-------|
| React | `hooks/useVizelEditor` | `utils/slashMenuRenderer` |
| Vue | `composables/useVizelEditor, useBubbleMenu, useSlashMenu, createSlashMenuRenderer` | `utils/slashMenuRenderer` |
| Svelte | `runes/createBubbleMenu, createSlashMenu` | `utils/createSlashMenuRenderer, slashMenuRenderer` |

## Test Plan

- [x] Type check passes for all packages
- [x] React demo works (http://localhost:3000)
- [x] Vue demo works (http://localhost:3001)
- [x] Svelte demo works (http://localhost:3002)
- [x] Slash menu functionality verified on all demos