### PR TITLE
fix(ci): add npm tag for prerelease versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,12 +145,29 @@ jobs:
 
       - name: Publish to npm
         if: ${{ !inputs.dry-run }}
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
+          # Determine npm tag for prerelease versions
+          # e.g., 1.0.0-alpha.1 -> alpha, 1.0.0-beta.2 -> beta, 1.0.0 -> (empty)
+          PRERELEASE_TAG=""
+          if [[ "$VERSION" == *-* ]]; then
+            # Extract prerelease identifier (e.g., alpha, beta, rc)
+            PRERELEASE_TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
+          fi
+
+          # Build publish command with optional tag
+          PUBLISH_OPTS="--provenance --access public"
+          if [ -n "$PRERELEASE_TAG" ]; then
+            PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
+            echo "📌 Publishing with tag: $PRERELEASE_TAG"
+          fi
+
           # Publish with provenance for supply chain security
-          npm publish --workspace=@vizel/core --provenance --access public
-          npm publish --workspace=@vizel/react --provenance --access public
-          npm publish --workspace=@vizel/vue --provenance --access public
-          npm publish --workspace=@vizel/svelte --provenance --access public
+          npm publish --workspace=@vizel/core $PUBLISH_OPTS
+          npm publish --workspace=@vizel/react $PUBLISH_OPTS
+          npm publish --workspace=@vizel/vue $PUBLISH_OPTS
+          npm publish --workspace=@vizel/svelte $PUBLISH_OPTS
           echo "✅ Published all packages to npm"
 
       - name: Commit version changes


### PR DESCRIPTION
## Summary

- Fix npm publish error for prerelease versions
- Extract prerelease identifier (alpha, beta, rc, etc.) from version
- Use extracted identifier as npm dist-tag

## Problem

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

Prerelease versions (e.g., `0.0.1-alpha.2`) require `--tag` option to avoid being published as `latest`.

## Solution

| Version | Tag |
|---------|-----|
| `1.0.0` | `latest` (default) |
| `1.0.0-alpha.1` | `alpha` |
| `1.0.0-beta.2` | `beta` |
| `1.0.0-rc.1` | `rc` |

## Test Plan

- [x] Verify tag extraction logic
- [ ] Re-run publish workflow with `0.0.1-alpha.2`