### PR TITLE
ci: improve publish workflow

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,7 +25,7 @@ runs:
       run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,18 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Verify package contents
+        run: |
+          echo "## 📦 Package Contents" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          for pkg in core react vue svelte; do
+            echo "### @vizel/$pkg" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            (cd packages/$pkg && npm pack --dry-run 2>&1) >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          done
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Summary

Closes #156

Two improvements to the CI/CD pipeline identified during 1.0.0 release readiness review.

### Changes

1. **Unify `actions/cache` version**: Updated `.github/actions/test/action.yml` from `actions/cache@v4` to `@v5` for consistency with the publish workflow's build job.

2. **Add package content verification**: Added `npm pack --dry-run` step to the publish workflow's build job that outputs each package's contents to the GitHub step summary. This enables pre-publish inspection of package contents to catch issues like missing files or unexpected inclusions.

## Test Plan

- [x] YAML syntax is valid
- [x] No security concerns (step uses no untrusted inputs)
- [ ] CI passes with updated cache action version