### PR TITLE
fix(ci): use exec npm for pkg set command in pnpm filter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,9 +133,9 @@ jobs:
           pnpm --filter @vizel/svelte exec npm version "$VERSION" --no-git-tag-version
 
           # Update internal dependency versions
-          pnpm --filter @vizel/react pkg set "dependencies.@vizel/core=^$VERSION"
-          pnpm --filter @vizel/vue pkg set "dependencies.@vizel/core=^$VERSION"
-          pnpm --filter @vizel/svelte pkg set "dependencies.@vizel/core=^$VERSION"
+          pnpm --filter @vizel/react exec npm pkg set "dependencies.@vizel/core=^$VERSION"
+          pnpm --filter @vizel/vue exec npm pkg set "dependencies.@vizel/core=^$VERSION"
+          pnpm --filter @vizel/svelte exec npm pkg set "dependencies.@vizel/core=^$VERSION"
 
           # Regenerate pnpm-lock.yaml with updated versions
           pnpm install --lockfile-only


### PR DESCRIPTION
## Summary

Fix the publish workflow failure caused by incorrect pnpm command usage.

- `pnpm --filter` interprets `pkg` as a script name, not the npm pkg command
- Use `exec npm pkg set` to correctly invoke npm's pkg command

## Problem

The publish workflow failed with:
```
ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT  None of the selected packages has a "pkg" script
```

Related workflow run: https://github.com/seijikohara/vizel/actions/runs/21231408051

## Solution

Change from:
```bash
pnpm --filter @vizel/react pkg set "dependencies.@vizel/core=^$VERSION"
```

To:
```bash
pnpm --filter @vizel/react exec npm pkg set "dependencies.@vizel/core=^$VERSION"
```

## Test plan

- [ ] Re-run the publish workflow with dry-run to verify the fix