### PR TITLE
refactor(core): replace double type casts with type guards

### DIFF
--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -161,14 +161,18 @@ export const vizelDefaultEditorProps = {
  * Type guard to check if character count storage is available.
  */
 function hasVizelCharacterCountStorage(
-  storage: Record<string, unknown>
+  storage: unknown
 ): storage is { characterCount: VizelCharacterCountStorage } {
+  if (typeof storage !== "object" || storage === null) return false;
+  if (!("characterCount" in storage)) return false;
+  const cc = (storage as { characterCount: unknown }).characterCount;
   return (
-    "characterCount" in storage &&
-    typeof storage.characterCount === "object" &&
-    storage.characterCount !== null &&
-    "characters" in storage.characterCount &&
-    "words" in storage.characterCount
+    typeof cc === "object" &&
+    cc !== null &&
+    "characters" in cc &&
+    typeof (cc as { characters: unknown }).characters === "function" &&
+    "words" in cc &&
+    typeof (cc as { words: unknown }).words === "function"
   );
 }
 
@@ -199,10 +203,10 @@ export function getVizelEditorState(editor: Editor | null | undefined): VizelEdi
     };
   }
 
-  const storage = editor.storage as unknown as Record<string, unknown>;
   let characterCount = 0;
   let wordCount = 0;
 
+  const storage: unknown = editor.storage;
   if (hasVizelCharacterCountStorage(storage)) {
     characterCount = storage.characterCount.characters();
     wordCount = storage.characterCount.words();


### PR DESCRIPTION
## Summary

- Replace `as unknown as T` double type casts with proper type guard functions in `packages/core/src/utils/markdown.ts` and `packages/core/src/utils/editorHelpers.ts`
- Add `EditorWithMarkdownExport` and `EditorWithMarkdownStorage` interfaces for type-safe markdown extension access
- Improve `hasVizelCharacterCountStorage` type guard to accept `unknown` parameter and validate function types

Closes #132

## Changes

| File | Change |
|------|--------|
| `packages/core/src/utils/markdown.ts` | Add `EditorWithMarkdownExport`, `EditorWithMarkdownStorage` interfaces and `hasMarkdownExport`, `hasMarkdownStorage` type guards; remove all `as unknown as` casts |
| `packages/core/src/utils/editorHelpers.ts` | Change `hasVizelCharacterCountStorage` parameter from `Record<string, unknown>` to `unknown`; add `typeof === "function"` checks; eliminate double cast at usage site |

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test:ct` passes (226 tests)