### PR TITLE
ci: add GitHub Actions CI workflow, Dependabot, and lefthook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Biome lint
+        run: bun run lint
+
+  typecheck:
+    name: TypeCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run TypeCheck
+        run: bun run typecheck
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,262 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+
+      "complexity": {
+        "recommended": true,
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": { "maxAllowedComplexity": 15 }
+        },
+        "noUselessStringConcat": "error",
+        "noUselessUndefinedInitialization": "error",
+        "useDateNow": "error",
+        "useSimplifiedLogicExpression": "warn",
+        "useNumericLiterals": "error",
+        "noUselessEscapeInRegex": "error",
+        "useLiteralKeys": "off",
+        "useArrowFunction": "error"
+      },
+
+      "correctness": {
+        "recommended": true,
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "noUnusedPrivateClassMembers": "error",
+        "noUndeclaredDependencies": "warn",
+        "useHookAtTopLevel": "error",
+        "noSwitchDeclarations": "error",
+        "noUnknownPseudoClass": "warn",
+        "noUnknownPseudoElement": "warn"
+      },
+
+      "performance": {
+        "recommended": true,
+        "noAccumulatingSpread": "warn",
+        "noBarrelFile": "off",
+        "noReExportAll": "warn"
+      },
+
+      "style": {
+        "recommended": true,
+        "noDefaultExport": "off",
+        "noNamespace": "error",
+        "noNegationElse": "error",
+        "noNonNullAssertion": "warn",
+        "noParameterAssign": "error",
+        "noRestrictedGlobals": "error",
+        "noShoutyConstants": "warn",
+        "useBlockStatements": "error",
+        "useCollapsedElseIf": "error",
+        "useConst": "error",
+        "useConsistentBuiltinInstantiation": "error",
+        "useDefaultSwitchClause": "warn",
+        "useExplicitLengthCheck": "error",
+        "useExponentiationOperator": "error",
+        "useForOf": "error",
+        "useFragmentSyntax": "error",
+        "useNamingConvention": {
+          "level": "warn",
+          "options": {
+            "strictCase": false,
+            "requireAscii": true,
+            "conventions": [
+              {
+                "selector": { "kind": "const" },
+                "formats": ["camelCase", "CONSTANT_CASE", "PascalCase"]
+              },
+              {
+                "selector": { "kind": "function" },
+                "formats": ["camelCase", "PascalCase"]
+              },
+              {
+                "selector": { "kind": "typeLike" },
+                "formats": ["PascalCase"]
+              },
+              {
+                "selector": { "kind": "objectLiteralProperty" },
+                "formats": ["camelCase", "CONSTANT_CASE", "PascalCase"]
+              },
+              {
+                "selector": { "kind": "typeProperty" },
+                "formats": ["camelCase", "PascalCase"]
+              }
+            ]
+          }
+        },
+        "useNodeAssertStrict": "error",
+        "useNodejsImportProtocol": "error",
+        "useNumberNamespace": "error",
+        "useShorthandAssign": "error",
+        "useTemplate": "error",
+        "useThrowNewError": "error",
+        "useThrowOnlyError": "error",
+        "useArrayLiterals": "error",
+        "useConsistentArrayType": { "level": "error", "options": { "syntax": "shorthand" } },
+        "noCommonJs": "error",
+        "noDescendingSpecificity": "warn",
+        "noEnum": "error",
+        "noExportedImports": "error",
+        "noNestedTernary": "warn",
+        "noSubstr": "error",
+        "noValueAtRule": "warn",
+        "useAtIndex": "error",
+        "useConsistentCurlyBraces": "error",
+        "useConsistentMemberAccessibility": {
+          "level": "error",
+          "options": { "accessibility": "noPublic" }
+        },
+        "useDeprecatedReason": "warn",
+        "useTrimStartEnd": "error"
+      },
+
+      "suspicious": {
+        "recommended": true,
+        "noApproximativeNumericConstant": "error",
+        "noAssignInExpressions": "error",
+        "noConfusingVoidType": "error",
+        "noConsole": "warn",
+        "noConstEnum": "error",
+        "noEmptyBlockStatements": "error",
+        "noEvolvingTypes": "error",
+        "noExplicitAny": "warn",
+        "noMisrefactoredShorthandAssign": "error",
+        "noSkippedTests": "warn",
+        "useAwait": "error",
+        "useErrorMessage": "error",
+        "noVar": "error",
+        "noDuplicateCustomProperties": "error",
+        "noIrregularWhitespace": "error",
+        "noShorthandPropertyOverrides": "error",
+        "noTemplateCurlyInString": "error",
+        "useAdjacentOverloadSignatures": "error",
+        "useStrictMode": "error"
+      },
+
+      "nursery": {
+        "noFloatingPromises": "error",
+        "useExplicitType": "warn",
+        "useSortedClasses": "off"
+      },
+      "security": {
+        "noSecrets": "off"
+      },
+      "a11y": {
+        "noStaticElementInteractions": "warn",
+        "useAriaPropsSupportedByRole": "warn",
+        "useValidAutocomplete": "warn"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useConst": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          },
+          "nursery": {
+            "useExplicitType": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.vue"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "useHookAtTopLevel": "off"
+          },
+          "nursery": {
+            "useExplicitType": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["*.test.ts", "*.test.tsx", "*.spec.ts", "*.spec.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.tsx"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "useExplicitType": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["packages/**/*"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noExportedImports": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["apps/demo/**/*"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
+          "nursery": {
+            "noFloatingPromises": "off",
+            "useExplicitType": "off"
+          },
+          "a11y": {
+            "noAutofocus": "off",
+            "noSvgWithoutTitle": "off"
+          },
+          "security": {
+            "noSecrets": "off"
+          },
+          "style": {
+            "useDefaultSwitchClause": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,50 @@
+# Lefthook configuration
+# https://github.com/evilmartians/lefthook
+
+pre-commit:
+  parallel: true
+  commands:
+    biome-check:
+      glob: "*.{js,ts,cjs,mjs,jsx,tsx,json,jsonc,vue,svelte}"
+      run: bunx biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      stage_fixed: true
+
+    typecheck-core:
+      glob: "packages/core/**/*.ts"
+      run: bun run --filter @vizel/core typecheck
+
+    typecheck-react:
+      glob: "packages/react/**/*.{ts,tsx}"
+      run: bun run --filter @vizel/react typecheck
+
+    typecheck-vue:
+      glob: "packages/vue/**/*.{ts,vue}"
+      run: bun run --filter @vizel/vue typecheck
+
+    typecheck-svelte:
+      glob: "packages/svelte/**/*.{ts,svelte}"
+      run: bun run --filter @vizel/svelte typecheck
+
+commit-msg:
+  commands:
+    commitlint:
+      run: |
+        # Validate commit message follows Conventional Commits
+        message=$(cat {1})
+        if ! echo "$message" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+"; then
+          echo "Error: Commit message must follow Conventional Commits format"
+          echo "Examples:"
+          echo "  feat: add new feature"
+          echo "  fix(core): resolve bug in editor"
+          echo "  docs: update README"
+          exit 1
+        fi
+
+pre-push:
+  parallel: true
+  commands:
+    lint:
+      run: bun run lint
+
+    typecheck:
+      run: bun run typecheck


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with lint, typecheck, and build jobs
- Add Dependabot configuration for npm and GitHub Actions updates
- Add lefthook for pre-commit, commit-msg, and pre-push hooks
- Add biome.json configuration for linting and formatting

## Changes
- `.github/workflows/ci.yml` - CI pipeline with parallel lint/typecheck and build
- `.github/dependabot.yml` - Weekly dependency updates with conventional commit prefixes
- `lefthook.yml` - Git hooks for code quality enforcement
- `biome.json` - Linter and formatter configuration

## Test plan
- [x] Typecheck passes for all packages
- [x] All demos (React, Vue, Svelte) work correctly
- [x] Lefthook hooks execute successfully