### PR TITLE
chore: add npm package metadata to all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,26 @@
     "url": "https://github.com/seijikohara/vizel",
     "directory": "packages/core"
   },
+  "description": "Framework-agnostic core for Vizel block-based Markdown editor built on Tiptap",
+  "license": "MIT",
+  "author": "Seiji Kohara",
+  "homepage": "https://seijikohara.github.io/vizel/",
+  "bugs": {
+    "url": "https://github.com/seijikohara/vizel/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "vizel",
+    "tiptap",
+    "editor",
+    "markdown",
+    "wysiwyg",
+    "rich-text",
+    "block-editor",
+    "prosemirror"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,26 @@
     "url": "https://github.com/seijikohara/vizel",
     "directory": "packages/react"
   },
+  "description": "React 19 components and hooks for Vizel block-based Markdown editor",
+  "license": "MIT",
+  "author": "Seiji Kohara",
+  "homepage": "https://seijikohara.github.io/vizel/",
+  "bugs": {
+    "url": "https://github.com/seijikohara/vizel/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "vizel",
+    "tiptap",
+    "editor",
+    "markdown",
+    "react",
+    "wysiwyg",
+    "rich-text",
+    "block-editor"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -7,6 +7,26 @@
     "url": "https://github.com/seijikohara/vizel",
     "directory": "packages/svelte"
   },
+  "description": "Svelte 5 components and runes for Vizel block-based Markdown editor",
+  "license": "MIT",
+  "author": "Seiji Kohara",
+  "homepage": "https://seijikohara.github.io/vizel/",
+  "bugs": {
+    "url": "https://github.com/seijikohara/vizel/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "vizel",
+    "tiptap",
+    "editor",
+    "markdown",
+    "svelte",
+    "wysiwyg",
+    "rich-text",
+    "block-editor"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "svelte": "./src/index.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -7,6 +7,26 @@
     "url": "https://github.com/seijikohara/vizel",
     "directory": "packages/vue"
   },
+  "description": "Vue 3 components and composables for Vizel block-based Markdown editor",
+  "license": "MIT",
+  "author": "Seiji Kohara",
+  "homepage": "https://seijikohara.github.io/vizel/",
+  "bugs": {
+    "url": "https://github.com/seijikohara/vizel/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "vizel",
+    "tiptap",
+    "editor",
+    "markdown",
+    "vue",
+    "wysiwyg",
+    "rich-text",
+    "block-editor"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Closes #155

Add essential npm metadata fields to all four package.json files for npm registry discoverability and professional presentation before the 1.0.0 release.

### Changes

Added the following fields to `@vizel/core`, `@vizel/react`, `@vizel/vue`, and `@vizel/svelte`:

- `description` — Package-specific description
- `license` — `"MIT"`
- `author` — `"Seiji Kohara"`
- `homepage` — Documentation site URL
- `bugs` — GitHub issues URL
- `engines` — `{ "node": ">=18" }`
- `keywords` — npm search keywords (framework-specific)

## Test Plan

- [x] `pnpm install` — no lockfile changes
- [x] `pnpm build` — all packages build successfully
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes