### PR TITLE
feat(core): add sticky toolbar with formatting actions

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -44,6 +44,7 @@ function FeatureToggle({ label, checked, onChange }: FeatureToggleProps) {
 }
 
 interface DemoFeatures {
+  toolbar: boolean;
   theme: boolean;
   autoSave: boolean;
   stats: boolean;
@@ -55,6 +56,7 @@ type PanelTab = "markdown" | "json";
 function AppContent() {
   // Feature toggles (all enabled by default)
   const [features, setFeatures] = useState<DemoFeatures>({
+    toolbar: true,
     theme: true,
     autoSave: true,
     stats: true,
@@ -134,6 +136,11 @@ function AppContent() {
         </div>
         <div className="features-toggles">
           <FeatureToggle
+            label="Toolbar"
+            checked={features.toolbar}
+            onChange={(v) => updateFeature("toolbar", v)}
+          />
+          <FeatureToggle
             label="Theme"
             checked={features.theme}
             onChange={(v) => updateFeature("theme", v)}
@@ -163,6 +170,7 @@ function AppContent() {
               initialMarkdown={initialMarkdown}
               autofocus="end"
               className="editor-content"
+              showToolbar={features.toolbar}
               enableEmbed
               features={{
                 markdown: true,

--- a/apps/demo/shared/styles/base.css
+++ b/apps/demo/shared/styles/base.css
@@ -193,7 +193,7 @@ body {
   box-shadow:
     0 4px 6px -1px oklch(0 0 0 / 0.1),
     0 2px 4px -2px oklch(0 0 0 / 0.1);
-  overflow: hidden;
+  overflow: clip;
   border: 1px solid oklch(0.922 0.007 247.896);
 }
 

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -18,6 +18,7 @@ type JSONContent = Record<string, unknown>;
 
 // Feature toggles (all enabled by default)
 let features = $state({
+  toolbar: true,
   theme: true,
   autoSave: true,
   stats: true,
@@ -108,6 +109,10 @@ function handleJsonChange(event: Event) {
     </div>
     <div class="features-toggles">
       <label class="feature-toggle">
+        <input type="checkbox" bind:checked={features.toolbar} />
+        <span class="feature-toggle-label">Toolbar</span>
+      </label>
+      <label class="feature-toggle">
         <input type="checkbox" bind:checked={features.theme} />
         <span class="feature-toggle-label">Theme</span>
       </label>
@@ -133,6 +138,7 @@ function handleJsonChange(event: Event) {
           {initialMarkdown}
           autofocus="end"
           class="editor-content"
+          showToolbar={features.toolbar}
           enableEmbed
           features={{
             markdown: true,

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -16,6 +16,7 @@ import ThemeToggle from "./ThemeToggle.vue";
 
 // Feature toggles (all enabled by default)
 const features = reactive({
+  toolbar: true,
   theme: true,
   autoSave: true,
   stats: true,
@@ -107,6 +108,10 @@ function handleJsonChange(event: Event) {
         </div>
         <div class="features-toggles">
           <label class="feature-toggle">
+            <input type="checkbox" v-model="features.toolbar" />
+            <span class="feature-toggle-label">Toolbar</span>
+          </label>
+          <label class="feature-toggle">
             <input type="checkbox" v-model="features.theme" />
             <span class="feature-toggle-label">Theme</span>
           </label>
@@ -132,6 +137,7 @@ function handleJsonChange(event: Event) {
               :initial-markdown="initialMarkdown"
               autofocus="end"
               class="editor-content"
+              :show-toolbar="features.toolbar"
               enable-embed
               :features="{
                 markdown: true,

--- a/packages/core/src/icons/index.ts
+++ b/packages/core/src/icons/index.ts
@@ -22,6 +22,7 @@ export {
   type VizelNodeTypeIconName,
   type VizelSlashCommandIconName,
   type VizelTableIconName,
+  type VizelToolbarIconName,
   type VizelUIIconName,
   vizelDefaultIconIds,
 } from "./types.ts";

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -87,6 +87,11 @@ export type VizelBubbleMenuIconName =
   | "highlighter";
 
 /**
+ * Icon names used in Toolbar.
+ */
+export type VizelToolbarIconName = "undo" | "redo";
+
+/**
  * Icon names used internally in NodeView rendering (drag handle, table controls).
  * These icons are rendered via the injected VizelIconRenderer from framework packages.
  */
@@ -114,6 +119,7 @@ export type VizelIconName =
   | VizelTableIconName
   | VizelUIIconName
   | VizelBubbleMenuIconName
+  | VizelToolbarIconName
   | VizelInternalIconName;
 
 /**
@@ -190,6 +196,9 @@ export const vizelDefaultIconIds: Record<VizelIconName, string> = {
   warning: "lucide:alert-triangle",
   chevronDown: "lucide:chevron-down",
   x: "lucide:x",
+  // Toolbar
+  undo: "lucide:undo-2",
+  redo: "lucide:redo-2",
   // BubbleMenu toolbar
   bold: "lucide:bold",
   italic: "lucide:italic",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,10 +185,10 @@ export {
   type VizelNodeTypeIconName,
   type VizelSlashCommandIconName,
   type VizelTableIconName,
+  type VizelToolbarIconName,
   type VizelUIIconName,
   vizelDefaultIconIds,
 } from "./icons/index.ts";
-
 // =============================================================================
 // Theme
 // =============================================================================
@@ -208,6 +208,14 @@ export {
   type VizelThemeProviderOptions,
   type VizelThemeState,
 } from "./theme.ts";
+// =============================================================================
+// Toolbar
+// =============================================================================
+export {
+  groupVizelToolbarActions,
+  type VizelToolbarAction,
+  vizelDefaultToolbarActions,
+} from "./toolbar/index.ts";
 
 // =============================================================================
 // Types

--- a/packages/core/src/styles/components.scss
+++ b/packages/core/src/styles/components.scss
@@ -27,6 +27,7 @@
 /* Component styles */
 @use "editor";
 @use "placeholder";
+@use "toolbar";
 @use "bubble-menu";
 @use "slash-menu";
 @use "link";

--- a/packages/core/src/styles/editor.scss
+++ b/packages/core/src/styles/editor.scss
@@ -11,7 +11,7 @@
   border-radius: v("radius-xl");
   box-shadow: v("shadow-md");
   border: 1px solid v("border");
-  overflow: hidden;
+  overflow: clip;
 }
 
 .vizel-editor {

--- a/packages/core/src/styles/index.scss
+++ b/packages/core/src/styles/index.scss
@@ -23,6 +23,7 @@
 /* Component styles */
 @use "editor";
 @use "placeholder";
+@use "toolbar";
 @use "bubble-menu";
 @use "slash-menu";
 @use "link";

--- a/packages/core/src/styles/toolbar.scss
+++ b/packages/core/src/styles/toolbar.scss
@@ -1,0 +1,75 @@
+/**
+ * Vizel Toolbar Styles
+ *
+ * Styles for the fixed toolbar that appears above the editor.
+ */
+
+@use "tokens" as *;
+
+.vizel-toolbar {
+  display: flex;
+  position: sticky;
+  top: 0;
+  background: v("background");
+  border-bottom: 1px solid v("border");
+  z-index: v("z-sticky");
+
+  &-content {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.375rem;
+    flex-wrap: wrap;
+  }
+
+  &-divider {
+    width: 1px;
+    height: 1.25rem;
+    background-color: v("border");
+    flex-shrink: 0;
+    margin: 0 0.1875rem;
+    opacity: 0.6;
+  }
+
+  &-button {
+    padding: 0.375rem 0.5rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: v("foreground");
+    transition: background-color 0.15s, color 0.15s;
+    border-radius: v("radius-sm");
+    min-width: 2rem;
+    min-height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover:not(:disabled) {
+      background-color: v("primary-bg");
+      color: v("primary-hover");
+    }
+
+    &:focus-visible {
+      outline: 2px solid v("primary");
+      outline-offset: -2px;
+    }
+
+    &:disabled {
+      opacity: 0.35;
+      cursor: not-allowed;
+    }
+
+    &.is-active {
+      background-color: v("primary");
+      color: v("background");
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vizel-toolbar-button {
+    transition: none;
+  }
+}

--- a/packages/core/src/toolbar/actions.ts
+++ b/packages/core/src/toolbar/actions.ts
@@ -1,0 +1,213 @@
+import type { Editor } from "@tiptap/core";
+import type { VizelIconName } from "../icons/types.ts";
+
+/**
+ * A single toolbar action definition.
+ */
+export interface VizelToolbarAction {
+  /** Unique action identifier */
+  id: string;
+  /** Display label */
+  label: string;
+  /** Icon name from the Vizel icon system */
+  icon: VizelIconName;
+  /** Group identifier for visual separation */
+  group: string;
+  /** Check if this action is currently active */
+  isActive: (editor: Editor) => boolean;
+  /** Check if this action can be executed */
+  isEnabled: (editor: Editor) => boolean;
+  /** Execute the action */
+  run: (editor: Editor) => void;
+  /** Optional keyboard shortcut label for tooltip */
+  shortcut?: string;
+}
+
+/**
+ * Default toolbar actions providing common formatting operations.
+ */
+export const vizelDefaultToolbarActions = [
+  // History
+  {
+    id: "undo",
+    label: "Undo",
+    icon: "undo",
+    group: "history",
+    isActive: () => false,
+    isEnabled: (editor) => editor.can().undo(),
+    run: (editor) => editor.chain().focus().undo().run(),
+    shortcut: "Mod+Z",
+  },
+  {
+    id: "redo",
+    label: "Redo",
+    icon: "redo",
+    group: "history",
+    isActive: () => false,
+    isEnabled: (editor) => editor.can().redo(),
+    run: (editor) => editor.chain().focus().redo().run(),
+    shortcut: "Mod+Shift+Z",
+  },
+  // Inline formatting
+  {
+    id: "bold",
+    label: "Bold",
+    icon: "bold",
+    group: "format",
+    isActive: (editor) => editor.isActive("bold"),
+    isEnabled: (editor) => editor.can().toggleBold(),
+    run: (editor) => editor.chain().focus().toggleBold().run(),
+    shortcut: "Mod+B",
+  },
+  {
+    id: "italic",
+    label: "Italic",
+    icon: "italic",
+    group: "format",
+    isActive: (editor) => editor.isActive("italic"),
+    isEnabled: (editor) => editor.can().toggleItalic(),
+    run: (editor) => editor.chain().focus().toggleItalic().run(),
+    shortcut: "Mod+I",
+  },
+  {
+    id: "strike",
+    label: "Strikethrough",
+    icon: "strikethrough",
+    group: "format",
+    isActive: (editor) => editor.isActive("strike"),
+    isEnabled: (editor) => editor.can().toggleStrike(),
+    run: (editor) => editor.chain().focus().toggleStrike().run(),
+  },
+  {
+    id: "underline",
+    label: "Underline",
+    icon: "underline",
+    group: "format",
+    isActive: (editor) => editor.isActive("underline"),
+    isEnabled: (editor) => editor.can().toggleUnderline(),
+    run: (editor) => editor.chain().focus().toggleUnderline().run(),
+    shortcut: "Mod+U",
+  },
+  {
+    id: "code",
+    label: "Code",
+    icon: "code",
+    group: "format",
+    isActive: (editor) => editor.isActive("code"),
+    isEnabled: (editor) => editor.can().toggleCode(),
+    run: (editor) => editor.chain().focus().toggleCode().run(),
+    shortcut: "Mod+E",
+  },
+  // Headings
+  {
+    id: "heading1",
+    label: "Heading 1",
+    icon: "heading1",
+    group: "heading",
+    isActive: (editor) => editor.isActive("heading", { level: 1 }),
+    isEnabled: (editor) => editor.can().toggleHeading({ level: 1 }),
+    run: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    id: "heading2",
+    label: "Heading 2",
+    icon: "heading2",
+    group: "heading",
+    isActive: (editor) => editor.isActive("heading", { level: 2 }),
+    isEnabled: (editor) => editor.can().toggleHeading({ level: 2 }),
+    run: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
+  {
+    id: "heading3",
+    label: "Heading 3",
+    icon: "heading3",
+    group: "heading",
+    isActive: (editor) => editor.isActive("heading", { level: 3 }),
+    isEnabled: (editor) => editor.can().toggleHeading({ level: 3 }),
+    run: (editor) => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+  },
+  // Lists
+  {
+    id: "bulletList",
+    label: "Bullet List",
+    icon: "bulletList",
+    group: "list",
+    isActive: (editor) => editor.isActive("bulletList"),
+    isEnabled: (editor) => editor.can().toggleBulletList(),
+    run: (editor) => editor.chain().focus().toggleBulletList().run(),
+  },
+  {
+    id: "orderedList",
+    label: "Numbered List",
+    icon: "orderedList",
+    group: "list",
+    isActive: (editor) => editor.isActive("orderedList"),
+    isEnabled: (editor) => editor.can().toggleOrderedList(),
+    run: (editor) => editor.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    id: "taskList",
+    label: "Task List",
+    icon: "taskList",
+    group: "list",
+    isActive: (editor) => editor.isActive("taskList"),
+    isEnabled: (editor) => editor.can().toggleTaskList(),
+    run: (editor) => editor.chain().focus().toggleTaskList().run(),
+  },
+  // Blocks
+  {
+    id: "blockquote",
+    label: "Quote",
+    icon: "blockquote",
+    group: "block",
+    isActive: (editor) => editor.isActive("blockquote"),
+    isEnabled: (editor) => editor.can().toggleBlockquote(),
+    run: (editor) => editor.chain().focus().toggleBlockquote().run(),
+  },
+  {
+    id: "codeBlock",
+    label: "Code Block",
+    icon: "codeBlock",
+    group: "block",
+    isActive: (editor) => editor.isActive("codeBlock"),
+    isEnabled: (editor) => editor.can().toggleCodeBlock(),
+    run: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+  {
+    id: "horizontalRule",
+    label: "Horizontal Rule",
+    icon: "horizontalRule",
+    group: "block",
+    isActive: () => false,
+    isEnabled: (editor) => editor.can().setHorizontalRule(),
+    run: (editor) => editor.chain().focus().setHorizontalRule().run(),
+  },
+] satisfies VizelToolbarAction[];
+
+/**
+ * Get toolbar actions grouped by their group identifier.
+ */
+export function groupVizelToolbarActions(
+  actions: VizelToolbarAction[] = vizelDefaultToolbarActions
+): VizelToolbarAction[][] {
+  const groups: VizelToolbarAction[][] = [];
+  let currentGroup: string | null = null;
+  let currentActions: VizelToolbarAction[] = [];
+
+  for (const action of actions) {
+    if (action.group !== currentGroup) {
+      if (currentActions.length > 0) {
+        groups.push(currentActions);
+      }
+      currentGroup = action.group;
+      currentActions = [];
+    }
+    currentActions.push(action);
+  }
+
+  if (currentActions.length > 0) {
+    groups.push(currentActions);
+  }
+
+  return groups;
+}

--- a/packages/core/src/toolbar/index.ts
+++ b/packages/core/src/toolbar/index.ts
@@ -1,0 +1,5 @@
+export {
+  groupVizelToolbarActions,
+  type VizelToolbarAction,
+  vizelDefaultToolbarActions,
+} from "./actions.ts";

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -4,6 +4,7 @@ import { useImperativeHandle } from "react";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
 import { VizelBubbleMenu } from "./VizelBubbleMenu.tsx";
 import { VizelEditor } from "./VizelEditor.tsx";
+import { VizelToolbar } from "./VizelToolbar.tsx";
 
 export interface VizelProps {
   /** Ref to access editor instance */
@@ -35,6 +36,10 @@ export interface VizelProps {
   features?: VizelFeatureOptions;
   /** Custom class name for the editor container */
   className?: string;
+  /** Whether to show the toolbar (default: false) */
+  showToolbar?: boolean;
+  /** Custom toolbar content */
+  toolbarContent?: ReactNode;
   /** Whether to show the bubble menu (default: true) */
   showBubbleMenu?: boolean;
   /** Enable embed option in bubble menu link editor (requires Embed extension) */
@@ -109,6 +114,8 @@ export function Vizel({
   autofocus = false,
   features,
   className,
+  showToolbar = false,
+  toolbarContent,
   showBubbleMenu = true,
   enableEmbed = false,
   bubbleMenuContent,
@@ -147,6 +154,10 @@ export function Vizel({
 
   return (
     <div className={`vizel-root ${className ?? ""}`} data-vizel-root="">
+      {showToolbar && editor && toolbarContent && (
+        <VizelToolbar editor={editor}>{toolbarContent}</VizelToolbar>
+      )}
+      {showToolbar && editor && !toolbarContent && <VizelToolbar editor={editor} />}
       <VizelEditor editor={editor} />
       {showBubbleMenu && editor && bubbleMenuContent && (
         <VizelBubbleMenu editor={editor} enableEmbed={enableEmbed}>

--- a/packages/react/src/components/VizelToolbar.tsx
+++ b/packages/react/src/components/VizelToolbar.tsx
@@ -1,0 +1,50 @@
+import type { Editor } from "@vizel/core";
+import type { ReactNode } from "react";
+import { useVizelContextSafe } from "./VizelContext.tsx";
+import { VizelToolbarDefault } from "./VizelToolbarDefault.tsx";
+
+export interface VizelToolbarProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Additional CSS class name */
+  className?: string;
+  /** Whether to show the default toolbar (default: true). Set to false when using custom children. */
+  showDefaultToolbar?: boolean;
+  /** Custom toolbar content. When provided, replaces the default toolbar. */
+  children?: ReactNode;
+}
+
+/**
+ * Fixed toolbar component for the Vizel editor.
+ * Displays formatting buttons above the editor content area.
+ *
+ * @example
+ * ```tsx
+ * // Default toolbar with all formatting buttons
+ * <VizelToolbar editor={editor} />
+ *
+ * // Custom toolbar content
+ * <VizelToolbar editor={editor}>
+ *   <VizelToolbarButton onClick={() => editor.chain().focus().toggleBold().run()}>
+ *     <strong>B</strong>
+ *   </VizelToolbarButton>
+ * </VizelToolbar>
+ * ```
+ */
+export function VizelToolbar({
+  editor: editorProp,
+  className,
+  showDefaultToolbar = true,
+  children,
+}: VizelToolbarProps) {
+  const context = useVizelContextSafe();
+  const editor = editorProp ?? context?.editor ?? null;
+
+  if (!editor) return null;
+
+  return (
+    <div className={`vizel-toolbar ${className ?? ""}`} role="toolbar" aria-label="Formatting">
+      {children ?? (showDefaultToolbar && <VizelToolbarDefault editor={editor} />)}
+    </div>
+  );
+}

--- a/packages/react/src/components/VizelToolbarButton.tsx
+++ b/packages/react/src/components/VizelToolbarButton.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+export interface VizelToolbarButtonProps {
+  /** Click handler */
+  onClick?: () => void;
+  /** Whether the action is currently active */
+  isActive?: boolean;
+  /** Whether the button is disabled */
+  disabled?: boolean;
+  /** Button content (typically an icon) */
+  children: ReactNode;
+  /** Tooltip text */
+  title?: string;
+  /** Additional CSS class name */
+  className?: string;
+  /** Action identifier for testing */
+  action?: string;
+}
+
+/**
+ * A button component for use in the VizelToolbar.
+ *
+ * @example
+ * ```tsx
+ * <VizelToolbarButton
+ *   onClick={() => editor.chain().focus().toggleBold().run()}
+ *   isActive={editor.isActive("bold")}
+ *   title="Bold (Cmd+B)"
+ * >
+ *   <VizelIcon name="bold" />
+ * </VizelToolbarButton>
+ * ```
+ */
+export function VizelToolbarButton({
+  onClick,
+  isActive = false,
+  disabled = false,
+  children,
+  title,
+  className,
+  action,
+}: VizelToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={isActive}
+      className={`vizel-toolbar-button ${isActive ? "is-active" : ""} ${className ?? ""}`}
+      title={title}
+      data-active={isActive || undefined}
+      data-action={action}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/react/src/components/VizelToolbarDefault.tsx
+++ b/packages/react/src/components/VizelToolbarDefault.tsx
@@ -1,0 +1,62 @@
+import type { Editor } from "@vizel/core";
+import {
+  groupVizelToolbarActions,
+  type VizelToolbarAction,
+  vizelDefaultToolbarActions,
+} from "@vizel/core";
+import { Fragment } from "react";
+import { useVizelState } from "../hooks/useVizelState.ts";
+import { VizelIcon } from "./VizelIcon.tsx";
+import { VizelToolbarButton } from "./VizelToolbarButton.tsx";
+import { VizelToolbarDivider } from "./VizelToolbarDivider.tsx";
+
+export interface VizelToolbarDefaultProps {
+  editor: Editor;
+  className?: string;
+  /** Custom toolbar actions (defaults to vizelDefaultToolbarActions) */
+  actions?: VizelToolbarAction[];
+}
+
+/**
+ * The default toolbar content for VizelToolbar.
+ * Provides formatting buttons grouped by category with dividers between groups.
+ *
+ * @example
+ * ```tsx
+ * <VizelToolbar>
+ *   <VizelToolbarDefault editor={editor} />
+ * </VizelToolbar>
+ * ```
+ */
+export function VizelToolbarDefault({
+  editor,
+  className,
+  actions = vizelDefaultToolbarActions,
+}: VizelToolbarDefaultProps) {
+  // Subscribe to editor state changes to update active/enabled states
+  useVizelState(() => editor);
+
+  const groups = groupVizelToolbarActions(actions);
+
+  return (
+    <div className={`vizel-toolbar-content ${className ?? ""}`} data-vizel-toolbar="">
+      {groups.map((group, groupIndex) => (
+        <Fragment key={group[0]?.group ?? groupIndex}>
+          {groupIndex > 0 && <VizelToolbarDivider />}
+          {group.map((action) => (
+            <VizelToolbarButton
+              key={action.id}
+              action={action.id}
+              onClick={() => action.run(editor)}
+              isActive={action.isActive(editor)}
+              disabled={!action.isEnabled(editor)}
+              title={action.shortcut ? `${action.label} (${action.shortcut})` : action.label}
+            >
+              <VizelIcon name={action.icon} />
+            </VizelToolbarButton>
+          ))}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/packages/react/src/components/VizelToolbarDivider.tsx
+++ b/packages/react/src/components/VizelToolbarDivider.tsx
@@ -1,0 +1,19 @@
+export interface VizelToolbarDividerProps {
+  className?: string;
+}
+
+/**
+ * A divider component for separating groups of buttons in the VizelToolbar.
+ *
+ * @example
+ * ```tsx
+ * <VizelToolbar>
+ *   <VizelToolbarButton>B</VizelToolbarButton>
+ *   <VizelToolbarDivider />
+ *   <VizelToolbarButton>H1</VizelToolbarButton>
+ * </VizelToolbar>
+ * ```
+ */
+export function VizelToolbarDivider({ className }: VizelToolbarDividerProps) {
+  return <span className={`vizel-toolbar-divider ${className ?? ""}`} />;
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -60,3 +60,14 @@ export {
   VizelThemeProvider,
   type VizelThemeProviderProps,
 } from "./VizelThemeProvider.tsx";
+// VizelToolbar components
+export { VizelToolbar, type VizelToolbarProps } from "./VizelToolbar.tsx";
+export { VizelToolbarButton, type VizelToolbarButtonProps } from "./VizelToolbarButton.tsx";
+export {
+  VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+} from "./VizelToolbarDefault.tsx";
+export {
+  VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+} from "./VizelToolbarDivider.tsx";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -73,6 +73,15 @@ export {
   // ThemeProvider
   VizelThemeProvider,
   type VizelThemeProviderProps,
+  // Toolbar
+  VizelToolbar,
+  VizelToolbarButton,
+  type VizelToolbarButtonProps,
+  VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+  VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+  type VizelToolbarProps,
 } from "./components/index.ts";
 
 // Hooks

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -44,6 +44,10 @@ export interface VizelProps {
   features?: VizelFeatureOptions;
   /** Custom class name for the editor container */
   class?: string;
+  /** Whether to show the toolbar (default: false) */
+  showToolbar?: boolean;
+  /** Custom toolbar content */
+  toolbar?: Snippet<[{ editor: Editor }]>;
   /** Whether to show the bubble menu (default: true) */
   showBubbleMenu?: boolean;
   /** Enable embed option in bubble menu link editor (requires Embed extension) */
@@ -75,11 +79,14 @@ import { getVizelMarkdown, setVizelMarkdown } from "@vizel/core";
 import { createVizelEditor } from "../runes/createVizelEditor.svelte.ts";
 import VizelBubbleMenu from "./VizelBubbleMenu.svelte";
 import VizelEditor from "./VizelEditor.svelte";
+import VizelToolbar from "./VizelToolbar.svelte";
 
 // Use $props() without destructuring to avoid state_referenced_locally warnings
 // Props are intentionally captured once at editor creation time
 let {
   class: className,
+  showToolbar = false,
+  toolbar,
   showBubbleMenu = true,
   enableEmbed = false,
   bubbleMenu,
@@ -144,6 +151,15 @@ $effect(() => {
 </script>
 
 <div class="vizel-root {className ?? ''}" data-vizel-root>
+  {#if showToolbar && editor && toolbar}
+    <VizelToolbar {editor}>
+      {#snippet children({ editor: e })}
+        {@render toolbar({ editor: e })}
+      {/snippet}
+    </VizelToolbar>
+  {:else if showToolbar && editor}
+    <VizelToolbar {editor} />
+  {/if}
   <VizelEditor {editor} />
   {#if showBubbleMenu && editor && bubbleMenu}
     <VizelBubbleMenu {editor} {enableEmbed}>

--- a/packages/svelte/src/components/VizelToolbar.svelte
+++ b/packages/svelte/src/components/VizelToolbar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" module>
+import type { Editor } from "@vizel/core";
+import type { Snippet } from "svelte";
+
+export interface VizelToolbarProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Custom class name */
+  class?: string;
+  /** Whether to show the default toolbar (default: true). Set to false when using custom children. */
+  showDefaultToolbar?: boolean;
+  /** Custom toolbar content */
+  children?: Snippet<[{ editor: Editor }]>;
+}
+</script>
+
+<script lang="ts">
+import { getVizelContextSafe } from "./VizelContext.ts";
+import VizelToolbarDefault from "./VizelToolbarDefault.svelte";
+
+let {
+  editor: editorProp,
+  class: className,
+  showDefaultToolbar = true,
+  children,
+}: VizelToolbarProps = $props();
+
+const contextEditor = getVizelContextSafe();
+const editor = $derived(editorProp ?? contextEditor?.() ?? null);
+</script>
+
+{#if editor}
+  <div class="vizel-toolbar {className ?? ''}" role="toolbar" aria-label="Formatting">
+    {#if children}
+      {@render children({ editor })}
+    {:else if showDefaultToolbar}
+      <VizelToolbarDefault {editor} />
+    {/if}
+  </div>
+{/if}

--- a/packages/svelte/src/components/VizelToolbarButton.svelte
+++ b/packages/svelte/src/components/VizelToolbarButton.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+import type { Snippet } from "svelte";
+
+export interface VizelToolbarButtonProps {
+  /** Whether the button is in active state */
+  isActive?: boolean;
+  /** Whether the button is disabled */
+  disabled?: boolean;
+  /** Tooltip title */
+  title?: string;
+  /** Custom class name */
+  class?: string;
+  /** Button content */
+  children: Snippet;
+  /** Click handler */
+  onclick?: () => void;
+  /** Action identifier for testing */
+  action?: string;
+}
+</script>
+
+<script lang="ts">
+let {
+  isActive = false,
+  disabled = false,
+  title,
+  class: className,
+  children,
+  onclick,
+  action,
+}: VizelToolbarButtonProps = $props();
+</script>
+
+<button
+  type="button"
+  {disabled}
+  aria-pressed={isActive}
+  class="vizel-toolbar-button {isActive ? 'is-active' : ''} {className ?? ''}"
+  {title}
+  data-active={isActive || undefined}
+  data-action={action}
+  {onclick}
+>
+  {@render children()}
+</button>

--- a/packages/svelte/src/components/VizelToolbarDefault.svelte
+++ b/packages/svelte/src/components/VizelToolbarDefault.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" module>
+import type { Editor, VizelToolbarAction } from "@vizel/core";
+
+export interface VizelToolbarDefaultProps {
+  /** The editor instance */
+  editor: Editor;
+  /** Custom class name */
+  class?: string;
+  /** Custom toolbar actions (defaults to vizelDefaultToolbarActions) */
+  actions?: VizelToolbarAction[];
+}
+</script>
+
+<script lang="ts">
+import {
+  groupVizelToolbarActions,
+  vizelDefaultToolbarActions,
+} from "@vizel/core";
+import { createVizelState } from "../runes/createVizelState.svelte.ts";
+import VizelIcon from "./VizelIcon.svelte";
+import VizelToolbarButton from "./VizelToolbarButton.svelte";
+import VizelToolbarDivider from "./VizelToolbarDivider.svelte";
+
+let {
+  editor,
+  class: className,
+  actions = vizelDefaultToolbarActions,
+}: VizelToolbarDefaultProps = $props();
+
+// Subscribe to editor state changes to update active/enabled states
+const editorState = createVizelState(() => editor);
+
+const groups = $derived.by(() => {
+  void editorState.current;
+  return groupVizelToolbarActions(actions);
+});
+</script>
+
+<div class="vizel-toolbar-content {className ?? ''}" data-vizel-toolbar>
+  {#each groups as group, groupIndex (group[0]?.group ?? groupIndex)}
+    {#if groupIndex > 0}
+      <VizelToolbarDivider />
+    {/if}
+    {#each group as action (action.id)}
+      <VizelToolbarButton
+        action={action.id}
+        isActive={action.isActive(editor)}
+        disabled={!action.isEnabled(editor)}
+        title={action.shortcut ? `${action.label} (${action.shortcut})` : action.label}
+        onclick={() => action.run(editor)}
+      >
+        <VizelIcon name={action.icon} />
+      </VizelToolbarButton>
+    {/each}
+  {/each}
+</div>

--- a/packages/svelte/src/components/VizelToolbarDivider.svelte
+++ b/packages/svelte/src/components/VizelToolbarDivider.svelte
@@ -1,0 +1,12 @@
+<script lang="ts" module>
+export interface VizelToolbarDividerProps {
+  /** Custom class name */
+  class?: string;
+}
+</script>
+
+<script lang="ts">
+let { class: className }: VizelToolbarDividerProps = $props();
+</script>
+
+<span class="vizel-toolbar-divider {className ?? ''}"></span>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -118,3 +118,22 @@ export {
   default as VizelThemeProvider,
   type VizelThemeProviderProps,
 } from "./VizelThemeProvider.svelte";
+// ============================================================================
+// Vizel Toolbar components
+// ============================================================================
+export {
+  default as VizelToolbar,
+  type VizelToolbarProps,
+} from "./VizelToolbar.svelte";
+export {
+  default as VizelToolbarButton,
+  type VizelToolbarButtonProps,
+} from "./VizelToolbarButton.svelte";
+export {
+  default as VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+} from "./VizelToolbarDefault.svelte";
+export {
+  default as VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+} from "./VizelToolbarDivider.svelte";

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -69,6 +69,15 @@ export {
   type VizelSlashMenuRef,
   VizelThemeProvider,
   type VizelThemeProviderProps,
+  // Toolbar
+  VizelToolbar,
+  VizelToolbarButton,
+  type VizelToolbarButtonProps,
+  VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+  VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+  type VizelToolbarProps,
 } from "./components/index.ts";
 
 // Runes (Svelte 5 reactive state)

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -14,6 +14,7 @@ import { useSlots, watch } from "vue";
 import { useVizelEditor } from "../composables/useVizelEditor.ts";
 import VizelBubbleMenu from "./VizelBubbleMenu.vue";
 import VizelEditor from "./VizelEditor.vue";
+import VizelToolbar from "./VizelToolbar.vue";
 
 /**
  * Exposed ref type for Vizel component.
@@ -52,6 +53,8 @@ export interface VizelProps {
   features?: VizelFeatureOptions;
   /** Custom class name for the editor container */
   class?: string;
+  /** Whether to show the toolbar (default: false) */
+  showToolbar?: boolean;
   /** Whether to show the bubble menu (default: true) */
   showBubbleMenu?: boolean;
   /** Enable embed option in bubble menu link editor (requires Embed extension) */
@@ -61,6 +64,7 @@ export interface VizelProps {
 const props = withDefaults(defineProps<VizelProps>(), {
   editable: true,
   autofocus: false,
+  showToolbar: false,
   showBubbleMenu: true,
   enableEmbed: false,
   transformDiagramsOnImport: true,
@@ -148,6 +152,10 @@ defineExpose<VizelRef & { getEditor: () => Editor | null }>({
 
 <template>
   <div :class="['vizel-root', $props.class]" data-vizel-root>
+    <VizelToolbar v-if="showToolbar && editor && slots['toolbar']" :editor="editor">
+      <slot name="toolbar" :editor="editor" />
+    </VizelToolbar>
+    <VizelToolbar v-else-if="showToolbar && editor" :editor="editor" />
     <VizelEditor v-if="editor" :editor="editor" />
     <VizelBubbleMenu v-if="showBubbleMenu && editor && slots['bubble-menu']" :editor="editor" :enable-embed="enableEmbed ?? false">
       <slot name="bubble-menu" :editor="editor" />

--- a/packages/vue/src/components/VizelToolbar.vue
+++ b/packages/vue/src/components/VizelToolbar.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { Editor } from "@vizel/core";
+import { computed } from "vue";
+import { useVizelContextSafe } from "./VizelContext.ts";
+import VizelToolbarDefault from "./VizelToolbarDefault.vue";
+
+export interface VizelToolbarProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Custom class name */
+  class?: string;
+  /** Whether to show the default toolbar (default: true). Set to false when using custom slot content. */
+  showDefaultToolbar?: boolean;
+}
+
+const props = withDefaults(defineProps<VizelToolbarProps>(), {
+  showDefaultToolbar: true,
+});
+
+const getContextEditor = useVizelContextSafe();
+const editor = computed(() => props.editor ?? getContextEditor?.() ?? null);
+</script>
+
+<template>
+  <div v-if="editor" :class="['vizel-toolbar', $props.class]" role="toolbar" aria-label="Formatting">
+    <slot :editor="editor">
+      <VizelToolbarDefault v-if="showDefaultToolbar" :editor="editor" />
+    </slot>
+  </div>
+</template>

--- a/packages/vue/src/components/VizelToolbarButton.vue
+++ b/packages/vue/src/components/VizelToolbarButton.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+export interface VizelToolbarButtonProps {
+  /** Whether the button is in active state */
+  isActive?: boolean;
+  /** Whether the button is disabled */
+  disabled?: boolean;
+  /** Tooltip title */
+  title?: string;
+  /** Custom class name */
+  class?: string;
+  /** Action identifier for testing */
+  action?: string;
+}
+
+const props = defineProps<VizelToolbarButtonProps>();
+
+const emit = defineEmits<{
+  click: [];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :disabled="disabled"
+    :aria-pressed="isActive"
+    :class="[
+      'vizel-toolbar-button',
+      { 'is-active': isActive },
+      $props.class,
+    ]"
+    :title="title"
+    :data-active="isActive || undefined"
+    :data-action="props.action"
+    @click="emit('click')"
+  >
+    <slot />
+  </button>
+</template>

--- a/packages/vue/src/components/VizelToolbarDefault.vue
+++ b/packages/vue/src/components/VizelToolbarDefault.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { Editor } from "@vizel/core";
+import {
+  groupVizelToolbarActions,
+  type VizelToolbarAction,
+  vizelDefaultToolbarActions,
+} from "@vizel/core";
+import { computed } from "vue";
+import { useVizelState } from "../composables/useVizelState.ts";
+import VizelIcon from "./VizelIcon.vue";
+import VizelToolbarButton from "./VizelToolbarButton.vue";
+import VizelToolbarDivider from "./VizelToolbarDivider.vue";
+
+export interface VizelToolbarDefaultProps {
+  /** The editor instance */
+  editor: Editor;
+  /** Custom class name */
+  class?: string;
+  /** Custom toolbar actions (defaults to vizelDefaultToolbarActions) */
+  actions?: VizelToolbarAction[];
+}
+
+const props = withDefaults(defineProps<VizelToolbarDefaultProps>(), {
+  actions: () => vizelDefaultToolbarActions,
+});
+
+// Subscribe to editor state changes to update active/enabled states
+const editorStateVersion = useVizelState(() => props.editor);
+
+const groups = computed(() => {
+  void editorStateVersion.value;
+  return groupVizelToolbarActions(props.actions);
+});
+</script>
+
+<template>
+  <div :class="['vizel-toolbar-content', $props.class]" data-vizel-toolbar>
+    <template v-for="(group, groupIndex) in groups" :key="group[0]?.group ?? groupIndex">
+      <VizelToolbarDivider v-if="groupIndex > 0" />
+      <VizelToolbarButton
+        v-for="action in group"
+        :key="action.id"
+        :action="action.id"
+        :is-active="action.isActive(props.editor)"
+        :disabled="!action.isEnabled(props.editor)"
+        :title="action.shortcut ? `${action.label} (${action.shortcut})` : action.label"
+        @click="action.run(props.editor)"
+      >
+        <VizelIcon :name="action.icon" />
+      </VizelToolbarButton>
+    </template>
+  </div>
+</template>

--- a/packages/vue/src/components/VizelToolbarDivider.vue
+++ b/packages/vue/src/components/VizelToolbarDivider.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+export interface VizelToolbarDividerProps {
+  /** Custom class name */
+  class?: string;
+}
+
+defineProps<VizelToolbarDividerProps>();
+</script>
+
+<template>
+  <span :class="['vizel-toolbar-divider', $props.class]" />
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -77,3 +77,17 @@ export {
   default as VizelThemeProvider,
   type VizelThemeProviderProps,
 } from "./VizelThemeProvider.vue";
+// VizelToolbar components
+export { default as VizelToolbar, type VizelToolbarProps } from "./VizelToolbar.vue";
+export {
+  default as VizelToolbarButton,
+  type VizelToolbarButtonProps,
+} from "./VizelToolbarButton.vue";
+export {
+  default as VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+} from "./VizelToolbarDefault.vue";
+export {
+  default as VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+} from "./VizelToolbarDivider.vue";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -69,6 +69,15 @@ export {
   type VizelSlashMenuRef,
   VizelThemeProvider,
   type VizelThemeProviderProps,
+  // Toolbar
+  VizelToolbar,
+  VizelToolbarButton,
+  type VizelToolbarButtonProps,
+  VizelToolbarDefault,
+  type VizelToolbarDefaultProps,
+  VizelToolbarDivider,
+  type VizelToolbarDividerProps,
+  type VizelToolbarProps,
 } from "./components/index.ts";
 
 // Composables


### PR DESCRIPTION
## Summary

- Add a fixed toolbar component with sticky positioning that follows scroll, providing quick access to formatting actions (undo/redo, bold/italic/strike/underline/code, headings, lists, blockquote/code block/horizontal rule)
- Implement toolbar for all three frameworks (React, Vue, Svelte) with consistent API and customizable content via children/slots/snippets
- Change `overflow: hidden` to `overflow: clip` on editor containers to support `position: sticky` without breaking visual clipping

### Core changes
- `VizelToolbarAction` interface and `vizelDefaultToolbarActions` constant with grouped actions
- `toolbar.scss` with `position: sticky; top: 0` and `z-index: v("z-sticky")`
- Add `@use "toolbar"` to `components.scss` (was missing from CSS-variables-free bundle)
- Undo/redo icon mappings (`lucide:undo-2`, `lucide:redo-2`)

### Framework components (React/Vue/Svelte)
- `VizelToolbar` — container with context fallback and `role="toolbar"`
- `VizelToolbarDefault` — renders all default actions grouped with dividers
- `VizelToolbarButton` — individual button with active/disabled states
- `VizelToolbarDivider` — visual separator between button groups
- `showToolbar` prop on `Vizel` component (default: `false`)

### Demo apps
- Add "Toolbar" feature toggle to all three demo apps

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Pre-commit hooks (typecheck × 4, biome, commitlint) pass
- [x] React demo: toolbar visible, sticky on scroll, toggle works, buttons functional
- [x] Verify toolbar sticks to viewport top when scrolling long content
- [x] Verify BubbleMenu renders above toolbar (Portal z-index: 9999 vs toolbar: 60)