### PR TITLE
fix(demo): use getter pattern for useVizelState and useVizelAutoSave in React demo

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -52,11 +52,11 @@ function AppContent() {
   const vizelRef = useRef<VizelRef>(null);
 
   // Track editor state for character/word count
-  useVizelState(vizelRef.current?.editor ?? null);
+  useVizelState(() => vizelRef.current?.editor ?? null);
   const editorState = getVizelEditorState(vizelRef.current?.editor ?? null);
 
   // Auto-save functionality
-  const { status, lastSaved } = useVizelAutoSave(vizelRef.current?.editor ?? null, {
+  const { status, lastSaved } = useVizelAutoSave(() => vizelRef.current?.editor ?? null, {
     debounceMs: 2000,
     storage: "localStorage",
     key: "vizel-demo-react",


### PR DESCRIPTION
## Summary

- Fix React demo to use getter pattern for `useVizelState` and `useVizelAutoSave` hooks

## Changes

```diff
-useVizelState(vizelRef.current?.editor ?? null);
+useVizelState(() => vizelRef.current?.editor ?? null);

-const { status, lastSaved } = useVizelAutoSave(vizelRef.current?.editor ?? null, {
+const { status, lastSaved } = useVizelAutoSave(() => vizelRef.current?.editor ?? null, {
```

## Test Plan

- [x] React demo works without console errors
- [x] Vue demo works (already using correct pattern)
- [x] Svelte demo works (already using correct pattern)