### PR TITLE
feat(docs): add comprehensive SEO optimization for VitePress documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,12 +1,115 @@
 import { withMermaid } from "vitepress-plugin-mermaid";
 
+const siteUrl = "https://seijikohara.github.io/vizel";
+
 export default withMermaid({
   title: "Vizel",
   description:
     "A block-based visual editor for Markdown built with Tiptap, supporting React, Vue, and Svelte",
   base: "/vizel/",
+  lang: "en-US",
 
-  head: [["link", { rel: "icon", type: "image/svg+xml", href: "/vizel/logo.svg" }]],
+  head: [
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/vizel/logo.svg" }],
+    ["meta", { name: "theme-color", content: "#6366F1" }],
+  ],
+
+  sitemap: {
+    hostname: "https://seijikohara.github.io",
+    transformItems: (items) => {
+      return items.map((item) => {
+        // Add base path to URL
+        const url = `vizel/${item.url}`;
+
+        if (item.url === "" || item.url === "index.html") {
+          return { ...item, url, priority: 1.0, changefreq: "weekly" };
+        }
+        if (item.url.startsWith("guide/")) {
+          return { ...item, url, priority: 0.8, changefreq: "weekly" };
+        }
+        if (item.url.startsWith("api/")) {
+          return { ...item, url, priority: 0.6, changefreq: "monthly" };
+        }
+        return { ...item, url, priority: 0.5, changefreq: "monthly" };
+      });
+    },
+  },
+
+  transformPageData(pageData) {
+    const ogImage = `${siteUrl}/og-image.png`;
+    const pageUrl = `${siteUrl}/${pageData.relativePath
+      .replace(/index\.md$/, "")
+      .replace(/\.md$/, ".html")}`;
+
+    const title = pageData.title
+      ? `${pageData.title} | Vizel`
+      : "Vizel - Block-based Visual Editor";
+    const description =
+      pageData.description ||
+      "A block-based visual editor for Markdown built with Tiptap, supporting React, Vue, and Svelte";
+
+    pageData.frontmatter.head ??= [];
+
+    // Canonical URL
+    pageData.frontmatter.head.push(["link", { rel: "canonical", href: pageUrl }]);
+
+    // Open Graph
+    pageData.frontmatter.head.push(
+      ["meta", { property: "og:type", content: "website" }],
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { property: "og:url", content: pageUrl }],
+      ["meta", { property: "og:image", content: ogImage }],
+      ["meta", { property: "og:site_name", content: "Vizel" }]
+    );
+
+    // Twitter Cards
+    pageData.frontmatter.head.push(
+      ["meta", { name: "twitter:card", content: "summary_large_image" }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      ["meta", { name: "twitter:image", content: ogImage }]
+    );
+
+    // JSON-LD Structured Data
+    if (pageData.relativePath === "index.md") {
+      const softwareSchema = {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: "Vizel",
+        description:
+          "A block-based visual editor for Markdown built with Tiptap, supporting React, Vue, and Svelte",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web",
+        offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+        author: { "@type": "Person", name: "Seiji Kohara" },
+        license: "https://opensource.org/licenses/MIT",
+        url: siteUrl,
+        codeRepository: "https://github.com/seijikohara/vizel",
+      };
+
+      pageData.frontmatter.head.push([
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify(softwareSchema),
+      ]);
+    } else {
+      const articleSchema = {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        headline: pageData.title || "Vizel Documentation",
+        description: pageData.description || "Vizel documentation page",
+        author: { "@type": "Person", name: "Seiji Kohara" },
+        mainEntityOfPage: { "@type": "WebPage", "@id": pageUrl },
+      };
+
+      pageData.frontmatter.head.push([
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify(articleSchema),
+      ]);
+    }
+  },
 
   themeConfig: {
     logo: "/logo.svg",

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://seijikohara.github.io/vizel/sitemap.xml


### PR DESCRIPTION
## Summary

- Add sitemap.xml generation with proper base path (`/vizel/`) and page priorities
- Add robots.txt with sitemap link
- Add Open Graph meta tags for social sharing
- Add Twitter Cards meta tags
- Add canonical URLs for all pages
- Add JSON-LD structured data (SoftwareApplication for home, TechArticle for docs)
- Add lang attribute (en-US)
- Add theme-color meta tag

## Changes

| File | Description |
|------|-------------|
| `docs/.vitepress/config.mts` | Add SEO settings (sitemap, transformPageData, head, lang) |
| `docs/public/robots.txt` | New file with crawler settings |

## SEO Features Added

| Feature | Status |
|---------|--------|
| Sitemap.xml | ✅ Auto-generated with priorities |
| robots.txt | ✅ Allow all with sitemap link |
| Open Graph | ✅ Dynamic per-page |
| Twitter Cards | ✅ summary_large_image |
| Canonical URL | ✅ Dynamic per-page |
| JSON-LD | ✅ SoftwareApplication / TechArticle |
| lang attribute | ✅ en-US |
| theme-color | ✅ #6366F1 |

## Test Plan

- [x] Run `pnpm docs:build` - builds successfully
- [x] Verify `sitemap.xml` contains correct URLs with `/vizel/` base path
- [x] Verify `robots.txt` is generated in dist
- [x] Verify index.html contains OG, Twitter, canonical, and JSON-LD tags
- [x] Verify lang="en-US" attribute in HTML tag