### PR TITLE
fix(publish): add repository field for npm provenance

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,11 @@
   "name": "@vizel/core",
   "version": "0.0.1",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/vizel",
+    "directory": "packages/core"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,11 @@
   "name": "@vizel/react",
   "version": "0.0.1",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/vizel",
+    "directory": "packages/react"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -2,6 +2,11 @@
   "name": "@vizel/svelte",
   "version": "0.0.1",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/vizel",
+    "directory": "packages/svelte"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "svelte": "./src/index.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,6 +2,11 @@
   "name": "@vizel/vue",
   "version": "0.0.1",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/vizel",
+    "directory": "packages/vue"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- Add `repository` field to all package.json files required for npm provenance verification
- Fixes publish workflow failure caused by `--provenance` flag validation

## Background

The publish workflow failed with:
```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is "", 
expected to match "https://github.com/seijikohara/vizel"
```

## Changes

Added `repository` field to:
- `packages/core/package.json`
- `packages/react/package.json`
- `packages/vue/package.json`
- `packages/svelte/package.json`

## Test Plan

- [x] Run lint (`npm run lint`)
- [x] Run typecheck (`npm run typecheck`)
- [ ] CI passes
- [ ] After merge, create release tag to verify publish works