### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them through [GitHub Security Advisories](https://github.com/seijikohara/vizel/security/advisories).
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Affected versions
+- Any potential impact
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours of receiving the report
+- **Initial assessment**: Within 1 week
+- **Fix or mitigation**: Depending on severity, typically within 2-4 weeks
+
+### What to Expect
+
+1. Your report will be acknowledged within 48 hours
+2. We will investigate and provide an initial assessment
+3. We will work on a fix and coordinate disclosure
+4. You will be credited (unless you prefer anonymity)
+
+## Disclosure Policy
+
+We follow coordinated disclosure. We ask that you:
+
+- Allow us reasonable time to fix the vulnerability before public disclosure
+- Make a good faith effort to avoid privacy violations, data destruction, or service disruption
+
+## Scope
+
+This security policy applies to the following packages:
+
+- `@vizel/core`
+- `@vizel/react`
+- `@vizel/vue`
+- `@vizel/svelte`


### PR DESCRIPTION
## Summary

- Add SECURITY.md with vulnerability reporting guidelines
- Supported versions: 1.x
- Reporting via [GitHub Security Advisories](https://github.com/seijikohara/vizel/security/advisories) (private disclosure)
- Explicitly states NOT to use public issues for security reports
- Includes response timeline and coordinated disclosure policy
- Scope: @vizel/core, @vizel/react, @vizel/vue, @vizel/svelte

Closes #160

## Test Plan

- [x] File exists at repository root
- [x] Clear vulnerability reporting procedure
- [x] Link to GitHub Security Advisories is correct
- [x] Public issue reporting explicitly prohibited
- [x] Response timeline included
- [x] Pre-commit hook passes