### PR TITLE
feat(core): add unified error handling utilities

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -242,6 +242,8 @@ export {
   convertVizelCodeBlocksToDiagrams,
   // Editor factory
   createVizelEditorInstance,
+  // Error handling
+  createVizelError,
   // Markdown utilities
   createVizelMarkdownSyncHandlers,
   createVizelPortalElement,
@@ -254,6 +256,7 @@ export {
   handleVizelSuggestionEscape,
   hasVizelPortalContainer,
   initializeVizelMarkdownContent,
+  isVizelError,
   // Color utilities
   isVizelValidHexColor,
   mountToVizelPortal,
@@ -275,6 +278,8 @@ export {
   type VizelContentNode,
   type VizelCreateUploadEventHandlerOptions,
   type VizelDOMRectGetter,
+  VizelError,
+  type VizelErrorCode,
   type VizelMarkdownSyncHandlers,
   type VizelMountPortalOptions,
   type VizelPortalLayer,
@@ -282,4 +287,6 @@ export {
   type VizelSuggestionContainer,
   type VizelTextSegment,
   vizelDefaultEditorProps,
+  type WrapAsVizelErrorOptions,
+  wrapAsVizelError,
 } from "./utils/index.ts";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,7 @@ import type { VizelTableOptions } from "./extensions/table.ts";
 import type { VizelTaskListExtensionsOptions } from "./extensions/task-list.ts";
 import type { VizelTextColorOptions } from "./extensions/text-color.ts";
 import type { VizelImageUploadPluginOptions } from "./plugins/image-upload.ts";
+import type { VizelError } from "./utils/errorHandling.ts";
 
 /**
  * Slash command feature options
@@ -112,6 +113,25 @@ export interface VizelEditorOptions {
   onFocus?: (props: { editor: Editor }) => void;
   /** Callback when editor loses focus */
   onBlur?: (props: { editor: Editor }) => void;
+  /**
+   * Callback when an error occurs during editor operations.
+   * Provides structured error information for logging or user feedback.
+   *
+   * Note: After this callback is invoked, the error is re-thrown to preserve
+   * existing error handling behavior. This callback is primarily for logging,
+   * analytics, or showing user notifications.
+   *
+   * @example
+   * ```typescript
+   * const editor = useVizelEditor({
+   *   onError: (error) => {
+   *     console.error(`[${error.code}] ${error.message}`);
+   *     // Optionally show user notification
+   *   },
+   * });
+   * ```
+   */
+  onError?: (error: VizelError) => void;
 }
 
 /**

--- a/packages/core/src/utils/errorHandling.ts
+++ b/packages/core/src/utils/errorHandling.ts
@@ -1,0 +1,194 @@
+/**
+ * Error codes for Vizel operations.
+ *
+ * @example
+ * ```typescript
+ * import { type VizelErrorCode, createVizelError } from '@vizel/core';
+ *
+ * const error = createVizelError(
+ *   "EDITOR_INIT_FAILED",
+ *   "Failed to initialize editor"
+ * );
+ * ```
+ */
+export type VizelErrorCode =
+  | "EDITOR_INIT_FAILED"
+  | "EXTENSION_LOAD_FAILED"
+  | "IMAGE_UPLOAD_FAILED"
+  | "IMAGE_VALIDATION_FAILED"
+  | "MARKDOWN_PARSE_FAILED"
+  | "UNKNOWN_ERROR";
+
+/**
+ * Structured error class for Vizel operations.
+ *
+ * Extends Error to provide stack traces and instanceof checks.
+ *
+ * @example
+ * ```typescript
+ * import { VizelError, isVizelError } from '@vizel/core';
+ *
+ * try {
+ *   // ... editor operations
+ * } catch (e) {
+ *   if (isVizelError(e)) {
+ *     console.error(`Vizel error [${e.code}]: ${e.message}`);
+ *   }
+ * }
+ * ```
+ */
+export class VizelError extends Error {
+  /**
+   * The error code identifying the type of error.
+   */
+  readonly code: VizelErrorCode;
+
+  /**
+   * The original error that caused this error, if any.
+   */
+  readonly originalError?: unknown;
+
+  constructor(code: VizelErrorCode, message: string, originalError?: unknown) {
+    super(message);
+    this.name = "VizelError";
+    this.code = code;
+    this.originalError = originalError;
+
+    // Maintains proper stack trace for where error was thrown (V8 engines)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, VizelError);
+    }
+  }
+}
+
+/**
+ * Create a VizelError instance.
+ *
+ * @param code - The error code
+ * @param message - Human-readable error message
+ * @param originalError - The original error that caused this error
+ * @returns A new VizelError instance
+ *
+ * @example
+ * ```typescript
+ * const error = createVizelError(
+ *   "IMAGE_UPLOAD_FAILED",
+ *   "Failed to upload image: network error",
+ *   originalError
+ * );
+ * ```
+ */
+export function createVizelError(
+  code: VizelErrorCode,
+  message: string,
+  originalError?: unknown
+): VizelError {
+  return new VizelError(code, message, originalError);
+}
+
+/**
+ * Type guard to check if a value is a VizelError.
+ *
+ * Uses both instanceof check and structural check for robustness
+ * across multiple bundles or different realms.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a VizelError
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await initEditor();
+ * } catch (e) {
+ *   if (isVizelError(e)) {
+ *     handleVizelError(e);
+ *   } else {
+ *     throw e;
+ *   }
+ * }
+ * ```
+ */
+export function isVizelError(value: unknown): value is VizelError {
+  // Fast path: instanceof check
+  if (value instanceof VizelError) {
+    return true;
+  }
+  // Structural check for cross-realm or multiple bundle scenarios
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    "code" in value &&
+    "message" in value &&
+    (value as { name: unknown }).name === "VizelError" &&
+    typeof (value as { code: unknown }).code === "string" &&
+    typeof (value as { message: unknown }).message === "string"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Options for wrapping an unknown error as a VizelError.
+ */
+export interface WrapAsVizelErrorOptions {
+  /**
+   * Optional context to include in the message prefix.
+   */
+  context?: string;
+  /**
+   * Error code to use. Defaults to "UNKNOWN_ERROR".
+   */
+  code?: VizelErrorCode;
+}
+
+/**
+ * Wrap an unknown error as a VizelError.
+ *
+ * If the error is already a VizelError, returns it unchanged (the code and
+ * context options are not applied). Otherwise, creates a new VizelError with
+ * the specified code (or UNKNOWN_ERROR).
+ *
+ * @param error - The error to wrap
+ * @param contextOrOptions - Optional context string or options object
+ * @returns A VizelError instance (the original if already a VizelError)
+ *
+ * @example
+ * ```typescript
+ * // With context string
+ * const vizelError = wrapAsVizelError(e, "During initialization");
+ *
+ * // With options object
+ * const vizelError = wrapAsVizelError(e, {
+ *   context: "During initialization",
+ *   code: "EDITOR_INIT_FAILED",
+ * });
+ * ```
+ */
+export function wrapAsVizelError(
+  error: unknown,
+  contextOrOptions?: string | WrapAsVizelErrorOptions
+): VizelError {
+  if (isVizelError(error)) {
+    return error;
+  }
+
+  const options: WrapAsVizelErrorOptions =
+    typeof contextOrOptions === "string" ? { context: contextOrOptions } : (contextOrOptions ?? {});
+
+  const { context, code = "UNKNOWN_ERROR" } = options;
+  const prefix = context ? `${context}: ` : "";
+
+  if (error instanceof Error) {
+    return createVizelError(code, `${prefix}${error.message}`, error);
+  }
+
+  // Include string representation of non-Error values for better logging
+  const errorMessage =
+    error === null || error === undefined
+      ? "An unknown error occurred"
+      : `An unknown error occurred: ${String(error)}`;
+
+  return createVizelError(code, `${prefix}${errorMessage}`, error);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -21,6 +21,15 @@ export {
   type VizelResolveFeaturesOptions,
   vizelDefaultEditorProps,
 } from "./editorHelpers.ts";
+// Error handling utilities
+export {
+  createVizelError,
+  isVizelError,
+  VizelError,
+  type VizelErrorCode,
+  type WrapAsVizelErrorOptions,
+  wrapAsVizelError,
+} from "./errorHandling.ts";
 // Lazy import utility
 export { createLazyLoader } from "./lazy-import.ts";
 // Markdown utilities


### PR DESCRIPTION
## Summary

- Add `VizelError` class extending Error with structured error codes
- Add utility functions: `createVizelError`, `isVizelError`, `wrapAsVizelError`
- Add `onError` callback to `VizelEditorOptions` for error notifications
- Integrate error handling in React, Vue, and Svelte hooks/composables/runes

## Error Codes

| Code | Description |
|------|-------------|
| `EDITOR_INIT_FAILED` | Editor initialization failed |
| `EXTENSION_LOAD_FAILED` | Extension loading failed |
| `IMAGE_UPLOAD_FAILED` | Image upload failed |
| `IMAGE_VALIDATION_FAILED` | Image validation failed |
| `MARKDOWN_PARSE_FAILED` | Markdown parsing failed |
| `UNKNOWN_ERROR` | Unknown error |

## Usage Example

```typescript
const editor = useVizelEditor({
  onError: (error) => {
    console.error(`[${error.code}] ${error.message}`);
    // Show user notification
  },
});
```

## Design Decisions

- **Non-breaking**: `onError` callback approach preserves existing return types
- **Cross-realm safe**: `isVizelError` includes structural check for multiple bundles
- **Re-throw pattern**: Errors are re-thrown after callback to maintain existing behavior

Closes #179

## Test Plan

- [x] Run typecheck (`pnpm typecheck`)
- [x] Run lint (`pnpm lint`)
- [x] Run E2E tests (`pnpm test:ct`)
  - Note: Firefox BubbleMenu failures are pre-existing issues unrelated to this PR