### PR TITLE
refactor(core): replace type assertions with type guards

### DIFF
--- a/packages/core/src/extensions/diagram.ts
+++ b/packages/core/src/extensions/diagram.ts
@@ -42,6 +42,18 @@ const loadGraphvizModule = createLazyLoader("@hpcc-js/wasm-graphviz", async () =
 export type VizelDiagramType = "mermaid" | "graphviz";
 
 /**
+ * Valid diagram type values for type guard.
+ */
+const VALID_DIAGRAM_TYPES: readonly VizelDiagramType[] = ["mermaid", "graphviz"];
+
+/**
+ * Type guard to check if a value is a valid VizelDiagramType.
+ */
+function isVizelDiagramType(value: unknown): value is VizelDiagramType {
+  return typeof value === "string" && VALID_DIAGRAM_TYPES.includes(value as VizelDiagramType);
+}
+
+/**
  * GraphViz layout engine options
  */
 export type GraphvizEngine = "dot" | "neato" | "fdp" | "sfdp" | "twopi" | "circo";
@@ -325,8 +337,10 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
       },
       type: {
         default: "mermaid",
-        parseHTML: (element) =>
-          (element.getAttribute("data-diagram-type") as VizelDiagramType) || "mermaid",
+        parseHTML: (element) => {
+          const typeAttr = element.getAttribute("data-diagram-type");
+          return isVizelDiagramType(typeAttr) ? typeAttr : "mermaid";
+        },
         renderHTML: (attributes) => ({
           "data-diagram-type": attributes.type,
         }),
@@ -621,7 +635,7 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
       type: "diagram",
       attrs: {
         code: token.code || "",
-        type: (token.diagramType as VizelDiagramType) || "mermaid",
+        type: isVizelDiagramType(token.diagramType) ? token.diagramType : "mermaid",
       },
     };
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -254,8 +254,13 @@ export {
   getVizelMarkdown,
   getVizelPortalContainer,
   handleVizelSuggestionEscape,
+  // Type guard utilities
+  hasFunction,
   hasVizelPortalContainer,
   initializeVizelMarkdownContent,
+  isOptionalString,
+  isRecord,
+  isString,
   isVizelError,
   // Color utilities
   isVizelValidHexColor,

--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -167,15 +167,13 @@ function hasVizelCharacterCountStorage(
 ): storage is { characterCount: VizelCharacterCountStorage } {
   if (typeof storage !== "object" || storage === null) return false;
   if (!("characterCount" in storage)) return false;
-  const cc = (storage as { characterCount: unknown }).characterCount;
-  return (
-    typeof cc === "object" &&
-    cc !== null &&
-    "characters" in cc &&
-    typeof (cc as { characters: unknown }).characters === "function" &&
-    "words" in cc &&
-    typeof (cc as { words: unknown }).words === "function"
-  );
+
+  const record = storage as Record<string, unknown>;
+  const cc = record.characterCount;
+  if (typeof cc !== "object" || cc === null) return false;
+
+  const ccRecord = cc as Record<string, unknown>;
+  return typeof ccRecord.characters === "function" && typeof ccRecord.words === "function";
 }
 
 /**
@@ -253,7 +251,8 @@ export function transformVizelDiagramCodeBlocks(content: VizelContentNode): Vize
   if (!content) return content;
 
   // Transform codeBlock with diagram language to diagram node
-  const language = content.attrs?.language as string | undefined;
+  const languageAttr = content.attrs?.language;
+  const language = typeof languageAttr === "string" ? languageAttr : undefined;
   if (content.type === "codeBlock" && language && language in DIAGRAM_LANGUAGES) {
     // Extract text content from the code block
     const code =
@@ -309,7 +308,8 @@ export function convertVizelCodeBlocksToDiagrams(editor: Editor): void {
 
   editor.state.doc.descendants((node, pos) => {
     if (node.type.name === "codeBlock") {
-      const language = node.attrs.language as string | undefined;
+      const languageAttr = node.attrs.language;
+      const language = typeof languageAttr === "string" ? languageAttr : undefined;
       const diagramType = language ? DIAGRAM_LANGUAGES[language] : undefined;
       if (diagramType) {
         replacements.push({

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -65,3 +65,5 @@ export {
 } from "./suggestionContainer.ts";
 // Text highlight utilities
 export { splitVizelTextByMatches, type VizelTextSegment } from "./textHighlight.ts";
+// Type guard utilities
+export { hasFunction, isOptionalString, isRecord, isString } from "./typeGuards.ts";

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -29,24 +29,22 @@ interface EditorWithMarkdownStorage {
  * Type guard: check if the editor has markdown export (getMarkdown method).
  */
 function hasMarkdownExport(editor: Editor): editor is Editor & EditorWithMarkdownExport {
-  return (
-    "getMarkdown" in editor &&
-    typeof (editor as EditorWithMarkdownExport).getMarkdown === "function"
-  );
+  const editorRecord = editor as unknown as Record<string, unknown>;
+  return "getMarkdown" in editor && typeof editorRecord.getMarkdown === "function";
 }
 
 /**
  * Type guard: check if the editor has markdown storage with parse capability.
  */
 function hasMarkdownStorage(editor: Editor): editor is Editor & EditorWithMarkdownStorage {
+  const editorRecord = editor as unknown as Record<string, unknown>;
   if (!("markdown" in editor)) return false;
-  const storage = (editor as Editor & { markdown: unknown }).markdown;
-  return (
-    typeof storage === "object" &&
-    storage !== null &&
-    "parse" in storage &&
-    typeof (storage as EditorWithMarkdownStorage["markdown"]).parse === "function"
-  );
+
+  const storage = editorRecord.markdown;
+  if (typeof storage !== "object" || storage === null) return false;
+
+  const storageRecord = storage as Record<string, unknown>;
+  return "parse" in storage && typeof storageRecord.parse === "function";
 }
 
 /**

--- a/packages/core/src/utils/typeGuards.ts
+++ b/packages/core/src/utils/typeGuards.ts
@@ -1,0 +1,74 @@
+/**
+ * Generic type guard utilities for runtime type checking.
+ *
+ * These guards provide safe alternatives to type assertions (`as` casts)
+ * and are designed to be composable for building domain-specific guards.
+ */
+
+/**
+ * Check if a value is a non-null object (excludes arrays).
+ *
+ * @param value - The value to check
+ * @returns True if value is a plain object
+ *
+ * @example
+ * ```typescript
+ * if (isRecord(value)) {
+ *   // value is Record<string, unknown>
+ *   console.log(value.someKey);
+ * }
+ * ```
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Check if an object has an own property that is a function.
+ *
+ * Note: Uses Object.hasOwn to check for own properties only,
+ * excluding inherited properties from the prototype chain.
+ *
+ * @param obj - The object to check
+ * @param key - The property key to check
+ * @returns True if the own property exists and is a function
+ *
+ * @example
+ * ```typescript
+ * if (hasFunction(storage, "characters")) {
+ *   // storage.characters is callable
+ *   storage.characters();
+ * }
+ * ```
+ */
+export function hasFunction<K extends string>(
+  obj: unknown,
+  key: K
+): obj is Record<K, (...args: unknown[]) => unknown> {
+  return isRecord(obj) && Object.hasOwn(obj, key) && typeof obj[key] === "function";
+}
+
+/**
+ * Check if a value is a string (including empty strings).
+ *
+ * @param value - The value to check
+ * @returns True if value is a string
+ *
+ * @example
+ * ```typescript
+ * const language = isString(attrs?.language) ? attrs.language : undefined;
+ * ```
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/**
+ * Check if a value is a string or undefined.
+ *
+ * @param value - The value to check
+ * @returns True if value is a string or undefined
+ */
+export function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}


