### PR TITLE
feat(core): add horizontal rule slash command and tests (#23)

### DIFF
--- a/apps/demo/shared/content.ts
+++ b/apps/demo/shared/content.ts
@@ -84,6 +84,15 @@ export const initialContent = {
             },
           ],
         },
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: 'Dividers - type "---" or "/divider" to insert' }],
+            },
+          ],
+        },
       ],
     },
     {
@@ -208,6 +217,19 @@ export const initialContent = {
             { type: "text", text: " from slash commands to create one." },
           ],
         },
+      ],
+    },
+    {
+      type: "horizontalRule",
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Use " },
+        { type: "text", marks: [{ type: "code" }], text: "---" },
+        { type: "text", text: " or " },
+        { type: "text", marks: [{ type: "code" }], text: '"/divider"' },
+        { type: "text", text: " to insert a horizontal divider like the one above." },
       ],
     },
   ],

--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -70,6 +70,14 @@ export const defaultSlashCommands = [
     },
   },
   {
+    title: "Divider",
+    description: "Insert a horizontal divider",
+    icon: "―",
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).setHorizontalRule().run();
+    },
+  },
+  {
     title: "Code Block",
     description: "Insert a code snippet",
     icon: "</>",

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -98,4 +98,15 @@
   border: none;
   border-top: 2px solid var(--vizel-border-color);
   margin: 1.5em 0;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.vizel-editor hr:hover {
+  border-top-color: var(--vizel-primary-color-light);
+}
+
+.vizel-editor hr.ProseMirror-selectednode {
+  border-top-color: var(--vizel-primary-color);
+  outline: none;
 }

--- a/tests/ct/react/specs/HorizontalRule.spec.tsx
+++ b/tests/ct/react/specs/HorizontalRule.spec.tsx
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testDividerInSlashMenu,
+  testHorizontalRuleDelete,
+  testHorizontalRuleSelection,
+  testHorizontalRuleViaAsterisks,
+  testHorizontalRuleViaHyphens,
+  testHorizontalRuleViaSlashCommand,
+  testHorizontalRuleViaUnderscores,
+} from "../../scenarios/horizontal-rule.scenario";
+import { EditorFixture } from "./EditorFixture";
+
+test.describe("HorizontalRule - React", () => {
+  test("can be inserted via slash command", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleViaSlashCommand(component, page);
+  });
+
+  test("can be inserted via --- input rule", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleViaHyphens(component, page);
+  });
+
+  test("can be inserted via *** + space input rule", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleViaAsterisks(component, page);
+  });
+
+  test("can be inserted via ___ + space input rule", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleViaUnderscores(component, page);
+  });
+
+  test("can be selected", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleSelection(component, page);
+  });
+
+  test("can be deleted with backspace", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testHorizontalRuleDelete(component, page);
+  });
+
+  test("divider appears in slash menu", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testDividerInSlashMenu(component, page);
+  });
+});

--- a/tests/ct/scenarios/horizontal-rule.scenario.ts
+++ b/tests/ct/scenarios/horizontal-rule.scenario.ts
@@ -1,0 +1,135 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared test scenarios for HorizontalRule functionality.
+ * These scenarios are framework-agnostic and can be used with React, Vue, and Svelte.
+ */
+
+const SLASH_MENU_SELECTOR = "[data-vizel-slash-menu]";
+
+/**
+ * Test that horizontal rule can be inserted via slash command
+ */
+export async function testHorizontalRuleViaSlashCommand(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("/divider");
+  await page.keyboard.press("Enter");
+
+  // Wait for slash menu to close
+  const slashMenu = page.locator(SLASH_MENU_SELECTOR);
+  await expect(slashMenu).not.toBeVisible();
+
+  // Horizontal rule should be inserted
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+}
+
+/**
+ * Test that horizontal rule can be inserted via "---" input rule
+ */
+export async function testHorizontalRuleViaHyphens(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("---");
+
+  // Horizontal rule should be inserted
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+}
+
+/**
+ * Test that horizontal rule can be inserted via "*** " input rule
+ * Note: Tiptap requires a space after *** to avoid conflicts with bold/italic syntax
+ */
+export async function testHorizontalRuleViaAsterisks(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("*** ");
+
+  // Horizontal rule should be inserted
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+}
+
+/**
+ * Test that horizontal rule can be inserted via "___ " input rule
+ * Note: Tiptap requires a space after ___ to avoid conflicts with bold/italic syntax
+ */
+export async function testHorizontalRuleViaUnderscores(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("___ ");
+
+  // Horizontal rule should be inserted
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+}
+
+/**
+ * Test that horizontal rule can be selected (node selection)
+ */
+export async function testHorizontalRuleSelection(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("---");
+
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+
+  // Click on the horizontal rule to select it
+  await hr.click();
+
+  // Should have the ProseMirror selected node class
+  await expect(hr).toHaveClass(/ProseMirror-selectednode/);
+}
+
+/**
+ * Test that horizontal rule can be deleted with backspace
+ */
+export async function testHorizontalRuleDelete(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("---");
+
+  const hr = editor.locator("hr");
+  await expect(hr).toBeVisible();
+
+  // Click on the horizontal rule to select it
+  await hr.click();
+  await expect(hr).toHaveClass(/ProseMirror-selectednode/);
+
+  // Delete it with backspace
+  await page.keyboard.press("Backspace");
+
+  // Should be deleted
+  await expect(hr).not.toBeVisible();
+}
+
+/**
+ * Test that the divider slash command appears in slash menu
+ */
+export async function testDividerInSlashMenu(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("/divider");
+
+  const slashMenu = page.locator(SLASH_MENU_SELECTOR);
+  await expect(slashMenu).toBeVisible();
+
+  // Should show "Divider" item
+  const dividerItem = slashMenu.locator(".vizel-slash-menu-item", {
+    hasText: "Divider",
+  });
+  await expect(dividerItem).toBeVisible();
+}

