### PR TITLE
ci: add PR automation workflows

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,85 @@
+name: Auto-Merge Dependabot PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  auto-merge-dependabot:
+    name: Auto-Merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.user.type == 'Bot'
+    permissions:
+      pull-requests: write
+      contents: write
+    timeout-minutes: 10
+
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          alert-lookup: true
+          compat-lookup: true
+
+      - name: Check for security vulnerabilities
+        if: |
+          steps.metadata.outputs.alert-state == 'OPEN' ||
+          (steps.metadata.outputs.cvss != '' && steps.metadata.outputs.cvss > 7.0)
+        run: |
+          echo "🚨 High severity security vulnerability detected (CVSS: ${{ steps.metadata.outputs.cvss }})"
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "🚨 Security vulnerability detected (CVSS: ${{ steps.metadata.outputs.cvss }}). Skipping auto-merge for manual review."
+          exit 1
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Auto-approve and merge
+        run: |
+          echo "✅ All checks passed. Auto-merging dependency update:"
+          echo "  - Package: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "  - Update type: ${{ steps.metadata.outputs.update-type }}"
+          echo "  - Previous version: ${{ steps.metadata.outputs.previous-version }}"
+          echo "  - New version: ${{ steps.metadata.outputs.new-version }}"
+
+          # Auto-approve the PR
+          gh pr review ${{ github.event.pull_request.number }} --approve \
+            --body "✅ Auto-approved ${{ steps.metadata.outputs.update-type }} update for ${{ steps.metadata.outputs.dependency-names }}"
+
+          # Enable auto-merge
+          gh pr merge ${{ github.event.pull_request.number }} --auto --rebase
+          # Add success comment
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "🚀 Auto-merge enabled for this ${{ steps.metadata.outputs.update-type }} update. Will merge once all checks pass."
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Handle failures
+        if: failure()
+        run: |
+          echo "❌ Auto-merge failed"
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "❌ Auto-merge failed. Please check the workflow logs and consider manual review."
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,55 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR based on title
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labels = [];
+
+            // Map Conventional Commits prefixes to labels
+            const prefixMap = {
+              'feat': 'feature',
+              'fix': 'fix',
+              'docs': 'documentation',
+              'refactor': 'refactor',
+              'perf': 'performance',
+              'test': 'test',
+              'chore': 'chore',
+              'ci': 'ci',
+              'build': 'build',
+            };
+
+            // Extract prefix from title (e.g., "feat(scope): description" or "feat: description")
+            const match = title.match(/^(\w+)(?:\([^)]+\))?:/);
+            if (match) {
+              const prefix = match[1].toLowerCase();
+              const label = prefixMap[prefix];
+              if (label) {
+                labels.push(label);
+              }
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labels,
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            } else {
+              console.log('No matching prefix found in title');
+            }


### PR DESCRIPTION
## Summary
- Add `pr-labeler.yml` workflow for automatic labeling based on Conventional Commits prefixes
- Add `auto-merge-dependabot.yml` workflow for automatic Dependabot PR merging

## Added Workflows

### PR Labeler
Automatically labels PRs based on Conventional Commits title prefixes:
- `feat:` → `feature`
- `fix:` → `fix`
- `docs:` → `documentation`
- `refactor:` → `refactor`
- `perf:` → `performance`
- `test:` → `test`
- `chore:` → `chore`
- `ci:` → `ci`
- `build:` → `build`

### Auto-Merge Dependabot
Automatically approves and enables auto-merge for Dependabot PRs after:
- All checks pass
- No high-severity security vulnerabilities detected (CVSS > 7.0)

**Note:** Requires GitHub App credentials (`DEV_AUTOMATION_APP_ID` and `DEV_AUTOMATION_PRIVATE_KEY`) to be configured in repository secrets/variables.

## Test plan
- [ ] Verify pr-labeler workflow triggers on PR creation
- [ ] Verify labels are applied correctly based on PR title
- [ ] Verify auto-merge-dependabot workflow triggers on Dependabot PRs
- [ ] Configure required GitHub App credentials