### PR TITLE
feat(core): add portal rendering system for floating UI elements

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,13 +178,24 @@ export type {
   VizelSlashCommandOptions,
 } from "./types.ts";
 // Utilities
+// Portal utilities
 export {
   type CreateUploadEventHandlerOptions,
+  createPortalElement,
   createUploadEventHandler,
   defaultEditorProps,
   getEditorState,
+  getPortalContainer,
+  hasPortalContainer,
+  type MountPortalOptions,
+  mountToPortal,
+  PORTAL_Z_INDEX,
+  type PortalLayer,
   type ResolveFeaturesOptions,
   registerUploadEventHandler,
+  removePortalContainer,
   resolveFeatures,
+  unmountFromPortal,
+  VIZEL_PORTAL_ID,
   VIZEL_UPLOAD_IMAGE_EVENT,
 } from "./utils/index.ts";

--- a/packages/core/src/styles/index.css
+++ b/packages/core/src/styles/index.css
@@ -20,6 +20,9 @@
 /* CSS Variables (must be first) */
 @import "./variables.css";
 
+/* Portal system */
+@import "./portal.css";
+
 /* Component styles */
 @import "./editor.css";
 @import "./placeholder.css";

--- a/packages/core/src/styles/portal.css
+++ b/packages/core/src/styles/portal.css
@@ -1,0 +1,35 @@
+/**
+ * Portal Container Styles
+ *
+ * Provides z-index management for floating UI elements rendered
+ * outside the normal DOM hierarchy.
+ */
+
+/* Portal root container */
+#vizel-portal-root {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: var(--vizel-portal-base-z-index, 9999);
+}
+
+/* Portal layer elements */
+[data-vizel-portal-layer] {
+  pointer-events: auto;
+}
+
+/* Z-index layers for different portal content types */
+[data-vizel-portal-layer="dropdown"] {
+  z-index: var(--vizel-portal-dropdown-z-index, 50);
+}
+
+[data-vizel-portal-layer="modal"] {
+  z-index: var(--vizel-portal-modal-z-index, 100);
+}
+
+[data-vizel-portal-layer="tooltip"] {
+  z-index: var(--vizel-portal-tooltip-z-index, 150);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,3 +9,17 @@ export {
   resolveFeatures,
   VIZEL_UPLOAD_IMAGE_EVENT,
 } from "./editorHelpers.ts";
+
+// Portal utilities
+export {
+  createPortalElement,
+  getPortalContainer,
+  hasPortalContainer,
+  type MountPortalOptions,
+  mountToPortal,
+  PORTAL_Z_INDEX,
+  type PortalLayer,
+  removePortalContainer,
+  unmountFromPortal,
+  VIZEL_PORTAL_ID,
+} from "./portal.ts";

--- a/packages/core/src/utils/portal.ts
+++ b/packages/core/src/utils/portal.ts
@@ -1,0 +1,149 @@
+/**
+ * Portal utility for rendering components outside the normal DOM hierarchy.
+ *
+ * This module provides a unified portal container management system
+ * for floating UI elements like SlashMenu, BubbleMenu, modals, and tooltips.
+ */
+
+/** Portal container ID */
+export const VIZEL_PORTAL_ID = "vizel-portal-root";
+
+/** Portal layer z-index values */
+export const PORTAL_Z_INDEX = {
+  /** Base layer for dropdowns and menus */
+  dropdown: 50,
+  /** Layer for modals and dialogs */
+  modal: 100,
+  /** Layer for tooltips (highest priority) */
+  tooltip: 150,
+} as const;
+
+/** Portal layer type */
+export type PortalLayer = keyof typeof PORTAL_Z_INDEX;
+
+/**
+ * Get or create the portal container element.
+ *
+ * This function ensures a single portal container exists in the document,
+ * creating one if necessary. The container is appended to document.body.
+ *
+ * @returns The portal container element
+ *
+ * @example
+ * ```typescript
+ * const container = getPortalContainer();
+ * container.appendChild(myFloatingElement);
+ * ```
+ */
+export function getPortalContainer(): HTMLElement {
+  let container = document.getElementById(VIZEL_PORTAL_ID);
+
+  if (!container) {
+    container = document.createElement("div");
+    container.id = VIZEL_PORTAL_ID;
+    container.setAttribute("data-vizel-portal", "");
+    document.body.appendChild(container);
+  }
+
+  return container;
+}
+
+/**
+ * Check if the portal container exists.
+ *
+ * @returns true if the portal container exists in the document
+ */
+export function hasPortalContainer(): boolean {
+  return document.getElementById(VIZEL_PORTAL_ID) !== null;
+}
+
+/**
+ * Remove the portal container from the document.
+ *
+ * This should only be called during cleanup when no more
+ * portal content is expected to be rendered.
+ */
+export function removePortalContainer(): void {
+  const container = document.getElementById(VIZEL_PORTAL_ID);
+  if (container?.parentNode) {
+    container.parentNode.removeChild(container);
+  }
+}
+
+/**
+ * Create a portal element with proper styling.
+ *
+ * Creates a container div for portal content with appropriate
+ * positioning and z-index based on the specified layer.
+ *
+ * @param layer - The z-index layer for the portal element
+ * @returns A configured portal element
+ *
+ * @example
+ * ```typescript
+ * const element = createPortalElement("dropdown");
+ * element.appendChild(menuContent);
+ * getPortalContainer().appendChild(element);
+ * ```
+ */
+export function createPortalElement(layer: PortalLayer = "dropdown"): HTMLDivElement {
+  const element = document.createElement("div");
+  element.setAttribute("data-vizel-portal-layer", layer);
+  element.style.position = "absolute";
+  element.style.top = "0";
+  element.style.left = "0";
+  element.style.zIndex = String(PORTAL_Z_INDEX[layer]);
+  return element;
+}
+
+/**
+ * Options for mounting portal content.
+ */
+export interface MountPortalOptions {
+  /** The z-index layer for the portal */
+  layer?: PortalLayer;
+  /** Additional CSS class names */
+  className?: string;
+}
+
+/**
+ * Mount an element to the portal container.
+ *
+ * @param content - The content element to mount
+ * @param options - Mount options
+ * @returns The wrapper element that was added to the portal
+ *
+ * @example
+ * ```typescript
+ * const wrapper = mountToPortal(menuElement, { layer: "dropdown" });
+ * // Later, to unmount:
+ * unmountFromPortal(wrapper);
+ * ```
+ */
+export function mountToPortal(
+  content: HTMLElement,
+  options: MountPortalOptions = {}
+): HTMLDivElement {
+  const { layer = "dropdown", className } = options;
+  const wrapper = createPortalElement(layer);
+
+  if (className) {
+    wrapper.className = className;
+  }
+
+  wrapper.appendChild(content);
+  getPortalContainer().appendChild(wrapper);
+
+  return wrapper;
+}
+
+/**
+ * Unmount an element from the portal container.
+ *
+ * @param wrapper - The wrapper element returned by mountToPortal
+ */
+export function unmountFromPortal(wrapper: HTMLElement): void {
+  if (wrapper.parentNode) {
+    wrapper.parentNode.removeChild(wrapper);
+  }
+}

--- a/packages/react/src/components/Portal.tsx
+++ b/packages/react/src/components/Portal.tsx
@@ -1,0 +1,75 @@
+import { getPortalContainer, PORTAL_Z_INDEX, type PortalLayer } from "@vizel/core";
+import { type ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Props for the Portal component.
+ */
+export interface PortalProps {
+  /** Content to render in the portal */
+  children: ReactNode;
+  /** Z-index layer for the portal content */
+  layer?: PortalLayer;
+  /** Additional CSS class name */
+  className?: string;
+  /** Whether the portal is disabled (renders children in place) */
+  disabled?: boolean;
+}
+
+/**
+ * Portal component for rendering content outside the DOM hierarchy.
+ *
+ * Renders children into a portal container at the document body level,
+ * ensuring proper z-index stacking for floating UI elements.
+ *
+ * @example
+ * ```tsx
+ * <Portal layer="dropdown">
+ *   <DropdownMenu />
+ * </Portal>
+ * ```
+ *
+ * @example Disabled portal (renders in place)
+ * ```tsx
+ * <Portal disabled>
+ *   <Content />
+ * </Portal>
+ * ```
+ */
+export function Portal({
+  children,
+  layer = "dropdown",
+  className,
+  disabled = false,
+}: PortalProps): ReactNode {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Don't render portal during SSR or when disabled
+  if (!mounted || disabled) {
+    return children;
+  }
+
+  const container = getPortalContainer();
+
+  return createPortal(
+    <div
+      data-vizel-portal-layer={layer}
+      className={className}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        zIndex: PORTAL_Z_INDEX[layer],
+      }}
+    >
+      {children}
+    </div>,
+    container
+  );
+}
+
+Portal.displayName = "Portal";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -34,6 +34,9 @@ export { EmbedView, type EmbedViewProps } from "./EmbedView.tsx";
 // NodeSelector component
 export { NodeSelector, type NodeSelectorProps } from "./NodeSelector.tsx";
 
