### PR TITLE
docs: fix README inconsistencies and separate KaTeX CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **Slash Commands** - Type `/` to insert blocks
 - **Floating Toolbar** - Inline formatting toolbar on text selection
 - **Tables** - Table editing with row/column controls
-- **Code Blocks** - Syntax highlighting with 190+ languages
+- **Code Blocks** - Syntax highlighting with 37+ languages (190+ available)
 - **Images** - Drag & drop, paste, resize support
 - **Markdown** - Import/export Markdown content
 - **Mathematics** - LaTeX equations with KaTeX
@@ -57,6 +57,24 @@ npm install @vizel/vue
 
 # Svelte
 npm install @vizel/svelte
+```
+
+### Optional Features
+
+Install additional packages to enable optional features:
+
+| Feature | Package | Install |
+|---------|---------|---------|
+| Mathematics (LaTeX) | `katex` | `npm install katex` |
+| Diagrams (Mermaid) | `mermaid` | `npm install mermaid` |
+| Diagrams (GraphViz) | `@hpcc-js/wasm-graphviz` | `npm install @hpcc-js/wasm-graphviz` |
+| Code syntax highlighting | `lowlight` | `npm install lowlight` |
+
+When using mathematics, also import the KaTeX stylesheet:
+
+```typescript
+import '@vizel/core/styles.css';
+import '@vizel/core/mathematics.css'; // KaTeX styles for math rendering
 ```
 
 ### With shadcn/ui (Optional)

--- a/apps/demo/shared/styles/base.css
+++ b/apps/demo/shared/styles/base.css
@@ -1,5 +1,7 @@
 /* Import Vizel core styles */
 @import "../../../../packages/core/src/styles/index.scss";
+/* Import KaTeX styles for mathematics feature */
+@import "../../../../packages/core/src/styles/katex-entry.scss";
 
 /* Base Styles */
 * {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
       "import": "./src/index.ts"
     },
     "./styles.css": "./src/styles/index.scss",
-    "./components.css": "./src/styles/components.scss"
+    "./components.css": "./src/styles/components.scss",
+    "./mathematics.css": "./src/styles/katex-entry.scss"
   },
   "publishConfig": {
     "main": "./dist/index.js",
@@ -26,7 +27,8 @@
         "import": "./dist/index.js"
       },
       "./styles.css": "./dist/styles.css",
-      "./components.css": "./dist/components.css"
+      "./components.css": "./dist/components.css",
+      "./mathematics.css": "./dist/mathematics.css"
     }
   },
   "files": [
@@ -34,9 +36,10 @@
   ],
   "scripts": {
     "build": "vite build && npm run build:css",
-    "build:css": "npm run build:css:styles && npm run build:css:components",
+    "build:css": "npm run build:css:styles && npm run build:css:components && npm run build:css:mathematics",
     "build:css:styles": "sass --load-path=src/styles --load-path=node_modules src/styles/index.scss dist/styles.css --style=compressed",
     "build:css:components": "sass --load-path=src/styles --load-path=node_modules src/styles/components.scss dist/components.css --style=compressed",
+    "build:css:mathematics": "sass --load-path=src/styles --load-path=node_modules src/styles/katex-entry.scss dist/mathematics.css --style=compressed",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/core/src/styles/index.scss
+++ b/packages/core/src/styles/index.scss
@@ -37,6 +37,3 @@
 @use "embed";
 @use "save-indicator";
 @use "diagram";
-
-/* External dependencies (must be after @use rules) */
-@import "katex/dist/katex.min.css";

--- a/packages/core/src/styles/katex-entry.scss
+++ b/packages/core/src/styles/katex-entry.scss
@@ -1,0 +1,14 @@
+/**
+ * Vizel Mathematics (KaTeX) Stylesheet
+ *
+ * Import this file when using the mathematics (LaTeX) feature.
+ * This includes KaTeX CSS required for rendering math expressions.
+ *
+ * @example
+ * ```ts
+ * import '@vizel/core/styles.css';
+ * import '@vizel/core/mathematics.css';
+ * ```
+ */
+
+@import "katex/dist/katex.min.css";

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -5,7 +5,7 @@ React components for Vizel block-based Markdown editor.
 ## Installation
 
 ```bash
-npm install @vizel/react @vizel/core
+npm install @vizel/react
 ```
 
 ## Requirements
@@ -37,8 +37,8 @@ function App() {
 
   return (
     <>
-      <VizelEditor editor={editor.current} />
-      <VizelBubbleMenu editor={editor.current} />
+      <VizelEditor editor={editor} />
+      <VizelBubbleMenu editor={editor} />
     </>
   );
 }
@@ -51,14 +51,14 @@ import { useVizelEditor, useVizelMarkdown } from "@vizel/react";
 
 function App() {
   const editor = useVizelEditor();
-  const { getMarkdown, setMarkdown } = useVizelMarkdown(() => editor.current);
+  const { getMarkdown, setMarkdown } = useVizelMarkdown(() => editor);
 
   const handleExport = () => {
     const markdown = getMarkdown();
     console.log(markdown);
   };
 
-  return <VizelEditor editor={editor.current} />;
+  return <VizelEditor editor={editor} />;
 }
 ```
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -5,7 +5,7 @@ Svelte 5 components for Vizel block-based Markdown editor.
 ## Installation
 
 ```bash
-npm install @vizel/svelte @vizel/core
+npm install @vizel/svelte
 ```
 
 ## Requirements

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -5,7 +5,7 @@ Vue 3 components for Vizel block-based Markdown editor.
 ## Installation
 
 ```bash
-npm install @vizel/vue @vizel/core
+npm install @vizel/vue
 ```
 
 ## Requirements


### PR DESCRIPTION
## Summary

- Remove unnecessary `@vizel/core` from installation instructions in all package READMEs
- Fix React README `editor.current` → `editor` (hook returns `Editor | null` directly)
- Add optional feature dependencies documentation to root README
- Update code block language count to "37+ languages (190+ available)" matching `common` preset default
- Separate KaTeX CSS into dedicated `mathematics.css` export entry point
- Add `build:css:mathematics` script to core package
- Update demo app CSS imports for KaTeX

Closes #124, Closes #123

## Test Plan

- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed
- [x] `pnpm build` — all packages built, `mathematics.css` generated correctly
- [x] `pnpm test:ct` — React 678 passed, Vue 678 passed, Svelte 673 passed (2 pre-existing flaky Firefox failures)
- [x] README accuracy verified across all packages