### PR TITLE
feat(demo): add vite aliases for development HMR

### DIFF
--- a/apps/demo/react/vite.config.ts
+++ b/apps/demo/react/vite.config.ts
@@ -1,9 +1,19 @@
+import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
   server: {
     port: 3000,
   },
-});
+  resolve:
+    mode === "development"
+      ? {
+          alias: {
+            "@vizel/core": path.resolve(__dirname, "../../../packages/core/src"),
+            "@vizel/react": path.resolve(__dirname, "../../../packages/react/src"),
+          },
+        }
+      : undefined,
+}));

--- a/apps/demo/svelte/vite.config.ts
+++ b/apps/demo/svelte/vite.config.ts
@@ -1,11 +1,21 @@
+import path from "node:path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [svelte()],
   server: {
     port: 3002,
   },
+  resolve:
+    mode === "development"
+      ? {
+          alias: {
+            "@vizel/core": path.resolve(__dirname, "../../../packages/core/src"),
+            "@vizel/svelte": path.resolve(__dirname, "../../../packages/svelte/src"),
+          },
+        }
+      : undefined,
   optimizeDeps: {
     // Exclude workspace packages so Vite can process .svelte files
     exclude: ["@vizel/svelte"],
@@ -14,4 +24,4 @@ export default defineConfig({
     // Ensure @vizel/svelte is bundled so .svelte files are processed
     noExternal: ["@vizel/svelte"],
   },
-});
+}));

--- a/apps/demo/vue/vite.config.ts
+++ b/apps/demo/vue/vite.config.ts
@@ -1,9 +1,19 @@
+import path from "node:path";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [vue()],
   server: {
     port: 3001,
   },
-});
+  resolve:
+    mode === "development"
+      ? {
+          alias: {
+            "@vizel/core": path.resolve(__dirname, "../../../packages/core/src"),
+            "@vizel/vue": path.resolve(__dirname, "../../../packages/vue/src"),
+          },
+        }
+      : undefined,
+}));


### PR DESCRIPTION
## Summary

- Add Vite aliases for development mode to enable faster HMR
- Aliases point directly to source directories instead of built packages
- Only active in development mode (`mode === "development"`)

## Changes

All three demo apps (`react`, `vue`, `svelte`) now have:

```typescript
resolve: mode === "development" ? {
  alias: {
    "@vizel/core": path.resolve(__dirname, "../../../packages/core/src"),
    "@vizel/[framework]": path.resolve(__dirname, "../../../packages/[framework]/src"),
  },
} : undefined,
```

## Benefits

- Instant HMR when modifying package source files
- No need to rebuild packages during development
- Production builds remain unchanged

## Test Plan

- [x] Run lint (`npm run lint`)
- [x] Run typecheck (`npm run typecheck`)
- [x] Run `npm run dev:react` and verify HMR works
- [x] Run `npm run dev:vue` and verify HMR works
- [x] Run `npm run dev:svelte` and verify HMR works