+// Portal component
+export { Portal, type PortalProps } from "./Portal.tsx";
+
 // SaveIndicator component
 export { SaveIndicator, type SaveIndicatorProps } from "./SaveIndicator.tsx";
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -133,6 +133,8 @@ export {
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  Portal,
+  type PortalProps,
   SaveIndicator,
   type SaveIndicatorProps,
   SlashMenu,

--- a/packages/svelte/src/components/Portal.svelte
+++ b/packages/svelte/src/components/Portal.svelte
@@ -1,0 +1,70 @@
+<script lang="ts" module>
+import type { PortalLayer } from "@vizel/core";
+import type { Snippet } from "svelte";
+
+/**
+ * Props for the Portal component.
+ */
+export interface PortalProps {
+  /** Content to render in the portal */
+  children: Snippet;
+  /** Z-index layer for the portal content */
+  layer?: PortalLayer;
+  /** Additional CSS class name */
+  class?: string;
+  /** Whether the portal is disabled (renders children in place) */
+  disabled?: boolean;
+}
+</script>
+
+<script lang="ts">
+  import { getPortalContainer, PORTAL_Z_INDEX } from "@vizel/core";
+
+  const {
+    children,
+    layer = "dropdown",
+    class: className,
+    disabled = false,
+  }: PortalProps = $props();
+
+  // Create portal action that moves content to the portal container
+  function portal(node: HTMLElement) {
+    const container = getPortalContainer();
+
+    // Create wrapper element
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-vizel-portal-layer", layer);
+    if (className) {
+      wrapper.className = className;
+    }
+    wrapper.style.position = "absolute";
+    wrapper.style.top = "0";
+    wrapper.style.left = "0";
+    wrapper.style.zIndex = String(PORTAL_Z_INDEX[layer]);
+
+    // Move node's children to wrapper
+    while (node.firstChild) {
+      wrapper.appendChild(node.firstChild);
+    }
+
+    container.appendChild(wrapper);
+
+    return {
+      destroy() {
+        // Move content back to original location for cleanup
+        while (wrapper.firstChild) {
+          node.appendChild(wrapper.firstChild);
+        }
+        wrapper.remove();
+      },
+    };
+  }
+</script>
+
+{#if disabled}
+  {@render children()}
+{:else}
+  <div use:portal>
+    {@render children()}
+  </div>
+{/if}

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -49,6 +49,9 @@ export {
   type NodeSelectorProps,
 } from "./NodeSelector.svelte";
 
+// Portal component
+export { default as Portal, type PortalProps } from "./Portal.svelte";
+
 // SaveIndicator component
 export {
   default as SaveIndicator,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -135,6 +135,8 @@ export {
   type EditorRootProps,
   getEditorContext,
   getEditorContextSafe,
+  Portal,
+  type PortalProps,
   SaveIndicator,
   type SaveIndicatorProps,
   SlashMenu,

--- a/packages/vue/src/components/Portal.vue
+++ b/packages/vue/src/components/Portal.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { getPortalContainer, PORTAL_Z_INDEX, type PortalLayer, VIZEL_PORTAL_ID } from "@vizel/core";
+import { computed, onMounted, ref, Teleport } from "vue";
+
+/**
+ * Props for the Portal component.
+ */
+export interface PortalProps {
+  /** Z-index layer for the portal content */
+  layer?: PortalLayer;
+  /** Additional CSS class name */
+  class?: string;
+  /** Whether the portal is disabled (renders children in place) */
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<PortalProps>(), {
+  layer: "dropdown",
+  disabled: false,
+});
+
+const mounted = ref(false);
+
+onMounted(() => {
+  // Ensure portal container exists
+  getPortalContainer();
+  mounted.value = true;
+});
+
+const portalTarget = computed(() => `#${VIZEL_PORTAL_ID}`);
+
+const wrapperStyle = computed(() => ({
+  position: "absolute" as const,
+  top: 0,
+  left: 0,
+  zIndex: PORTAL_Z_INDEX[props.layer],
+}));
+</script>
+
+<template>
+  <Teleport v-if="mounted && !disabled" :to="portalTarget">
+    <div
+      :data-vizel-portal-layer="layer"
+      :class="props.class"
+      :style="wrapperStyle"
+    >
+      <slot />
+    </div>
+  </Teleport>
+  <slot v-else />
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -40,6 +40,9 @@ export {
   type NodeSelectorProps,
 } from "./NodeSelector.vue";
 
+// Portal component
+export { default as Portal, type PortalProps } from "./Portal.vue";
+
 // SaveIndicator component
 export {
   default as SaveIndicator,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -133,6 +133,8 @@ export {
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  Portal,
+  type PortalProps,
   SaveIndicator,
   type SaveIndicatorProps,
   SlashMenu,

--- a/tests/ct/react/specs/Portal.spec.tsx
+++ b/tests/ct/react/specs/Portal.spec.tsx
@@ -1,0 +1,60 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testPortalContainerCreated,
+  testPortalContentRendered,
+  testPortalCustomClass,
+  testPortalDisabled,
+  testPortalEscapesOverflow,
+  testPortalZIndexLayer,
+} from "../../scenarios/portal.scenario";
+import { PortalFixture } from "./PortalFixture";
+
+test.describe("Portal - React", () => {
+  test.describe("Display", () => {
+    test("creates portal container in document.body", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture />);
+      await testPortalContainerCreated(component, page);
+    });
+
+    test("renders content in portal container", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture />);
+      await testPortalContentRendered(component, page);
+    });
+
+    test("applies custom className", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture className="custom-portal-class" />);
+      await testPortalCustomClass(component, page);
+    });
+  });
+
+  test.describe("Z-Index Layers", () => {
+    test("dropdown layer has z-index 50", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture layer="dropdown" />);
+      await testPortalZIndexLayer(component, page, "dropdown");
+    });
+
+    test("modal layer has z-index 100", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture layer="modal" />);
+      await testPortalZIndexLayer(component, page, "modal");
+    });
+
+    test("tooltip layer has z-index 150", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture layer="tooltip" />);
+      await testPortalZIndexLayer(component, page, "tooltip");
+    });
+  });
+
+  test.describe("Disabled Mode", () => {
+    test("renders content in place when disabled", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture disabled />);
+      await testPortalDisabled(component, page);
+    });
+  });
+
+  test.describe("Overflow Container", () => {
+    test("content escapes overflow:hidden container", async ({ mount, page }) => {
+      const component = await mount(<PortalFixture withOverflowContainer />);
+      await testPortalEscapesOverflow(component, page);
+    });
+  });
+});

