### PR TITLE
feat(core): add Find & Replace functionality

### DIFF
--- a/packages/core/src/extensions/find-replace.ts
+++ b/packages/core/src/extensions/find-replace.ts
@@ -1,0 +1,404 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Options for the Find & Replace extension
+ */
+export interface VizelFindReplaceOptions {
+  /** Whether search is case-sensitive. Default: false */
+  caseSensitive?: boolean;
+  /** Callback when search results change */
+  onResultsChange?: (results: { total: number; current: number }) => void;
+}
+
+/**
+ * Represents a single match in the document
+ */
+export interface VizelFindMatch {
+  from: number;
+  to: number;
+}
+
+/**
+ * Internal state for the Find & Replace plugin
+ */
+export interface VizelFindReplaceState {
+  query: string;
+  matches: VizelFindMatch[];
+  activeIndex: number;
+  caseSensitive: boolean;
+  isOpen: boolean;
+  mode: "find" | "replace";
+}
+
+type VizelFindReplaceMeta =
+  | { type: "setQuery"; query: string }
+  | { type: "setActiveIndex"; index: number }
+  | { type: "setCaseSensitive"; caseSensitive: boolean }
+  | { type: "setOpen"; mode: "find" | "replace" }
+  | { type: "setClosed" }
+  | { type: "clear" };
+
+/**
+ * Plugin key for accessing Find & Replace state
+ */
+export const vizelFindReplacePluginKey = new PluginKey<VizelFindReplaceState>("vizelFindReplace");
+
+function createEmptyState(caseSensitive: boolean): VizelFindReplaceState {
+  return {
+    query: "",
+    matches: [],
+    activeIndex: -1,
+    caseSensitive,
+    isOpen: false,
+    mode: "find",
+  };
+}
+
+function isFindReplaceMeta(value: unknown): value is VizelFindReplaceMeta {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
+function buildMatches(
+  doc: ProseMirrorNode,
+  query: string,
+  caseSensitive: boolean
+): VizelFindMatch[] {
+  if (!query) return [];
+  const needle = caseSensitive ? query : query.toLowerCase();
+  const matches: VizelFindMatch[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isText) return true;
+
+    const text = node.text ?? "";
+    const haystack = caseSensitive ? text : text.toLowerCase();
+    let index = 0;
+
+    while (index <= haystack.length - needle.length) {
+      const found = haystack.indexOf(needle, index);
+      if (found === -1) break;
+
+      matches.push({
+        from: pos + found,
+        to: pos + found + needle.length,
+      });
+
+      index = found + Math.max(needle.length, 1);
+    }
+
+    return true;
+  });
+
+  return matches;
+}
+
+function clampActiveIndex(activeIndex: number, matches: VizelFindMatch[]): number {
+  if (matches.length === 0) return -1;
+  return Math.min(Math.max(activeIndex, 0), matches.length - 1);
+}
+
+/**
+ * Get the current Find & Replace state from the editor
+ */
+export function getVizelFindReplaceState(state: EditorState): VizelFindReplaceState | null {
+  return vizelFindReplacePluginKey.getState(state) ?? null;
+}
+
+/**
+ * Create the Find & Replace extension
+ */
+export function createVizelFindReplaceExtension(options: VizelFindReplaceOptions = {}): Extension {
+  return Extension.create<VizelFindReplaceOptions>({
+    name: "vizelFindReplace",
+
+    addOptions() {
+      return {
+        caseSensitive: false,
+        ...options,
+      };
+    },
+
+    addCommands() {
+      return {
+        openFindReplace:
+          (mode: "find" | "replace" = "find") =>
+          ({ tr, dispatch }) => {
+            if (dispatch) {
+              dispatch(tr.setMeta(vizelFindReplacePluginKey, { type: "setOpen", mode }));
+            }
+            return true;
+          },
+
+        closeFindReplace:
+          () =>
+          ({ tr, dispatch }) => {
+            if (dispatch) {
+              dispatch(tr.setMeta(vizelFindReplacePluginKey, { type: "setClosed" }));
+            }
+            return true;
+          },
+
+        setFindCaseSensitive:
+          (caseSensitive: boolean) =>
+          ({ tr, dispatch }) => {
+            if (dispatch) {
+              dispatch(
+                tr.setMeta(vizelFindReplacePluginKey, {
+                  type: "setCaseSensitive",
+                  caseSensitive,
+                })
+              );
+            }
+            return true;
+          },
+
+        find:
+          (query: string) =>
+          ({ tr, dispatch }) => {
+            if (dispatch) {
+              dispatch(tr.setMeta(vizelFindReplacePluginKey, { type: "setQuery", query }));
+            }
+            return true;
+          },
+
+        findNext:
+          () =>
+          ({ state, dispatch }) => {
+            const pluginState = getVizelFindReplaceState(state);
+            if (!pluginState || pluginState.matches.length === 0) return false;
+
+            const nextIndex =
+              (pluginState.activeIndex + 1 + pluginState.matches.length) %
+              pluginState.matches.length;
+            const match = pluginState.matches[nextIndex];
+            if (!match) return false;
+
+            const tr = state.tr
+              .setSelection(TextSelection.create(state.doc, match.from, match.to))
+              .setMeta(vizelFindReplacePluginKey, {
+                type: "setActiveIndex",
+                index: nextIndex,
+              });
+
+            if (dispatch) dispatch(tr.scrollIntoView());
+            return true;
+          },
+
+        findPrevious:
+          () =>
+          ({ state, dispatch }) => {
+            const pluginState = getVizelFindReplaceState(state);
+            if (!pluginState || pluginState.matches.length === 0) return false;
+
+            const prevIndex =
+              (pluginState.activeIndex - 1 + pluginState.matches.length) %
+              pluginState.matches.length;
+            const match = pluginState.matches[prevIndex];
+            if (!match) return false;
+
+            const tr = state.tr
+              .setSelection(TextSelection.create(state.doc, match.from, match.to))
+              .setMeta(vizelFindReplacePluginKey, {
+                type: "setActiveIndex",
+                index: prevIndex,
+              });
+
+            if (dispatch) dispatch(tr.scrollIntoView());
+            return true;
+          },
+
+        replace:
+          (text: string) =>
+          ({ state, dispatch }) => {
+            const pluginState = getVizelFindReplaceState(state);
+            if (!pluginState || pluginState.activeIndex < 0) return false;
+
+            const match = pluginState.matches[pluginState.activeIndex];
+            if (!match) return false;
+            const tr = state.tr.insertText(text, match.from, match.to);
+
+            if (dispatch) dispatch(tr.scrollIntoView());
+            return true;
+          },
+
+        replaceAll:
+          (text: string) =>
+          ({ state, dispatch }) => {
+            const pluginState = getVizelFindReplaceState(state);
+            if (!pluginState || pluginState.matches.length === 0) return false;
+
+            // Replace from back to front to preserve positions
+            let tr = state.tr;
+            for (let i = pluginState.matches.length - 1; i >= 0; i -= 1) {
+              const match = pluginState.matches[i];
+              if (match) {
+                tr = tr.insertText(text, match.from, match.to);
+              }
+            }
+
+            if (dispatch) dispatch(tr.scrollIntoView());
+            return true;
+          },
+
+        clearFind:
+          () =>
+          ({ tr, dispatch }) => {
+            if (dispatch) {
+              dispatch(tr.setMeta(vizelFindReplacePluginKey, { type: "clear" }));
+            }
+            return true;
+          },
+      };
+    },
+
+    addKeyboardShortcuts() {
+      return {
+        "Mod-f": () => this.editor.commands.openFindReplace("find"),
+        // Note: Mod-h may conflict with macOS "Hide" shortcut
+        "Mod-Shift-h": () => this.editor.commands.openFindReplace("replace"),
+      };
+    },
+
+    addProseMirrorPlugins() {
+      const initialCaseSensitive = this.options.caseSensitive ?? false;
+      const extensionOptions = this.options;
+
+      return [
+        new Plugin<VizelFindReplaceState>({
+          key: vizelFindReplacePluginKey,
+
+          state: {
+            init: () => createEmptyState(initialCaseSensitive),
+            apply: (tr, value) => {
+              const metaRaw = tr.getMeta(vizelFindReplacePluginKey);
+              let next = value;
+
+              if (isFindReplaceMeta(metaRaw)) {
+                switch (metaRaw.type) {
+                  case "setQuery": {
+                    const matches = buildMatches(tr.doc, metaRaw.query, next.caseSensitive);
+                    next = {
+                      ...next,
+                      query: metaRaw.query,
+                      matches,
+                      activeIndex: matches.length > 0 ? 0 : -1,
+                    };
+                    break;
+                  }
+                  case "setActiveIndex":
+                    next = {
+                      ...next,
+                      activeIndex: clampActiveIndex(metaRaw.index, next.matches),
+                    };
+                    break;
+                  case "setCaseSensitive": {
+                    const matches = buildMatches(tr.doc, next.query, metaRaw.caseSensitive);
+                    next = {
+                      ...next,
+                      caseSensitive: metaRaw.caseSensitive,
+                      matches,
+                      activeIndex: clampActiveIndex(next.activeIndex, matches),
+                    };
+                    break;
+                  }
+                  case "setOpen":
+                    next = { ...next, isOpen: true, mode: metaRaw.mode };
+                    break;
+                  case "setClosed":
+                    next = { ...next, isOpen: false };
+                    break;
+                  case "clear":
+                    next = createEmptyState(next.caseSensitive);
+                    break;
+                  default:
+                    // All cases are handled; this satisfies the linter
+                    break;
+                }
+              }
+
+              // Rebuild matches if document changed and we have a query
+              if (tr.docChanged && next.query) {
+                const matches = buildMatches(tr.doc, next.query, next.caseSensitive);
+                next = {
+                  ...next,
+                  matches,
+                  activeIndex: clampActiveIndex(next.activeIndex, matches),
+                };
+              }
+
+              return next;
+            },
+          },
+
+          props: {
+            decorations(state) {
+              const pluginState = vizelFindReplacePluginKey.getState(state);
+              if (!pluginState || pluginState.matches.length === 0) {
+                return DecorationSet.empty;
+              }
+
+              const decorations = pluginState.matches.map((match, index) => {
+                const isCurrent = index === pluginState.activeIndex;
+                return Decoration.inline(match.from, match.to, {
+                  class: isCurrent ? "vizel-find-current" : "vizel-find-match",
+                  "data-vizel-find-match": "true",
+                });
+              });
+
+              return DecorationSet.create(state.doc, decorations);
+            },
+          },
+
+          view: () => {
+            let prev = { total: 0, current: 0 };
+            return {
+              update: (view) => {
+                const pluginState = vizelFindReplacePluginKey.getState(view.state);
+                if (!pluginState) return;
+
+                const next = {
+                  total: pluginState.matches.length,
+                  current: pluginState.activeIndex >= 0 ? pluginState.activeIndex + 1 : 0,
+                };
+
+                if (next.total !== prev.total || next.current !== prev.current) {
+                  extensionOptions.onResultsChange?.(next);
+                  prev = next;
+                }
+              },
+            };
+          },
+        }),
+      ];
+    },
+  });
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    vizelFindReplace: {
+      /** Open the Find & Replace panel */
+      openFindReplace: (mode?: "find" | "replace") => ReturnType;
+      /** Close the Find & Replace panel */
+      closeFindReplace: () => ReturnType;
+      /** Toggle case-sensitive search */
+      setFindCaseSensitive: (caseSensitive: boolean) => ReturnType;
+      /** Search for text in the document */
+      find: (query: string) => ReturnType;
+      /** Navigate to the next match */
+      findNext: () => ReturnType;
+      /** Navigate to the previous match */
+      findPrevious: () => ReturnType;
+      /** Replace the current match with text */
+      replace: (text: string) => ReturnType;
+      /** Replace all matches with text */
+      replaceAll: (text: string) => ReturnType;
+      /** Clear the search state */
+      clearFind: () => ReturnType;
+    };
+  }
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -74,6 +74,16 @@ export {
   type VizelImageFileHandlers,
 } from "./file-handler.ts";
 