### PR DESCRIPTION
## Summary

- Add generic type guard utilities (`isRecord`, `hasFunction`, `isString`, `isOptionalString`)
- Replace unsafe `as` casts with runtime type checks in high-priority files
- Add `isVizelDiagramType` for diagram type validation

## Changes

### New: `packages/core/src/utils/typeGuards.ts`
Generic type guards for common runtime type checking patterns.

### Modified: `packages/core/src/utils/editorHelpers.ts`
- Refactored `hasVizelCharacterCountStorage` to use cleaner Record patterns
- Replaced `language as string | undefined` with `typeof` checks

### Modified: `packages/core/src/utils/markdown.ts`
- Improved `hasMarkdownExport` and `hasMarkdownStorage` type guards

### Modified: `packages/core/src/extensions/diagram.ts`
- Added `isVizelDiagramType` type guard
- Replaced attribute type assertions with type guard checks

## Intentionally Retained Type Assertions

1. `editor.view as EditorView` - Guaranteed by Tiptap's Editor type
2. `this.storage as {...}` - Guaranteed by Extension.addStorage definition
3. `as const` / import aliases - Do not compromise type safety

Closes #180

## Test Plan

- [x] Run typecheck (`pnpm typecheck`)
- [x] Run lint (`pnpm lint`)