### PR TITLE
fix(ci): prevent OIDC token conflict by publishing packages sequentially

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,7 +168,7 @@ jobs:
           cd packages/core && npm publish $PUBLISH_OPTS
           echo "✅ Published @vizel/core@$VERSION"
 
-  # Publish framework packages in parallel (each job has its own OIDC token)
+  # Publish framework packages sequentially to avoid OIDC token conflicts
   publish-framework:
     name: Publish @vizel/${{ matrix.package }}
     runs-on: ubuntu-latest
@@ -177,6 +177,7 @@ jobs:
     environment: npm
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         package: [react, vue, svelte]
     steps:


### PR DESCRIPTION
## Summary

- Fix root cause of partial publish failures in the npm publish workflow
- Add `max-parallel: 1` to framework package Matrix strategy

## Root Cause Analysis

When publishing framework packages (react, vue, svelte) in parallel using Matrix strategy:
1. All 3 jobs share the same GitHub environment (`npm`)
2. Each job requests an OIDC token simultaneously
3. Token conflicts occur - some packages succeed while others fail with "Access token expired or revoked"

**Evidence from Run #21233625881:**
- `@vizel/vue` and `@vizel/svelte` published successfully
- `@vizel/react` failed with:
  ```
  npm notice Access token expired or revoked. Please try logging in again.
  npm error code E404
  ```

## Solution

Set `max-parallel: 1` in the Matrix strategy to ensure framework packages are published sequentially, avoiding OIDC token conflicts.

```yaml
strategy:
  fail-fast: false
  max-parallel: 1  # Added
  matrix:
    package: [react, vue, svelte]
```

## Test Plan

- [ ] Run publish workflow with version `0.0.1-alpha.5`
- [ ] Verify all 4 packages are published successfully
- [ ] Verify provenance attestations are generated for all packages