### PR TITLE
feat(icons): implement Iconify-based icon system with dependency injection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -128,10 +128,13 @@
       "name": "@vizel/react",
       "version": "0.0.1",
       "dependencies": {
+        "@iconify/react": "^5",
         "@tiptap/suggestion": "^3.14.0",
         "@vizel/core": "workspace:*",
       },
       "devDependencies": {
+        "@iconify-json/lucide": "^1.2.82",
+        "@iconify/utils": "^3.1.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
@@ -147,11 +150,14 @@
       "name": "@vizel/svelte",
       "version": "0.0.1",
       "dependencies": {
+        "@iconify/svelte": "^4",
         "@tiptap/core": "^3.14.0",
         "@tiptap/suggestion": "^3.14.0",
         "@vizel/core": "workspace:*",
       },
       "devDependencies": {
+        "@iconify-json/lucide": "^1.2.82",
+        "@iconify/utils": "^3.1.0",
         "@sveltejs/package": "^2",
         "@sveltejs/vite-plugin-svelte": "^5",
         "svelte-check": "^4",
@@ -164,10 +170,13 @@
       "name": "@vizel/vue",
       "version": "0.0.1",
       "dependencies": {
+        "@iconify/vue": "^5",
         "@tiptap/suggestion": "^3.14.0",
         "@vizel/core": "workspace:*",
       },
       "devDependencies": {
+        "@iconify-json/lucide": "^1.2.82",
+        "@iconify/utils": "^3.1.0",
         "@vitejs/plugin-vue": "^5",
         "vite": "^7",
         "vite-plugin-dts": "^4",
@@ -309,9 +318,17 @@
 
     "@hpcc-js/wasm-graphviz": ["@hpcc-js/wasm-graphviz@1.18.0", "", {}, "sha512-qfd3gTqtVQG+dWrNy6uwRH7czKw/RiJ9EwDB4F+pYTEfFW+E9kIZXQnLYtgxbGt1nNN2bowHBcOJ9F78PJ5IAQ=="],
 
+    "@iconify-json/lucide": ["@iconify-json/lucide@1.2.82", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-fHZWegspOZonl5GNTvOkHsjnTMdSslFh3EzpzUtRyLxO8bOonqk2OTU3hCl0k4VXzViMjqpRK3X1sotnuBXkFA=="],
+
+    "@iconify/react": ["@iconify/react@5.2.1", "", { "dependencies": { "@iconify/types": "^2.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-37GDR3fYDZmnmUn9RagyaX+zca24jfVOMY8E1IXTqJuE8pxNtN51KWPQe3VODOWvuUurq7q9uUu3CFrpqj5Iqg=="],
+
+    "@iconify/svelte": ["@iconify/svelte@4.2.0", "", { "dependencies": { "@iconify/types": "^2.0.0" }, "peerDependencies": { "svelte": ">4.0.0" } }, "sha512-fEl0T7SAPonK7xk6xUlRPDmFDZVDe2Z7ZstlqeDS/sS8ve2uyU+Qa8rTWbIqzZJlRvONkK5kVXiUf9nIc+6OOQ=="],
+
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
     "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
+
+    "@iconify/vue": ["@iconify/vue@5.0.0", "", { "dependencies": { "@iconify/types": "^2.0.0" }, "peerDependencies": { "vue": ">=3" } }, "sha512-C+KuEWIF5nSBrobFJhT//JS87OZ++QDORB6f2q2Wm6fl2mueSTpFBeBsveK0KW9hWiZ4mNiPjsh6Zs4jjdROSg=="],
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 

--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -1,6 +1,7 @@
 import type { Editor } from "@tiptap/core";
 import type { IFuseOptions } from "fuse.js";
 import Fuse from "fuse.js";
+import type { SlashCommandIconName } from "../icons/types.ts";
 
 /**
  * Range for slash command execution
@@ -18,8 +19,8 @@ export interface SlashCommandItem {
   title: string;
   /** Description of the command */
   description: string;
-  /** Icon to display (text/emoji) */
-  icon: string;
+  /** Icon name (semantic name, rendered by framework packages) */
+  icon: SlashCommandIconName;
   /** Command to execute */
   command: (props: { editor: Editor; range: SlashCommandRange }) => void;
   /** Keyboard shortcut hint (e.g., "⌘B") */
@@ -60,7 +61,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Heading 1",
     description: "Large section heading",
-    icon: "H1",
+    icon: "heading1",
     group: "Text",
     keywords: ["h1", "title", "header", "big"],
     shortcut: "⌘⌥1",
@@ -71,7 +72,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Heading 2",
     description: "Medium section heading",
-    icon: "H2",
+    icon: "heading2",
     group: "Text",
     keywords: ["h2", "subtitle", "header"],
     shortcut: "⌘⌥2",
@@ -82,7 +83,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Heading 3",
     description: "Small section heading",
-    icon: "H3",
+    icon: "heading3",
     group: "Text",
     keywords: ["h3", "header", "section"],
     shortcut: "⌘⌥3",
@@ -94,7 +95,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Bullet List",
     description: "Create a simple bullet list",
-    icon: "•",
+    icon: "bulletList",
     group: "Lists",
     keywords: ["ul", "unordered", "bullets", "points"],
     shortcut: "⌘⇧8",
@@ -105,7 +106,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Numbered List",
     description: "Create a numbered list",
-    icon: "1.",
+    icon: "orderedList",
     group: "Lists",
     keywords: ["ol", "ordered", "numbers", "steps"],
     shortcut: "⌘⇧7",
@@ -116,7 +117,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Task List",
     description: "Create a task list with checkboxes",
-    icon: "☑",
+    icon: "taskList",
     group: "Lists",
     keywords: ["todo", "checkbox", "checklist", "tasks"],
     command: ({ editor, range }) => {
@@ -127,7 +128,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Quote",
     description: "Capture a quote",
-    icon: '"',
+    icon: "blockquote",
     group: "Blocks",
     keywords: ["blockquote", "citation", "cite"],
     shortcut: "⌘⇧B",
@@ -138,7 +139,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Divider",
     description: "Insert a horizontal divider",
-    icon: "―",
+    icon: "horizontalRule",
     group: "Blocks",
     keywords: ["hr", "horizontal", "line", "separator", "break"],
     command: ({ editor, range }) => {
@@ -148,7 +149,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Details",
     description: "Collapsible content block",
-    icon: "▸",
+    icon: "details",
     group: "Blocks",
     keywords: ["accordion", "toggle", "collapse", "expand", "summary", "details"],
     command: ({ editor, range }) => {
@@ -162,7 +163,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Code Block",
     description: "Insert a code snippet",
-    icon: "</>",
+    icon: "codeBlock",
     group: "Blocks",
     keywords: ["pre", "code", "programming", "syntax", "snippet"],
     shortcut: "⌘⌥C",
@@ -173,7 +174,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Table",
     description: "Insert a table",
-    icon: "⊞",
+    icon: "table",
     group: "Blocks",
     keywords: ["grid", "spreadsheet", "columns", "rows"],
     command: ({ editor, range }) => {
@@ -189,7 +190,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Image",
     description: "Insert an image from URL",
-    icon: "🖼",
+    icon: "image",
     group: "Media",
     keywords: ["picture", "photo", "img", "url"],
     command: ({ editor, range }) => {
@@ -202,7 +203,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Upload Image",
     description: "Upload an image from your device",
-    icon: "📤",
+    icon: "imageUpload",
     group: "Media",
     keywords: ["picture", "photo", "upload", "file"],
     command: ({ editor, range }) => {
@@ -233,7 +234,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Embed",
     description: "Embed a URL (YouTube, Twitter, etc.)",
-    icon: "🔗",
+    icon: "embed",
     group: "Media",
     keywords: ["link", "url", "youtube", "video", "twitter", "embed", "iframe", "oembed"],
     command: ({ editor, range }) => {
@@ -258,7 +259,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Math Equation",
     description: "Insert a mathematical expression",
-    icon: "∑",
+    icon: "mathBlock",
     group: "Advanced",
     keywords: ["latex", "formula", "equation", "katex", "math"],
     command: ({ editor, range }) => {
@@ -272,7 +273,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Inline Math",
     description: "Insert an inline math expression",
-    icon: "x²",
+    icon: "mathInline",
     group: "Advanced",
     keywords: ["latex", "formula", "inline", "katex", "math"],
     command: ({ editor, range }) => {
@@ -286,7 +287,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "Mermaid Diagram",
     description: "Insert a Mermaid diagram",
-    icon: "📊",
+    icon: "mermaid",
     group: "Advanced",
     keywords: ["diagram", "chart", "flowchart", "mermaid", "sequence", "graph", "uml"],
     command: ({ editor, range }) => {
@@ -300,7 +301,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   {
     title: "GraphViz Diagram",
     description: "Insert a GraphViz (DOT) diagram",
-    icon: "🔵",
+    icon: "graphviz",
     group: "Advanced",
     keywords: ["diagram", "graphviz", "dot", "graph", "network", "nodes", "edges"],
     command: ({ editor, range }) => {

--- a/packages/core/src/extensions/code-block-lowlight.ts
+++ b/packages/core/src/extensions/code-block-lowlight.ts
@@ -8,6 +8,7 @@ import CodeBlockLowlight, {
   type CodeBlockLowlightOptions,
 } from "@tiptap/extension-code-block-lowlight";
 import { all, createLowlight } from "lowlight";
+import { renderIcon } from "../icons/types.ts";
 
 /**
  * Language definition for the code block language selector
@@ -195,6 +196,7 @@ export function createCodeBlockLowlightExtension(
         const lineNumbersBtn = document.createElement("button");
         lineNumbersBtn.type = "button";
         lineNumbersBtn.classList.add("vizel-code-block-line-numbers-toggle");
+        lineNumbersBtn.innerHTML = renderIcon("listOrdered", { width: 16, height: 16 });
         if (node.attrs.lineNumbers) {
           lineNumbersBtn.classList.add("active");
         }

--- a/packages/core/src/extensions/drag-handle.ts
+++ b/packages/core/src/extensions/drag-handle.ts
@@ -1,5 +1,6 @@
 import { Extension } from "@tiptap/core";
 import DragHandle, { type DragHandleOptions } from "@tiptap/extension-drag-handle";
+import { renderIcon } from "../icons/types.ts";
 
 export { DragHandle };
 export type { DragHandleOptions };
@@ -38,16 +39,7 @@ export function createDragHandleExtension(options: VizelDragHandleOptions = {}):
       // Create grip icon (6 dots pattern)
       const grip = document.createElement("div");
       grip.classList.add("vizel-drag-handle-grip");
-      grip.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-          <circle cx="9" cy="5" r="2"/>
-          <circle cx="15" cy="5" r="2"/>
-          <circle cx="9" cy="12" r="2"/>
-          <circle cx="15" cy="12" r="2"/>
-          <circle cx="9" cy="19" r="2"/>
-          <circle cx="15" cy="19" r="2"/>
-        </svg>
-      `;
+      grip.innerHTML = renderIcon("grip", { width: 14, height: 14 });
       element.appendChild(grip);
 
       // Store reference for onNodeChange callback

--- a/packages/core/src/extensions/node-types.ts
+++ b/packages/core/src/extensions/node-types.ts
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/core";
+import type { NodeTypeIconName } from "../icons/types.ts";
 
 /**
  * Node type option for the node selector dropdown
@@ -8,8 +9,8 @@ export interface NodeTypeOption {
   name: string;
   /** Display label */
   label: string;
-  /** Icon character or symbol */
-  icon: string;
+  /** Icon name (semantic name, rendered by framework packages) */
+  icon: NodeTypeIconName;
   /** Check if this node type is currently active */
   isActive: (editor: Editor) => boolean;
   /** Command to transform the current block to this node type */
@@ -23,7 +24,7 @@ export const defaultNodeTypes = [
   {
     name: "paragraph",
     label: "Text",
-    icon: "¶",
+    icon: "paragraph",
     isActive: (editor) =>
       editor.isActive("paragraph") &&
       !editor.isActive("bulletList") &&
@@ -34,56 +35,56 @@ export const defaultNodeTypes = [
   {
     name: "heading1",
     label: "Heading 1",
-    icon: "H1",
+    icon: "heading1",
     isActive: (editor) => editor.isActive("heading", { level: 1 }),
     command: (editor) => editor.chain().focus().setHeading({ level: 1 }).run(),
   },
   {
     name: "heading2",
     label: "Heading 2",
-    icon: "H2",
+    icon: "heading2",
     isActive: (editor) => editor.isActive("heading", { level: 2 }),
     command: (editor) => editor.chain().focus().setHeading({ level: 2 }).run(),
   },
   {
     name: "heading3",
     label: "Heading 3",
-    icon: "H3",
+    icon: "heading3",
     isActive: (editor) => editor.isActive("heading", { level: 3 }),
     command: (editor) => editor.chain().focus().setHeading({ level: 3 }).run(),
   },
   {
     name: "bulletList",
     label: "Bullet List",
-    icon: "•",
+    icon: "bulletList",
     isActive: (editor) => editor.isActive("bulletList"),
     command: (editor) => editor.chain().focus().toggleBulletList().run(),
   },
   {
     name: "orderedList",
     label: "Numbered List",
-    icon: "1.",
+    icon: "orderedList",
     isActive: (editor) => editor.isActive("orderedList"),
     command: (editor) => editor.chain().focus().toggleOrderedList().run(),
   },
   {
     name: "taskList",
     label: "Task List",
-    icon: "☑",
+    icon: "taskList",
     isActive: (editor) => editor.isActive("taskList"),
     command: (editor) => editor.chain().focus().toggleTaskList().run(),
   },
   {
     name: "blockquote",
     label: "Quote",
-    icon: '"',
+    icon: "blockquote",
     isActive: (editor) => editor.isActive("blockquote"),
     command: (editor) => editor.chain().focus().toggleBlockquote().run(),
   },
   {
     name: "codeBlock",
     label: "Code",
-    icon: "</>",
+    icon: "codeBlock",
     isActive: (editor) => editor.isActive("codeBlock"),
     command: (editor) => editor.chain().focus().toggleCodeBlock().run(),
   },

--- a/packages/core/src/extensions/table-controls.ts
+++ b/packages/core/src/extensions/table-controls.ts
@@ -1,6 +1,7 @@
 import type { Editor } from "@tiptap/core";
 import type { TableOptions } from "@tiptap/extension-table";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { type InternalIconName, renderIcon, type TableIconName } from "../icons/types.ts";
 import { VizelTable } from "./table-base";
 
 /**
@@ -33,7 +34,7 @@ export type TableControlsOptions = Partial<TableOptions> & TableControlsUIOption
 
 interface TableMenuItem {
   label: string;
-  icon?: string;
+  icon?: TableIconName;
   command: string | ((editor: Editor) => void);
   destructive?: boolean;
   divider?: boolean;
@@ -41,8 +42,8 @@ interface TableMenuItem {
 
 /** Row-specific menu items (shown from row handle) */
 const ROW_MENU_ITEMS: TableMenuItem[] = [
-  { label: "Add row above", icon: "↑", command: "addRowBefore" },
-  { label: "Add row below", icon: "↓", command: "addRowAfter" },
+  { label: "Add row above", icon: "arrowUp", command: "addRowBefore" },
+  { label: "Add row below", icon: "arrowDown", command: "addRowAfter" },
   { label: "Delete row", command: "deleteRow", destructive: true },
   { divider: true, label: "", command: "" },
   { label: "Toggle header row", command: "toggleHeaderRow" },
@@ -52,8 +53,8 @@ const ROW_MENU_ITEMS: TableMenuItem[] = [
 
 /** Base column menu items (without alignment - those are added dynamically) */
 const COLUMN_MENU_ITEMS_BASE: TableMenuItem[] = [
-  { label: "Add column left", icon: "←", command: "addColumnBefore" },
-  { label: "Add column right", icon: "→", command: "addColumnAfter" },
+  { label: "Add column left", icon: "arrowLeft", command: "addColumnBefore" },
+  { label: "Add column right", icon: "arrowRight", command: "addColumnAfter" },
   { label: "Delete column", command: "deleteColumn", destructive: true },
   { divider: true, label: "", command: "" },
   { label: "Toggle header column", command: "toggleHeaderColumn" },
@@ -69,17 +70,17 @@ function createColumnMenuItems(tablePos: number, colIndex: number): TableMenuIte
     // Column-wide alignment (Markdown compatible)
     {
       label: "Align left",
-      icon: "⫷",
+      icon: "alignLeft",
       command: (editor) => setColumnAlignment(editor, tablePos, colIndex, "left"),
     },
     {
       label: "Align center",
-      icon: "⫶",
+      icon: "alignCenter",
       command: (editor) => setColumnAlignment(editor, tablePos, colIndex, "center"),
     },
     {
       label: "Align right",
-      icon: "⫸",
+      icon: "alignRight",
       command: (editor) => setColumnAlignment(editor, tablePos, colIndex, "right"),
     },
     { divider: true, label: "", command: "" },
@@ -416,7 +417,8 @@ function createTableMenu(
     if (item.icon) {
       const icon = document.createElement("span");
       icon.className = "vizel-table-menu-item-icon";
-      icon.textContent = item.icon;
+      // Render SVG icon instead of text
+      icon.innerHTML = renderIcon(item.icon as InternalIconName, { width: 16, height: 16 });
       button.appendChild(icon);
     }
 
@@ -506,7 +508,7 @@ export const VizelTableWithControls = VizelTable.extend<TableControlsOptions>({
       const columnInsertBtn = document.createElement("button");
       columnInsertBtn.className = "vizel-table-insert-button vizel-table-column-insert";
       columnInsertBtn.type = "button";
-      columnInsertBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M6 0v12M0 6h12" stroke="currentColor" stroke-width="2" fill="none"/></svg>`;
+      columnInsertBtn.innerHTML = renderIcon("plusSmall", { width: 12, height: 12 });
       columnInsertBtn.setAttribute("aria-label", "Insert column");
       columnInsertBtn.title = "Insert column";
       // Initial position at first column boundary (CSS translateX(-50%) centers it)
@@ -518,7 +520,7 @@ export const VizelTableWithControls = VizelTable.extend<TableControlsOptions>({
       const rowInsertBtn = document.createElement("button");
       rowInsertBtn.className = "vizel-table-insert-button vizel-table-row-insert";
       rowInsertBtn.type = "button";
-      rowInsertBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M6 0v12M0 6h12" stroke="currentColor" stroke-width="2" fill="none"/></svg>`;
+      rowInsertBtn.innerHTML = renderIcon("plusSmall", { width: 12, height: 12 });
       rowInsertBtn.setAttribute("aria-label", "Insert row");
       rowInsertBtn.title = "Insert row";
       // Initial position at first row boundary (CSS translateY(-50%) centers it)
@@ -530,7 +532,7 @@ export const VizelTableWithControls = VizelTable.extend<TableControlsOptions>({
       const rowHandle = document.createElement("button");
       rowHandle.className = "vizel-table-row-handle";
       rowHandle.type = "button";
-      rowHandle.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="5" r="2"/><circle cx="15" cy="5" r="2"/><circle cx="9" cy="12" r="2"/><circle cx="15" cy="12" r="2"/><circle cx="9" cy="19" r="2"/><circle cx="15" cy="19" r="2"/></svg>`;
+      rowHandle.innerHTML = renderIcon("grip", { width: 12, height: 12 });
       rowHandle.setAttribute("aria-label", "Table row options");
       rowHandle.title = "Row options (delete, align, etc.)";
       // Initial position at first row (in padding area)
@@ -542,7 +544,7 @@ export const VizelTableWithControls = VizelTable.extend<TableControlsOptions>({
       const columnHandle = document.createElement("button");
       columnHandle.className = "vizel-table-column-handle";
       columnHandle.type = "button";
-      columnHandle.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="9" r="2"/><circle cx="5" cy="15" r="2"/><circle cx="12" cy="9" r="2"/><circle cx="12" cy="15" r="2"/><circle cx="19" cy="9" r="2"/><circle cx="19" cy="15" r="2"/></svg>`;
+      columnHandle.innerHTML = renderIcon("gripHorizontal", { width: 12, height: 12 });
       columnHandle.setAttribute("aria-label", "Table column options");
       columnHandle.title = "Column options (delete, align, etc.)";
       // Initial position at first column (in padding area)

--- a/packages/core/src/icons/index.ts
+++ b/packages/core/src/icons/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Icon system for Vizel editor.
+ *
+ * Provides semantic icon names and default Iconify icon IDs.
+ * Framework packages implement the actual rendering using Iconify components.
+ */
+
+export {
+  type BubbleMenuIconName,
+  defaultIconIds,
+  getIconId,
+  type IconName,
+  type IconRenderer,
+  type IconRendererOptions,
+  type IconRendererWithOptions,
+  type InternalIconName,
+  type NodeTypeIconName,
+  renderIcon,
+  type SlashCommandIconName,
+  setIconRenderer,
+  type TableIconName,
+  type UIIconName,
+} from "./types.ts";

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -1,0 +1,258 @@
+/**
+ * Icon system types for Vizel editor.
+ *
+ * This module defines the icon names and types used throughout the editor.
+ * Framework packages (react, vue, svelte) provide the actual icon implementations
+ * using Iconify or other icon libraries.
+ */
+
+/**
+ * Icon names used in slash commands and menus.
+ * These are semantic names that map to actual icons in framework packages.
+ */
+export type SlashCommandIconName =
+  // Text/Headings
+  | "heading1"
+  | "heading2"
+  | "heading3"
+  // Lists
+  | "bulletList"
+  | "orderedList"
+  | "taskList"
+  // Blocks
+  | "blockquote"
+  | "horizontalRule"
+  | "details"
+  | "codeBlock"
+  | "table"
+  // Media
+  | "image"
+  | "imageUpload"
+  | "embed"
+  // Advanced
+  | "mathBlock"
+  | "mathInline"
+  | "mermaid"
+  | "graphviz";
+
+/**
+ * Icon names used in node type selector.
+ */
+export type NodeTypeIconName =
+  | "paragraph"
+  | "heading1"
+  | "heading2"
+  | "heading3"
+  | "bulletList"
+  | "orderedList"
+  | "taskList"
+  | "blockquote"
+  | "codeBlock";
+
+/**
+ * Icon names used in table controls.
+ */
+export type TableIconName =
+  | "arrowUp"
+  | "arrowDown"
+  | "arrowLeft"
+  | "arrowRight"
+  | "alignLeft"
+  | "alignCenter"
+  | "alignRight"
+  | "plus"
+  | "gripVertical"
+  | "gripHorizontal";
+
+/**
+ * Icon names used in UI components (SaveIndicator, etc.).
+ */
+export type UIIconName = "check" | "loader" | "circle" | "warning" | "chevronDown" | "x";
+
+/**
+ * Icon names used in BubbleMenu toolbar.
+ */
+export type BubbleMenuIconName =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "underline"
+  | "code"
+  | "link"
+  | "textColor"
+  | "highlighter";
+
+/**
+ * Icon names used internally in NodeView rendering (drag handle, table controls).
+ * These icons are rendered via the injected IconRenderer from framework packages.
+ */
+export type InternalIconName =
+  | "grip"
+  | "gripHorizontal"
+  | "plusSmall"
+  // Table menu icons
+  | "arrowUp"
+  | "arrowDown"
+  | "arrowLeft"
+  | "arrowRight"
+  | "alignLeft"
+  | "alignCenter"
+  | "alignRight"
+  // Code block icons
+  | "listOrdered";
+
+/**
+ * All icon names used in Vizel.
+ */
+export type IconName =
+  | SlashCommandIconName
+  | NodeTypeIconName
+  | TableIconName
+  | UIIconName
+  | BubbleMenuIconName
+  | InternalIconName;
+
+/**
+ * Default Iconify icon IDs for each icon name.
+ * Uses Lucide icons as the default set.
+ * Users can override these by providing their own icon mappings.
+ */
+export const defaultIconIds: Record<IconName, string> = {
+  // Text/Headings
+  heading1: "lucide:heading-1",
+  heading2: "lucide:heading-2",
+  heading3: "lucide:heading-3",
+  // Lists
+  bulletList: "lucide:list",
+  orderedList: "lucide:list-ordered",
+  taskList: "lucide:list-checks",
+  // Blocks
+  paragraph: "lucide:pilcrow",
+  blockquote: "lucide:quote",
+  horizontalRule: "lucide:minus",
+  details: "lucide:chevron-right",
+  codeBlock: "lucide:code",
+  table: "lucide:table",
+  // Media
+  image: "lucide:image",
+  imageUpload: "lucide:image-up",
+  embed: "lucide:link",
+  // Advanced
+  mathBlock: "lucide:sigma",
+  mathInline: "lucide:superscript",
+  mermaid: "lucide:git-graph",
+  graphviz: "lucide:workflow",
+  // Table controls
+  arrowUp: "lucide:arrow-up",
+  arrowDown: "lucide:arrow-down",
+  arrowLeft: "lucide:arrow-left",
+  arrowRight: "lucide:arrow-right",
+  alignLeft: "lucide:align-left",
+  alignCenter: "lucide:align-center",
+  alignRight: "lucide:align-right",
+  plus: "lucide:plus",
+  gripVertical: "lucide:grip-vertical",
+  gripHorizontal: "lucide:grip-horizontal",
+  // UI
+  check: "lucide:check",
+  loader: "lucide:loader-2",
+  circle: "lucide:circle",
+  warning: "lucide:alert-triangle",
+  chevronDown: "lucide:chevron-down",
+  x: "lucide:x",
+  // BubbleMenu toolbar
+  bold: "lucide:bold",
+  italic: "lucide:italic",
+  strikethrough: "lucide:strikethrough",
+  underline: "lucide:underline",
+  code: "lucide:code",
+  link: "lucide:link",
+  textColor: "lucide:baseline",
+  highlighter: "lucide:highlighter",
+  // Internal (NodeView rendering)
+  grip: "lucide:grip-vertical",
+  plusSmall: "lucide:plus",
+  listOrdered: "lucide:list-ordered",
+};
+
+/**
+ * Get the Iconify icon ID for a given icon name.
+ * @param name - The semantic icon name
+ * @param customIcons - Optional custom icon mappings to override defaults
+ * @returns The Iconify icon ID (e.g., "lucide:heading-1")
+ */
+export function getIconId(name: IconName, customIcons?: Partial<Record<IconName, string>>): string {
+  return customIcons?.[name] ?? defaultIconIds[name];
+}
+
+/**
+ * Icon renderer function type.
+ * Framework packages inject their implementation to render icons as SVG strings.
+ */
+export type IconRenderer = (name: InternalIconName) => string;
+
+/**
+ * Icon renderer options for customization.
+ */
+export interface IconRendererOptions {
+  /** Icon width in pixels */
+  width?: number;
+  /** Icon height in pixels */
+  height?: number;
+}
+
+/**
+ * Extended icon renderer function type with options support.
+ */
+export type IconRendererWithOptions = (
+  name: InternalIconName,
+  options?: IconRendererOptions
+) => string;
+
+// Global icon renderer, injected by framework packages
+let iconRenderer: IconRendererWithOptions | null = null;
+
+/**
+ * Set the icon renderer function.
+ * Called by framework packages (react, vue, svelte) to inject their Iconify-based implementation.
+ *
+ * @example
+ * ```typescript
+ * // In @vizel/react
+ * import { setIconRenderer, defaultIconIds } from "@vizel/core";
+ * import { iconToSVG, getIconData } from "@iconify/utils";
+ * import lucideIcons from "@iconify-json/lucide";
+ *
+ * setIconRenderer((name, options) => {
+ *   const iconId = defaultIconIds[name];
+ *   const [, iconName] = iconId.split(":");
+ *   const data = getIconData(lucideIcons, iconName);
+ *   if (!data) return "";
+ *   const svg = iconToSVG(data, { width: options?.width, height: options?.height });
+ *   return `<svg ...>${svg.body}</svg>`;
+ * });
+ * ```
+ */
+export function setIconRenderer(renderer: IconRendererWithOptions): void {
+  iconRenderer = renderer;
+}
+
+/**
+ * Render an internal icon as an SVG string.
+ * Uses the injected renderer from framework packages.
+ *
+ * @param name - The internal icon name
+ * @param options - Optional rendering options (width, height)
+ * @returns The SVG string, or empty string if no renderer is set
+ */
+export function renderIcon(name: InternalIconName, options?: IconRendererOptions): string {
+  if (!iconRenderer) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn(
+        `[Vizel] Icon renderer not set. Call setIconRenderer() from your framework package (@vizel/react, @vizel/vue, or @vizel/svelte).`
+      );
+    }
+    return "";
+  }
+  return iconRenderer(name, options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,6 +167,23 @@ export {
   type VizelTextColorOptions,
   validateImageFile,
 } from "./extensions/index.ts";
+// Icons
+export {
+  type BubbleMenuIconName,
+  defaultIconIds,
+  getIconId,
+  type IconName,
+  type IconRenderer,
+  type IconRendererOptions,
+  type IconRendererWithOptions,
+  type InternalIconName,
+  type NodeTypeIconName,
+  renderIcon,
+  type SlashCommandIconName,
+  setIconRenderer,
+  type TableIconName,
+  type UIIconName,
+} from "./icons/index.ts";
 // Theme
 export {
   applyTheme,

--- a/packages/core/src/styles/bubble-menu.scss
+++ b/packages/core/src/styles/bubble-menu.scss
@@ -59,19 +59,6 @@
     }
   }
 
-  &-highlight-icon {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.875rem;
-    font-weight: 700;
-
-    &::before {
-      content: "A";
-    }
-  }
-
   &-highlight-bar {
     position: absolute;
     bottom: 0;

--- a/packages/core/src/styles/code-block.scss
+++ b/packages/core/src/styles/code-block.scss
@@ -28,7 +28,7 @@
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
     font-family: v("font-mono");
-    color: v("code-block-language-color");
+    color: v("primary");
     background-color: v("code-block-input-bg");
     border: 1px solid v("code-block-input-border");
     border-radius: 0.25rem;
@@ -57,37 +57,22 @@
     border-radius: 0.25rem;
     cursor: pointer;
     transition: background-color 0.15s ease, border-color 0.15s ease;
+    color: v("code-block-button-color");
 
-    &::before {
-      content: "";
-      display: block;
+    svg {
       width: 0.875rem;
       height: 0.875rem;
-      background-color: v("code-block-button-color");
-      mask-image: var(
-        --vizel-code-block-line-numbers-icon,
-        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='3' y1='6' x2='5' y2='6'/%3E%3Cline x1='8' y1='6' x2='21' y2='6'/%3E%3Cline x1='3' y1='12' x2='5' y2='12'/%3E%3Cline x1='8' y1='12' x2='21' y2='12'/%3E%3Cline x1='3' y1='18' x2='5' y2='18'/%3E%3Cline x1='8' y1='18' x2='21' y2='18'/%3E%3C/svg%3E")
-      );
-      mask-size: contain;
-      mask-repeat: no-repeat;
-      mask-position: center;
-      transition: background-color 0.15s ease;
+      transition: color 0.15s ease;
     }
 
     &:hover {
       background-color: v("code-block-button-hover-bg");
-
-      &::before {
-        background-color: v("code-block-button-hover-color");
-      }
+      color: v("code-block-button-hover-color");
     }
 
     &.active {
       border-color: v("primary");
-
-      &::before {
-        background-color: v("primary");
-      }
+      color: v("primary");
     }
   }
 

--- a/packages/core/src/styles/table-controls.scss
+++ b/packages/core/src/styles/table-controls.scss
@@ -80,8 +80,8 @@
 .vizel-table-row-handle,
 .vizel-table-column-handle {
   position: absolute;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   border-radius: 4px;
   background-color: v("muted");
   color: v("muted-foreground");
@@ -109,8 +109,8 @@
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
   }
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@iconify/react": "^5",
     "@tiptap/suggestion": "^3.14.0",
     "@vizel/core": "workspace:*"
   },
@@ -36,6 +37,8 @@
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "^1.2.82",
+    "@iconify/utils": "^3.1.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",

--- a/packages/react/src/components/BubbleMenuColorPicker.tsx
+++ b/packages/react/src/components/BubbleMenuColorPicker.tsx
@@ -8,6 +8,7 @@ import {
 } from "@vizel/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ColorPicker } from "./ColorPicker";
+import { Icon } from "./Icon.tsx";
 
 export interface BubbleMenuColorPickerProps {
   editor: Editor;
@@ -96,13 +97,7 @@ export function BubbleMenuColorPicker({
   }, [isOpen]);
 
   const isTextColor = type === "textColor";
-  const icon = isTextColor ? (
-    "A"
-  ) : (
-    <span className="vizel-color-picker-highlight-icon">
-      <span className="vizel-color-picker-highlight-bar" />
-    </span>
-  );
+  const icon = isTextColor ? <Icon name="textColor" /> : <Icon name="highlighter" />;
 
   return (
     <div ref={containerRef} className={`vizel-color-picker ${className ?? ""}`} data-type={type}>

--- a/packages/react/src/components/BubbleMenuLinkEditor.tsx
+++ b/packages/react/src/components/BubbleMenuLinkEditor.tsx
@@ -1,5 +1,6 @@
 import { detectProvider, type Editor } from "@vizel/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "./Icon.tsx";
 
 export interface BubbleMenuLinkEditorProps {
   editor: Editor;
@@ -132,7 +133,7 @@ export function BubbleMenuLinkEditor({
           className="vizel-link-input"
         />
         <button type="submit" className="vizel-link-button" title="Apply">
-          OK
+          <Icon name="check" />
         </button>
         {currentHref && (
           <button
@@ -141,7 +142,7 @@ export function BubbleMenuLinkEditor({
             className="vizel-link-button vizel-link-remove"
             title="Remove link"
           >
-            X
+            <Icon name="x" />
           </button>
         )}
       </div>

--- a/packages/react/src/components/BubbleMenuToolbar.tsx
+++ b/packages/react/src/components/BubbleMenuToolbar.tsx
@@ -4,6 +4,7 @@ import { useEditorState } from "../hooks/useEditorState.ts";
 import { BubbleMenuButton } from "./BubbleMenuButton.tsx";
 import { BubbleMenuColorPicker } from "./BubbleMenuColorPicker.tsx";
 import { BubbleMenuLinkEditor } from "./BubbleMenuLinkEditor.tsx";
+import { Icon } from "./Icon.tsx";
 import { NodeSelector } from "./NodeSelector.tsx";
 
 export interface BubbleMenuToolbarProps {
@@ -48,7 +49,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("bold")}
         title="Bold (Cmd+B)"
       >
-        <strong>B</strong>
+        <Icon name="bold" />
       </BubbleMenuButton>
       <BubbleMenuButton
         action="italic"
@@ -56,7 +57,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("italic")}
         title="Italic (Cmd+I)"
       >
-        <em>I</em>
+        <Icon name="italic" />
       </BubbleMenuButton>
       <BubbleMenuButton
         action="strike"
@@ -64,7 +65,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("strike")}
         title="Strikethrough"
       >
-        <s>S</s>
+        <Icon name="strikethrough" />
       </BubbleMenuButton>
       <BubbleMenuButton
         action="underline"
@@ -72,7 +73,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("underline")}
         title="Underline (Cmd+U)"
       >
-        <u>U</u>
+        <Icon name="underline" />
       </BubbleMenuButton>
       <BubbleMenuButton
         action="code"
@@ -80,7 +81,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("code")}
         title="Code (Cmd+E)"
       >
-        <code>&lt;/&gt;</code>
+        <Icon name="code" />
       </BubbleMenuButton>
       <BubbleMenuButton
         action="link"
@@ -88,7 +89,7 @@ export function BubbleMenuToolbar({ editor, className, enableEmbed }: BubbleMenu
         isActive={editor.isActive("link")}
         title="Link (Cmd+K)"
       >
-        <span>L</span>
+        <Icon name="link" />
       </BubbleMenuButton>
       <BubbleMenuColorPicker editor={editor} type="textColor" />
       <BubbleMenuColorPicker editor={editor} type="highlight" />

--- a/packages/react/src/components/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import { type ColorDefinition, isValidHexColor, normalizeHexColor } from "@vizel/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "./Icon.tsx";
 
 export interface ColorPickerProps {
   /** Color palette to display */
@@ -202,7 +203,11 @@ export function ColorPicker({
                 }}
                 data-color={color}
               >
-                {isNoneValue(color) ? <span className="vizel-color-picker-none">×</span> : null}
+                {isNoneValue(color) ? (
+                  <span className="vizel-color-picker-none">
+                    <Icon name="x" />
+                  </span>
+                ) : null}
               </button>
             ))}
           </div>
@@ -234,7 +239,9 @@ export function ColorPicker({
                 data-color={colorDef.color}
               >
                 {isNoneValue(colorDef.color) ? (
-                  <span className="vizel-color-picker-none">×</span>
+                  <span className="vizel-color-picker-none">
+                    <Icon name="x" />
+                  </span>
                 ) : null}
               </button>
             );
@@ -269,7 +276,7 @@ export function ColorPicker({
             title="Apply"
             aria-label="Apply custom color"
           >
-            ✓
+            <Icon name="check" />
           </button>
         </div>
       )}

--- a/packages/react/src/components/EmbedView.tsx
+++ b/packages/react/src/components/EmbedView.tsx
@@ -1,6 +1,7 @@
 import type { EmbedData, EmbedType } from "@vizel/core";
 import type React from "react";
 import { useEffect, useRef } from "react";
+import { Icon } from "./Icon.tsx";
 
 export interface EmbedViewProps {
   /** Embed data */
@@ -93,11 +94,15 @@ function renderOGPCard(baseClass: string, data: EmbedData): React.JSX.Element {
 }
 
 /** Render title link */
-function renderTitleLink(baseClass: string, data: EmbedData): React.JSX.Element {
+function renderTitleLink(
+  baseClass: string,
+  data: EmbedData,
+  LinkIcon: React.JSX.Element
+): React.JSX.Element {
   return (
     <div className={baseClass} data-embed-type="title" data-embed-provider={data.provider}>
       <a href={data.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
-        <span className="vizel-embed-link-icon">🔗</span>
+        <span className="vizel-embed-link-icon">{LinkIcon}</span>
         <span className="vizel-embed-link-text">{data.title}</span>
       </a>
     </div>
@@ -105,11 +110,15 @@ function renderTitleLink(baseClass: string, data: EmbedData): React.JSX.Element 
 }
 
 /** Render plain link (fallback) */
-function renderPlainLink(baseClass: string, data: EmbedData): React.JSX.Element {
+function renderPlainLink(
+  baseClass: string,
+  data: EmbedData,
+  LinkIcon: React.JSX.Element
+): React.JSX.Element {
   return (
     <div className={baseClass} data-embed-type="link" data-embed-provider={data.provider}>
       <a href={data.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
-        <span className="vizel-embed-link-icon">🔗</span>
+        <span className="vizel-embed-link-icon">{LinkIcon}</span>
         <span className="vizel-embed-link-text">{data.url}</span>
       </a>
     </div>
@@ -162,13 +171,15 @@ export function EmbedView({ data, className, selected }: EmbedViewProps) {
     return renderOGPCard(baseClass, data);
   }
 
+  const linkIcon = <Icon name="link" />;
+
   // Title link
   if (data.type === "title" && data.title) {
-    return renderTitleLink(baseClass, data);
+    return renderTitleLink(baseClass, data, linkIcon);
   }
 
   // Plain link (fallback)
-  return renderPlainLink(baseClass, data);
+  return renderPlainLink(baseClass, data, linkIcon);
 }
 
 /**

--- a/packages/react/src/components/Icon.tsx
+++ b/packages/react/src/components/Icon.tsx
@@ -1,0 +1,46 @@
+import { Icon as IconifyIcon } from "@iconify/react";
+import { defaultIconIds, type IconName } from "@vizel/core";
+import type { ComponentProps } from "react";
+import { type CustomIconMap, useIconContext } from "./IconContext";
+
+export interface IconProps extends Omit<ComponentProps<typeof IconifyIcon>, "icon"> {
+  /**
+   * The semantic icon name from Vizel's icon system.
+   */
+  name: IconName;
+  /**
+   * Custom icon mappings to override default Iconify icon IDs.
+   * If provided, will take precedence over context icons.
+   */
+  customIcons?: CustomIconMap;
+}
+
+/**
+ * Icon component that renders Iconify icons based on semantic icon names.
+ * Uses Lucide icons by default, but can be customized via:
+ * 1. customIcons prop (highest priority)
+ * 2. IconProvider context
+ * 3. Default Lucide icons (fallback)
+ *
+ * @example
+ * ```tsx
+ * // Using default Lucide icons
+ * <Icon name="heading1" />
+ *
+ * // With custom icon override (prop takes precedence)
+ * <Icon name="heading1" customIcons={{ heading1: "mdi:format-header-1" }} />
+ *
+ * // With IconProvider context
+ * <IconProvider icons={{ heading1: "ph:text-h-one" }}>
+ *   <Icon name="heading1" /> {/* Uses Phosphor icon *\/}
+ * </IconProvider>
+ *
+ * // With size and color
+ * <Icon name="check" width={24} height={24} color="green" />
+ * ```
+ */
+export function Icon({ name, customIcons, style, ...props }: IconProps) {
+  const { customIcons: contextIcons } = useIconContext();
+  const iconId = customIcons?.[name] ?? contextIcons?.[name] ?? defaultIconIds[name];
+  return <IconifyIcon icon={iconId} style={{ pointerEvents: "none", ...style }} {...props} />;
+}

--- a/packages/react/src/components/IconContext.tsx
+++ b/packages/react/src/components/IconContext.tsx
@@ -1,0 +1,86 @@
+import type { IconName } from "@vizel/core";
+import { createContext, type ReactNode, useContext } from "react";
+
+/**
+ * Custom icon mappings to override default Iconify icon IDs.
+ * Keys are semantic icon names, values are Iconify icon IDs.
+ *
+ * @example
+ * ```tsx
+ * const customIcons = {
+ *   heading1: "mdi:format-header-1",
+ *   bold: "mdi:format-bold",
+ *   // Use any Iconify icon set: Material Design, Heroicons, Phosphor, etc.
+ * };
+ * ```
+ */
+export type CustomIconMap = Partial<Record<IconName, string>>;
+
+export interface IconContextValue {
+  /**
+   * Custom icon mappings that override default Lucide icons.
+   */
+  customIcons?: CustomIconMap | undefined;
+}
+
+const IconContext = createContext<IconContextValue>({});
+
+export interface IconProviderProps {
+  /**
+   * Custom icon mappings to override default Lucide icons.
+   * Any icon not specified will fall back to the default Lucide icon.
+   *
+   * @example
+   * ```tsx
+   * // Use Material Design Icons for some icons
+   * <IconProvider icons={{ bold: "mdi:format-bold", italic: "mdi:format-italic" }}>
+   *   <App />
+   * </IconProvider>
+   *
+   * // Use Heroicons
+   * <IconProvider icons={{ check: "heroicons:check", warning: "heroicons:exclamation-triangle" }}>
+   *   <App />
+   * </IconProvider>
+   * ```
+   */
+  icons?: CustomIconMap;
+  children: ReactNode;
+}
+
+/**
+ * Provider component for customizing icons throughout the application.
+ * Wrap your application or editor with this provider to use custom icon sets.
+ *
+ * @example
+ * ```tsx
+ * import { IconProvider } from "@vizel/react";
+ *
+ * // Use Phosphor icons
+ * const phosphorIcons = {
+ *   heading1: "ph:text-h-one",
+ *   heading2: "ph:text-h-two",
+ *   bold: "ph:text-b-bold",
+ *   italic: "ph:text-italic",
+ *   // ... more icons
+ * };
+ *
+ * function App() {
+ *   return (
+ *     <IconProvider icons={phosphorIcons}>
+ *       <VizelEditor />
+ *     </IconProvider>
+ *   );
+ * }
+ * ```
+ */
+export function IconProvider({ icons, children }: IconProviderProps) {
+  return <IconContext.Provider value={{ customIcons: icons }}>{children}</IconContext.Provider>;
+}
+
+/**
+ * Hook to access custom icon mappings from IconProvider.
+ * Returns undefined if no IconProvider is present (falls back to defaults).
+ */
+export function useIconContext(): IconContextValue {
+  return useContext(IconContext);
+}

--- a/packages/react/src/components/NodeSelector.tsx
+++ b/packages/react/src/components/NodeSelector.tsx
@@ -1,6 +1,7 @@
 import { defaultNodeTypes, type Editor, getActiveNodeType, type NodeTypeOption } from "@vizel/core";
 import { useEffect, useRef, useState } from "react";
 import { useEditorState } from "../hooks/useEditorState.ts";
+import { Icon } from "./Icon.tsx";
 
 export interface NodeSelectorProps {
   /** The editor instance */
@@ -35,7 +36,7 @@ export function NodeSelector({
 
   const activeNodeType = getActiveNodeType(editor, nodeTypes);
   const currentLabel = activeNodeType?.label ?? "Text";
-  const currentIcon = activeNodeType?.icon ?? "¶";
+  const currentIcon = activeNodeType?.icon ?? "paragraph";
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -126,10 +127,12 @@ export function NodeSelector({
         aria-label={`Current block type: ${currentLabel}`}
         title="Change block type"
       >
-        <span className="vizel-node-selector-icon">{currentIcon}</span>
+        <span className="vizel-node-selector-icon">
+          <Icon name={currentIcon} />
+        </span>
         <span className="vizel-node-selector-label">{currentLabel}</span>
         <span className="vizel-node-selector-chevron" aria-hidden="true">
-          ▼
+          <Icon name="chevronDown" />
         </span>
       </button>
 
@@ -158,11 +161,13 @@ export function NodeSelector({
                 onMouseEnter={() => setFocusedIndex(index)}
                 tabIndex={isFocused ? 0 : -1}
               >
-                <span className="vizel-node-selector-option-icon">{nodeType.icon}</span>
+                <span className="vizel-node-selector-option-icon">
+                  <Icon name={nodeType.icon} />
+                </span>
                 <span className="vizel-node-selector-option-label">{nodeType.label}</span>
                 {isActive && (
                   <span className="vizel-node-selector-check" aria-hidden="true">
-                    ✓
+                    <Icon name="check" />
                   </span>
                 )}
               </button>

--- a/packages/react/src/components/SaveIndicator.tsx
+++ b/packages/react/src/components/SaveIndicator.tsx
@@ -1,5 +1,6 @@
 import { formatRelativeTime, type SaveStatus } from "@vizel/core";
 import { useEffect, useState } from "react";
+import { Icon } from "./Icon.tsx";
 
 export interface SaveIndicatorProps {
   /** Current save status */
@@ -52,17 +53,17 @@ export function SaveIndicator({
   const getStatusIcon = () => {
     switch (status) {
       case "saved":
-        return "✓";
+        return <Icon name="check" />;
       case "saving":
         return (
           <span className="vizel-save-indicator-spinner" aria-hidden="true">
-            ⟳
+            <Icon name="loader" />
           </span>
         );
       case "unsaved":
-        return "•";
+        return <Icon name="circle" />;
       case "error":
-        return "⚠";
+        return <Icon name="warning" />;
       default:
         return null;
     }

--- a/packages/react/src/components/SlashMenuItem.tsx
+++ b/packages/react/src/components/SlashMenuItem.tsx
@@ -1,4 +1,5 @@
 import type { SlashCommandItem } from "@vizel/core";
+import { Icon } from "./Icon.tsx";
 
 export interface SlashMenuItemProps {
   item: SlashCommandItem;
@@ -69,7 +70,9 @@ export function SlashMenuItem({
       onClick={onClick}
       data-selected={isSelected || undefined}
     >
-      <span className="vizel-slash-menu-icon">{item.icon}</span>
+      <span className="vizel-slash-menu-icon">
+        <Icon name={item.icon} />
+      </span>
       <div className="vizel-slash-menu-text">
         <span className="vizel-slash-menu-title">{highlightMatches(item.title, titleMatches)}</span>
         <span className="vizel-slash-menu-description">{item.description}</span>

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -22,14 +22,21 @@ export {
 } from "./BubbleMenuToolbar.tsx";
 // ColorPicker component
 export { ColorPicker, type ColorPickerProps } from "./ColorPicker.tsx";
-
 // Editor components
 export { EditorContent, type EditorContentProps } from "./EditorContent.tsx";
 export { useEditorContext, useEditorContextSafe } from "./EditorContext.tsx";
 export { EditorRoot, type EditorRootProps } from "./EditorRoot.tsx";
-
 // EmbedView component
 export { EmbedView, type EmbedViewProps } from "./EmbedView.tsx";
+// Icon component
+export { Icon, type IconProps } from "./Icon.tsx";
+export {
+  type CustomIconMap,
+  type IconContextValue,
+  IconProvider,
+  type IconProviderProps,
+  useIconContext,
+} from "./IconContext.tsx";
 
 // NodeSelector component
 export { NodeSelector, type NodeSelectorProps } from "./NodeSelector.tsx";

--- a/packages/react/src/iconRenderer.ts
+++ b/packages/react/src/iconRenderer.ts
@@ -1,0 +1,66 @@
+/**
+ * Icon renderer implementation for React package.
+ * Uses Iconify utilities to render SVG strings from icon data.
+ */
+
+import type { IconifyIcon } from "@iconify/utils";
+import { getIconData, iconToSVG } from "@iconify/utils";
+import lucide from "@iconify-json/lucide/icons.json";
+import {
+  defaultIconIds,
+  type IconRendererOptions,
+  type InternalIconName,
+  setIconRenderer,
+} from "@vizel/core";
+
+/**
+ * Render an Iconify icon as an SVG string.
+ */
+function renderIconSvg(name: InternalIconName, options?: IconRendererOptions): string {
+  const iconId = defaultIconIds[name];
+  if (!iconId) return "";
+
+  // Parse icon ID (format: "prefix:name")
+  const [, iconName] = iconId.split(":");
+  if (!iconName) return "";
+
+  // Get icon data from the Lucide icon set
+  const iconData = getIconData(lucide, iconName) as IconifyIcon | null;
+  if (!iconData) return "";
+
+  // Convert icon data to SVG
+  const result = iconToSVG(iconData, {
+    height: options?.height ?? 24,
+    width: options?.width ?? 24,
+  });
+
+  // Build SVG element
+  const attrs: string[] = [
+    'xmlns="http://www.w3.org/2000/svg"',
+    `width="${options?.width ?? 24}"`,
+    `height="${options?.height ?? 24}"`,
+    `viewBox="0 0 ${iconData.width ?? 24} ${iconData.height ?? 24}"`,
+  ];
+
+  // Add additional attributes from the result
+  if (result.attributes) {
+    for (const [key, value] of Object.entries(result.attributes)) {
+      if (!["width", "height", "viewBox"].includes(key)) {
+        attrs.push(`${key}="${value}"`);
+      }
+    }
+  }
+
+  return `<svg ${attrs.join(" ")}>${result.body}</svg>`;
+}
+
+/**
+ * Initialize the icon renderer for the React package.
+ * This should be called once when the package is loaded.
+ */
+export function initIconRenderer(): void {
+  setIconRenderer(renderIconSvg);
+}
+
+// Auto-initialize when this module is imported
+initIconRenderer();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,9 @@
  * React components and hooks for the Vizel visual editor.
  */
 
+// Initialize icon renderer (auto-registers with core)
+import "./iconRenderer.ts";
+
 // Re-export core types for convenience
 // Re-export auto-save types from core
 export type {
@@ -133,10 +136,16 @@ export {
   type BubbleMenuToolbarProps,
   ColorPicker,
   type ColorPickerProps,
+  type CustomIconMap,
   EditorContent,
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  Icon,
+  type IconContextValue,
+  type IconProps,
+  IconProvider,
+  type IconProviderProps,
   Portal,
   type PortalProps,
   SaveIndicator,
@@ -152,6 +161,7 @@ export {
   type ThemeProviderProps,
   useEditorContext,
   useEditorContextSafe,
+  useIconContext,
   useTheme,
   useThemeSafe,
 } from "./components/index.ts";

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -32,6 +32,7 @@
     "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
+    "@iconify/svelte": "^4",
     "@tiptap/core": "^3.14.0",
     "@tiptap/suggestion": "^3.14.0",
     "@vizel/core": "workspace:*"
@@ -40,6 +41,8 @@
     "svelte": "^5"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "^1.2.82",
+    "@iconify/utils": "^3.1.0",
     "@sveltejs/package": "^2",
     "@sveltejs/vite-plugin-svelte": "^5",
     "svelte-check": "^4"

--- a/packages/svelte/src/components/BubbleMenuColorPicker.svelte
+++ b/packages/svelte/src/components/BubbleMenuColorPicker.svelte
@@ -26,6 +26,7 @@ import {
 } from "@vizel/core";
 import { onMount, onDestroy } from "svelte";
 import ColorPicker from "./ColorPicker.svelte";
+import Icon from "./Icon.svelte";
 
 let {
   editor,
@@ -113,11 +114,9 @@ function getTriggerStyle(): string {
     onclick={() => (isOpen = !isOpen)}
   >
     {#if isTextColor}
-      A
+      <Icon name="textColor" />
     {:else}
-      <span class="vizel-color-picker-highlight-icon">
-        <span class="vizel-color-picker-highlight-bar"></span>
-      </span>
+      <Icon name="highlighter" />
     {/if}
   </button>
 

--- a/packages/svelte/src/components/BubbleMenuLinkEditor.svelte
+++ b/packages/svelte/src/components/BubbleMenuLinkEditor.svelte
@@ -16,6 +16,7 @@ export interface BubbleMenuLinkEditorProps {
 <script lang="ts">
 import { detectProvider } from "@vizel/core";
 import { onMount, untrack } from "svelte";
+import Icon from "./Icon.svelte";
 
 let {
   editor,
@@ -116,7 +117,7 @@ function handleRemove() {
       class="vizel-link-input"
     />
     <button type="submit" class="vizel-link-button" title="Apply">
-      OK
+      <Icon name="check" />
     </button>
     {#if currentHref}
       <button
@@ -125,7 +126,7 @@ function handleRemove() {
         title="Remove link"
         onclick={handleRemove}
       >
-        X
+        <Icon name="x" />
       </button>
     {/if}
   </div>

--- a/packages/svelte/src/components/BubbleMenuToolbar.svelte
+++ b/packages/svelte/src/components/BubbleMenuToolbar.svelte
@@ -16,6 +16,7 @@ import { createEditorState } from "../runes/createEditorState.svelte.ts";
 import BubbleMenuButton from "./BubbleMenuButton.svelte";
 import BubbleMenuColorPicker from "./BubbleMenuColorPicker.svelte";
 import BubbleMenuLinkEditor from "./BubbleMenuLinkEditor.svelte";
+import Icon from "./Icon.svelte";
 import NodeSelector from "./NodeSelector.svelte";
 
 let { editor, class: className, enableEmbed }: BubbleMenuToolbarProps = $props();
@@ -62,7 +63,7 @@ const isLinkActive = $derived.by(() => {
       title="Bold (Cmd+B)"
       onclick={() => editor.chain().focus().toggleBold().run()}
     >
-      <strong>B</strong>
+      <Icon name="bold" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="italic"
@@ -70,7 +71,7 @@ const isLinkActive = $derived.by(() => {
       title="Italic (Cmd+I)"
       onclick={() => editor.chain().focus().toggleItalic().run()}
     >
-      <em>I</em>
+      <Icon name="italic" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="strike"
@@ -78,7 +79,7 @@ const isLinkActive = $derived.by(() => {
       title="Strikethrough"
       onclick={() => editor.chain().focus().toggleStrike().run()}
     >
-      <s>S</s>
+      <Icon name="strikethrough" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="underline"
@@ -86,7 +87,7 @@ const isLinkActive = $derived.by(() => {
       title="Underline (Cmd+U)"
       onclick={() => editor.chain().focus().toggleUnderline().run()}
     >
-      <u>U</u>
+      <Icon name="underline" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="code"
@@ -94,7 +95,7 @@ const isLinkActive = $derived.by(() => {
       title="Code (Cmd+E)"
       onclick={() => editor.chain().focus().toggleCode().run()}
     >
-      <code>&lt;/&gt;</code>
+      <Icon name="code" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="link"
@@ -102,7 +103,7 @@ const isLinkActive = $derived.by(() => {
       title="Link (Cmd+K)"
       onclick={() => (showLinkEditor = true)}
     >
-      <span>L</span>
+      <Icon name="link" />
     </BubbleMenuButton>
     <BubbleMenuColorPicker {editor} type="textColor" />
     <BubbleMenuColorPicker {editor} type="highlight" />

--- a/packages/svelte/src/components/ColorPicker.svelte
+++ b/packages/svelte/src/components/ColorPicker.svelte
@@ -26,6 +26,7 @@ export interface ColorPickerProps {
 <script lang="ts">
 import { isValidHexColor, normalizeHexColor } from "@vizel/core";
 import { onMount } from "svelte";
+import Icon from "./Icon.svelte";
 
 const GRID_COLUMNS = 4;
 
@@ -201,7 +202,7 @@ const previewColor = $derived(isInputValid ? normalizeHexColor(inputValue) : und
             onkeydown={(e) => handleKeyDown(e, idx)}
           >
             {#if isNoneValue(color)}
-              <span class="vizel-color-picker-none">×</span>
+              <span class="vizel-color-picker-none"><Icon name="x" /></span>
             {/if}
           </button>
         {/each}
@@ -228,7 +229,7 @@ const previewColor = $derived(isInputValid ? normalizeHexColor(inputValue) : und
           onkeydown={(e) => handleKeyDown(e, idx)}
         >
           {#if isNoneValue(colorDef.color)}
-            <span class="vizel-color-picker-none">×</span>
+            <span class="vizel-color-picker-none"><Icon name="x" /></span>
           {/if}
         </button>
       {/each}
@@ -262,7 +263,7 @@ const previewColor = $derived(isInputValid ? normalizeHexColor(inputValue) : und
         aria-label="Apply custom color"
         onclick={handleInputSubmit}
       >
-        ✓
+        <Icon name="check" />
       </button>
     </div>
   {/if}

--- a/packages/svelte/src/components/EmbedView.svelte
+++ b/packages/svelte/src/components/EmbedView.svelte
@@ -13,6 +13,7 @@ export interface EmbedViewProps {
 
 <script lang="ts">
 import { onMount } from "svelte";
+import Icon from "./Icon.svelte";
 
 let { data, class: className, selected = false }: EmbedViewProps = $props();
 
@@ -146,7 +147,7 @@ onMount(loadScripts);
     data-embed-provider={data.provider}
   >
     <a href={data.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon">🔗</span>
+      <span class="vizel-embed-link-icon"><Icon name="link" /></span>
       <span class="vizel-embed-link-text">{data.title}</span>
     </a>
   </div>
@@ -158,7 +159,7 @@ onMount(loadScripts);
     data-embed-provider={data.provider}
   >
     <a href={data.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon">🔗</span>
+      <span class="vizel-embed-link-icon"><Icon name="link" /></span>
       <span class="vizel-embed-link-text">{data.url}</span>
     </a>
   </div>

--- a/packages/svelte/src/components/Icon.svelte
+++ b/packages/svelte/src/components/Icon.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+import type { IconifyIconProps } from "@iconify/svelte";
+import Icon from "@iconify/svelte";
+import { defaultIconIds, type IconName } from "@vizel/core";
+import { type CustomIconMap, getIconContext } from "./IconContext";
+
+interface Props {
+  /**
+   * The semantic icon name from Vizel's icon system.
+   */
+  name: IconName;
+  /**
+   * Custom icon mappings to override default Iconify icon IDs.
+   * If provided, will take precedence over context icons.
+   */
+  customIcons?: CustomIconMap;
+  /**
+   * Icon width in pixels or CSS value.
+   */
+  width?: string | number;
+  /**
+   * Icon height in pixels or CSS value.
+   */
+  height?: string | number;
+  /**
+   * Icon color.
+   */
+  color?: string;
+  /**
+   * Additional CSS class.
+   */
+  class?: string;
+}
+
+const { name, customIcons, width, height, color, class: className }: Props = $props();
+const { customIcons: contextIcons } = getIconContext();
+
+const iconId = $derived(customIcons?.[name] ?? contextIcons?.[name] ?? defaultIconIds[name]);
+
+// Build props object excluding undefined values to satisfy exactOptionalPropertyTypes
+const iconProps = $derived.by(() => {
+  const props: IconifyIconProps = { icon: iconId };
+  if (width !== undefined) props.width = width;
+  if (height !== undefined) props.height = height;
+  if (color !== undefined) props.color = color;
+  return props;
+});
+</script>
+
+<Icon {...iconProps} class={className} style="pointer-events: none;" />

--- a/packages/svelte/src/components/IconContext.ts
+++ b/packages/svelte/src/components/IconContext.ts
@@ -1,0 +1,57 @@
+import type { IconName } from "@vizel/core";
+import { getContext, setContext } from "svelte";
+
+/**
+ * Custom icon mappings to override default Iconify icon IDs.
+ * Keys are semantic icon names, values are Iconify icon IDs.
+ *
+ * @example
+ * ```ts
+ * const customIcons: CustomIconMap = {
+ *   heading1: "mdi:format-header-1",
+ *   bold: "mdi:format-bold",
+ *   // Use any Iconify icon set: Material Design, Heroicons, Phosphor, etc.
+ * };
+ * ```
+ */
+export type CustomIconMap = Partial<Record<IconName, string>>;
+
+export interface IconContextValue {
+  /**
+   * Custom icon mappings that override default Lucide icons.
+   */
+  customIcons?: CustomIconMap | undefined;
+}
+
+const ICON_CONTEXT_KEY = Symbol("vizel-icon-context");
+
+/**
+ * Set custom icon mappings for child components.
+ * Call this in a parent component to customize icons for all descendants.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { setIconContext } from "@vizel/svelte";
+ *
+ *   // Use Phosphor icons
+ *   setIconContext({
+ *     heading1: "ph:text-h-one",
+ *     heading2: "ph:text-h-two",
+ *     bold: "ph:text-b-bold",
+ *     italic: "ph:text-italic",
+ *   });
+ * </script>
+ * ```
+ */
+export function setIconContext(customIcons?: CustomIconMap): void {
+  setContext(ICON_CONTEXT_KEY, { customIcons } satisfies IconContextValue);
+}
+
+/**
+ * Get custom icon mappings from parent context.
+ * Returns an empty object if no context is set.
+ */
+export function getIconContext(): IconContextValue {
+  return getContext<IconContextValue>(ICON_CONTEXT_KEY) ?? {};
+}

--- a/packages/svelte/src/components/NodeSelector.svelte
+++ b/packages/svelte/src/components/NodeSelector.svelte
@@ -15,6 +15,7 @@ export interface NodeSelectorProps {
 import { defaultNodeTypes, getActiveNodeType } from "@vizel/core";
 import { onMount } from "svelte";
 import { createEditorState } from "../runes/createEditorState.svelte.ts";
+import Icon from "./Icon.svelte";
 
 let { editor, nodeTypes = defaultNodeTypes, class: className }: NodeSelectorProps = $props();
 
@@ -32,7 +33,7 @@ const activeNodeType = $derived.by(() => {
 });
 
 const currentLabel = $derived(activeNodeType?.label ?? "Text");
-const currentIcon = $derived(activeNodeType?.icon ?? "¶");
+const currentIcon = $derived(activeNodeType?.icon ?? "paragraph");
 
 // Close dropdown when clicking outside
 function handleClickOutside(event: MouseEvent) {
@@ -125,9 +126,13 @@ function isNodeTypeActive(nodeType: NodeTypeOption): boolean {
     onclick={() => (isOpen = !isOpen)}
     onkeydown={handleKeyDown}
   >
-    <span class="vizel-node-selector-icon">{currentIcon}</span>
+    <span class="vizel-node-selector-icon">
+      <Icon name={currentIcon} />
+    </span>
     <span class="vizel-node-selector-label">{currentLabel}</span>
-    <span class="vizel-node-selector-chevron" aria-hidden="true">▼</span>
+    <span class="vizel-node-selector-chevron" aria-hidden="true">
+      <Icon name="chevronDown" />
+    </span>
   </button>
 
   {#if isOpen}
@@ -152,10 +157,14 @@ function isNodeTypeActive(nodeType: NodeTypeOption): boolean {
           onclick={() => handleSelectNodeType(nodeType)}
           onmouseenter={() => (focusedIndex = index)}
         >
-          <span class="vizel-node-selector-option-icon">{nodeType.icon}</span>
+          <span class="vizel-node-selector-option-icon">
+            <Icon name={nodeType.icon} />
+          </span>
           <span class="vizel-node-selector-option-label">{nodeType.label}</span>
           {#if active}
-            <span class="vizel-node-selector-check" aria-hidden="true">✓</span>
+            <span class="vizel-node-selector-check" aria-hidden="true">
+              <Icon name="check" />
+            </span>
           {/if}
         </button>
       {/each}

--- a/packages/svelte/src/components/SaveIndicator.svelte
+++ b/packages/svelte/src/components/SaveIndicator.svelte
@@ -16,6 +16,7 @@ export interface SaveIndicatorProps {
 <script lang="ts">
 import { formatRelativeTime } from "@vizel/core";
 import { onMount } from "svelte";
+import Icon from "./Icon.svelte";
 
 let {
   status,
@@ -76,13 +77,15 @@ const shouldShowTimestamp = $derived(showTimestamp && lastSaved && relativeTime 
 >
   <span class="vizel-save-indicator-icon" aria-hidden="true">
     {#if status === "saved"}
-      ✓
+      <Icon name="check" />
     {:else if status === "saving"}
-      <span class="vizel-save-indicator-spinner" aria-hidden="true">⟳</span>
+      <span class="vizel-save-indicator-spinner" aria-hidden="true">
+        <Icon name="loader" />
+      </span>
     {:else if status === "unsaved"}
-      •
+      <Icon name="circle" />
     {:else if status === "error"}
-      ⚠
+      <Icon name="warning" />
     {/if}
   </span>
   <span class="vizel-save-indicator-text">{statusText}</span>

--- a/packages/svelte/src/components/SlashMenuItem.svelte
+++ b/packages/svelte/src/components/SlashMenuItem.svelte
@@ -48,6 +48,8 @@ export function highlightMatches(
 </script>
 
 <script lang="ts">
+import Icon from "./Icon.svelte";
+
 let {
   item,
   isSelected = false,
@@ -65,7 +67,9 @@ const parts = $derived(highlightMatches(item.title, titleMatches));
   data-selected={isSelected || undefined}
   {onclick}
 >
-  <span class="vizel-slash-menu-icon">{item.icon}</span>
+  <span class="vizel-slash-menu-icon">
+    <Icon name={item.icon} />
+  </span>
   <div class="vizel-slash-menu-text">
     <span class="vizel-slash-menu-title">
       {#each parts as part}

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -28,7 +28,6 @@ export {
   type ColorPickerProps,
   default as ColorPicker,
 } from "./ColorPicker.svelte";
-
 // Editor components
 export {
   default as EditorContent,
@@ -36,12 +35,19 @@ export {
 } from "./EditorContent.svelte";
 export { getEditorContext, getEditorContextSafe } from "./EditorContext.ts";
 export { default as EditorRoot, type EditorRootProps } from "./EditorRoot.svelte";
-
 // EmbedView component
 export {
   default as EmbedView,
   type EmbedViewProps,
 } from "./EmbedView.svelte";
+// Icon component
+export { default as Icon } from "./Icon.svelte";
+export {
+  type CustomIconMap,
+  getIconContext,
+  type IconContextValue,
+  setIconContext,
+} from "./IconContext.ts";
 
 // NodeSelector component
 export {

--- a/packages/svelte/src/iconRenderer.ts
+++ b/packages/svelte/src/iconRenderer.ts
@@ -1,0 +1,66 @@
+/**
+ * Icon renderer implementation for Svelte package.
+ * Uses Iconify utilities to render SVG strings from icon data.
+ */
+
+import type { IconifyIcon } from "@iconify/utils";
+import { getIconData, iconToSVG } from "@iconify/utils";
+import lucide from "@iconify-json/lucide/icons.json";
+import {
+  defaultIconIds,
+  type IconRendererOptions,
+  type InternalIconName,
+  setIconRenderer,
+} from "@vizel/core";
+
+/**
+ * Render an Iconify icon as an SVG string.
+ */
+function renderIconSvg(name: InternalIconName, options?: IconRendererOptions): string {
+  const iconId = defaultIconIds[name];
+  if (!iconId) return "";
+
+  // Parse icon ID (format: "prefix:name")
+  const [, iconName] = iconId.split(":");
+  if (!iconName) return "";
+
+  // Get icon data from the Lucide icon set
+  const iconData = getIconData(lucide, iconName) as IconifyIcon | null;
+  if (!iconData) return "";
+
+  // Convert icon data to SVG
+  const result = iconToSVG(iconData, {
+    height: options?.height ?? 24,
+    width: options?.width ?? 24,
+  });
+
+  // Build SVG element
+  const attrs: string[] = [
+    'xmlns="http://www.w3.org/2000/svg"',
+    `width="${options?.width ?? 24}"`,
+    `height="${options?.height ?? 24}"`,
+    `viewBox="0 0 ${iconData.width ?? 24} ${iconData.height ?? 24}"`,
+  ];
+
+  // Add additional attributes from the result
+  if (result.attributes) {
+    for (const [key, value] of Object.entries(result.attributes)) {
+      if (!["width", "height", "viewBox"].includes(key)) {
+        attrs.push(`${key}="${value}"`);
+      }
+    }
+  }
+
+  return `<svg ${attrs.join(" ")}>${result.body}</svg>`;
+}
+
+/**
+ * Initialize the icon renderer for the Svelte package.
+ * This should be called once when the package is loaded.
+ */
+export function initIconRenderer(): void {
+  setIconRenderer(renderIconSvg);
+}
+
+// Auto-initialize when this module is imported
+initIconRenderer();

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -4,6 +4,9 @@
  * Svelte 5 components and runes for the Vizel visual editor.
  */
 
+// Initialize icon renderer (auto-registers with core)
+import "./iconRenderer.ts";
+
 // Re-export core types for convenience
 // Re-export auto-save types from core
 export type {
@@ -133,12 +136,16 @@ export {
   type BubbleMenuToolbarProps,
   ColorPicker,
   type ColorPickerProps,
+  type CustomIconMap,
   EditorContent,
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
   getEditorContext,
   getEditorContextSafe,
+  getIconContext,
+  Icon,
+  type IconContextValue,
   Portal,
   type PortalProps,
   SaveIndicator,
@@ -150,6 +157,7 @@ export {
   type SlashMenuItemProps,
   type SlashMenuProps,
   type SlashMenuRef,
+  setIconContext,
   THEME_CONTEXT_KEY,
   ThemeProvider,
 } from "./components/index.ts";

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,6 +28,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@iconify/vue": "^5",
     "@tiptap/suggestion": "^3.14.0",
     "@vizel/core": "workspace:*"
   },
@@ -35,6 +36,8 @@
     "vue": "^3.4"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "^1.2.82",
+    "@iconify/utils": "^3.1.0",
     "@vitejs/plugin-vue": "^5",
     "vite": "^7",
     "vite-plugin-dts": "^4",

--- a/packages/vue/src/components/BubbleMenuColorPicker.vue
+++ b/packages/vue/src/components/BubbleMenuColorPicker.vue
@@ -9,6 +9,7 @@ import {
 } from "@vizel/core";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import ColorPicker from "./ColorPicker.vue";
+import Icon from "./Icon.vue";
 
 export interface BubbleMenuColorPickerProps {
   /** The editor instance */
@@ -109,10 +110,8 @@ function getTriggerStyle() {
       :style="getTriggerStyle()"
       @click="isOpen = !isOpen"
     >
-      <template v-if="isTextColor">A</template>
-      <span v-else class="vizel-color-picker-highlight-icon">
-        <span class="vizel-color-picker-highlight-bar" />
-      </span>
+      <Icon v-if="isTextColor" name="textColor" />
+      <Icon v-else name="highlighter" />
     </button>
 
     <div v-if="isOpen" class="vizel-color-picker-dropdown">

--- a/packages/vue/src/components/BubbleMenuLinkEditor.vue
+++ b/packages/vue/src/components/BubbleMenuLinkEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { detectProvider, type Editor } from "@vizel/core";
 import { computed, onMounted, onUnmounted, ref } from "vue";
+import Icon from "./Icon.vue";
 
 export interface BubbleMenuLinkEditorProps {
   /** The editor instance */
@@ -111,7 +112,7 @@ function handleRemove() {
         class="vizel-link-input"
       />
       <button type="submit" class="vizel-link-button" title="Apply">
-        OK
+        <Icon name="check" />
       </button>
       <button
         v-if="currentHref"
@@ -120,7 +121,7 @@ function handleRemove() {
         title="Remove link"
         @click="handleRemove"
       >
-        X
+        <Icon name="x" />
       </button>
     </div>
     <div v-if="canEmbed && isEmbedProvider" class="vizel-link-editor-embed-toggle">

--- a/packages/vue/src/components/BubbleMenuToolbar.vue
+++ b/packages/vue/src/components/BubbleMenuToolbar.vue
@@ -5,6 +5,7 @@ import { useEditorState } from "../composables/useEditorState.ts";
 import BubbleMenuButton from "./BubbleMenuButton.vue";
 import BubbleMenuColorPicker from "./BubbleMenuColorPicker.vue";
 import BubbleMenuLinkEditor from "./BubbleMenuLinkEditor.vue";
+import Icon from "./Icon.vue";
 import NodeSelector from "./NodeSelector.vue";
 
 export interface BubbleMenuToolbarProps {
@@ -65,7 +66,7 @@ const showLinkEditor = ref(false);
       title="Bold (Cmd+B)"
       @click="props.editor.chain().focus().toggleBold().run()"
     >
-      <strong>B</strong>
+      <Icon name="bold" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="italic"
@@ -73,7 +74,7 @@ const showLinkEditor = ref(false);
       title="Italic (Cmd+I)"
       @click="props.editor.chain().focus().toggleItalic().run()"
     >
-      <em>I</em>
+      <Icon name="italic" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="strike"
@@ -81,7 +82,7 @@ const showLinkEditor = ref(false);
       title="Strikethrough"
       @click="props.editor.chain().focus().toggleStrike().run()"
     >
-      <s>S</s>
+      <Icon name="strikethrough" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="underline"
@@ -89,7 +90,7 @@ const showLinkEditor = ref(false);
       title="Underline (Cmd+U)"
       @click="props.editor.chain().focus().toggleUnderline().run()"
     >
-      <u>U</u>
+      <Icon name="underline" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="code"
@@ -97,7 +98,7 @@ const showLinkEditor = ref(false);
       title="Code (Cmd+E)"
       @click="props.editor.chain().focus().toggleCode().run()"
     >
-      <code>&lt;/&gt;</code>
+      <Icon name="code" />
     </BubbleMenuButton>
     <BubbleMenuButton
       action="link"
@@ -105,7 +106,7 @@ const showLinkEditor = ref(false);
       title="Link (Cmd+K)"
       @click="showLinkEditor = true"
     >
-      <span>L</span>
+      <Icon name="link" />
     </BubbleMenuButton>
     <BubbleMenuColorPicker :editor="props.editor" type="textColor" />
     <BubbleMenuColorPicker :editor="props.editor" type="highlight" />

--- a/packages/vue/src/components/ColorPicker.vue
+++ b/packages/vue/src/components/ColorPicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { type ColorDefinition, isValidHexColor, normalizeHexColor } from "@vizel/core";
 import { computed, onMounted, ref, watch } from "vue";
+import Icon from "./Icon.vue";
 
 export interface ColorPickerProps {
   /** Color palette to display */
@@ -206,7 +207,7 @@ const previewColor = computed(() =>
           @click="handleSelect(color)"
           @keydown="handleKeyDown($event, idx)"
         >
-          <span v-if="isNoneValue(color)" class="vizel-color-picker-none">×</span>
+          <span v-if="isNoneValue(color)" class="vizel-color-picker-none"><Icon name="x" /></span>
         </button>
       </div>
     </div>
@@ -229,7 +230,7 @@ const previewColor = computed(() =>
           @click="handleSelect(colorDef.color)"
           @keydown="handleKeyDown($event, paletteOffset + i)"
         >
-          <span v-if="isNoneValue(colorDef.color)" class="vizel-color-picker-none">×</span>
+          <span v-if="isNoneValue(colorDef.color)" class="vizel-color-picker-none"><Icon name="x" /></span>
         </button>
       </div>
     </div>
@@ -260,7 +261,7 @@ const previewColor = computed(() =>
         aria-label="Apply custom color"
         @click="handleInputSubmit"
       >
-        ✓
+        <Icon name="check" />
       </button>
     </div>
   </div>

--- a/packages/vue/src/components/EmbedView.vue
+++ b/packages/vue/src/components/EmbedView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { EmbedData, EmbedType } from "@vizel/core";
 import { computed, onMounted, ref, watch } from "vue";
+import Icon from "./Icon.vue";
 
 export interface EmbedViewProps {
   /** Embed data */
@@ -135,7 +136,7 @@ watch(() => [props.data.type, props.data.html], loadScripts);
     :data-embed-provider="data.provider"
   >
     <a :href="data.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon">🔗</span>
+      <span class="vizel-embed-link-icon"><Icon name="link" /></span>
       <span class="vizel-embed-link-text">{{ data.title }}</span>
     </a>
   </div>
@@ -148,7 +149,7 @@ watch(() => [props.data.type, props.data.html], loadScripts);
     :data-embed-provider="data.provider"
   >
     <a :href="data.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon">🔗</span>
+      <span class="vizel-embed-link-icon"><Icon name="link" /></span>
       <span class="vizel-embed-link-text">{{ data.url }}</span>
     </a>
   </div>

--- a/packages/vue/src/components/Icon.vue
+++ b/packages/vue/src/components/Icon.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { Icon as IconifyIcon } from "@iconify/vue";
+import { defaultIconIds, type IconName } from "@vizel/core";
+import { computed } from "vue";
+import { type CustomIconMap, useIconContext } from "./IconContext";
+
+export interface IconProps {
+  /**
+   * The semantic icon name from Vizel's icon system.
+   */
+  name: IconName;
+  /**
+   * Custom icon mappings to override default Iconify icon IDs.
+   * If provided, will take precedence over context icons.
+   */
+  customIcons?: CustomIconMap;
+  /**
+   * Icon width in pixels or CSS value.
+   */
+  width?: string | number;
+  /**
+   * Icon height in pixels or CSS value.
+   */
+  height?: string | number;
+  /**
+   * Icon color.
+   */
+  color?: string;
+}
+
+const props = defineProps<IconProps>();
+const { customIcons: contextIcons } = useIconContext();
+
+const iconId = computed(
+  () => props.customIcons?.[props.name] ?? contextIcons?.[props.name] ?? defaultIconIds[props.name]
+);
+</script>
+
+<template>
+  <IconifyIcon
+    :icon="iconId"
+    :style="{ pointerEvents: 'none' }"
+    v-bind="{
+      ...(props.width !== undefined && { width: props.width }),
+      ...(props.height !== undefined && { height: props.height }),
+      ...(props.color !== undefined && { color: props.color }),
+    }"
+  />
+</template>

--- a/packages/vue/src/components/IconContext.ts
+++ b/packages/vue/src/components/IconContext.ts
@@ -1,0 +1,61 @@
+import type { IconName } from "@vizel/core";
+import type { InjectionKey } from "vue";
+import { inject, provide } from "vue";
+
+/**
+ * Custom icon mappings to override default Iconify icon IDs.
+ * Keys are semantic icon names, values are Iconify icon IDs.
+ *
+ * @example
+ * ```ts
+ * const customIcons: CustomIconMap = {
+ *   heading1: "mdi:format-header-1",
+ *   bold: "mdi:format-bold",
+ *   // Use any Iconify icon set: Material Design, Heroicons, Phosphor, etc.
+ * };
+ * ```
+ */
+export type CustomIconMap = Partial<Record<IconName, string>>;
+
+export interface IconContextValue {
+  /**
+   * Custom icon mappings that override default Lucide icons.
+   */
+  customIcons?: CustomIconMap | undefined;
+}
+
+/**
+ * Injection key for icon context.
+ */
+export const IconContextKey: InjectionKey<IconContextValue> = Symbol("vizel-icon-context");
+
+/**
+ * Provide custom icon mappings to child components.
+ * Call this in a parent component's setup to customize icons for all descendants.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { provideIconContext } from "@vizel/vue";
+ *
+ * // Use Phosphor icons
+ * provideIconContext({
+ *   heading1: "ph:text-h-one",
+ *   heading2: "ph:text-h-two",
+ *   bold: "ph:text-b-bold",
+ *   italic: "ph:text-italic",
+ * });
+ * </script>
+ * ```
+ */
+export function provideIconContext(customIcons?: CustomIconMap): void {
+  provide(IconContextKey, { customIcons });
+}
+
+/**
+ * Inject custom icon mappings from parent IconProvider.
+ * Returns an empty object if no provider is present.
+ */
+export function useIconContext(): IconContextValue {
+  return inject(IconContextKey, {});
+}

--- a/packages/vue/src/components/NodeSelector.vue
+++ b/packages/vue/src/components/NodeSelector.vue
@@ -2,6 +2,7 @@
 import { defaultNodeTypes, type Editor, getActiveNodeType, type NodeTypeOption } from "@vizel/core";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useEditorState } from "../composables/useEditorState.ts";
+import Icon from "./Icon.vue";
 
 export interface NodeSelectorProps {
   /** The editor instance */
@@ -30,7 +31,7 @@ const activeNodeType = computed(() => {
 });
 
 const currentLabel = computed(() => activeNodeType.value?.label ?? "Text");
-const currentIcon = computed(() => activeNodeType.value?.icon ?? "¶");
+const currentIcon = computed(() => activeNodeType.value?.icon ?? "paragraph");
 
 // Close dropdown when clicking outside
 function handleClickOutside(event: MouseEvent) {
@@ -130,9 +131,13 @@ function isNodeTypeActive(nodeType: NodeTypeOption): boolean {
       @click="isOpen = !isOpen"
       @keydown="handleKeyDown"
     >
-      <span class="vizel-node-selector-icon">{{ currentIcon }}</span>
+      <span class="vizel-node-selector-icon">
+        <Icon :name="currentIcon" />
+      </span>
       <span class="vizel-node-selector-label">{{ currentLabel }}</span>
-      <span class="vizel-node-selector-chevron" aria-hidden="true">▼</span>
+      <span class="vizel-node-selector-chevron" aria-hidden="true">
+        <Icon name="chevronDown" />
+      </span>
     </button>
 
     <div
@@ -160,14 +165,16 @@ function isNodeTypeActive(nodeType: NodeTypeOption): boolean {
         @click="handleSelectNodeType(nodeType)"
         @mouseenter="focusedIndex = index"
       >
-        <span class="vizel-node-selector-option-icon">{{ nodeType.icon }}</span>
+        <span class="vizel-node-selector-option-icon">
+          <Icon :name="nodeType.icon" />
+        </span>
         <span class="vizel-node-selector-option-label">{{ nodeType.label }}</span>
         <span
           v-if="isNodeTypeActive(nodeType)"
           class="vizel-node-selector-check"
           aria-hidden="true"
         >
-          ✓
+          <Icon name="check" />
         </span>
       </button>
     </div>

--- a/packages/vue/src/components/SaveIndicator.vue
+++ b/packages/vue/src/components/SaveIndicator.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { formatRelativeTime, type SaveStatus } from "@vizel/core";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import Icon from "./Icon.vue";
 
 export interface SaveIndicatorProps {
   /** Current save status */
@@ -74,12 +75,20 @@ const shouldShowTimestamp = computed(() => {
     data-vizel-save-indicator
   >
     <span class="vizel-save-indicator-icon" aria-hidden="true">
-      <template v-if="props.status === 'saved'">✓</template>
-      <template v-else-if="props.status === 'saving'">
-        <span class="vizel-save-indicator-spinner" aria-hidden="true">⟳</span>
+      <template v-if="props.status === 'saved'">
+        <Icon name="check" />
       </template>
-      <template v-else-if="props.status === 'unsaved'">•</template>
-      <template v-else-if="props.status === 'error'">⚠</template>
+      <template v-else-if="props.status === 'saving'">
+        <span class="vizel-save-indicator-spinner" aria-hidden="true">
+          <Icon name="loader" />
+        </span>
+      </template>
+      <template v-else-if="props.status === 'unsaved'">
+        <Icon name="circle" />
+      </template>
+      <template v-else-if="props.status === 'error'">
+        <Icon name="warning" />
+      </template>
     </span>
     <span class="vizel-save-indicator-text">{{ statusText }}</span>
     <span v-if="shouldShowTimestamp" class="vizel-save-indicator-timestamp">{{ relativeTime }}</span>

--- a/packages/vue/src/components/SlashMenuItem.vue
+++ b/packages/vue/src/components/SlashMenuItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SlashCommandItem } from "@vizel/core";
+import Icon from "./Icon.vue";
 
 export interface SlashMenuItemProps {
   /** The slash command item to display */
@@ -62,7 +63,9 @@ function highlightMatches(
     :data-selected="isSelected || undefined"
     @click="emit('click')"
   >
-    <span class="vizel-slash-menu-icon">{{ item.icon }}</span>
+    <span class="vizel-slash-menu-icon">
+      <Icon :name="item.icon" />
+    </span>
     <div class="vizel-slash-menu-text">
       <span class="vizel-slash-menu-title">
         <template v-for="(part, idx) in highlightMatches(item.title, titleMatches)" :key="idx">

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -25,14 +25,21 @@ export {
   type ColorPickerProps,
   default as ColorPicker,
 } from "./ColorPicker.vue";
-
 // Editor components
 export { default as EditorContent, type EditorContentProps } from "./EditorContent.vue";
 export { useEditorContext, useEditorContextSafe } from "./EditorContext.ts";
 export { default as EditorRoot, type EditorRootProps } from "./EditorRoot.vue";
-
 // EmbedView component
 export { default as EmbedView, type EmbedViewProps } from "./EmbedView.vue";
+// Icon component
+export { default as Icon, type IconProps } from "./Icon.vue";
+export {
+  type CustomIconMap,
+  IconContextKey,
+  type IconContextValue,
+  provideIconContext,
+  useIconContext,
+} from "./IconContext.ts";
 
 // NodeSelector component
 export {

--- a/packages/vue/src/iconRenderer.ts
+++ b/packages/vue/src/iconRenderer.ts
@@ -1,0 +1,66 @@
+/**
+ * Icon renderer implementation for Vue package.
+ * Uses Iconify utilities to render SVG strings from icon data.
+ */
+
+import type { IconifyIcon } from "@iconify/utils";
+import { getIconData, iconToSVG } from "@iconify/utils";
+import lucide from "@iconify-json/lucide/icons.json";
+import {
+  defaultIconIds,
+  type IconRendererOptions,
+  type InternalIconName,
+  setIconRenderer,
+} from "@vizel/core";
+
+/**
+ * Render an Iconify icon as an SVG string.
+ */
+function renderIconSvg(name: InternalIconName, options?: IconRendererOptions): string {
+  const iconId = defaultIconIds[name];
+  if (!iconId) return "";
+
+  // Parse icon ID (format: "prefix:name")
+  const [, iconName] = iconId.split(":");
+  if (!iconName) return "";
+
+  // Get icon data from the Lucide icon set
+  const iconData = getIconData(lucide, iconName) as IconifyIcon | null;
+  if (!iconData) return "";
+
+  // Convert icon data to SVG
+  const result = iconToSVG(iconData, {
+    height: options?.height ?? 24,
+    width: options?.width ?? 24,
+  });
+
+  // Build SVG element
+  const attrs: string[] = [
+    'xmlns="http://www.w3.org/2000/svg"',
+    `width="${options?.width ?? 24}"`,
+    `height="${options?.height ?? 24}"`,
+    `viewBox="0 0 ${iconData.width ?? 24} ${iconData.height ?? 24}"`,
+  ];
+
+  // Add additional attributes from the result
+  if (result.attributes) {
+    for (const [key, value] of Object.entries(result.attributes)) {
+      if (!["width", "height", "viewBox"].includes(key)) {
+        attrs.push(`${key}="${value}"`);
+      }
+    }
+  }
+
+  return `<svg ${attrs.join(" ")}>${result.body}</svg>`;
+}
+
+/**
+ * Initialize the icon renderer for the Vue package.
+ * This should be called once when the package is loaded.
+ */
+export function initIconRenderer(): void {
+  setIconRenderer(renderIconSvg);
+}
+
+// Auto-initialize when this module is imported
+initIconRenderer();

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -4,6 +4,9 @@
  * Vue 3 components and composables for the Vizel visual editor.
  */
 
+// Initialize icon renderer (auto-registers with core)
+import "./iconRenderer.ts";
+
 // Re-export core types for convenience
 // Re-export auto-save types from core
 export type {
@@ -133,12 +136,18 @@ export {
   type BubbleMenuToolbarProps,
   ColorPicker,
   type ColorPickerProps,
+  type CustomIconMap,
   EditorContent,
   type EditorContentProps,
   EditorRoot,
   type EditorRootProps,
+  Icon,
+  IconContextKey,
+  type IconContextValue,
+  type IconProps,
   Portal,
   type PortalProps,
+  provideIconContext,
   SaveIndicator,
   type SaveIndicatorProps,
   SlashMenu,
@@ -153,6 +162,7 @@ export {
   type ThemeProviderProps,
   useEditorContext,
   useEditorContextSafe,
+  useIconContext,
 } from "./components/index.ts";
 // Composables
 export {

--- a/tests/ct/scenarios/color-picker.scenario.ts
+++ b/tests/ct/scenarios/color-picker.scenario.ts
@@ -271,6 +271,8 @@ export async function testNoneValueDisplay(_component: Locator, page: Page): Pro
   const noneSwatch = page.locator('.vizel-color-picker-swatch[data-color="transparent"]');
   await expect(noneSwatch).toBeVisible();
 
+  // None indicator should contain an icon (SVG)
   const noneIndicator = noneSwatch.locator(".vizel-color-picker-none");
-  await expect(noneIndicator).toHaveText("×");
+  await expect(noneIndicator).toBeVisible();
+  await expect(noneIndicator.locator("svg")).toBeVisible();
 }


### PR DESCRIPTION
## Summary

- Implement Iconify-based icon system with semantic icon names and dependency injection pattern
- Add Icon and IconProvider components for React, Vue, and Svelte with customization support
- Reduce table grip handle size and apply primary color to code block language input

## Changes

### Core Package
- Add `icons/` module with semantic icon name types and Iconify ID mappings
- Use dependency injection pattern (`setIconRenderer`/`renderIcon`) for NodeView icons
- Update drag-handle, table-controls, and code-block extensions to use `renderIcon()`
- Reduce table grip handle size (24px → 20px, icon 14px → 12px)
- Apply primary color to code block language input

### Framework Packages (React, Vue, Svelte)
- Add `Icon` component that renders Iconify icons based on semantic names
- Add `IconContext`/`IconProvider` for custom icon overrides
- Add `iconRenderer.ts` to inject Iconify SVG renderer into core
- Add `@iconify/utils` and `@iconify-json/lucide` dependencies
- Update all components to use `<Icon name="..." />` instead of hardcoded SVGs

### Architecture
```
@vizel/core (headless)
  └── icons/types.ts
        - IconName types
        - defaultIconIds (semantic → Iconify ID)
        - setIconRenderer() / renderIcon()
              ▲
              │ injection
              │
@vizel/{react,vue,svelte}
  └── iconRenderer.ts
        - Uses @iconify/utils + @iconify-json/lucide
        - Auto-registers on import

  └── Icon.tsx/vue/svelte
        - Uses @iconify/{react,vue,svelte}
        - Supports IconProvider context for customization
```