### PR TITLE
fix(core): use setNodeMarkup for code block toolbar updates

### DIFF
--- a/packages/core/src/extensions/code-block-lowlight.ts
+++ b/packages/core/src/extensions/code-block-lowlight.ts
@@ -167,7 +167,16 @@ export function createCodeBlockLowlightExtension(
           if (pos !== null && pos !== undefined) {
             const newLanguage = languageInput.value.toLowerCase().trim() || defaultLanguage;
             languageInput.value = newLanguage;
-            editor.chain().focus().updateAttributes("codeBlock", { language: newLanguage }).run();
+            // Use setNodeMarkup to update the specific node at this position
+            const { tr } = editor.state;
+            const nodeAtPos = editor.state.doc.nodeAt(pos);
+            if (nodeAtPos) {
+              tr.setNodeMarkup(pos, undefined, {
+                ...nodeAtPos.attrs,
+                language: newLanguage,
+              });
+              editor.view.dispatch(tr);
+            }
           }
         };
 
@@ -255,7 +264,16 @@ export function createCodeBlockLowlightExtension(
           const pos = typeof getPos === "function" ? getPos() : null;
           if (pos !== null && pos !== undefined) {
             const newValue = !currentLineNumbers;
-            editor.chain().focus().updateAttributes("codeBlock", { lineNumbers: newValue }).run();
+            // Use setNodeMarkup to update the specific node at this position
+            const { tr } = editor.state;
+            const nodeAtPos = editor.state.doc.nodeAt(pos);
+            if (nodeAtPos) {
+              tr.setNodeMarkup(pos, undefined, {
+                ...nodeAtPos.attrs,
+                lineNumbers: newValue,
+              });
+              editor.view.dispatch(tr);
+            }
           }
         });
 


### PR DESCRIPTION
## Summary

- Fix code block toolbar buttons (line numbers toggle, language selector) not working on code blocks loaded from initial content
- Change from `updateAttributes()` (cursor position-based) to `setNodeMarkup()` (position-based) for reliable node updates
- Toolbar buttons now correctly update their associated code block regardless of cursor position

## Root Cause

The toolbar buttons have `contenteditable="false"`, so clicking them doesn't place the cursor inside the code block. The previous implementation using `editor.chain().focus().updateAttributes("codeBlock", {...})` updated the node at the cursor position, which wasn't the clicked code block.

## Solution

Use `setNodeMarkup()` with the exact node position from `getPos()` to ensure the correct code block is always updated.

## Test Plan

- [x] Run typecheck (`bun run typecheck`)
- [x] Run build (`bun run build`)
- [x] Run CodeBlock tests for React (`bun run test:ct:react` - 24 passed)
- [x] Run CodeBlock tests for Vue (`bun run test:ct:vue` - 24 passed)
- [x] Run CodeBlock tests for Svelte (`bun run test:ct:svelte` - 24 passed)
- [x] Manual testing: Verified line numbers toggle and language change work on initial content code blocks