### PR TITLE
fix(ci): use recursive publish for single OIDC token session

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,10 +143,8 @@ jobs:
         if: ${{ inputs.dry-run }}
         run: |
           echo "🔍 Running dry-run publish..."
-          pnpm --filter @vizel/core publish --dry-run --no-git-checks
-          pnpm --filter @vizel/react publish --dry-run --no-git-checks
-          pnpm --filter @vizel/vue publish --dry-run --no-git-checks
-          pnpm --filter @vizel/svelte publish --dry-run --no-git-checks
+          # Use recursive publish to handle all packages in dependency order
+          pnpm publish -r --dry-run --no-git-checks --filter "./packages/*"
           echo "✅ Dry-run completed successfully"
 
       - name: Publish to npm
@@ -162,18 +160,16 @@ jobs:
             PRERELEASE_TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
           fi
 
-          # Build publish command with optional tag
+          # Build publish options
           PUBLISH_OPTS="--provenance --access public --no-git-checks"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing with tag: $PRERELEASE_TAG"
           fi
 
-          # Publish with provenance for supply chain security
-          pnpm --filter @vizel/core publish $PUBLISH_OPTS
-          pnpm --filter @vizel/react publish $PUBLISH_OPTS
-          pnpm --filter @vizel/vue publish $PUBLISH_OPTS
-          pnpm --filter @vizel/svelte publish $PUBLISH_OPTS
+          # Publish all packages recursively in dependency order
+          # Using -r (recursive) ensures proper ordering and single OIDC token usage
+          pnpm publish -r $PUBLISH_OPTS --filter "./packages/*"
           echo "✅ Published all packages to npm"
 
       - name: Commit version changes


### PR DESCRIPTION
## Summary

- Replace individual `pnpm --filter` publish calls with `pnpm publish -r`
- This ensures all packages are published in a single npm session
- Fixes OIDC token expiration when publishing multiple packages sequentially

## Problem

The publish workflow failed because:
1. Each `pnpm --filter @vizel/xxx publish` call consumed the OIDC token
2. After publishing @vizel/core, the token expired for subsequent packages
3. Result: @vizel/react, @vizel/vue, @vizel/svelte failed with 404

```
npm notice Access token expired or revoked.
npm error 404 Not Found - PUT https://registry.npmjs.org/@vizel%2freact
```

## Solution

Use `pnpm publish -r` (recursive) instead of individual `--filter` calls:
- Publishes all packages in a single npm session
- Respects dependency order (core first, then framework packages)
- Uses single OIDC token for entire publish operation

## Test plan

- [ ] Re-run publish workflow with 0.0.1-alpha.2