### PR TITLE
feat(core): add auto-save functionality with SaveIndicator component (#24, #25)

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -3,6 +3,8 @@ import {
   EditorContent,
   getEditorState,
   type JSONContent,
+  SaveIndicator,
+  useAutoSave,
   useEditorState,
   useVizelEditor,
 } from "@vizel/react";
@@ -61,6 +63,13 @@ export function App() {
   // Track editor state for character/word count
   useEditorState(editor);
   const editorState = getEditorState(editor);
+
+  // Auto-save functionality
+  const { status, lastSaved } = useAutoSave(editor, {
+    debounceMs: 2000,
+    storage: "localStorage",
+    key: "vizel-demo-react",
+  });
 
   const handleImportMarkdown = () => {
     if (editor && markdownInput.trim()) {
@@ -123,6 +132,10 @@ export function App() {
             <span className="feature-icon">∑</span>
             <span>Math (LaTeX)</span>
           </div>
+          <div className="feature-tag">
+            <span className="feature-icon">💾</span>
+            <span>Auto-save</span>
+          </div>
         </div>
 
         <div className="editor-container">
@@ -131,6 +144,8 @@ export function App() {
             {editor && <BubbleMenu editor={editor} />}
           </div>
           <div className="status-bar">
+            <SaveIndicator status={status} lastSaved={lastSaved} />
+            <span className="status-divider">·</span>
             <span className="status-item">{editorState.characterCount} characters</span>
             <span className="status-divider">·</span>
             <span className="status-item">{editorState.wordCount} words</span>

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import {
   BubbleMenu,
+  createAutoSave,
   createEditorState,
   createVizelEditor,
   EditorContent,
   getEditorState,
   type JSONContent,
+  SaveIndicator,
 } from "@vizel/svelte";
 import { initialContent } from "../../shared/content";
 import { mockUploadImage } from "../../shared/utils";
@@ -49,6 +51,13 @@ const updateCount = createEditorState(() => editor.current);
 const editorState = $derived.by(() => {
   void updateCount.current;
   return getEditorState(editor.current);
+});
+
+// Auto-save functionality
+const autoSave = createAutoSave(() => editor.current, {
+  debounceMs: 2000,
+  storage: "localStorage",
+  key: "vizel-demo-svelte",
 });
 
 function handleImportMarkdown() {
@@ -115,6 +124,10 @@ function handleImportMarkdown() {
         <span class="feature-icon">∑</span>
         <span>Math (LaTeX)</span>
       </div>
+      <div class="feature-tag">
+        <span class="feature-icon">💾</span>
+        <span>Auto-save</span>
+      </div>
     </div>
 
     <div class="editor-container">
@@ -125,6 +138,8 @@ function handleImportMarkdown() {
         {/if}
       </div>
       <div class="status-bar">
+        <SaveIndicator status={autoSave.status} lastSaved={autoSave.lastSaved} />
+        <span class="status-divider">·</span>
         <span class="status-item">{editorState.characterCount} characters</span>
         <span class="status-divider">·</span>
         <span class="status-item">{editorState.wordCount} words</span>

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -4,6 +4,8 @@ import {
   EditorContent,
   getEditorState,
   type JSONContent,
+  SaveIndicator,
+  useAutoSave,
   useEditorState,
   useVizelEditor,
 } from "@vizel/vue";
@@ -50,6 +52,13 @@ const updateCount = useEditorState(() => editor.value);
 const editorState = computed(() => {
   void updateCount.value;
   return getEditorState(editor.value);
+});
+
+// Auto-save functionality
+const { status, lastSaved } = useAutoSave(() => editor.value, {
+  debounceMs: 2000,
+  storage: "localStorage",
+  key: "vizel-demo-vue",
 });
 
 function handleImportMarkdown() {
@@ -117,6 +126,10 @@ function handleImportMarkdown() {
           <span class="feature-icon">∑</span>
           <span>Math (LaTeX)</span>
         </div>
+        <div class="feature-tag">
+          <span class="feature-icon">💾</span>
+          <span>Auto-save</span>
+        </div>
       </div>
 
       <div class="editor-container">
@@ -125,6 +138,8 @@ function handleImportMarkdown() {
           <BubbleMenu v-if="editor" :editor="editor" />
         </div>
         <div class="status-bar">
+          <SaveIndicator :status="status" :lastSaved="lastSaved" />
+          <span class="status-divider">·</span>
           <span class="status-item">{{ editorState.characterCount }} characters</span>
           <span class="status-divider">·</span>
           <span class="status-item">{{ editorState.wordCount }} words</span>

--- a/packages/core/src/auto-save.ts
+++ b/packages/core/src/auto-save.ts
@@ -1,0 +1,244 @@
+import type { Editor, JSONContent } from "@tiptap/core";
+
+/**
+ * Storage backend type for auto-save
+ */
+export type StorageBackend =
+  | "localStorage"
+  | "sessionStorage"
+  | {
+      save: (content: JSONContent) => void | Promise<void>;
+      load?: () => JSONContent | null | Promise<JSONContent | null>;
+    };
+
+/**
+ * Auto-save configuration options
+ */
+export interface AutoSaveOptions {
+  /** Enable auto-save (default: true) */
+  enabled?: boolean;
+  /** Debounce delay in milliseconds (default: 1000) */
+  debounceMs?: number;
+  /** Storage backend (default: 'localStorage') */
+  storage?: StorageBackend;
+  /** Storage key for localStorage/sessionStorage (default: 'vizel-content') */
+  key?: string;
+  /** Callback when content is saved */
+  onSave?: (content: JSONContent) => void;
+  /** Callback when save fails */
+  onError?: (error: Error) => void;
+  /** Callback when restore is attempted */
+  onRestore?: (content: JSONContent | null) => void;
+}
+
+/**
+ * Save status type
+ */
+export type SaveStatus = "saved" | "saving" | "unsaved" | "error";
+
+/**
+ * Auto-save state
+ */
+export interface AutoSaveState {
+  /** Current save status */
+  status: SaveStatus;
+  /** Whether there are unsaved changes */
+  hasUnsavedChanges: boolean;
+  /** Timestamp of last successful save */
+  lastSaved: Date | null;
+  /** Last error that occurred */
+  error: Error | null;
+}
+
+/**
+ * Default auto-save options
+ */
+export const DEFAULT_AUTO_SAVE_OPTIONS = {
+  enabled: true,
+  debounceMs: 1000,
+  storage: "localStorage" as const,
+  key: "vizel-content",
+} satisfies AutoSaveOptions;
+
+/**
+ * Creates a debounced function
+ */
+export function debounce<T extends (...args: Parameters<T>) => void>(
+  fn: T,
+  ms: number
+): { (...args: Parameters<T>): void; cancel: () => void } {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = (...args: Parameters<T>) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      fn(...args);
+      timeoutId = null;
+    }, ms);
+  };
+
+  debounced.cancel = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  return debounced;
+}
+
+/**
+ * Gets the storage object based on backend type
+ */
+export function getStorageBackend(
+  storage: StorageBackend,
+  key: string
+): {
+  save: (content: JSONContent) => Promise<void>;
+  load: () => Promise<JSONContent | null>;
+} {
+  if (storage === "localStorage" || storage === "sessionStorage") {
+    const storageObject = storage === "localStorage" ? localStorage : sessionStorage;
+    return {
+      save: (content: JSONContent) => {
+        storageObject.setItem(key, JSON.stringify(content));
+        return Promise.resolve();
+      },
+      load: () => {
+        const data = storageObject.getItem(key);
+        if (data) {
+          try {
+            return Promise.resolve(JSON.parse(data) as JSONContent);
+          } catch {
+            return Promise.resolve(null);
+          }
+        }
+        return Promise.resolve(null);
+      },
+    };
+  }
+
+  // Custom storage backend
+  return {
+    save: async (content: JSONContent) => {
+      await storage.save(content);
+    },
+    load: async () => {
+      if (storage.load) {
+        return await storage.load();
+      }
+      return null;
+    },
+  };
+}
+
+/**
+ * Creates auto-save handlers for an editor
+ */
+export function createAutoSaveHandlers(
+  getEditor: () => Editor | null | undefined,
+  options: AutoSaveOptions,
+  onStateChange: (state: Partial<AutoSaveState>) => void
+): {
+  /** Trigger a debounced save */
+  save: () => void;
+  /** Save immediately without debouncing */
+  saveNow: () => Promise<void>;
+  /** Restore content from storage */
+  restore: () => Promise<JSONContent | null>;
+  /** Handler for editor update events */
+  handleUpdate: () => void;
+  /** Cancel any pending debounced save */
+  cancel: () => void;
+} {
+  const opts = { ...DEFAULT_AUTO_SAVE_OPTIONS, ...options };
+  const storageBackend = getStorageBackend(opts.storage, opts.key);
+
+  const saveContent = async () => {
+    const editor = getEditor();
+    if (!editor) return;
+
+    onStateChange({ status: "saving" });
+
+    try {
+      const content = editor.getJSON();
+      await storageBackend.save(content);
+
+      const now = new Date();
+      onStateChange({
+        status: "saved",
+        hasUnsavedChanges: false,
+        lastSaved: now,
+        error: null,
+      });
+
+      opts.onSave?.(content);
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({
+        status: "error",
+        error,
+      });
+      opts.onError?.(error);
+    }
+  };
+
+  const debouncedSave = debounce(saveContent, opts.debounceMs);
+
+  const handleUpdate = () => {
+    if (!opts.enabled) return;
+
+    onStateChange({
+      status: "unsaved",
+      hasUnsavedChanges: true,
+    });
+
+    debouncedSave();
+  };
+
+  const restore = async (): Promise<JSONContent | null> => {
+    try {
+      const content = await storageBackend.load();
+      opts.onRestore?.(content);
+      return content;
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    save: debouncedSave,
+    saveNow: saveContent,
+    restore,
+    handleUpdate,
+    cancel: debouncedSave.cancel,
+  };
+}
+
+/**
+ * Format relative time for display
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 5) {
+    return "Just now";
+  }
+  if (diffSec < 60) {
+    return `${diffSec}s ago`;
+  }
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  if (diffHour < 24) {
+    return `${diffHour}h ago`;
+  }
+  return `${diffDay}d ago`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,18 @@ export {
   BubbleMenuPlugin,
   default as BubbleMenuExtension,
 } from "@tiptap/extension-bubble-menu";
-
+// Auto-save
+export {
+  type AutoSaveOptions,
+  type AutoSaveState,
+  createAutoSaveHandlers,
+  DEFAULT_AUTO_SAVE_OPTIONS,
+  debounce,
+  formatRelativeTime,
+  getStorageBackend,
+  type SaveStatus,
+  type StorageBackend,
+} from "./auto-save.ts";
 // Extensions
 export {
   addRecentColor,
@@ -112,7 +123,6 @@ export {
   type VizelTextColorOptions,
   validateImageFile,
 } from "./extensions/index.ts";
-
 // Types
 export type {
   Extensions,
@@ -123,7 +133,6 @@ export type {
   VizelImageFeatureOptions,
   VizelSlashCommandOptions,
 } from "./types.ts";
-
 // Utilities
 export {
   type CreateUploadEventHandlerOptions,

--- a/packages/core/src/styles/index.css
+++ b/packages/core/src/styles/index.css
@@ -32,3 +32,4 @@
 @import "./code-block.css";
 @import "./mathematics.css";
 @import "./drag-handle.css";
+@import "./save-indicator.css";

--- a/packages/core/src/styles/save-indicator.css
+++ b/packages/core/src/styles/save-indicator.css
@@ -1,0 +1,94 @@
+/**
+ * Save Indicator Styles
+ *
+ * Displays the current save state with visual feedback.
+ */
+
+.vizel-save-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--vizel-text-muted, #6b7280);
+  border-radius: 0.25rem;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.vizel-save-indicator-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.vizel-save-indicator-text {
+  white-space: nowrap;
+}
+
+.vizel-save-indicator-timestamp {
+  white-space: nowrap;
+  opacity: 0.75;
+  font-size: 0.625rem;
+}
+
+/* Saved state */
+.vizel-save-indicator--saved {
+  color: var(--vizel-success-color, #10b981);
+}
+
+/* Saving state */
+.vizel-save-indicator--saving {
+  color: var(--vizel-primary-color, #3b82f6);
+}
+
+.vizel-save-indicator-spinner {
+  display: inline-block;
+  animation: vizel-spin 1s linear infinite;
+}
+
+@keyframes vizel-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Unsaved state */
+.vizel-save-indicator--unsaved {
+  color: var(--vizel-warning-color, #f59e0b);
+}
+
+/* Error state */
+.vizel-save-indicator--error {
+  color: var(--vizel-error-color, #ef4444);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .vizel-save-indicator {
+    color: var(--vizel-text-muted-dark, #9ca3af);
+  }
+
+  .vizel-save-indicator--saved {
+    color: var(--vizel-success-color-dark, #34d399);
+  }
+
+  .vizel-save-indicator--saving {
+    color: var(--vizel-primary-color-dark, #60a5fa);
+  }
+
+  .vizel-save-indicator--unsaved {
+    color: var(--vizel-warning-color-dark, #fbbf24);
+  }
+
+  .vizel-save-indicator--error {
+    color: var(--vizel-error-color-dark, #f87171);
+  }
+}

--- a/packages/react/src/components/SaveIndicator.tsx
+++ b/packages/react/src/components/SaveIndicator.tsx
@@ -1,0 +1,105 @@
+import { formatRelativeTime, type SaveStatus } from "@vizel/core";
+import { useEffect, useState } from "react";
+
+export interface SaveIndicatorProps {
+  /** Current save status */
+  status: SaveStatus;
+  /** Timestamp of last successful save */
+  lastSaved?: Date | null;
+  /** Show relative timestamp (default: true) */
+  showTimestamp?: boolean;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Visual indicator for the current save state of the editor.
+ *
+ * @example
+ * ```tsx
+ * <SaveIndicator
+ *   status={status}
+ *   lastSaved={lastSaved}
+ *   showTimestamp
+ * />
+ * ```
+ */
+export function SaveIndicator({
+  status,
+  lastSaved,
+  showTimestamp = true,
+  className,
+}: SaveIndicatorProps) {
+  const [relativeTime, setRelativeTime] = useState<string>("");
+
+  // Update relative time every 10 seconds
+  useEffect(() => {
+    if (!lastSaved) {
+      setRelativeTime("");
+      return;
+    }
+
+    const updateTime = () => {
+      setRelativeTime(formatRelativeTime(lastSaved));
+    };
+
+    updateTime();
+    const interval = setInterval(updateTime, 10000);
+
+    return () => clearInterval(interval);
+  }, [lastSaved]);
+
+  const getStatusIcon = () => {
+    switch (status) {
+      case "saved":
+        return "✓";
+      case "saving":
+        return (
+          <span className="vizel-save-indicator-spinner" aria-hidden="true">
+            ⟳
+          </span>
+        );
+      case "unsaved":
+        return "•";
+      case "error":
+        return "⚠";
+      default:
+        return null;
+    }
+  };
+
+  const getStatusText = () => {
+    switch (status) {
+      case "saved":
+        return "Saved";
+      case "saving":
+        return "Saving...";
+      case "unsaved":
+        return "Unsaved";
+      case "error":
+        return "Error saving";
+      default:
+        return "";
+    }
+  };
+
+  const shouldShowTimestamp = showTimestamp && lastSaved && relativeTime && status === "saved";
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="status" is appropriate for non-form status announcements
+    <div
+      className={`vizel-save-indicator vizel-save-indicator--${status} ${className ?? ""}`}
+      role="status"
+      aria-live="polite"
+      data-vizel-save-indicator
+    >
+      <span className="vizel-save-indicator-icon" aria-hidden="true">
+        {getStatusIcon()}
+      </span>
+      <span className="vizel-save-indicator-text">{getStatusText()}</span>
+      {shouldShowTimestamp && (
+        <span className="vizel-save-indicator-timestamp">{relativeTime}</span>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -31,6 +31,9 @@ export { EditorRoot, type EditorRootProps } from "./EditorRoot.tsx";
 // NodeSelector component
 export { NodeSelector, type NodeSelectorProps } from "./NodeSelector.tsx";
 
+// SaveIndicator component
+export { SaveIndicator, type SaveIndicatorProps } from "./SaveIndicator.tsx";
+
 // SlashMenu components
 export {
   SlashMenu,

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -2,5 +2,6 @@ export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
 } from "./createSlashMenuRenderer.ts";
+export { type UseAutoSaveResult, useAutoSave } from "./useAutoSave.ts";
 export { useEditorState } from "./useEditorState.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";

--- a/packages/react/src/hooks/useAutoSave.ts
+++ b/packages/react/src/hooks/useAutoSave.ts
@@ -1,0 +1,110 @@
+import {
+  type AutoSaveOptions,
+  type AutoSaveState,
+  createAutoSaveHandlers,
+  DEFAULT_AUTO_SAVE_OPTIONS,
+  type Editor,
+  type JSONContent,
+  type SaveStatus,
+} from "@vizel/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Auto-save hook result
+ */
+export interface UseAutoSaveResult {
+  /** Current save status */
+  status: SaveStatus;
+  /** Whether there are unsaved changes */
+  hasUnsavedChanges: boolean;
+  /** Timestamp of last successful save */
+  lastSaved: Date | null;
+  /** Last error that occurred */
+  error: Error | null;
+  /** Manually trigger save */
+  save: () => Promise<void>;
+  /** Restore content from storage */
+  restore: () => Promise<JSONContent | null>;
+}
+
+/**
+ * Hook for auto-saving editor content with debouncing.
+ *
+ * @param editor - The editor instance
+ * @param options - Auto-save configuration options
+ * @returns Auto-save state and controls
+ *
+ * @example
+ * ```tsx
+ * function Editor() {
+ *   const editor = useVizelEditor({ ... });
+ *   const { status, lastSaved, save } = useAutoSave(editor, {
+ *     debounceMs: 2000,
+ *     storage: 'localStorage',
+ *     key: 'my-document',
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <EditorContent editor={editor} />
+ *       <SaveIndicator status={status} lastSaved={lastSaved} />
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useAutoSave(
+  editor: Editor | null,
+  options: AutoSaveOptions = {}
+): UseAutoSaveResult {
+  const opts = useMemo(() => ({ ...DEFAULT_AUTO_SAVE_OPTIONS, ...options }), [options]);
+
+  const [state, setState] = useState<AutoSaveState>({
+    status: "saved",
+    hasUnsavedChanges: false,
+    lastSaved: null,
+    error: null,
+  });
+
+  // Keep a ref to the editor for the handlers
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+
+  const handleStateChange = useCallback((partial: Partial<AutoSaveState>) => {
+    setState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const handlers = useMemo(
+    () => createAutoSaveHandlers(() => editorRef.current, opts, handleStateChange),
+    [opts, handleStateChange]
+  );
+
+  // Subscribe to editor updates
+  useEffect(() => {
+    if (!(editor && opts.enabled)) return;
+
+    editor.on("update", handlers.handleUpdate);
+
+    return () => {
+      editor.off("update", handlers.handleUpdate);
+      handlers.cancel();
+    };
+  }, [editor, opts.enabled, handlers]);
+
+  const save = useCallback(async () => {
+    await handlers.saveNow();
+  }, [handlers]);
+
+  const restore = useCallback(async () => {
+    return await handlers.restore();
+  }, [handlers]);
+
+  return {
+    status: state.status,
+    hasUnsavedChanges: state.hasUnsavedChanges,
+    lastSaved: state.lastSaved,
+    error: state.error,
+    save,
+    restore,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,16 +5,20 @@
  */
 
 // Re-export core types for convenience
+// Re-export auto-save types from core
 export type {
+  AutoSaveOptions,
+  AutoSaveState,
   JSONContent,
+  SaveStatus,
   SlashCommandItem,
   SlashCommandOptions,
+  StorageBackend,
   VizelEditorOptions,
   VizelEditorState,
   VizelLinkOptions,
   VizelTableOptions,
 } from "@vizel/core";
-
 // Re-export core extensions and utilities
 export {
   // Text color and highlight
@@ -49,6 +53,7 @@ export {
   Editor,
   filterSlashCommands,
   findLanguage,
+  formatRelativeTime,
   Gapcursor,
   getAllLanguageIds,
   getEditorState,
@@ -104,7 +109,6 @@ export {
   type VizelTextColorOptions,
   validateImageFile,
 } from "@vizel/core";
-
 // Components
 export {
   BubbleMenu,
@@ -125,6 +129,8 @@ export {
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  SaveIndicator,
+  type SaveIndicatorProps,
   SlashMenu,
   SlashMenuEmpty,
   type SlashMenuEmptyProps,
@@ -135,12 +141,13 @@ export {
   useEditorContext,
   useEditorContextSafe,
 } from "./components/index.ts";
-
 // Hooks
 export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
+  type UseAutoSaveResult,
   type UseVizelEditorOptions,
+  useAutoSave,
   useEditorState,
   useVizelEditor,
 } from "./hooks/index.ts";

--- a/packages/svelte/src/components/SaveIndicator.svelte
+++ b/packages/svelte/src/components/SaveIndicator.svelte
@@ -1,0 +1,95 @@
+<script lang="ts" module>
+import type { SaveStatus } from "@vizel/core";
+
+export interface SaveIndicatorProps {
+  /** Current save status */
+  status: SaveStatus;
+  /** Timestamp of last successful save */
+  lastSaved?: Date | null;
+  /** Show relative timestamp (default: true) */
+  showTimestamp?: boolean;
+  /** Custom class name */
+  class?: string;
+}
+</script>
+
+<script lang="ts">
+import { formatRelativeTime } from "@vizel/core";
+import { onDestroy, onMount } from "svelte";
+
+let {
+  status,
+  lastSaved = null,
+  showTimestamp = true,
+  class: className,
+}: SaveIndicatorProps = $props();
+
+let relativeTime = $state("");
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function updateTime() {
+  if (lastSaved) {
+    relativeTime = formatRelativeTime(lastSaved);
+  } else {
+    relativeTime = "";
+  }
+}
+
+onMount(() => {
+  updateTime();
+  intervalId = setInterval(updateTime, 10000);
+});
+
+// Watch lastSaved changes
+$effect(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  lastSaved;
+  updateTime();
+});
+
+onDestroy(() => {
+  if (intervalId) {
+    clearInterval(intervalId);
+  }
+});
+
+const statusText = $derived.by(() => {
+  switch (status) {
+    case "saved":
+      return "Saved";
+    case "saving":
+      return "Saving...";
+    case "unsaved":
+      return "Unsaved";
+    case "error":
+      return "Error saving";
+    default:
+      return "";
+  }
+});
+
+const shouldShowTimestamp = $derived(showTimestamp && lastSaved && relativeTime && status === "saved");
+</script>
+
+<div
+  class="vizel-save-indicator vizel-save-indicator--{status} {className ?? ''}"
+  role="status"
+  aria-live="polite"
+  data-vizel-save-indicator
+>
+  <span class="vizel-save-indicator-icon" aria-hidden="true">
+    {#if status === "saved"}
+      ✓
+    {:else if status === "saving"}
+      <span class="vizel-save-indicator-spinner" aria-hidden="true">⟳</span>
+    {:else if status === "unsaved"}
+      •
+    {:else if status === "error"}
+      ⚠
+    {/if}
+  </span>
+  <span class="vizel-save-indicator-text">{statusText}</span>
+  {#if shouldShowTimestamp}
+    <span class="vizel-save-indicator-timestamp">{relativeTime}</span>
+  {/if}
+</div>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -43,6 +43,12 @@ export {
   type NodeSelectorProps,
 } from "./NodeSelector.svelte";
 
+// SaveIndicator component
+export {
+  default as SaveIndicator,
+  type SaveIndicatorProps,
+} from "./SaveIndicator.svelte";
+
 // SlashMenu components
 export {
   default as SlashMenu,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -5,16 +5,20 @@
  */
 
 // Re-export core types for convenience
+// Re-export auto-save types from core
 export type {
+  AutoSaveOptions,
+  AutoSaveState,
   JSONContent,
+  SaveStatus,
   SlashCommandItem,
   SlashCommandOptions,
+  StorageBackend,
   VizelEditorOptions,
   VizelEditorState,
   VizelLinkOptions,
   VizelTableOptions,
 } from "@vizel/core";
-
 // Re-export core extensions and utilities
 export {
   // Text color and highlight
@@ -49,6 +53,7 @@ export {
   Editor,
   filterSlashCommands,
   findLanguage,
+  formatRelativeTime,
   Gapcursor,
   getAllLanguageIds,
   getEditorState,
@@ -104,7 +109,6 @@ export {
   type VizelTextColorOptions,
   validateImageFile,
 } from "@vizel/core";
-
 // Components
 export {
   BubbleMenu,
@@ -127,6 +131,8 @@ export {
   type EditorRootProps,
   getEditorContext,
   getEditorContextSafe,
+  SaveIndicator,
+  type SaveIndicatorProps,
   SlashMenu,
   SlashMenuEmpty,
   type SlashMenuEmptyProps,
@@ -135,10 +141,11 @@ export {
   type SlashMenuProps,
   type SlashMenuRef,
 } from "./components/index.ts";
-
 // Runes (Svelte 5 reactive state)
 export {
+  type CreateAutoSaveResult,
   type CreateVizelEditorOptions,
+  createAutoSave,
   createEditorState,
   createSlashMenuRenderer,
   createVizelEditor,

--- a/packages/svelte/src/runes/createAutoSave.svelte.ts
+++ b/packages/svelte/src/runes/createAutoSave.svelte.ts
@@ -1,0 +1,139 @@
+import {
+  type AutoSaveOptions,
+  type AutoSaveState,
+  createAutoSaveHandlers,
+  DEFAULT_AUTO_SAVE_OPTIONS,
+  type Editor,
+  type JSONContent,
+  type SaveStatus,
+} from "@vizel/core";
+import { onDestroy } from "svelte";
+
+/**
+ * Auto-save rune result
+ */
+export interface CreateAutoSaveResult {
+  /** Current save status */
+  readonly status: SaveStatus;
+  /** Whether there are unsaved changes */
+  readonly hasUnsavedChanges: boolean;
+  /** Timestamp of last successful save */
+  readonly lastSaved: Date | null;
+  /** Last error that occurred */
+  readonly error: Error | null;
+  /** Manually trigger save */
+  save: () => Promise<void>;
+  /** Restore content from storage */
+  restore: () => Promise<JSONContent | null>;
+}
+
+/**
+ * Svelte 5 rune for auto-saving editor content with debouncing.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Auto-save configuration options
+ * @returns Auto-save state and controls
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import { createVizelEditor, createAutoSave, EditorContent, SaveIndicator } from '@vizel/svelte';
+ *
+ * const editor = createVizelEditor({ ... });
+ * const autoSave = createAutoSave(() => editor.current, {
+ *   debounceMs: 2000,
+ *   storage: 'localStorage',
+ *   key: 'my-document',
+ * });
+ * </script>
+ *
+ * <EditorContent editor={editor.current} />
+ * <SaveIndicator status={autoSave.status} lastSaved={autoSave.lastSaved} />
+ * ```
+ */
+export function createAutoSave(
+  getEditor: () => Editor | null | undefined,
+  options: AutoSaveOptions = {}
+): CreateAutoSaveResult {
+  const opts = { ...DEFAULT_AUTO_SAVE_OPTIONS, ...options };
+
+  let status = $state<SaveStatus>("saved");
+  let hasUnsavedChanges = $state(false);
+  let lastSaved = $state<Date | null>(null);
+  let error = $state<Error | null>(null);
+
+  let currentEditor: Editor | null = null;
+  let handlers: ReturnType<typeof createAutoSaveHandlers> | null = null;
+
+  function handleStateChange(partial: Partial<AutoSaveState>) {
+    if (partial.status !== undefined) status = partial.status;
+    if (partial.hasUnsavedChanges !== undefined) hasUnsavedChanges = partial.hasUnsavedChanges;
+    if (partial.lastSaved !== undefined) lastSaved = partial.lastSaved;
+    if (partial.error !== undefined) error = partial.error;
+  }
+
+  function subscribe(editor: Editor | null | undefined) {
+    // Unsubscribe from previous editor
+    if (currentEditor && handlers) {
+      currentEditor.off("update", handlers.handleUpdate);
+      handlers.cancel();
+    }
+
+    currentEditor = editor ?? null;
+
+    if (!(currentEditor && opts.enabled)) {
+      handlers = null;
+      return;
+    }
+
+    handlers = createAutoSaveHandlers(() => currentEditor, opts, handleStateChange);
+
+    currentEditor.on("update", handlers.handleUpdate);
+  }
+
+  // Watch for editor changes
+  $effect(() => {
+    const editor = getEditor();
+    subscribe(editor);
+
+    return () => {
+      if (currentEditor && handlers) {
+        currentEditor.off("update", handlers.handleUpdate);
+        handlers.cancel();
+      }
+    };
+  });
+
+  // Also cleanup on destroy
+  onDestroy(() => {
+    if (currentEditor && handlers) {
+      currentEditor.off("update", handlers.handleUpdate);
+      handlers.cancel();
+    }
+  });
+
+  async function save(): Promise<void> {
+    await handlers?.saveNow();
+  }
+
+  async function restore(): Promise<JSONContent | null> {
+    return (await handlers?.restore()) ?? null;
+  }
+
+  return {
+    get status() {
+      return status;
+    },
+    get hasUnsavedChanges() {
+      return hasUnsavedChanges;
+    },
+    get lastSaved() {
+      return lastSaved;
+    },
+    get error() {
+      return error;
+    },
+    save,
+    restore,
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -1,3 +1,7 @@
+export {
+  type CreateAutoSaveResult,
+  createAutoSave,
+} from "./createAutoSave.svelte.ts";
 export { createEditorState } from "./createEditorState.svelte.ts";
 export {
   createSlashMenuRenderer,

--- a/packages/vue/src/components/SaveIndicator.vue
+++ b/packages/vue/src/components/SaveIndicator.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { formatRelativeTime, type SaveStatus } from "@vizel/core";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+
+export interface SaveIndicatorProps {
+  /** Current save status */
+  status: SaveStatus;
+  /** Timestamp of last successful save */
+  lastSaved?: Date | null;
+  /** Show relative timestamp (default: true) */
+  showTimestamp?: boolean;
+  /** Custom class name */
+  class?: string;
+}
+
+const props = withDefaults(defineProps<SaveIndicatorProps>(), {
+  showTimestamp: true,
+});
+
+const relativeTime = ref("");
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function updateTime() {
+  if (props.lastSaved) {
+    relativeTime.value = formatRelativeTime(props.lastSaved);
+  } else {
+    relativeTime.value = "";
+  }
+}
+
+onMounted(() => {
+  updateTime();
+  intervalId = setInterval(updateTime, 10000);
+});
+
+watch(
+  () => props.lastSaved,
+  () => {
+    updateTime();
+  }
+);
+
+onBeforeUnmount(() => {
+  if (intervalId) {
+    clearInterval(intervalId);
+  }
+});
+
+const statusText = computed(() => {
+  switch (props.status) {
+    case "saved":
+      return "Saved";
+    case "saving":
+      return "Saving...";
+    case "unsaved":
+      return "Unsaved";
+    case "error":
+      return "Error saving";
+    default:
+      return "";
+  }
+});
+
+const shouldShowTimestamp = computed(() => {
+  return props.showTimestamp && props.lastSaved && relativeTime.value && props.status === "saved";
+});
+</script>
+
+<template>
+  <div
+    :class="['vizel-save-indicator', `vizel-save-indicator--${props.status}`, $props.class]"
+    role="status"
+    aria-live="polite"
+    data-vizel-save-indicator
+  >
+    <span class="vizel-save-indicator-icon" aria-hidden="true">
+      <template v-if="props.status === 'saved'">✓</template>
+      <template v-else-if="props.status === 'saving'">
+        <span class="vizel-save-indicator-spinner" aria-hidden="true">⟳</span>
+      </template>
+      <template v-else-if="props.status === 'unsaved'">•</template>
+      <template v-else-if="props.status === 'error'">⚠</template>
+    </span>
+    <span class="vizel-save-indicator-text">{{ statusText }}</span>
+    <span v-if="shouldShowTimestamp" class="vizel-save-indicator-timestamp">{{ relativeTime }}</span>
+  </div>
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -37,6 +37,12 @@ export {
   type NodeSelectorProps,
 } from "./NodeSelector.vue";
 
+// SaveIndicator component
+export {
+  default as SaveIndicator,
+  type SaveIndicatorProps,
+} from "./SaveIndicator.vue";
+
 // SlashMenu components
 export {
   default as SlashMenu,

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -2,5 +2,6 @@ export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
 } from "./createSlashMenuRenderer.ts";
+export { type UseAutoSaveResult, useAutoSave } from "./useAutoSave.ts";
 export { useEditorState } from "./useEditorState.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";

--- a/packages/vue/src/composables/useAutoSave.ts
+++ b/packages/vue/src/composables/useAutoSave.ts
@@ -1,0 +1,136 @@
+import {
+  type AutoSaveOptions,
+  type AutoSaveState,
+  createAutoSaveHandlers,
+  DEFAULT_AUTO_SAVE_OPTIONS,
+  type Editor,
+  type JSONContent,
+  type SaveStatus,
+} from "@vizel/core";
+import { computed, onBeforeUnmount, onMounted, type Ref, reactive, watch } from "vue";
+
+/**
+ * Auto-save composable result
+ */
+export interface UseAutoSaveResult {
+  /** Current save status */
+  status: Ref<SaveStatus>;
+  /** Whether there are unsaved changes */
+  hasUnsavedChanges: Ref<boolean>;
+  /** Timestamp of last successful save */
+  lastSaved: Ref<Date | null>;
+  /** Last error that occurred */
+  error: Ref<Error | null>;
+  /** Manually trigger save */
+  save: () => Promise<void>;
+  /** Restore content from storage */
+  restore: () => Promise<JSONContent | null>;
+}
+
+/**
+ * Composable for auto-saving editor content with debouncing.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Auto-save configuration options
+ * @returns Auto-save state and controls
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useVizelEditor, useAutoSave, EditorContent, SaveIndicator } from '@vizel/vue';
+ *
+ * const editor = useVizelEditor({ ... });
+ * const { status, lastSaved, save } = useAutoSave(() => editor.value, {
+ *   debounceMs: 2000,
+ *   storage: 'localStorage',
+ *   key: 'my-document',
+ * });
+ * </script>
+ *
+ * <template>
+ *   <EditorContent :editor="editor" />
+ *   <SaveIndicator :status="status" :lastSaved="lastSaved" />
+ * </template>
+ * ```
+ */
+export function useAutoSave(
+  getEditor: () => Editor | null | undefined,
+  options: AutoSaveOptions = {}
+): UseAutoSaveResult {
+  const opts = { ...DEFAULT_AUTO_SAVE_OPTIONS, ...options };
+
+  const state = reactive<AutoSaveState>({
+    status: "saved",
+    hasUnsavedChanges: false,
+    lastSaved: null,
+    error: null,
+  });
+
+  let currentEditor: Editor | null = null;
+  let handlers: ReturnType<typeof createAutoSaveHandlers> | null = null;
+
+  function handleStateChange(partial: Partial<AutoSaveState>) {
+    if (partial.status !== undefined) state.status = partial.status;
+    if (partial.hasUnsavedChanges !== undefined)
+      state.hasUnsavedChanges = partial.hasUnsavedChanges;
+    if (partial.lastSaved !== undefined) state.lastSaved = partial.lastSaved;
+    if (partial.error !== undefined) state.error = partial.error;
+  }
+
+  function subscribe() {
+    const editor = getEditor();
+
+    // Unsubscribe from previous editor
+    if (currentEditor && handlers) {
+      currentEditor.off("update", handlers.handleUpdate);
+      handlers.cancel();
+    }
+
+    currentEditor = editor ?? null;
+
+    if (!(currentEditor && opts.enabled)) {
+      handlers = null;
+      return;
+    }
+
+    handlers = createAutoSaveHandlers(() => currentEditor, opts, handleStateChange);
+
+    currentEditor.on("update", handlers.handleUpdate);
+  }
+
+  onMounted(() => {
+    subscribe();
+  });
+
+  // Watch for editor changes
+  watch(
+    () => getEditor(),
+    () => {
+      subscribe();
+    }
+  );
+
+  onBeforeUnmount(() => {
+    if (currentEditor && handlers) {
+      currentEditor.off("update", handlers.handleUpdate);
+      handlers.cancel();
+    }
+  });
+
+  async function save(): Promise<void> {
+    await handlers?.saveNow();
+  }
+
+  async function restore(): Promise<JSONContent | null> {
+    return (await handlers?.restore()) ?? null;
+  }
+
+  return {
+    status: computed(() => state.status),
+    hasUnsavedChanges: computed(() => state.hasUnsavedChanges),
+    lastSaved: computed(() => state.lastSaved),
+    error: computed(() => state.error),
+    save,
+    restore,
+  };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,16 +5,20 @@
  */
 
 // Re-export core types for convenience
+// Re-export auto-save types from core
 export type {
+  AutoSaveOptions,
+  AutoSaveState,
   JSONContent,
+  SaveStatus,
   SlashCommandItem,
   SlashCommandOptions,
+  StorageBackend,
   VizelEditorOptions,
   VizelEditorState,
   VizelLinkOptions,
   VizelTableOptions,
 } from "@vizel/core";
-
 // Re-export core extensions and utilities
 export {
   // Text color and highlight
@@ -49,6 +53,7 @@ export {
   Editor,
   filterSlashCommands,
   findLanguage,
+  formatRelativeTime,
   Gapcursor,
   getAllLanguageIds,
   getEditorState,
@@ -104,7 +109,6 @@ export {
   type VizelTextColorOptions,
   validateImageFile,
 } from "@vizel/core";
-
 // Components
 export {
   BubbleMenu,
@@ -125,6 +129,8 @@ export {
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  SaveIndicator,
+  type SaveIndicatorProps,
   SlashMenu,
   SlashMenuEmpty,
   type SlashMenuEmptyProps,
@@ -135,12 +141,13 @@ export {
   useEditorContext,
   useEditorContextSafe,
 } from "./components/index.ts";
-
 // Composables
 export {
   createSlashMenuRenderer,
   type SlashMenuRendererOptions,
+  type UseAutoSaveResult,
   type UseVizelEditorOptions,
+  useAutoSave,
   useEditorState,
   useVizelEditor,
 } from "./composables/index.ts";

--- a/tests/ct/react/specs/SaveIndicator.spec.tsx
+++ b/tests/ct/react/specs/SaveIndicator.spec.tsx
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import {
+  testSaveIndicatorCustomClass,
+  testSaveIndicatorHideTimestamp,
+  testSaveIndicatorIcons,
+  testSaveIndicatorTimestamp,
+} from "../../scenarios/save-indicator.scenario";
+import { SaveIndicatorFixture } from "./SaveIndicatorFixture";
+
+test.describe("SaveIndicator - React", () => {
+  test("renders with saved status", async ({ mount, page }) => {
+    const component = await mount(<SaveIndicatorFixture status="saved" />);
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saved/);
+    await expect(component).toContainText("Saved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with saving status", async ({ mount, page }) => {
+    const component = await mount(<SaveIndicatorFixture status="saving" />);
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saving/);
+    await expect(component).toContainText("Saving");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with unsaved status", async ({ mount, page }) => {
+    const component = await mount(<SaveIndicatorFixture status="unsaved" />);
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--unsaved/);
+    await expect(component).toContainText("Unsaved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with error status", async ({ mount, page }) => {
+    const component = await mount(<SaveIndicatorFixture status="error" />);
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--error/);
+    await expect(component).toContainText("Error");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("shows timestamp when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(
+      <SaveIndicatorFixture status="saved" lastSaved={lastSaved} showTimestamp={true} />
+    );
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("hides timestamp when showTimestamp is false", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(
+      <SaveIndicatorFixture status="saved" lastSaved={lastSaved} showTimestamp={false} />
+    );
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+
+  test("accepts custom className", async ({ mount, page }) => {
+    const component = await mount(
+      <SaveIndicatorFixture status="saved" className="my-custom-class" />
+    );
+    await testSaveIndicatorCustomClass(component, page, "my-custom-class");
+  });
+
+  test("shows timestamp by default when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(<SaveIndicatorFixture status="saved" lastSaved={lastSaved} />);
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("does not show timestamp when lastSaved is null", async ({ mount, page }) => {
+    const component = await mount(<SaveIndicatorFixture status="saved" lastSaved={null} />);
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+});

--- a/tests/ct/react/specs/SaveIndicatorFixture.tsx
+++ b/tests/ct/react/specs/SaveIndicatorFixture.tsx
@@ -1,0 +1,24 @@
+import { SaveIndicator, type SaveStatus } from "@vizel/react";
+
+interface SaveIndicatorFixtureProps {
+  status: SaveStatus;
+  lastSaved?: Date | null;
+  showTimestamp?: boolean;
+  className?: string;
+}
+
+export function SaveIndicatorFixture({
+  status,
+  lastSaved,
+  showTimestamp,
+  className,
+}: SaveIndicatorFixtureProps) {
+  return (
+    <SaveIndicator
+      status={status}
+      lastSaved={lastSaved}
+      showTimestamp={showTimestamp}
+      className={className}
+    />
+  );
+}

--- a/tests/ct/scenarios/save-indicator.scenario.ts
+++ b/tests/ct/scenarios/save-indicator.scenario.ts
@@ -1,0 +1,79 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import type { SaveStatus } from "@vizel/core";
+
+/**
+ * Shared test scenarios for SaveIndicator component
+ */
+
+/**
+ * Test that SaveIndicator renders correctly with each status
+ */
+export async function testSaveIndicatorStatuses(
+  mount: (status: SaveStatus) => Promise<Locator>,
+  _page: Page
+): Promise<void> {
+  // Test 'saved' status
+  let component = await mount("saved");
+  await expect(component).toBeVisible();
+  await expect(component).toHaveClass(/vizel-save-indicator--saved/);
+  await expect(component).toContainText("Saved");
+
+  // Test 'saving' status
+  component = await mount("saving");
+  await expect(component).toBeVisible();
+  await expect(component).toHaveClass(/vizel-save-indicator--saving/);
+  await expect(component).toContainText("Saving");
+
+  // Test 'unsaved' status
+  component = await mount("unsaved");
+  await expect(component).toBeVisible();
+  await expect(component).toHaveClass(/vizel-save-indicator--unsaved/);
+  await expect(component).toContainText("Unsaved");
+
+  // Test 'error' status
+  component = await mount("error");
+  await expect(component).toBeVisible();
+  await expect(component).toHaveClass(/vizel-save-indicator--error/);
+  await expect(component).toContainText("Error");
+}
+
+/**
+ * Test that SaveIndicator shows icons for each status
+ */
+export async function testSaveIndicatorIcons(component: Locator, _page: Page): Promise<void> {
+  const icon = component.locator(".vizel-save-indicator-icon");
+  await expect(icon).toBeVisible();
+}
+
+/**
+ * Test that SaveIndicator shows timestamp when provided
+ */
+export async function testSaveIndicatorTimestamp(component: Locator, _page: Page): Promise<void> {
+  const timestamp = component.locator(".vizel-save-indicator-timestamp");
+  await expect(timestamp).toBeVisible();
+  // Should show relative time like "Just now" or "Xs ago"
+  await expect(timestamp).toHaveText(/(Just now|ago)/);
+}
+
+/**
+ * Test that SaveIndicator hides timestamp when showTimestamp is false
+ */
+export async function testSaveIndicatorHideTimestamp(
+  component: Locator,
+  _page: Page
+): Promise<void> {
+  const timestamp = component.locator(".vizel-save-indicator-timestamp");
+  await expect(timestamp).not.toBeVisible();
+}
+
+/**
+ * Test that SaveIndicator accepts custom className
+ */
+export async function testSaveIndicatorCustomClass(
+  component: Locator,
+  _page: Page,
+  customClass: string
+): Promise<void> {
+  await expect(component).toHaveClass(new RegExp(customClass));
+}

--- a/tests/ct/svelte/specs/SaveIndicator.spec.ts
+++ b/tests/ct/svelte/specs/SaveIndicator.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/experimental-ct-svelte";
+import {
+  testSaveIndicatorCustomClass,
+  testSaveIndicatorHideTimestamp,
+  testSaveIndicatorIcons,
+  testSaveIndicatorTimestamp,
+} from "../../scenarios/save-indicator.scenario";
+import SaveIndicatorFixture from "./SaveIndicatorFixture.svelte";
+
+test.describe("SaveIndicator - Svelte", () => {
+  test("renders with saved status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saved/);
+    await expect(component).toContainText("Saved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with saving status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saving" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saving/);
+    await expect(component).toContainText("Saving");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with unsaved status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "unsaved" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--unsaved/);
+    await expect(component).toContainText("Unsaved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with error status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "error" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--error/);
+    await expect(component).toContainText("Error");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("shows timestamp when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved, showTimestamp: true },
+    });
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("hides timestamp when showTimestamp is false", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved, showTimestamp: false },
+    });
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+
+  test("accepts custom class", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", class: "my-custom-class" },
+    });
+    await testSaveIndicatorCustomClass(component, page, "my-custom-class");
+  });
+
+  test("shows timestamp by default when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved },
+    });
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("does not show timestamp when lastSaved is null", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved: null },
+    });
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/SaveIndicatorFixture.svelte
+++ b/tests/ct/svelte/specs/SaveIndicatorFixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { SaveIndicator, type SaveStatus } from "@vizel/svelte";
+
+interface Props {
+  status: SaveStatus;
+  lastSaved?: Date | null;
+  showTimestamp?: boolean;
+  class?: string;
+}
+
+let { status, lastSaved, showTimestamp, class: className }: Props = $props();
+</script>
+
+<SaveIndicator
+  {status}
+  {lastSaved}
+  {showTimestamp}
+  class={className}
+/>

--- a/tests/ct/vue/specs/SaveIndicator.spec.ts
+++ b/tests/ct/vue/specs/SaveIndicator.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/experimental-ct-vue";
+import {
+  testSaveIndicatorCustomClass,
+  testSaveIndicatorHideTimestamp,
+  testSaveIndicatorIcons,
+  testSaveIndicatorTimestamp,
+} from "../../scenarios/save-indicator.scenario";
+import SaveIndicatorFixture from "./SaveIndicatorFixture.vue";
+
+test.describe("SaveIndicator - Vue", () => {
+  test("renders with saved status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saved/);
+    await expect(component).toContainText("Saved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with saving status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saving" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--saving/);
+    await expect(component).toContainText("Saving");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with unsaved status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "unsaved" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--unsaved/);
+    await expect(component).toContainText("Unsaved");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("renders with error status", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "error" },
+    });
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(/vizel-save-indicator--error/);
+    await expect(component).toContainText("Error");
+    await testSaveIndicatorIcons(component, page);
+  });
+
+  test("shows timestamp when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved, showTimestamp: true },
+    });
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("hides timestamp when showTimestamp is false", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved, showTimestamp: false },
+    });
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+
+  test("accepts custom class", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", class: "my-custom-class" },
+    });
+    await testSaveIndicatorCustomClass(component, page, "my-custom-class");
+  });
+
+  test("shows timestamp by default when lastSaved is provided", async ({ mount, page }) => {
+    const lastSaved = new Date();
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved },
+    });
+    await testSaveIndicatorTimestamp(component, page);
+  });
+
+  test("does not show timestamp when lastSaved is null", async ({ mount, page }) => {
+    const component = await mount(SaveIndicatorFixture, {
+      props: { status: "saved", lastSaved: null },
+    });
+    await testSaveIndicatorHideTimestamp(component, page);
+  });
+});

--- a/tests/ct/vue/specs/SaveIndicatorFixture.vue
+++ b/tests/ct/vue/specs/SaveIndicatorFixture.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { SaveIndicator, type SaveStatus } from "@vizel/vue";
+
+const props = withDefaults(
+  defineProps<{
+    status: SaveStatus;
+    lastSaved?: Date | null;
+    showTimestamp?: boolean;
+    class?: string;
+  }>(),
+  {
+    showTimestamp: true,
+  }
+);
+</script>
+
+<template>
+  <SaveIndicator
+    :status="props.status"
+    :lastSaved="props.lastSaved"
+    :showTimestamp="props.showTimestamp"
+    :class="props.class"
+  />
+</template>


### PR DESCRIPTION
## Summary

Implements auto-save functionality (Issue #24) and save state indicator (Issue #25) for the Vizel editor:

- Add auto-save utility with debounced persistence to localStorage/sessionStorage/custom backends
- Add `SaveIndicator` component for React, Vue, and Svelte with status states (saved, saving, unsaved, error)
- Add `useAutoSave` hook for React, `useAutoSave` composable for Vue, `createAutoSave` rune for Svelte
- Add relative time formatting for "Saved X ago" display
- Add CSS styles for SaveIndicator with dark mode support
- Add component tests for SaveIndicator across all frameworks
- Update demos to showcase auto-save feature

## Features

### Auto-save Hook/Composable/Rune

```tsx
// React
const { status, lastSaved, save, restore } = useAutoSave(editor, {
  debounceMs: 2000,
  storage: 'localStorage',
  key: 'my-document',
});

// Vue
const { status, lastSaved, save, restore } = useAutoSave(() => editor.value, { ... });

// Svelte
const autoSave = createAutoSave(() => editor.current, { ... });
```

### SaveIndicator Component

```tsx
<SaveIndicator status={status} lastSaved={lastSaved} />
```

- Displays current save status (saved ✓, saving ⟳, unsaved •, error ⚠)
- Shows relative timestamp for last saved time ("Just now", "5s ago", etc.)
- Updates timestamp every 10 seconds
- Supports dark mode via CSS custom properties

### Storage Backends

- `localStorage` (default)
- `sessionStorage`
- Custom backend with `save()` and optional `load()` functions

## Closes

- Closes #24
- Closes #25

## Test Plan

- [x] Run typecheck (`bun run typecheck`)
- [x] Run lint (`bun run lint`)
- [x] Run build (`bun run build`)
- [x] SaveIndicator tests pass for all frameworks
- [x] Demo apps show auto-save feature with SaveIndicator