--- a/tests/ct/react/specs/PortalFixture.tsx
+++ b/tests/ct/react/specs/PortalFixture.tsx
@@ -1,0 +1,41 @@
+import { Portal, type PortalLayer } from "@vizel/react";
+
+interface PortalFixtureProps {
+  layer?: PortalLayer;
+  disabled?: boolean;
+  className?: string;
+  withOverflowContainer?: boolean;
+}
+
+export function PortalFixture({
+  layer = "dropdown",
+  disabled = false,
+  className,
+  withOverflowContainer = false,
+}: PortalFixtureProps) {
+  const content = (
+    <Portal layer={layer} disabled={disabled} className={className}>
+      <div className="test-portal-content" data-testid="portal-content">
+        Portal Content
+      </div>
+    </Portal>
+  );
+
+  if (withOverflowContainer) {
+    return (
+      <div
+        data-testid="portal-fixture"
+        style={{
+          overflow: "hidden",
+          width: "100px",
+          height: "50px",
+          position: "relative",
+        }}
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return <div data-testid="portal-fixture">{content}</div>;
+}

--- a/tests/ct/scenarios/portal.scenario.ts
+++ b/tests/ct/scenarios/portal.scenario.ts
@@ -1,0 +1,89 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Test that portal container is created in document.body
+ */
+export async function testPortalContainerCreated(component: Locator, page: Page): Promise<void> {
+  // Wait for fixture to be attached (component may be empty due to portal)
+  await expect(component).toBeAttached();
+
+  // Check that portal container exists in body
+  const portalContainer = page.locator("#vizel-portal-root");
+  await expect(portalContainer).toBeAttached();
+}
+
+/**
+ * Test that portal content is rendered in portal container
+ */
+export async function testPortalContentRendered(component: Locator, page: Page): Promise<void> {
+  await expect(component).toBeAttached();
+
+  // Content should be inside the portal container
+  const portalContent = page.locator("#vizel-portal-root [data-vizel-portal-layer]");
+  await expect(portalContent).toBeAttached();
+
+  // Check that test content is visible
+  const testContent = page.locator("#vizel-portal-root .test-portal-content");
+  await expect(testContent).toBeVisible();
+}
+
+/**
+ * Test that portal has correct z-index layer
+ */
+export async function testPortalZIndexLayer(
+  component: Locator,
+  page: Page,
+  layer: "dropdown" | "modal" | "tooltip"
+): Promise<void> {
+  await expect(component).toBeAttached();
+
+  // Check layer attribute
+  const portalWrapper = page.locator(`#vizel-portal-root [data-vizel-portal-layer="${layer}"]`);
+  await expect(portalWrapper).toBeAttached();
+
+  // Check z-index
+  const expectedZIndex = { dropdown: "50", modal: "100", tooltip: "150" };
+  await expect(portalWrapper).toHaveCSS("z-index", expectedZIndex[layer]);
+}
+
+/**
+ * Test that disabled portal renders content in place
+ */
+export async function testPortalDisabled(component: Locator, page: Page): Promise<void> {
+  await expect(component).toBeAttached();
+
+  // Content should NOT be in portal container
+  const portalContent = page.locator("#vizel-portal-root [data-vizel-portal-layer]");
+  await expect(portalContent).not.toBeAttached();
+
+  // Content should be rendered in place (inside component)
+  const inPlaceContent = component.locator(".test-portal-content");
+  await expect(inPlaceContent).toBeVisible();
+}
+
+/**
+ * Test that portal content escapes overflow:hidden container
+ */
+export async function testPortalEscapesOverflow(component: Locator, page: Page): Promise<void> {
+  await expect(component).toBeAttached();
+
+  // The portal content should be visible even with overflow hidden
+  const portalContent = page.locator("#vizel-portal-root .test-portal-content");
+  await expect(portalContent).toBeVisible();
+
+  // Verify it's positioned at body level, not inside the overflow container
+  const portalWrapper = page.locator("#vizel-portal-root [data-vizel-portal-layer]");
+  await expect(portalWrapper).toBeAttached();
+}
+
+/**
+ * Test that custom className is applied to portal wrapper
+ */
+export async function testPortalCustomClass(component: Locator, page: Page): Promise<void> {
+  await expect(component).toBeAttached();
+
+  // Check that custom class is applied
+  const portalWrapper = page.locator("#vizel-portal-root .custom-portal-class");
+  await expect(portalWrapper).toBeAttached();
+}

--- a/tests/ct/svelte/specs/Portal.spec.ts
+++ b/tests/ct/svelte/specs/Portal.spec.ts
@@ -1,0 +1,72 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testPortalContainerCreated,
+  testPortalContentRendered,
+  testPortalCustomClass,
+  testPortalDisabled,
+  testPortalEscapesOverflow,
+  testPortalZIndexLayer,
+} from "../../scenarios/portal.scenario";
+import PortalFixture from "./PortalFixture.svelte";
+
+test.describe("Portal - Svelte", () => {
+  test.describe("Display", () => {
+    test("creates portal container in document.body", async ({ mount, page }) => {
+      const component = await mount(PortalFixture);
+      await testPortalContainerCreated(component, page);
+    });
+
+    test("renders content in portal container", async ({ mount, page }) => {
+      const component = await mount(PortalFixture);
+      await testPortalContentRendered(component, page);
+    });
+
+    test("applies custom className", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { class: "custom-portal-class" },
+      });
+      await testPortalCustomClass(component, page);
+    });
+  });
+
+  test.describe("Z-Index Layers", () => {
+    test("dropdown layer has z-index 50", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "dropdown" },
+      });
+      await testPortalZIndexLayer(component, page, "dropdown");
+    });
+
+    test("modal layer has z-index 100", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "modal" },
+      });
+      await testPortalZIndexLayer(component, page, "modal");
+    });
+
+    test("tooltip layer has z-index 150", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "tooltip" },
+      });
+      await testPortalZIndexLayer(component, page, "tooltip");
+    });
+  });
+
+  test.describe("Disabled Mode", () => {
+    test("renders content in place when disabled", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { disabled: true },
+      });
+      await testPortalDisabled(component, page);
+    });
+  });
+
+  test.describe("Overflow Container", () => {
+    test("content escapes overflow:hidden container", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { withOverflowContainer: true },
+      });
+      await testPortalEscapesOverflow(component, page);
+    });
+  });
+});

