### PR TITLE
docs: clarify project as visual editor for Markdown

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Vizel Project
 
-A block-based rich text editor built with Tiptap, supporting React, Vue, and Svelte.
+A block-based visual editor for Markdown built with Tiptap, supporting React, Vue, and Svelte.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vizel
 
-A block-based rich text editor built with [Tiptap](https://tiptap.dev/), supporting React, Vue, and Svelte.
+A block-based visual editor for Markdown built with [Tiptap](https://tiptap.dev/), supporting React, Vue, and Svelte.
 
 ## Packages
 


### PR DESCRIPTION
## Summary

- Update project description to clarify that Vizel is a visual editor for Markdown
- Changed from "rich text editor" to "visual editor for Markdown"

## Files Changed

- `README.md`
- `.claude/CLAUDE.md`