### PR TITLE
refactor(svelte): rename runes to follow Svelte naming conventions

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -63,8 +63,17 @@ interface BubbleMenuProps {
 | React | Vue | Svelte |
 |-------|-----|--------|
 | `hooks/` | `composables/` | `runes/` |
-| `useVizelEditor` | `useVizelEditor` | `useVizelEditor` |
+| `useVizelEditor` | `useVizelEditor` | `createVizelEditor` |
+| `useEditorState` | `useEditorState` | `createEditorState` |
 | `createSlashMenuRenderer` | `createSlashMenuRenderer` | `createSlashMenuRenderer` |
+
+### Naming Conventions
+
+Each framework follows its idiomatic naming:
+
+- **React**: `use*` prefix for hooks (React convention)
+- **Vue**: `use*` prefix for composables (Vue convention)
+- **Svelte**: `create*` for factory functions, `get*` for context getters (Svelte convention)
 
 ### Options Interface
 
@@ -72,8 +81,9 @@ All must accept identical options (defined in core):
 
 ```typescript
 // @vizel/core - shared type
-interface UseVizelEditorOptions extends VizelEditorOptions {
+interface VizelEditorOptions {
   extensions?: Extensions;
+  // ...
 }
 ```
 
@@ -88,8 +98,8 @@ interface UseVizelEditorOptions extends VizelEditorOptions {
 | Feature | React | Vue | Svelte |
 |---------|-------|-----|--------|
 | Provider | `EditorProvider` | `provide()` | `setContext()` |
-| Consumer | `useEditorContext()` | `inject()` | `getContext()` |
-| Safe access | `useEditorContextSafe()` | `useEditorContextSafe()` | `useEditorContextSafe()` |
+| Consumer | `useEditorContext()` | `useEditorContext()` | `getEditorContext()` |
+| Safe access | `useEditorContextSafe()` | `useEditorContextSafe()` | `getEditorContextSafe()` |
 
 ## Adding New Features
 

--- a/.claude/rules/packages/svelte.md
+++ b/.claude/rules/packages/svelte.md
@@ -73,12 +73,19 @@ let isActive = $derived(editor?.isActive("bold") ?? false);
 
 ## Runes
 
-### useVizelEditor
+### Naming Conventions
+
+Svelte runes follow Svelte-idiomatic naming (NOT React-style `use*`):
+
+- `create*` for factory functions that create reactive state
+- `get*` for context getters
+
+### createVizelEditor
 
 Primary rune for creating editor instances.
 
 ```typescript
-const editor = useVizelEditor({
+const editor = createVizelEditor({
   initialContent,
   placeholder,
   features: {
@@ -89,6 +96,15 @@ const editor = useVizelEditor({
 
 // Access editor with .current
 editor.current?.commands.setContent(content);
+```
+
+### createEditorState
+
+Rune for tracking editor state changes.
+
+```typescript
+const updateCount = createEditorState(() => editor.current);
+// Use updateCount.current to trigger reactivity
 ```
 
 ### Rune Conventions

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import {
   BubbleMenu,
+  createEditorState,
+  createVizelEditor,
   EditorContent,
   getEditorState,
   type JSONContent,
-  useEditorState,
-  useVizelEditor,
 } from "@vizel/svelte";
 import { initialContent } from "../../shared/content";
 import { mockUploadImage } from "../../shared/utils";
@@ -17,7 +17,7 @@ let showMarkdown = $state(false);
 let markdownInput = $state("");
 let showMarkdownInput = $state(false);
 
-const editor = useVizelEditor({
+const editor = createVizelEditor({
   initialContent,
   autofocus: "end",
   features: {
@@ -45,7 +45,7 @@ const editor = useVizelEditor({
 });
 
 // Track editor state for character/word count
-const updateCount = useEditorState(() => editor.current);
+const updateCount = createEditorState(() => editor.current);
 const editorState = $derived.by(() => {
   void updateCount.current;
   return getEditorState(editor.current);

--- a/packages/svelte/src/components/BubbleMenu.svelte
+++ b/packages/svelte/src/components/BubbleMenu.svelte
@@ -24,7 +24,7 @@ export interface BubbleMenuProps {
 import { BubbleMenuPlugin } from "@vizel/core";
 import { onDestroy } from "svelte";
 import BubbleMenuToolbar from "./BubbleMenuToolbar.svelte";
-import { useEditorContextSafe } from "./EditorContext.ts";
+import { getEditorContextSafe } from "./EditorContext.ts";
 
 let {
   editor: editorProp,
@@ -36,7 +36,7 @@ let {
   children,
 }: BubbleMenuProps = $props();
 
-const contextEditor = useEditorContextSafe();
+const contextEditor = getEditorContextSafe();
 const editor = $derived(editorProp ?? contextEditor?.());
 
 let menuElement = $state<HTMLElement | null>(null);

--- a/packages/svelte/src/components/BubbleMenuToolbar.svelte
+++ b/packages/svelte/src/components/BubbleMenuToolbar.svelte
@@ -10,7 +10,7 @@ export interface BubbleMenuToolbarProps {
 </script>
 
 <script lang="ts">
-import { useEditorState } from "../runes/useEditorState.svelte.ts";
+import { createEditorState } from "../runes/createEditorState.svelte.ts";
 import BubbleMenuButton from "./BubbleMenuButton.svelte";
 import BubbleMenuColorPicker from "./BubbleMenuColorPicker.svelte";
 import BubbleMenuLinkEditor from "./BubbleMenuLinkEditor.svelte";
@@ -19,7 +19,7 @@ let { editor, class: className }: BubbleMenuToolbarProps = $props();
 let showLinkEditor = $state(false);
 
 // Subscribe to editor state changes to update active states
-const editorState = useEditorState(() => editor);
+const editorState = createEditorState(() => editor);
 
 // Create derived values that depend on editorState.current to trigger re-renders
 const isBoldActive = $derived.by(() => {

--- a/packages/svelte/src/components/EditorContent.svelte
+++ b/packages/svelte/src/components/EditorContent.svelte
@@ -10,11 +10,11 @@ export interface EditorContentProps {
 </script>
 
 <script lang="ts">
-import { useEditorContextSafe } from "./EditorContext.ts";
+import { getEditorContextSafe } from "./EditorContext.ts";
 
 let { editor: editorProp, class: className }: EditorContentProps = $props();
 
-const contextEditor = useEditorContextSafe();
+const contextEditor = getEditorContextSafe();
 const editor = $derived(editorProp ?? contextEditor?.());
 
 let element: HTMLElement | undefined = $state();

--- a/packages/svelte/src/components/EditorContext.ts
+++ b/packages/svelte/src/components/EditorContext.ts
@@ -11,9 +11,9 @@ export const EDITOR_CONTEXT_KEY = Symbol("vizel-editor");
  * @example
  * ```svelte
  * <script lang="ts">
- * import { useEditorContext } from '@vizel/svelte';
+ * import { getEditorContext } from '@vizel/svelte';
  *
- * const getEditor = useEditorContext();
+ * const getEditor = getEditorContext();
  * </script>
  *
  * <button onclick={() => getEditor()?.chain().focus().toggleBold().run()}>
@@ -21,10 +21,10 @@ export const EDITOR_CONTEXT_KEY = Symbol("vizel-editor");
  * </button>
  * ```
  */
-export function useEditorContext(): () => Editor | null {
+export function getEditorContext(): () => Editor | null {
   const getEditor = getContext<(() => Editor | null) | undefined>(EDITOR_CONTEXT_KEY);
   if (!getEditor) {
-    throw new Error("useEditorContext must be used within an EditorRoot");
+    throw new Error("getEditorContext must be used within an EditorRoot");
   }
   return getEditor;
 }
@@ -33,6 +33,6 @@ export function useEditorContext(): () => Editor | null {
  * Get the editor instance from context.
  * Returns undefined if used outside of EditorRoot (does not throw).
  */
-export function useEditorContextSafe(): (() => Editor | null) | undefined {
+export function getEditorContextSafe(): (() => Editor | null) | undefined {
   return getContext<(() => Editor | null) | undefined>(EDITOR_CONTEXT_KEY);
 }

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -29,7 +29,7 @@ export {
   default as EditorContent,
   type EditorContentProps,
 } from "./EditorContent.svelte";
-export { useEditorContext, useEditorContextSafe } from "./EditorContext.ts";
+export { getEditorContext, getEditorContextSafe } from "./EditorContext.ts";
 export { default as EditorRoot, type EditorRootProps } from "./EditorRoot.svelte";
 
 // SlashMenu components

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -123,6 +123,8 @@ export {
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  getEditorContext,
+  getEditorContextSafe,
   SlashMenu,
   SlashMenuEmpty,
   type SlashMenuEmptyProps,
@@ -130,15 +132,13 @@ export {
   type SlashMenuItemProps,
   type SlashMenuProps,
   type SlashMenuRef,
-  useEditorContext,
-  useEditorContextSafe,
 } from "./components/index.ts";
 
 // Runes (Svelte 5 reactive state)
 export {
+  type CreateVizelEditorOptions,
+  createEditorState,
   createSlashMenuRenderer,
+  createVizelEditor,
   type SlashMenuRendererOptions,
-  type UseVizelEditorOptions,
-  useEditorState,
-  useVizelEditor,
 } from "./runes/index.ts";

--- a/packages/svelte/src/runes/createEditorState.svelte.ts
+++ b/packages/svelte/src/runes/createEditorState.svelte.ts
@@ -12,13 +12,13 @@ import { onDestroy } from "svelte";
  * @example
  * ```svelte
  * <script lang="ts">
- * const state = useEditorState(() => editor);
+ * const state = createEditorState(() => editor);
  * // Access state.current to trigger reactivity
  * </script>
  * <button class:active={state.current >= 0 && editor.isActive('bold')}>Bold</button>
  * ```
  */
-export function useEditorState(getEditor: () => Editor | null | undefined): {
+export function createEditorState(getEditor: () => Editor | null | undefined): {
   readonly current: number;
 } {
   let updateCount = $state(0);

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -10,7 +10,7 @@ import {
 import { onDestroy, onMount } from "svelte";
 import { createSlashMenuRenderer } from "./createSlashMenuRenderer.ts";
 
-export interface UseVizelEditorOptions extends VizelEditorOptions {
+export interface CreateVizelEditorOptions extends VizelEditorOptions {
   /** Additional extensions to include */
   extensions?: Extensions;
 }
@@ -22,9 +22,9 @@ export interface UseVizelEditorOptions extends VizelEditorOptions {
  * @example
  * ```svelte
  * <script lang="ts">
- * import { useVizelEditor, EditorContent, BubbleMenu } from '@vizel/svelte';
+ * import { createVizelEditor, EditorContent, BubbleMenu } from '@vizel/svelte';
  *
- * const editor = useVizelEditor({
+ * const editor = createVizelEditor({
  *   placeholder: "Start typing...",
  *   onUpdate: ({ editor }) => {
  *     console.log(editor.getJSON());
@@ -38,7 +38,7 @@ export interface UseVizelEditorOptions extends VizelEditorOptions {
  * {/if}
  * ```
  */
-export function useVizelEditor(options: UseVizelEditorOptions = {}) {
+export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
   const {
     initialContent,
     placeholder,

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -1,11 +1,10 @@
+export { createEditorState } from "./createEditorState.svelte.ts";
 export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
 } from "./createSlashMenuRenderer.ts";
 
-export { useEditorState } from "./useEditorState.svelte.ts";
-
 export {
-  type UseVizelEditorOptions,
-  useVizelEditor,
-} from "./useVizelEditor.svelte.ts";
+  type CreateVizelEditorOptions,
+  createVizelEditor,
+} from "./createVizelEditor.svelte.ts";

--- a/tests/ct/svelte/specs/CreateEditorState.spec.ts
+++ b/tests/ct/svelte/specs/CreateEditorState.spec.ts
@@ -7,38 +7,38 @@ import {
   testEditorStateUpdatesOnChange,
   testEditorStateWithNullEditor,
 } from "../../scenarios/use-editor-state.scenario";
-import UseEditorStateFixture from "./UseEditorStateFixture.svelte";
+import CreateEditorStateFixture from "./CreateEditorStateFixture.svelte";
 
-test.describe("useEditorState - Svelte", () => {
+test.describe("createEditorState - Svelte", () => {
   test("updates when editor state changes", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture);
+    const component = await mount(CreateEditorStateFixture);
     await testEditorStateUpdatesOnChange(component, page);
   });
 
   test("tracks bold formatting state", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture);
+    const component = await mount(CreateEditorStateFixture);
     await testEditorStateTracksBoldActive(component, page);
   });
 
   test("tracks italic formatting state", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture);
+    const component = await mount(CreateEditorStateFixture);
     await testEditorStateTracksItalicActive(component, page);
   });
 
   test("handles null editor", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture, {
+    const component = await mount(CreateEditorStateFixture, {
       props: { nullEditor: true },
     });
     await testEditorStateWithNullEditor(component, page);
   });
 
   test("tracks character and word count", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture);
+    const component = await mount(CreateEditorStateFixture);
     await testEditorStateCharacterCount(component, page);
   });
 
   test("tracks empty and focus state", async ({ mount, page }) => {
-    const component = await mount(UseEditorStateFixture);
+    const component = await mount(CreateEditorStateFixture);
     await testEditorStateEmptyAndFocus(component, page);
   });
 });

--- a/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
+++ b/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import {
+  createEditorState,
+  createVizelEditor,
   EditorContent,
   EditorRoot,
   getEditorState,
-  useEditorState,
-  useVizelEditor,
 } from "@vizel/svelte";
 
 interface Props {
@@ -13,32 +13,32 @@ interface Props {
 
 let { nullEditor = false }: Props = $props();
 
-const editor = useVizelEditor({
+const editor = createVizelEditor({
   immediatelyRender: false,
 });
 
 const actualEditor = $derived(nullEditor ? null : editor.current);
-const editorStateHook = useEditorState(() => actualEditor);
+const editorStateRune = createEditorState(() => actualEditor);
 
-// Depend on editorStateHook.current to trigger re-evaluation when editor state changes
+// Depend on editorStateRune.current to trigger re-evaluation when editor state changes
 const isBoldActive = $derived.by(() => {
-  void editorStateHook.current;
+  void editorStateRune.current;
   return actualEditor?.isActive("bold") ?? false;
 });
 const isItalicActive = $derived.by(() => {
-  void editorStateHook.current;
+  void editorStateRune.current;
   return actualEditor?.isActive("italic") ?? false;
 });
 
 // Use getEditorState to get full state including character/word counts
 const fullEditorState = $derived.by(() => {
-  void editorStateHook.current;
+  void editorStateRune.current;
   return getEditorState(actualEditor);
 });
 </script>
 
 <EditorRoot editor={actualEditor}>
-  <div data-testid="update-count">{editorStateHook.current}</div>
+  <div data-testid="update-count">{editorStateRune.current}</div>
   <div data-testid="bold-active">{String(isBoldActive)}</div>
   <div data-testid="italic-active">{String(isItalicActive)}</div>
   <div data-testid="character-count">{fullEditorState.characterCount}</div>

--- a/tests/ct/svelte/specs/EditorFixture.svelte
+++ b/tests/ct/svelte/specs/EditorFixture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { BubbleMenu, EditorContent, EditorRoot, useVizelEditor } from "@vizel/svelte";
+import { BubbleMenu, createVizelEditor, EditorContent, EditorRoot } from "@vizel/svelte";
 
 interface Props {
   placeholder?: string;
@@ -13,7 +13,7 @@ let {
   showBubbleMenu = true,
 }: Props = $props();
 
-const editor = useVizelEditor({
+const editor = createVizelEditor({
   placeholder,
   initialContent,
   features: {

--- a/tests/ct/svelte/specs/MarkdownFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFixture.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { Markdown } from "@vizel/core";
-import { EditorContent, EditorRoot, useVizelEditor } from "@vizel/svelte";
+import { createVizelEditor, EditorContent, EditorRoot } from "@vizel/svelte";
 
 let markdownOutput = $state("");
 
-const editor = useVizelEditor({
+const editor = createVizelEditor({
   extensions: [Markdown],
 });
 


### PR DESCRIPTION
## Summary

- Rename Svelte runes and context functions to follow Svelte-idiomatic naming conventions
- Replace React-style `use*` prefix with `create*` for factory functions and `get*` for context getters
- Update all related imports, tests, and documentation

## BREAKING CHANGE

Renamed Svelte runes and context functions:

| Old Name | New Name |
|----------|----------|
| `useVizelEditor` | `createVizelEditor` |
| `useEditorState` | `createEditorState` |
| `useEditorContext` | `getEditorContext` |
| `useEditorContextSafe` | `getEditorContextSafe` |

### Migration

Replace the following imports and usages:

```typescript
// Before
import { useVizelEditor, useEditorState, useEditorContext } from "@vizel/svelte";
const editor = useVizelEditor({ ... });
const state = useEditorState(() => editor.current);
const ctx = useEditorContext();

// After
import { createVizelEditor, createEditorState, getEditorContext } from "@vizel/svelte";
const editor = createVizelEditor({ ... });
const state = createEditorState(() => editor.current);
const ctx = getEditorContext();
```

## Rationale

Svelte 5 conventions differ from React:
- **React**: `use*` prefix for hooks
- **Vue**: `use*` prefix for composables  
- **Svelte**: `create*` for factory functions, `get*` for context getters

This change aligns the Svelte package with Svelte community conventions while React and Vue packages retain their framework-appropriate `use*` naming.

## Test Plan

- [x] Run lint (`bun run lint`)
- [x] Run typecheck (`bun run typecheck`)
- [x] Run Svelte component tests (`bun run test:ct:svelte`) - 73 tests passed
- [x] Build all packages (`bun run build`)