--- a/tests/ct/svelte/specs/PortalFixture.svelte
+++ b/tests/ct/svelte/specs/PortalFixture.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import type { PortalLayer } from "@vizel/core";
+import { Portal } from "@vizel/svelte";
+
+interface Props {
+  layer?: PortalLayer;
+  disabled?: boolean;
+  class?: string;
+  withOverflowContainer?: boolean;
+}
+
+const {
+  layer = "dropdown",
+  disabled = false,
+  class: className,
+  withOverflowContainer = false,
+}: Props = $props();
+</script>
+
+{#if withOverflowContainer}
+  <div
+    data-testid="portal-fixture"
+    style="overflow: hidden; width: 100px; height: 50px; position: relative;"
+  >
+    <Portal {layer} {disabled} class={className}>
+      <div class="test-portal-content" data-testid="portal-content">
+        Portal Content
+      </div>
+    </Portal>
+  </div>
+{:else}
+  <div data-testid="portal-fixture">
+    <Portal {layer} {disabled} class={className}>
+      <div class="test-portal-content" data-testid="portal-content">
+        Portal Content
+      </div>
+    </Portal>
+  </div>
+{/if}

--- a/tests/ct/vue/specs/Portal.spec.ts
+++ b/tests/ct/vue/specs/Portal.spec.ts
@@ -1,0 +1,72 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testPortalContainerCreated,
+  testPortalContentRendered,
+  testPortalCustomClass,
+  testPortalDisabled,
+  testPortalEscapesOverflow,
+  testPortalZIndexLayer,
+} from "../../scenarios/portal.scenario";
+import PortalFixture from "./PortalFixture.vue";
+
+test.describe("Portal - Vue", () => {
+  test.describe("Display", () => {
+    test("creates portal container in document.body", async ({ mount, page }) => {
+      const component = await mount(PortalFixture);
+      await testPortalContainerCreated(component, page);
+    });
+
+    test("renders content in portal container", async ({ mount, page }) => {
+      const component = await mount(PortalFixture);
+      await testPortalContentRendered(component, page);
+    });
+
+    test("applies custom className", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { class: "custom-portal-class" },
+      });
+      await testPortalCustomClass(component, page);
+    });
+  });
+
+  test.describe("Z-Index Layers", () => {
+    test("dropdown layer has z-index 50", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "dropdown" },
+      });
+      await testPortalZIndexLayer(component, page, "dropdown");
+    });
+
+    test("modal layer has z-index 100", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "modal" },
+      });
+      await testPortalZIndexLayer(component, page, "modal");
+    });
+
+    test("tooltip layer has z-index 150", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { layer: "tooltip" },
+      });
+      await testPortalZIndexLayer(component, page, "tooltip");
+    });
+  });
+
+  test.describe("Disabled Mode", () => {
+    test("renders content in place when disabled", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { disabled: true },
+      });
+      await testPortalDisabled(component, page);
+    });
+  });
+
+  test.describe("Overflow Container", () => {
+    test("content escapes overflow:hidden container", async ({ mount, page }) => {
+      const component = await mount(PortalFixture, {
+        props: { withOverflowContainer: true },
+      });
+      await testPortalEscapesOverflow(component, page);
+    });
+  });
+});

