### PR TITLE
fix(ci): use pnpm workspace:^ protocol for internal dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,18 +127,12 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           # Update version in all publishable packages
+          # Note: Internal dependencies use workspace:^ protocol, which pnpm
+          # automatically converts to semver ranges (e.g., ^0.0.1-alpha.2) during publish
           pnpm --filter @vizel/core exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/react exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/vue exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/svelte exec npm version "$VERSION" --no-git-tag-version
-
-          # Update internal dependency versions
-          pnpm --filter @vizel/react exec npm pkg set "dependencies.@vizel/core=^$VERSION"
-          pnpm --filter @vizel/vue exec npm pkg set "dependencies.@vizel/core=^$VERSION"
-          pnpm --filter @vizel/svelte exec npm pkg set "dependencies.@vizel/core=^$VERSION"
-
-          # Regenerate pnpm-lock.yaml with updated versions
-          pnpm install --lockfile-only
 
           echo "✅ Updated all packages to version $VERSION"
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6",
-    "@vizel/core": "workspace:*"
+    "@vizel/core": "workspace:^"
   },
   "peerDependencies": {
     "react": "^19",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@iconify/svelte": "^5",
-    "@vizel/core": "workspace:*"
+    "@vizel/core": "workspace:^"
   },
   "peerDependencies": {
     "svelte": "^5"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@iconify/vue": "^5",
-    "@vizel/core": "workspace:*"
+    "@vizel/core": "workspace:^"
   },
   "peerDependencies": {
     "vue": "^3.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         specifier: ^6
         version: 6.0.2(react@19.2.3)
       '@vizel/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       react:
         specifier: ^19
@@ -374,7 +374,7 @@ importers:
         specifier: ^5
         version: 5.2.1(svelte@5.47.1)
       '@vizel/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       svelte:
         specifier: ^5
@@ -420,7 +420,7 @@ importers:
         specifier: ^5
         version: 5.0.0(vue@3.5.27(typescript@5.9.3))
       '@vizel/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       vue:
         specifier: ^3.4


### PR DESCRIPTION
## Summary

- Remove manual dependency version updates in publish workflow
- Use pnpm's `workspace:^` protocol which automatically converts to semver ranges during publish
- This avoids `ERR_PNPM_NO_MATCHING_VERSION` when lockfile tries to resolve unpublished versions

## Problem

The publish workflow failed because:
1. `npm pkg set "dependencies.@vizel/core=^0.0.1-alpha.2"` updated the dependency version
2. `pnpm install --lockfile-only` tried to resolve the version from npm registry
3. But `@vizel/core@0.0.1-alpha.2` wasn't published yet → Error

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @vizel/core@^0.0.1-alpha.2
```

## Solution

Use pnpm's workspace protocol:
- `"@vizel/core": "workspace:^"` in package.json
- pnpm automatically converts this to `"@vizel/core": "^0.0.1-alpha.2"` during publish
- No need to manually update dependency versions or regenerate lockfile

Reference: https://pnpm.io/workspaces#publishing-workspace-packages

## Test plan

- [x] Local `pnpm pack` confirms workspace:^ is converted to ^version
- [ ] Re-run publish workflow with dry-run to verify the fix