### PR TITLE
fix(ci): build packages before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - name: Run Biome lint
         run: bun run lint
 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
   typecheck:
     name: TypeCheck
     runs-on: ubuntu-latest
@@ -40,22 +56,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run TypeCheck
-        run: bun run typecheck
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Build packages
         run: bun run build
+
+      - name: Run TypeCheck
+        run: bun run typecheck


### PR DESCRIPTION
## Summary
The typecheck job needs dist directories to exist because package.json now points to dist for types. This PR makes the typecheck job build packages before running typecheck.

## Changes
- Reorder CI jobs: lint and build run in parallel
- Typecheck job now builds packages first before running type checks

## Test plan
- [ ] CI passes with all jobs succeeding