+// Find & Replace
+export {
+  createVizelFindReplaceExtension,
+  getVizelFindReplaceState,
+  type VizelFindMatch,
+  type VizelFindReplaceOptions,
+  type VizelFindReplaceState,
+  vizelFindReplacePluginKey,
+} from "./find-replace.ts";
+
 // Image
 export {
   createVizelImageExtension,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,8 @@ export {
   createVizelExtensions,
   // File handler
   createVizelFileHandlerExtension,
+  // Find & Replace
+  createVizelFindReplaceExtension,
   // Image
   createVizelImageExtension,
   createVizelImageFileHandlers,
@@ -78,6 +80,7 @@ export {
   getAllVizelLanguageIds,
   // Node types
   getVizelActiveNodeType,
+  getVizelFindReplaceState,
   getVizelImageUploadPluginKey,
   getVizelRecentColors,
   getVizelRegisteredLanguages,
@@ -115,6 +118,9 @@ export {
   type VizelFileHandlerError,
   type VizelFileHandlerErrorType,
   type VizelFileHandlerOptions,
+  type VizelFindMatch,
+  type VizelFindReplaceOptions,
+  type VizelFindReplaceState,
   VizelImage,
   type VizelImageFileHandlerOptions,
   type VizelImageFileHandlers,
@@ -163,6 +169,7 @@ export {
   vizelDefaultNodeTypes,
   vizelDefaultSlashCommands,
   vizelEmbedPastePluginKey,
+  vizelFindReplacePluginKey,
 } from "./extensions/index.ts";
 
 // =============================================================================

--- a/packages/core/src/styles/components.scss
+++ b/packages/core/src/styles/components.scss
@@ -42,3 +42,4 @@
 @use "embed";
 @use "save-indicator";
 @use "diagram";
+@use "components/find-replace";

--- a/packages/core/src/styles/components/_find-replace.scss
+++ b/packages/core/src/styles/components/_find-replace.scss
@@ -1,0 +1,161 @@
+// Find & Replace styles
+// Highlight styles for search matches
+
+.vizel-find-match {
+  background-color: var(--vizel-find-match-bg, rgba(255, 213, 0, 0.4));
+  border-radius: 2px;
+}
+
+.vizel-find-current {
+  background-color: var(--vizel-find-current-bg, rgba(255, 150, 0, 0.6));
+  border-radius: 2px;
+  outline: 2px solid var(--vizel-find-current-outline, rgba(255, 120, 0, 0.8));
+  outline-offset: -1px;
+}
+
+// Find & Replace panel styles
+.vizel-find-replace-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background-color: var(--vizel-find-replace-bg, var(--vizel-bg-primary, #ffffff));
+  border: 1px solid var(--vizel-find-replace-border, var(--vizel-border-color, #e0e0e0));
+  border-radius: 8px;
+  box-shadow: var(--vizel-find-replace-shadow, 0 4px 12px rgba(0, 0, 0, 0.15));
+  min-width: 320px;
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-find-replace-bg, var(--vizel-bg-primary, #1e1e1e));
+    border-color: var(--vizel-find-replace-border, var(--vizel-border-color, #3e3e3e));
+  }
+}
+
+.vizel-find-replace-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.vizel-find-replace-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid var(--vizel-input-border, #d0d0d0);
+  border-radius: 4px;
+  background-color: var(--vizel-input-bg, #ffffff);
+  color: var(--vizel-text-primary, #1a1a1a);
+  outline: none;
+  transition: border-color 0.15s ease;
+
+  &:focus {
+    border-color: var(--vizel-primary, #6366f1);
+    box-shadow: 0 0 0 2px var(--vizel-primary-alpha, rgba(99, 102, 241, 0.2));
+  }
+
+  &::placeholder {
+    color: var(--vizel-text-muted, #9ca3af);
+  }
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-input-bg, #2d2d2d);
+    border-color: var(--vizel-input-border, #4a4a4a);
+    color: var(--vizel-text-primary, #e0e0e0);
+  }
+}
+
+.vizel-find-replace-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  min-width: 32px;
+  height: 32px;
+  font-size: 14px;
+  border: 1px solid var(--vizel-button-border, #d0d0d0);
+  border-radius: 4px;
+  background-color: var(--vizel-button-bg, #f5f5f5);
+  color: var(--vizel-text-primary, #1a1a1a);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background-color: var(--vizel-button-hover-bg, #e8e8e8);
+    border-color: var(--vizel-button-hover-border, #c0c0c0);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-button-bg, #3a3a3a);
+    border-color: var(--vizel-button-border, #4a4a4a);
+    color: var(--vizel-text-primary, #e0e0e0);
+
+    &:hover:not(:disabled) {
+      background-color: var(--vizel-button-hover-bg, #4a4a4a);
+    }
+  }
+}
+
+.vizel-find-replace-button--primary {
+  background-color: var(--vizel-primary, #6366f1);
+  border-color: var(--vizel-primary, #6366f1);
+  color: #ffffff;
+
+  &:hover:not(:disabled) {
+    background-color: var(--vizel-primary-hover, #5558e3);
+    border-color: var(--vizel-primary-hover, #5558e3);
+  }
+}
+
+.vizel-find-replace-count {
+  font-size: 13px;
+  color: var(--vizel-text-muted, #6b7280);
+  white-space: nowrap;
+  min-width: 60px;
+  text-align: center;
+}
+
+.vizel-find-replace-options {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--vizel-text-secondary, #4b5563);
+}
+
+.vizel-find-replace-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+
+  input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: var(--vizel-primary, #6366f1);
+  }
+}
+
+.vizel-find-replace-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--vizel-text-muted, #6b7280);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--vizel-hover-bg, rgba(0, 0, 0, 0.05));
+  }
+}

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -1,0 +1,227 @@
+import { type Editor, getVizelFindReplaceState, type VizelFindReplaceState } from "@vizel/core";
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export interface VizelFindReplaceProps {
+  /** The Tiptap editor instance */
+  editor: Editor | null;
+  /** Custom class name */
+  className?: string;
+  /** Callback when the panel is closed */
+  onClose?: () => void;
+}
+
+/**
+ * Find & Replace panel component for React
+ */
+export function VizelFindReplace({ editor, className, onClose }: VizelFindReplaceProps) {
+  const [findText, setFindText] = useState("");
+  const [replaceText, setReplaceText] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [state, setState] = useState<VizelFindReplaceState | null>(null);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Subscribe to plugin state changes
+  useEffect(() => {
+    if (!editor) return;
+
+    const updateState = () => {
+      const pluginState = getVizelFindReplaceState(editor.state);
+      setState(pluginState);
+    };
+
+    updateState();
+    editor.on("transaction", updateState);
+
+    return () => {
+      editor.off("transaction", updateState);
+    };
+  }, [editor]);
+
+  // Focus input when panel opens
+  useEffect(() => {
+    if (state?.isOpen) {
+      findInputRef.current?.focus();
+      findInputRef.current?.select();
+    }
+  }, [state?.isOpen]);
+
+  const handleFindInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setFindText(value);
+      if (editor) {
+        editor.commands.find(value);
+      }
+    },
+    [editor]
+  );
+
+  const handleFindNext = useCallback(() => {
+    editor?.commands.findNext();
+  }, [editor]);
+
+  const handleFindPrevious = useCallback(() => {
+    editor?.commands.findPrevious();
+  }, [editor]);
+
+  const handleReplace = useCallback(() => {
+    if (editor) {
+      editor.commands.replace(replaceText);
+      editor.commands.findNext();
+    }
+  }, [editor, replaceText]);
+
+  const handleReplaceAll = useCallback(() => {
+    if (editor) {
+      editor.commands.replaceAll(replaceText);
+    }
+  }, [editor, replaceText]);
+
+  const handleClose = useCallback(() => {
+    if (editor) {
+      editor.commands.clearFind();
+      editor.commands.closeFindReplace();
+    }
+    setFindText("");
+    setReplaceText("");
+    onClose?.();
+  }, [editor, onClose]);
+
+  const handleCaseSensitiveChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const checked = e.target.checked;
+      setCaseSensitive(checked);
+      editor?.commands.setFindCaseSensitive(checked);
+      if (findText) {
+        editor?.commands.find(findText);
+      }
+    },
+    [editor, findText]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          handleFindPrevious();
+        } else {
+          handleFindNext();
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+      }
+    },
+    [handleFindNext, handleFindPrevious, handleClose]
+  );
+
+  if (!state?.isOpen) {
+    return null;
+  }
+
+  const matchCount = state.matches.length;
+  const currentMatch = state.activeIndex >= 0 ? state.activeIndex + 1 : 0;
+  const isReplaceMode = state.mode === "replace";
+
+  return (
+    <div
+      className={`vizel-find-replace-panel ${className || ""}`}
+      role="dialog"
+      aria-label="Find and Replace"
+    >
+      <div className="vizel-find-replace-row">
+        <input
+          ref={findInputRef}
+          type="text"
+          className="vizel-find-replace-input"
+          placeholder="Find..."
+          value={findText}
+          onChange={handleFindInputChange}
+          onKeyDown={handleKeyDown}
+          aria-label="Find text"
+        />
+        <span className="vizel-find-replace-count">
+          {matchCount > 0 ? `${currentMatch}/${matchCount}` : "No results"}
+        </span>
+        <button
+          type="button"
+          className="vizel-find-replace-button"
+          onClick={handleFindPrevious}
+          disabled={matchCount === 0}
+          aria-label="Find previous"
+          title="Find previous (Shift+Enter)"
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          className="vizel-find-replace-button"
+          onClick={handleFindNext}
+          disabled={matchCount === 0}
+          aria-label="Find next"
+          title="Find next (Enter)"
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className="vizel-find-replace-button"
+          onClick={handleClose}
+          aria-label="Close"
+          title="Close (Escape)"
+        >
+          ✕
+        </button>
+      </div>
+
+      {isReplaceMode && (
+        <div className="vizel-find-replace-row">
+          <input
+            type="text"
+            className="vizel-find-replace-input"
+            placeholder="Replace with..."
+            value={replaceText}
+            onChange={(e) => setReplaceText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Replace text"
+          />
+          <button
+            type="button"
+            className="vizel-find-replace-button"
+            onClick={handleReplace}
+            disabled={matchCount === 0}
+            aria-label="Replace"
+            title="Replace current match"
+          >
+            Replace
+          </button>
+          <button
+            type="button"
+            className="vizel-find-replace-button vizel-find-replace-button--primary"
+            onClick={handleReplaceAll}
+            disabled={matchCount === 0}
+            aria-label="Replace all"
+            title="Replace all matches"
+          >
+            All
+          </button>
+        </div>
+      )}
+
+      <div className="vizel-find-replace-options">
+        <label className="vizel-find-replace-checkbox">
+          <input type="checkbox" checked={caseSensitive} onChange={handleCaseSensitiveChange} />
+          Case sensitive
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -27,6 +27,8 @@ export { useVizelContext, useVizelContextSafe } from "./VizelContext.tsx";
 export { VizelEditor, type VizelEditorProps, type VizelExposed } from "./VizelEditor.tsx";
 // VizelEmbedView component
 export { VizelEmbedView, type VizelEmbedViewProps } from "./VizelEmbedView.tsx";
+// VizelFindReplace component
+export { VizelFindReplace, type VizelFindReplaceProps } from "./VizelFindReplace.tsx";
 // Icon component
 export { VizelIcon, type VizelIconProps } from "./VizelIcon.tsx";
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -42,6 +42,9 @@ export {
   VizelEmbedView,
   type VizelEmbedViewProps,
   type VizelExposed,
+  // FindReplace
+  VizelFindReplace,
+  type VizelFindReplaceProps,
   // Icon
   VizelIcon,
   type VizelIconProps,

--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -1,0 +1,228 @@
+<script lang="ts" module>
+import type { Editor } from "@vizel/core";
+
+export interface VizelFindReplaceProps {
+  /** The Tiptap editor instance */
+  editor: Editor | null;
+  /** Custom class name */
+  class?: string;
+  /** Callback when the panel is closed */
+  onClose?: () => void;
+}
+</script>
+
+<script lang="ts">
+import {
+  getVizelFindReplaceState,
+  type VizelFindReplaceState,
+} from "@vizel/core";
+import { tick } from "svelte";
+
+let { editor, class: className, onClose }: VizelFindReplaceProps = $props();
+
+// Empty state for initial value
+const emptyState: VizelFindReplaceState = {
+  query: "",
+  matches: [],
+  activeIndex: -1,
+  caseSensitive: false,
+  isOpen: false,
+  mode: "find",
+};
+
+let findText = $state("");
+let replaceText = $state("");
+let caseSensitive = $state(false);
+let findReplaceState = $state(emptyState);
+let findInputRef: HTMLInputElement | null = $state(null);
+
+const matchCount = $derived(findReplaceState.matches.length);
+const currentMatch = $derived(
+  findReplaceState.activeIndex >= 0 ? findReplaceState.activeIndex + 1 : 0,
+);
+const isReplaceMode = $derived(findReplaceState.mode === "replace");
+const isOpen = $derived(findReplaceState.isOpen);
+
+function updateFindReplaceState() {
+  if (editor) {
+    findReplaceState = getVizelFindReplaceState(editor.state) ?? emptyState;
+  }
+}
+
+// Subscribe to editor transactions
+$effect(() => {
+  if (editor) {
+    updateFindReplaceState();
+    editor.on("transaction", updateFindReplaceState);
+    return () => {
+      editor.off("transaction", updateFindReplaceState);
+    };
+  }
+  return undefined;
+});
+
+// Focus input when panel opens
+$effect(() => {
+  if (isOpen && findInputRef) {
+    tick().then(() => {
+      findInputRef?.focus();
+      findInputRef?.select();
+    });
+  }
+});
+
+function handleFindInputChange(e: Event) {
+  const value = (e.target as HTMLInputElement).value;
+  findText = value;
+  editor?.commands.find(value);
+}
+
+function handleFindNext() {
+  editor?.commands.findNext();
+}
+
+function handleFindPrevious() {
+  editor?.commands.findPrevious();
+}
+
+function handleReplace() {
+  if (editor) {
+    editor.commands.replace(replaceText);
+    editor.commands.findNext();
+  }
+}
+
+function handleReplaceAll() {
+  editor?.commands.replaceAll(replaceText);
+}
+
+function handleClose() {
+  if (editor) {
+    editor.commands.clearFind();
+    editor.commands.closeFindReplace();
+  }
+  findText = "";
+  replaceText = "";
+  onClose?.();
+}
+
+function handleCaseSensitiveChange(e: Event) {
+  const checked = (e.target as HTMLInputElement).checked;
+  caseSensitive = checked;
+  editor?.commands.setFindCaseSensitive(checked);
+  if (findText) {
+    editor?.commands.find(findText);
+  }
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    if (e.shiftKey) {
+      handleFindPrevious();
+    } else {
+      handleFindNext();
+    }
+  } else if (e.key === "Escape") {
+    e.preventDefault();
+    handleClose();
+  }
+}
+</script>
+
+{#if isOpen}
+  <div
+    class={`vizel-find-replace-panel ${className || ""}`}
+    role="dialog"
+    aria-label="Find and Replace"
+  >
+    <div class="vizel-find-replace-row">
+      <input
+        bind:this={findInputRef}
+        type="text"
+        class="vizel-find-replace-input"
+        placeholder="Find..."
+        value={findText}
+        oninput={handleFindInputChange}
+        onkeydown={handleKeyDown}
+        aria-label="Find text"
+      />
+      <span class="vizel-find-replace-count">
+        {matchCount > 0 ? `${currentMatch}/${matchCount}` : "No results"}
+      </span>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        disabled={matchCount === 0}
+        aria-label="Find previous"
+        title="Find previous (Shift+Enter)"
+        onclick={handleFindPrevious}
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        disabled={matchCount === 0}
+        aria-label="Find next"
+        title="Find next (Enter)"
+        onclick={handleFindNext}
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        aria-label="Close"
+        title="Close (Escape)"
+        onclick={handleClose}
+      >
+        ✕
+      </button>
+    </div>
+
+    {#if isReplaceMode}
+      <div class="vizel-find-replace-row">
+        <input
+          type="text"
+          class="vizel-find-replace-input"
+          placeholder="Replace with..."
+          bind:value={replaceText}
+          onkeydown={handleKeyDown}
+          aria-label="Replace text"
+        />
+        <button
+          type="button"
+          class="vizel-find-replace-button"
+          disabled={matchCount === 0}
+          aria-label="Replace"
+          title="Replace current match"
+          onclick={handleReplace}
+        >
+          Replace
+        </button>
+        <button
+          type="button"
+          class="vizel-find-replace-button vizel-find-replace-button--primary"
+          disabled={matchCount === 0}
+          aria-label="Replace all"
+          title="Replace all matches"
+          onclick={handleReplaceAll}
+        >
+          All
+        </button>
+      </div>
+    {/if}
+
+    <div class="vizel-find-replace-options">
+      <label class="vizel-find-replace-checkbox">
+        <input
+          type="checkbox"
+          checked={caseSensitive}
+          onchange={handleCaseSensitiveChange}
+        />
+        Case sensitive
+      </label>
+    </div>
+  </div>
+{/if}

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -52,6 +52,13 @@ export {
   type VizelEmbedViewProps,
 } from "./VizelEmbedView.svelte";
 // ============================================================================
+// Vizel FindReplace component
+// ============================================================================
+export {
+  default as VizelFindReplace,
+  type VizelFindReplaceProps,
+} from "./VizelFindReplace.svelte";
+// ============================================================================
 // Vizel Icon component
 // ============================================================================
 export { default as VizelIcon, type VizelIconProps } from "./VizelIcon.svelte";

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -39,6 +39,9 @@ export {
   VizelEmbedView,
   type VizelEmbedViewProps,
   type VizelExposed,
+  // FindReplace
+  VizelFindReplace,
+  type VizelFindReplaceProps,
   // Icon
   VizelIcon,
   type VizelIconProps,

--- a/packages/vue/src/components/VizelFindReplace.vue
+++ b/packages/vue/src/components/VizelFindReplace.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { type Editor, getVizelFindReplaceState, type VizelFindReplaceState } from "@vizel/core";
+import { computed, onUnmounted, ref, watch } from "vue";
+
+export interface VizelFindReplaceProps {
+  /** The Tiptap editor instance */
+  editor: Editor | null;
+  /** Custom class name */
+  class?: string;
+}
+
+const props = defineProps<VizelFindReplaceProps>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const findText = ref("");
+const replaceText = ref("");
+const caseSensitive = ref(false);
+const state = ref<VizelFindReplaceState | null>(null);
+const findInputRef = ref<HTMLInputElement | null>(null);
+
+const matchCount = computed(() => state.value?.matches.length ?? 0);
+const currentMatch = computed(() =>
+  state.value && state.value.activeIndex >= 0 ? state.value.activeIndex + 1 : 0
+);
+const isReplaceMode = computed(() => state.value?.mode === "replace");
+const isOpen = computed(() => state.value?.isOpen ?? false);
+
+function updateState() {
+  if (props.editor) {
+    state.value = getVizelFindReplaceState(props.editor.state);
+  }
+}
+
+watch(
+  () => props.editor,
+  (editor, oldEditor) => {
+    if (oldEditor) {
+      oldEditor.off("transaction", updateState);
+    }
+    if (editor) {
+      updateState();
+      editor.on("transaction", updateState);
+    }
+  },
+  { immediate: true }
+);
+
+onUnmounted(() => {
+  props.editor?.off("transaction", updateState);
+});
+
+// Focus input when panel opens
+watch(isOpen, (open) => {
+  if (open) {
+    setTimeout(() => {
+      findInputRef.value?.focus();
+      findInputRef.value?.select();
+    }, 0);
+  }
+});
+
+function handleFindInputChange(e: Event) {
+  const value = (e.target as HTMLInputElement).value;
+  findText.value = value;
+  props.editor?.commands.find(value);
+}
+
+function handleFindNext() {
+  props.editor?.commands.findNext();
+}
+
+function handleFindPrevious() {
+  props.editor?.commands.findPrevious();
+}
+
+function handleReplace() {
+  if (props.editor) {
+    props.editor.commands.replace(replaceText.value);
+    props.editor.commands.findNext();
+  }
+}
+
+function handleReplaceAll() {
+  props.editor?.commands.replaceAll(replaceText.value);
+}
+
+function handleClose() {
+  if (props.editor) {
+    props.editor.commands.clearFind();
+    props.editor.commands.closeFindReplace();
+  }
+  findText.value = "";
+  replaceText.value = "";
+  emit("close");
+}
+
+function handleCaseSensitiveChange(e: Event) {
+  const checked = (e.target as HTMLInputElement).checked;
+  caseSensitive.value = checked;
+  props.editor?.commands.setFindCaseSensitive(checked);
+  if (findText.value) {
+    props.editor?.commands.find(findText.value);
+  }
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    if (e.shiftKey) {
+      handleFindPrevious();
+    } else {
+      handleFindNext();
+    }
+  } else if (e.key === "Escape") {
+    e.preventDefault();
+    handleClose();
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="isOpen"
+    :class="['vizel-find-replace-panel', props.class]"
+    role="dialog"
+    aria-label="Find and Replace"
+  >
+    <div class="vizel-find-replace-row">
+      <input
+        ref="findInputRef"
+        type="text"
+        class="vizel-find-replace-input"
+        placeholder="Find..."
+        :value="findText"
+        @input="handleFindInputChange"
+        @keydown="handleKeyDown"
+        aria-label="Find text"
+      />
+      <span class="vizel-find-replace-count">
+        {{ matchCount > 0 ? `${currentMatch}/${matchCount}` : 'No results' }}
+      </span>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        :disabled="matchCount === 0"
+        aria-label="Find previous"
+        title="Find previous (Shift+Enter)"
+        @click="handleFindPrevious"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        :disabled="matchCount === 0"
+        aria-label="Find next"
+        title="Find next (Enter)"
+        @click="handleFindNext"
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        aria-label="Close"
+        title="Close (Escape)"
+        @click="handleClose"
+      >
+        ✕
+      </button>
+    </div>
+
+    <div v-if="isReplaceMode" class="vizel-find-replace-row">
+      <input
+        type="text"
+        class="vizel-find-replace-input"
+        placeholder="Replace with..."
+        v-model="replaceText"
+        @keydown="handleKeyDown"
+        aria-label="Replace text"
+      />
+      <button
+        type="button"
+        class="vizel-find-replace-button"
+        :disabled="matchCount === 0"
+        aria-label="Replace"
+        title="Replace current match"
+        @click="handleReplace"
+      >
+        Replace
+      </button>
+      <button
+        type="button"
+        class="vizel-find-replace-button vizel-find-replace-button--primary"
+        :disabled="matchCount === 0"
+        aria-label="Replace all"
+        title="Replace all matches"
+        @click="handleReplaceAll"
+      >
+        All
+      </button>
+    </div>
+
+    <div class="vizel-find-replace-options">
+      <label class="vizel-find-replace-checkbox">
+        <input
+          type="checkbox"
+          :checked="caseSensitive"
+          @change="handleCaseSensitiveChange"
+        />
+        Case sensitive
+      </label>
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -34,6 +34,11 @@ export {
 } from "./VizelEditor.vue";
 // VizelEmbedView component
 export { default as VizelEmbedView, type VizelEmbedViewProps } from "./VizelEmbedView.vue";
+// VizelFindReplace component
+export {
+  default as VizelFindReplace,
+  type VizelFindReplaceProps,
+} from "./VizelFindReplace.vue";
 // VizelIcon component
 export { default as VizelIcon, type VizelIconProps } from "./VizelIcon.vue";
 export { provideVizelIcons, useVizelIconContext } from "./VizelIconContext.ts";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -39,6 +39,9 @@ export {
   VizelEmbedView,
   type VizelEmbedViewProps,
   type VizelExposed,
+  // FindReplace
+  VizelFindReplace,
+  type VizelFindReplaceProps,
   // Icon
   VizelIcon,
   type VizelIconProps,


### PR DESCRIPTION
## Summary

- Add ProseMirror-based Find & Replace extension with:
  - Text search with case-sensitive option
  - Match highlighting using DecorationSet
  - Find next/previous navigation
  - Single match and replace all operations
  - Keyboard shortcuts (`Mod-f` for find, `Mod-Shift-h` for replace)
- Add UI components for React, Vue, and Svelte
- Add CSS styles for match highlighting and panel UI
- Export types and state helper functions

## New Files

**Core package:**
- `packages/core/src/extensions/find-replace.ts` - Find & Replace extension
- `packages/core/src/styles/components/_find-replace.scss` - CSS styles

**Framework components:**
- `packages/react/src/components/VizelFindReplace.tsx`
- `packages/vue/src/components/VizelFindReplace.vue`
- `packages/svelte/src/components/VizelFindReplace.svelte`

## Usage

```typescript
import { createVizelFindReplaceExtension } from '@vizel/core';
import { VizelFindReplace } from '@vizel/react'; // or vue, svelte

// Add extension to editor
const extensions = createVizelExtensions({
  // ...options
});
extensions.push(createVizelFindReplaceExtension());

// Use component
<VizelFindReplace editor={editor} />

// Or trigger via commands
editor.commands.openFindReplace('find'); // or 'replace'
editor.commands.find('search text');
editor.commands.findNext();
editor.commands.replace('replacement');
```

## Test Plan

- [x] Run typecheck (`pnpm typecheck`)
- [x] Run lint (`pnpm lint`)
- [x] Run E2E tests (`pnpm test:ct`) - 702/705 passed (3 flaky tests unrelated to this change)

Closes #183