### PR TITLE
feat(core): add underline extension with bubble menu integration (#15)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "@tiptap/extension-task-item": "^3.14.0",
         "@tiptap/extension-task-list": "^3.14.0",
         "@tiptap/extension-text": "^3.14.0",
+        "@tiptap/extension-underline": "^3.14.0",
         "@tiptap/markdown": "^3.14.0",
         "@tiptap/pm": "^3.14.0",
         "@tiptap/suggestion": "^3.14.0",
@@ -433,6 +434,8 @@
     "@tiptap/extension-task-list": ["@tiptap/extension-task-list@3.14.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.14.0" } }, "sha512-uFJkjxF8+yVewU/JR2PWgY2TGKqa0GntMPe/prozyIrKW6felcQ+Pypa6Mr3luk5e8C6GQB8Uh5+cVhLVTjZ/w=="],
 
     "@tiptap/extension-text": ["@tiptap/extension-text@3.14.0", "", { "peerDependencies": { "@tiptap/core": "^3.14.0" } }, "sha512-XlpnD87LQ7lLcDcBenHgzxv3uivQzPdVHM16CY4lXR4aKDIp2mxjPZr4twHT+cOnRQHc8VYpRgkEo6LLX6VylA=="],
+
+    "@tiptap/extension-underline": ["@tiptap/extension-underline@3.14.0", "", { "peerDependencies": { "@tiptap/core": "^3.14.0" } }, "sha512-zmnWlsi2g/tMlThHby0Je9O+v24j4d+qcXF3nuzLUUaDsGCEtOyC9RzwITft59ViK+Nc2PD2W/J14rsB0j+qoQ=="],
 
     "@tiptap/extensions": ["@tiptap/extensions@3.14.0", "", { "peerDependencies": { "@tiptap/core": "^3.14.0", "@tiptap/pm": "^3.14.0" } }, "sha512-qQBVKqzU4ZVjRn8W0UbdfE4LaaIgcIWHOMrNnJ+PutrRzQ6ZzhmD/kRONvRWBfG9z3DU7pSKGwVYSR2hztsGuQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "@tiptap/extension-task-item": "^3.14.0",
     "@tiptap/extension-task-list": "^3.14.0",
     "@tiptap/extension-text": "^3.14.0",
+    "@tiptap/extension-underline": "^3.14.0",
     "@tiptap/markdown": "^3.14.0",
     "@tiptap/pm": "^3.14.0",
     "@tiptap/suggestion": "^3.14.0"

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -19,6 +19,7 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Strike from "@tiptap/extension-strike";
 import Text from "@tiptap/extension-text";
+import Underline from "@tiptap/extension-underline";
 import type { VizelFeatureOptions } from "../types.ts";
 import { createCharacterCountExtension } from "./character-count.ts";
 import {
@@ -73,6 +74,7 @@ function createBaseExtensions(
     Code,
     Italic,
     Strike,
+    Underline,
     // Functionality
     Dropcursor.configure({ color: "#3b82f6", width: 2 }),
     Gapcursor,
@@ -265,4 +267,5 @@ export {
   Placeholder,
   Strike,
   Text,
+  Underline,
 };

--- a/packages/react/src/components/BubbleMenuToolbar.tsx
+++ b/packages/react/src/components/BubbleMenuToolbar.tsx
@@ -56,6 +56,14 @@ export function BubbleMenuToolbar({ editor, className }: BubbleMenuToolbarProps)
         <s>S</s>
       </BubbleMenuButton>
       <BubbleMenuButton
+        action="underline"
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        isActive={editor.isActive("underline")}
+        title="Underline (Cmd+U)"
+      >
+        <u>U</u>
+      </BubbleMenuButton>
+      <BubbleMenuButton
         action="code"
         onClick={() => editor.chain().focus().toggleCode().run()}
         isActive={editor.isActive("code")}

--- a/packages/svelte/src/components/BubbleMenuToolbar.svelte
+++ b/packages/svelte/src/components/BubbleMenuToolbar.svelte
@@ -33,6 +33,10 @@ const isStrikeActive = $derived.by(() => {
   void editorState.current;
   return editor.isActive("strike");
 });
+const isUnderlineActive = $derived.by(() => {
+  void editorState.current;
+  return editor.isActive("underline");
+});
 const isCodeActive = $derived.by(() => {
   void editorState.current;
   return editor.isActive("code");
@@ -70,6 +74,14 @@ const isLinkActive = $derived.by(() => {
       onclick={() => editor.chain().focus().toggleStrike().run()}
     >
       <s>S</s>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      action="underline"
+      isActive={isUnderlineActive}
+      title="Underline (Cmd+U)"
+      onclick={() => editor.chain().focus().toggleUnderline().run()}
+    >
+      <u>U</u>
     </BubbleMenuButton>
     <BubbleMenuButton
       action="code"

--- a/packages/vue/src/components/BubbleMenuToolbar.vue
+++ b/packages/vue/src/components/BubbleMenuToolbar.vue
@@ -30,6 +30,10 @@ const isStrikeActive = computed(() => {
   void editorStateVersion.value;
   return props.editor.isActive("strike");
 });
+const isUnderlineActive = computed(() => {
+  void editorStateVersion.value;
+  return props.editor.isActive("underline");
+});
 const isCodeActive = computed(() => {
   void editorStateVersion.value;
   return props.editor.isActive("code");
@@ -72,6 +76,14 @@ const showLinkEditor = ref(false);
       @click="props.editor.chain().focus().toggleStrike().run()"
     >
       <s>S</s>
+    </BubbleMenuButton>
+    <BubbleMenuButton
+      action="underline"
+      :is-active="isUnderlineActive"
+      title="Underline (Cmd+U)"
+      @click="props.editor.chain().focus().toggleUnderline().run()"
+    >
+      <u>U</u>
     </BubbleMenuButton>
     <BubbleMenuButton
       action="code"

--- a/tests/ct/react/specs/BubbleMenu.spec.tsx
+++ b/tests/ct/react/specs/BubbleMenu.spec.tsx
@@ -8,6 +8,8 @@ import {
   testBubbleMenuItalicToggle,
   testBubbleMenuLinkEditor,
   testBubbleMenuStrikeToggle,
+  testBubbleMenuUnderlineShortcut,
+  testBubbleMenuUnderlineToggle,
 } from "../../scenarios/bubble-menu.scenario";
 import { EditorFixture } from "./EditorFixture";
 
@@ -35,6 +37,16 @@ test.describe("BubbleMenu - React", () => {
   test("toggles strikethrough formatting", async ({ mount, page }) => {
     const component = await mount(<EditorFixture />);
     await testBubbleMenuStrikeToggle(component, page);
+  });
+
+  test("toggles underline formatting", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testBubbleMenuUnderlineToggle(component, page);
+  });
+
+  test("toggles underline with keyboard shortcut", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testBubbleMenuUnderlineShortcut(component, page);
   });
 
   test("toggles inline code formatting", async ({ mount, page }) => {

--- a/tests/ct/scenarios/bubble-menu.scenario.ts
+++ b/tests/ct/scenarios/bubble-menu.scenario.ts
@@ -78,6 +78,37 @@ export async function testBubbleMenuStrikeToggle(component: Locator, page: Page)
   await expect(strike).toContainText("Select this text");
 }
 
+/** Verify underline button toggles underline formatting */
+export async function testBubbleMenuUnderlineToggle(component: Locator, page: Page): Promise<void> {
+  await selectTextInEditor(component, page);
+
+  const bubbleMenu = component.locator(BUBBLE_MENU_SELECTOR);
+  const underlineButton = bubbleMenu.locator('[data-action="underline"]');
+
+  await underlineButton.click();
+
+  const editor = component.locator(".vizel-editor");
+  const underline = editor.locator("u");
+  await expect(underline).toContainText("Select this text");
+}
+
+/** Verify underline keyboard shortcut (Cmd+U) works */
+export async function testBubbleMenuUnderlineShortcut(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Type text with underline using keyboard shortcut
+  await page.keyboard.press("ControlOrMeta+u");
+  await page.keyboard.type("Underlined");
+  await page.keyboard.press("ControlOrMeta+u");
+
+  const underline = editor.locator("u");
+  await expect(underline).toContainText("Underlined");
+}
+
 /** Verify code button toggles inline code formatting */
 export async function testBubbleMenuCodeToggle(component: Locator, page: Page): Promise<void> {
   await selectTextInEditor(component, page);

--- a/tests/ct/svelte/specs/BubbleMenu.spec.ts
+++ b/tests/ct/svelte/specs/BubbleMenu.spec.ts
@@ -8,6 +8,8 @@ import {
   testBubbleMenuItalicToggle,
   testBubbleMenuLinkEditor,
   testBubbleMenuStrikeToggle,
+  testBubbleMenuUnderlineShortcut,
+  testBubbleMenuUnderlineToggle,
 } from "../../scenarios/bubble-menu.scenario";
 import EditorFixture from "./EditorFixture.svelte";
 
@@ -35,6 +37,16 @@ test.describe("BubbleMenu - Svelte", () => {
   test("toggles strikethrough formatting", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testBubbleMenuStrikeToggle(component, page);
+  });
+
+  test("toggles underline formatting", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testBubbleMenuUnderlineToggle(component, page);
+  });
+
+  test("toggles underline with keyboard shortcut", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testBubbleMenuUnderlineShortcut(component, page);
   });
 
   test("toggles inline code formatting", async ({ mount, page }) => {

--- a/tests/ct/vue/specs/BubbleMenu.spec.ts
+++ b/tests/ct/vue/specs/BubbleMenu.spec.ts
@@ -8,6 +8,8 @@ import {
   testBubbleMenuItalicToggle,
   testBubbleMenuLinkEditor,
   testBubbleMenuStrikeToggle,
+  testBubbleMenuUnderlineShortcut,
+  testBubbleMenuUnderlineToggle,
 } from "../../scenarios/bubble-menu.scenario";
 import EditorFixture from "./EditorFixture.vue";
 
@@ -35,6 +37,16 @@ test.describe("BubbleMenu - Vue", () => {
   test("toggles strikethrough formatting", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testBubbleMenuStrikeToggle(component, page);
+  });
+
+  test("toggles underline formatting", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testBubbleMenuUnderlineToggle(component, page);
+  });
+
+  test("toggles underline with keyboard shortcut", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testBubbleMenuUnderlineShortcut(component, page);
   });
 
   test("toggles inline code formatting", async ({ mount, page }) => {


### PR DESCRIPTION
## Summary

- Add `@tiptap/extension-underline` to base extensions
- Add underline button to BubbleMenuToolbar in all frameworks (React, Vue, Svelte)
- Add keyboard shortcut support (`Cmd+U` / `Ctrl+U`)
- Add comprehensive Playwright component tests

## Changes

### Core Package
- Install `@tiptap/extension-underline@3.14.0` dependency
- Import and configure Underline in `base.ts`
- Export Underline from base extensions for advanced usage

### Framework Packages
- Add underline button to BubbleMenuToolbar (React, Vue, Svelte)
- Add `isUnderlineActive` reactive state for button active state

### Tests
- Add `testBubbleMenuUnderlineToggle` scenario for button toggle
- Add `testBubbleMenuUnderlineShortcut` scenario for keyboard shortcut
- Update all framework test specs (6 new test cases total)

## Usage

```typescript
// Toggle underline on selected text
editor.chain().focus().toggleUnderline().run();

// Set underline
editor.chain().focus().setUnderline().run();

// Remove underline
editor.chain().focus().unsetUnderline().run();

// Check if active
editor.isActive('underline');
```

### Keyboard Shortcut
- `Cmd+U` (macOS) / `Ctrl+U` (Windows/Linux)

Closes #15

## Test Plan

- [x] Run lint (`bun run lint`)
- [x] Run typecheck (`bun run typecheck`)
- [x] Run E2E tests (`bun run test:ct`) - 495 tests passed (165 × 3 frameworks)
- [x] Verify underline button appears in bubble menu
- [x] Verify keyboard shortcut works