--- a/tests/ct/vue/specs/PortalFixture.vue
+++ b/tests/ct/vue/specs/PortalFixture.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { PortalLayer } from "@vizel/core";
+import { Portal } from "@vizel/vue";
+
+interface Props {
+  layer?: PortalLayer;
+  disabled?: boolean;
+  class?: string;
+  withOverflowContainer?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  layer: "dropdown",
+  disabled: false,
+  withOverflowContainer: false,
+});
+</script>
+
+<template>
+  <div
+    v-if="withOverflowContainer"
+    data-testid="portal-fixture"
+    :style="{
+      overflow: 'hidden',
+      width: '100px',
+      height: '50px',
+      position: 'relative',
+    }"
+  >
+    <Portal :layer="layer" :disabled="disabled" :class="props.class">
+      <div class="test-portal-content" data-testid="portal-content">
+        Portal Content
+      </div>
+    </Portal>
+  </div>
+  <div v-else data-testid="portal-fixture">
+    <Portal :layer="layer" :disabled="disabled" :class="props.class">
+      <div class="test-portal-content" data-testid="portal-content">
+        Portal Content
+      </div>
+    </Portal>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- Add unified portal system for rendering floating UI elements outside component tree
- Implement Portal component for React, Vue, and Svelte with framework-idiomatic patterns
- Add core utilities: `getPortalContainer`, `createPortalElement`, `mountToPortal`, `unmountFromPortal`
- Support configurable z-index layers: dropdown (50), modal (100), tooltip (150)
- Add Playwright component tests for all frameworks

## Implementation Details

### Core Package (`@vizel/core`)
- `src/utils/portal.ts` - Framework-agnostic portal utilities
- `src/styles/portal.css` - CSS for portal container and layers

### Framework Packages
- **React**: Uses `createPortal` from `react-dom`
- **Vue**: Uses built-in `<Teleport>` component
- **Svelte**: Uses Svelte action pattern with DOM manipulation

### Features
- Single shared portal container (`#vizel-portal-root`)
- `disabled` prop for inline rendering
- Custom `className` support
- Automatic cleanup on unmount

## Test Plan

- [x] Run lint (`bun run lint`)
- [x] Run typecheck (`bun run typecheck`)
- [x] Run build (`bun run build`)
- [x] Add Playwright component tests for Portal in React, Vue, Svelte

Closes #32