--- a/tests/ct/svelte/specs/HorizontalRule.spec.ts
+++ b/tests/ct/svelte/specs/HorizontalRule.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testDividerInSlashMenu,
+  testHorizontalRuleDelete,
+  testHorizontalRuleSelection,
+  testHorizontalRuleViaAsterisks,
+  testHorizontalRuleViaHyphens,
+  testHorizontalRuleViaSlashCommand,
+  testHorizontalRuleViaUnderscores,
+} from "../../scenarios/horizontal-rule.scenario";
+import EditorFixture from "./EditorFixture.svelte";
+
+test.describe("HorizontalRule - Svelte", () => {
+  test("can be inserted via slash command", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaSlashCommand(component, page);
+  });
+
+  test("can be inserted via --- input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaHyphens(component, page);
+  });
+
+  test("can be inserted via *** + space input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaAsterisks(component, page);
+  });
+
+  test("can be inserted via ___ + space input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaUnderscores(component, page);
+  });
+
+  test("can be selected", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleSelection(component, page);
+  });
+
+  test("can be deleted with backspace", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleDelete(component, page);
+  });
+
+  test("divider appears in slash menu", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testDividerInSlashMenu(component, page);
+  });
+});

--- a/tests/ct/vue/specs/HorizontalRule.spec.ts
+++ b/tests/ct/vue/specs/HorizontalRule.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testDividerInSlashMenu,
+  testHorizontalRuleDelete,
+  testHorizontalRuleSelection,
+  testHorizontalRuleViaAsterisks,
+  testHorizontalRuleViaHyphens,
+  testHorizontalRuleViaSlashCommand,
+  testHorizontalRuleViaUnderscores,
+} from "../../scenarios/horizontal-rule.scenario";
+import EditorFixture from "./EditorFixture.vue";
+
+test.describe("HorizontalRule - Vue", () => {
+  test("can be inserted via slash command", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaSlashCommand(component, page);
+  });
+
+  test("can be inserted via --- input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaHyphens(component, page);
+  });
+
+  test("can be inserted via *** + space input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaAsterisks(component, page);
+  });
+
+  test("can be inserted via ___ + space input rule", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleViaUnderscores(component, page);
+  });
+
+  test("can be selected", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleSelection(component, page);
+  });
+
+  test("can be deleted with backspace", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testHorizontalRuleDelete(component, page);
+  });
+
+  test("divider appears in slash menu", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testDividerInSlashMenu(component, page);
+  });
+});


### PR DESCRIPTION
## Summary

Implements horizontal rule (divider) functionality for Issue #23:

- Add "Divider" slash command to slash menu (`/divider`)
- Enhance CSS styling for horizontal rule with hover and selection states
- Add horizontal rule example to demo content
- Add comprehensive Playwright tests for React, Vue, and Svelte

## Features

### Slash Command
Type `/divider` to insert a horizontal rule from the slash menu.

### Input Rules
- `---` - Insert horizontal rule (no space needed)
- `*** ` - Insert horizontal rule (space required to avoid markdown conflicts)
- `___ ` - Insert horizontal rule (space required to avoid markdown conflicts)

### CSS Styling
- Hover state with lighter border color
- Selection state (ProseMirror-selectednode) with primary color
- Cursor pointer for better UX

## Test Coverage

Added 7 tests for each framework (21 total):
- Slash command insertion
- Input rules (`---`, `*** `, `___ `)
- Selection via click
- Deletion via backspace
- Divider appears in slash menu

## Test Plan

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:ct:react -- --grep "HorizontalRule"` passes (7 tests)
- [x] `bun run test:ct:vue -- --grep "HorizontalRule"` passes (7 tests)
- [x] `bun run test:ct:svelte -- --grep "HorizontalRule"` passes (7 tests)

Closes #23