### PR TITLE
feat(core): add wiki links extension for internal linking

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,6 +137,7 @@ export default withMermaid({
             { text: "Theming", link: "/guide/theming" },
             { text: "Auto-Save", link: "/guide/auto-save" },
             { text: "Plugins", link: "/guide/plugins" },
+            { text: "Wiki Links", link: "/guide/wiki-links" },
             { text: "Performance", link: "/guide/performance" },
             { text: "Accessibility", link: "/guide/accessibility" },
             { text: "Troubleshooting", link: "/guide/troubleshooting" },

--- a/docs/guide/wiki-links.md
+++ b/docs/guide/wiki-links.md
@@ -1,0 +1,297 @@
+# Wiki Links
+
+Vizel supports wiki-style internal links using `[[page-name]]` syntax, enabling knowledge base and note-taking use cases.
+
+## Overview
+
+Wiki links provide:
+
+- **`[[page]]` syntax** — quickly link between pages by typing double brackets
+- **Display text aliases** — `[[page|custom text]]` for custom link labels
+- **Visual differentiation** — existing vs non-existing page styling
+- **Custom link resolution** — control where links point to
+- **Click handling** — intercept clicks for SPA navigation
+
+::: info
+Wiki links are **disabled by default**. Enable them via the `wikiLink` feature option.
+:::
+
+## Quick Start
+
+### Enable Wiki Links
+
+```typescript
+import { useVizelEditor } from "@vizel/react";
+
+const editor = useVizelEditor({
+  features: {
+    wikiLink: true,
+  },
+});
+```
+
+### With Custom Options
+
+```typescript
+const editor = useVizelEditor({
+  features: {
+    wikiLink: {
+      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+      pageExists: (page) => knownPages.has(page),
+      onLinkClick: (page) => router.push(`/wiki/${page}`),
+    },
+  },
+});
+```
+
+## Syntax
+
+Type double brackets to create a wiki link:
+
+| Input | Result |
+|-------|--------|
+| `[[My Page]]` | Link to "My Page" with "My Page" as display text |
+| `[[My Page\|Custom Label]]` | Link to "My Page" with "Custom Label" as display text |
+
+The link is automatically created when you close the double brackets (`]]`).
+
+## Options
+
+```typescript
+interface VizelWikiLinkOptions {
+  /** Resolve a page name to a URL (default: `#pageName`) */
+  resolveLink?: (pageName: string) => string;
+  /** Check if a page exists (default: `() => true`) */
+  pageExists?: (pageName: string) => boolean;
+  /** Get page suggestions for autocomplete */
+  getPageSuggestions?: (query: string) => VizelWikiLinkSuggestion[];
+  /** Callback when a wiki link is clicked */
+  onLinkClick?: (pageName: string, event: MouseEvent) => void;
+  /** CSS class for existing page links */
+  existingClass?: string;
+  /** CSS class for non-existing page links */
+  newClass?: string;
+  /** Additional HTML attributes */
+  HTMLAttributes?: Record<string, unknown>;
+}
+```
+
+### `resolveLink`
+
+Converts a page name to a URL. Used for the `href` attribute on rendered links.
+
+```typescript
+{
+  wikiLink: {
+    resolveLink: (page) => `/docs/${page.toLowerCase().replace(/\s+/g, "-")}`,
+  },
+}
+```
+
+### `pageExists`
+
+Determines if a linked page exists. Controls visual styling — existing pages get a solid underline, non-existing pages get a dashed underline with muted color.
+
+```typescript
+const existingPages = new Set(["Getting Started", "API Reference", "FAQ"]);
+
+{
+  wikiLink: {
+    pageExists: (page) => existingPages.has(page),
+  },
+}
+```
+
+### `onLinkClick`
+
+Intercepts wiki link clicks for client-side navigation. Without this, links follow standard browser navigation using the `href` from `resolveLink`.
+
+```typescript
+{
+  wikiLink: {
+    onLinkClick: (pageName, event) => {
+      // SPA navigation
+      router.push(`/wiki/${pageName}`);
+    },
+  },
+}
+```
+
+### `getPageSuggestions`
+
+Provides autocomplete suggestions. This callback is available for future autocomplete UI integration.
+
+```typescript
+{
+  wikiLink: {
+    getPageSuggestions: (query) =>
+      allPages
+        .filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
+        .slice(0, 10),
+  },
+}
+```
+
+## Commands
+
+The wiki link extension adds two editor commands:
+
+```typescript
+// Insert a wiki link
+editor.commands.setWikiLink("My Page");
+
+// Insert with custom display text
+editor.commands.setWikiLink("My Page", "Click here");
+
+// Remove wiki link mark from selection
+editor.commands.unsetWikiLink();
+```
+
+## Styling
+
+Wiki links use the following CSS classes:
+
+| Class | Description |
+|-------|-------------|
+| `.vizel-wiki-link` | Base wiki link style |
+| `.vizel-wiki-link--existing` | Existing page (solid underline) |
+| `.vizel-wiki-link--new` | Non-existing page (dashed underline, muted color) |
+
+### Custom Styling
+
+Override the default styles with CSS custom properties:
+
+```css
+.vizel-wiki-link {
+  color: var(--vizel-primary);
+  border-bottom: 1px dashed var(--vizel-primary);
+}
+
+.vizel-wiki-link--new {
+  color: var(--vizel-muted-foreground);
+  border-bottom-color: var(--vizel-muted-foreground);
+}
+```
+
+## Framework Integration
+
+### React
+
+```tsx
+import { useVizelEditor, VizelProvider, VizelEditor } from "@vizel/react";
+
+function WikiEditor() {
+  const knownPages = new Set(["Home", "About", "Contact"]);
+
+  const editor = useVizelEditor({
+    features: {
+      wikiLink: {
+        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+        pageExists: (page) => knownPages.has(page),
+        onLinkClick: (page) => {
+          console.log(`Navigate to: ${page}`);
+        },
+      },
+    },
+  });
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+    </VizelProvider>
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { useVizelEditor, VizelProvider, VizelEditor } from "@vizel/vue";
+
+const knownPages = new Set(["Home", "About", "Contact"]);
+
+const editor = useVizelEditor({
+  features: {
+    wikiLink: {
+      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+      pageExists: (page) => knownPages.has(page),
+      onLinkClick: (page) => {
+        console.log(`Navigate to: ${page}`);
+      },
+    },
+  },
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+  </VizelProvider>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+import { createVizelEditor, VizelProvider, VizelEditor } from "@vizel/svelte";
+
+const knownPages = new Set(["Home", "About", "Contact"]);
+
+const editor = createVizelEditor({
+  features: {
+    wikiLink: {
+      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+      pageExists: (page) => knownPages.has(page),
+      onLinkClick: (page) => {
+        console.log(`Navigate to: ${page}`);
+      },
+    },
+  },
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+</VizelProvider>
+```
+
+## Advanced Usage
+
+### Standalone Extension
+
+For advanced setups, use the extension directly instead of the feature option:
+
+```typescript
+import { createVizelWikiLinkExtension } from "@vizel/core";
+
+const editor = useVizelEditor({
+  extensions: [
+    createVizelWikiLinkExtension({
+      resolveLink: (page) => `/wiki/${page}`,
+    }),
+  ],
+});
+```
+
+### Backlink Tracking
+
+Track which pages link to a given page by inspecting the editor content:
+
+```typescript
+function getBacklinks(editor: Editor): string[] {
+  const links: string[] = [];
+
+  editor.state.doc.descendants((node) => {
+    node.marks.forEach((mark) => {
+      if (mark.type.name === "wikiLink" && mark.attrs.pageName) {
+        links.push(mark.attrs.pageName as string);
+      }
+    });
+    return true;
+  });
+
+  return [...new Set(links)];
+}
+```

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -42,6 +42,7 @@ import {
 import { createVizelTableExtensions } from "./table.ts";
 import { createVizelTaskListExtensions } from "./task-list.ts";
 import { createVizelTextColorExtensions } from "./text-color.ts";
+import { createVizelWikiLinkExtension } from "./wiki-link.ts";
 
 export interface VizelExtensionsOptions {
   /** Placeholder text when editor is empty */
@@ -262,6 +263,16 @@ function addDiagramExtension(extensions: Extensions, features: VizelFeatureOptio
 }
 
 /**
+ * Add Wiki Link extension if enabled (disabled by default)
+ */
+function addWikiLinkExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (!features.wikiLink) return;
+
+  const wikiLinkOptions = typeof features.wikiLink === "object" ? features.wikiLink : {};
+  extensions.push(createVizelWikiLinkExtension(wikiLinkOptions));
+}
+
+/**
  * Create the default set of extensions for Vizel editor.
  * All features are enabled by default. Set any feature to `false` to disable it.
  *
@@ -347,6 +358,7 @@ export async function createVizelExtensions(
   addDetailsExtension(extensions, features);
   addEmbedExtension(extensions, features);
   addDiagramExtension(extensions, features);
+  addWikiLinkExtension(extensions, features);
 
   // Add code block extension (async - lowlight is loaded dynamically)
   await addCodeBlockExtension(extensions, features);

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -181,7 +181,6 @@ export {
   type VizelTaskListExtensionsOptions,
   type VizelTaskListOptions,
 } from "./task-list.ts";
-
 // Text color
 export {
   addVizelRecentColor,
@@ -192,3 +191,11 @@ export {
   type VizelColorDefinition,
   type VizelTextColorOptions,
 } from "./text-color.ts";
+// Wiki link
+export {
+  createVizelWikiLinkExtension,
+  VizelWikiLink,
+  type VizelWikiLinkOptions,
+  type VizelWikiLinkSuggestion,
+  vizelWikiLinkPluginKey,
+} from "./wiki-link.ts";

--- a/packages/core/src/extensions/wiki-link.ts
+++ b/packages/core/src/extensions/wiki-link.ts
@@ -1,0 +1,279 @@
+import { InputRule, Mark, mergeAttributes } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Suggestion item for wiki link autocomplete
+ */
+export interface VizelWikiLinkSuggestion {
+  /** Page name */
+  name: string;
+  /** Optional display label (defaults to name) */
+  label?: string;
+}
+
+/**
+ * Options for the Wiki Link extension
+ */
+export interface VizelWikiLinkOptions {
+  /**
+   * Resolve a page name to a URL.
+   * Called when rendering the link in the editor.
+   * @default (pageName) => `#${pageName}`
+   */
+  resolveLink?: (pageName: string) => string;
+
+  /**
+   * Check if a page exists. Used for visual differentiation
+   * between existing and non-existing pages.
+   * @default () => true
+   */
+  pageExists?: (pageName: string) => boolean;
+
+  /**
+   * Get page suggestions for autocomplete.
+   * Return an empty array to disable autocomplete.
+   */
+  getPageSuggestions?: (query: string) => VizelWikiLinkSuggestion[];
+
+  /**
+   * Callback when a wiki link is clicked.
+   * If not provided, the default browser navigation is used.
+   */
+  onLinkClick?: (pageName: string, event: MouseEvent) => void;
+
+  /**
+   * CSS class for existing page links.
+   * @default "vizel-wiki-link--existing"
+   */
+  existingClass?: string;
+
+  /**
+   * CSS class for non-existing page links.
+   * @default "vizel-wiki-link--new"
+   */
+  newClass?: string;
+
+  /**
+   * Additional HTML attributes to add to wiki links.
+   */
+  HTMLAttributes?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Plugin Key
+// =============================================================================
+
+/**
+ * Plugin key for accessing Wiki Link plugin state
+ */
+export const vizelWikiLinkPluginKey = new PluginKey("vizelWikiLink");
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    wikiLink: {
+      /** Insert a wiki link at the current position */
+      setWikiLink: (pageName: string, displayText?: string) => ReturnType;
+      /** Remove wiki link mark from the current selection */
+      unsetWikiLink: () => ReturnType;
+    };
+  }
+}
+
+// =============================================================================
+// Mark Extension
+// =============================================================================
+
+/**
+ * Wiki Link mark extension for Vizel editor.
+ *
+ * Supports `[[page-name]]` and `[[page-name|display text]]` syntax.
+ * Links are rendered with visual differentiation for existing vs non-existing pages.
+ *
+ * @example
+ * ```typescript
+ * import { VizelWikiLink } from "@vizel/core";
+ *
+ * const editor = new Editor({
+ *   extensions: [
+ *     VizelWikiLink.configure({
+ *       resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+ *       pageExists: (page) => knownPages.has(page),
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export const VizelWikiLink = Mark.create<VizelWikiLinkOptions>({
+  name: "wikiLink",
+
+  priority: 1001,
+
+  addOptions() {
+    return {
+      resolveLink: (pageName: string) => `#${pageName}`,
+      pageExists: () => true,
+      existingClass: "vizel-wiki-link--existing",
+      newClass: "vizel-wiki-link--new",
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      pageName: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-wiki-page"),
+        renderHTML: (attributes) => ({
+          "data-wiki-page": attributes.pageName as string,
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "a[data-wiki-link]",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes, mark }) {
+    const pageName = (mark.attrs.pageName as string) ?? "";
+    const href = this.options.resolveLink?.(pageName) ?? `#${pageName}`;
+    const exists = this.options.pageExists?.(pageName) ?? true;
+    const statusClass = exists ? this.options.existingClass : this.options.newClass;
+
+    return [
+      "a",
+      mergeAttributes(this.options.HTMLAttributes ?? {}, HTMLAttributes, {
+        class: `vizel-wiki-link ${statusClass}`,
+        href,
+        "data-wiki-link": "",
+        "data-wiki-page": pageName,
+      }),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setWikiLink:
+        (pageName: string, displayText?: string) =>
+        ({ editor }) => {
+          const text = displayText ?? pageName;
+          return editor
+            .chain()
+            .insertContent({
+              type: "text",
+              text,
+              marks: [{ type: this.name, attrs: { pageName } }],
+            })
+            .run();
+        },
+      unsetWikiLink:
+        () =>
+        ({ editor }) => {
+          return editor.chain().unsetMark(this.name).run();
+        },
+    };
+  },
+
+  addInputRules() {
+    // Match [[page-name]] or [[page-name|display text]]
+    const wikiLinkRegex = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]$/;
+
+    return [
+      new InputRule({
+        find: wikiLinkRegex,
+        handler: ({ state, range, match }) => {
+          const rawPageName = match[1];
+          if (!rawPageName) return;
+          const pageName = rawPageName.trim();
+          const displayText = match[2]?.trim() ?? pageName;
+
+          const { tr } = state;
+          const markType = state.schema.marks[this.name];
+
+          if (!markType) return;
+
+          const mark = markType.create({ pageName });
+
+          tr.replaceWith(range.from, range.to, state.schema.text(displayText, [mark]));
+        },
+      }),
+    ];
+  },
+
+  addProseMirrorPlugins() {
+    const { onLinkClick } = this.options;
+
+    return [
+      new Plugin({
+        key: vizelWikiLinkPluginKey,
+        props: {
+          handleClick: (_view, _pos, event) => {
+            if (!onLinkClick) return false;
+
+            const target = event.target as HTMLElement;
+            const link = target.closest("a[data-wiki-link]");
+            if (!link) return false;
+
+            const pageName = link.getAttribute("data-wiki-page");
+            if (!pageName) return false;
+
+            event.preventDefault();
+            onLinkClick(pageName, event);
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+// =============================================================================
+// Factory Function
+// =============================================================================
+
+/**
+ * Create a configured Wiki Link extension for Vizel editor.
+ *
+ * Wiki links use `[[page-name]]` syntax for linking between pages.
+ * Supports display text aliases with `[[page-name|display text]]`.
+ *
+ * @example Basic usage
+ * ```typescript
+ * const extension = createVizelWikiLinkExtension();
+ * ```
+ *
+ * @example With custom link resolution
+ * ```typescript
+ * const extension = createVizelWikiLinkExtension({
+ *   resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+ *   pageExists: (page) => pages.has(page),
+ *   onLinkClick: (page) => router.push(`/wiki/${page}`),
+ * });
+ * ```
+ *
+ * @example With autocomplete
+ * ```typescript
+ * const extension = createVizelWikiLinkExtension({
+ *   getPageSuggestions: (query) =>
+ *     allPages
+ *       .filter((p) => p.toLowerCase().includes(query.toLowerCase()))
+ *       .map((name) => ({ name })),
+ * });
+ * ```
+ */
+export function createVizelWikiLinkExtension(options: VizelWikiLinkOptions = {}) {
+  return VizelWikiLink.configure(options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export {
   // Task list
   createVizelTaskListExtensions,
   createVizelTextColorExtensions,
+  createVizelWikiLinkExtension,
   detectVizelEmbedProvider,
   filterVizelFilesByMimeType,
   // Slash command
@@ -162,6 +163,9 @@ export {
   type VizelTaskListOptions,
   type VizelTextColorOptions,
   type VizelUploadImageFn,
+  VizelWikiLink,
+  type VizelWikiLinkOptions,
+  type VizelWikiLinkSuggestion,
   validateVizelImageFile,
   vizelDefaultBase64Upload,
   vizelDefaultEmbedProviders,
@@ -170,6 +174,7 @@ export {
   vizelDefaultSlashCommands,
   vizelEmbedPastePluginKey,
   vizelFindReplacePluginKey,
+  vizelWikiLinkPluginKey,
 } from "./extensions/index.ts";
 // =============================================================================
 // Icons

--- a/packages/core/src/styles/components.scss
+++ b/packages/core/src/styles/components.scss
@@ -42,4 +42,5 @@
 @use "embed";
 @use "save-indicator";
 @use "diagram";
+@use "wiki-link";
 @use "components/find-replace";

--- a/packages/core/src/styles/wiki-link.scss
+++ b/packages/core/src/styles/wiki-link.scss
@@ -1,0 +1,38 @@
+/**
+ * Vizel Wiki Link Styles
+ */
+
+@use "tokens" as *;
+
+.vizel-wiki-link {
+  color: v("primary");
+  text-decoration: none;
+  border-bottom: 1px dashed v("primary");
+  cursor: pointer;
+  padding: 0 0.125rem;
+  border-radius: v("radius-sm");
+  transition: background-color v("transition-fast") ease,
+    color v("transition-fast") ease;
+
+  &:hover {
+    background-color: v("primary-bg");
+    color: v("primary-hover");
+  }
+
+  // Existing page - solid underline
+  &--existing {
+    border-bottom-style: solid;
+  }
+
+  // Non-existing page - dashed underline with muted color
+  &--new {
+    color: v("muted-foreground");
+    border-bottom-color: v("muted-foreground");
+    border-bottom-style: dashed;
+
+    &:hover {
+      background-color: v("hover-bg");
+      color: v("foreground");
+    }
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,7 @@ import type { VizelSlashCommandItem } from "./extensions/slash-command.ts";
 import type { VizelTableOptions } from "./extensions/table.ts";
 import type { VizelTaskListExtensionsOptions } from "./extensions/task-list.ts";
 import type { VizelTextColorOptions } from "./extensions/text-color.ts";
+import type { VizelWikiLinkOptions } from "./extensions/wiki-link.ts";
 import type { VizelImageUploadPluginOptions } from "./plugins/image-upload.ts";
 import type { VizelError } from "./utils/errorHandling.ts";
 
@@ -68,6 +69,8 @@ export interface VizelFeatureOptions {
   details?: VizelDetailsOptions | boolean;
   /** Diagram support (Mermaid, GraphViz) */
   diagram?: VizelDiagramOptions | boolean;
+  /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
+  wikiLink?: VizelWikiLinkOptions | boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `VizelWikiLink` mark extension supporting `[[page-name]]` and `[[page|display text]]` syntax
- Input rule automatically converts `[[...]]` to wiki link marks
- Visual differentiation for existing vs non-existing pages (solid vs dashed underline)
- Custom link resolution (`resolveLink`), existence checking (`pageExists`), and click handling (`onLinkClick`)
- Page suggestion API (`getPageSuggestions`) for future autocomplete integration
- Editor commands: `setWikiLink()` and `unsetWikiLink()`
- Disabled by default — enable via `features: { wikiLink: true }` or pass options
- Comprehensive documentation with React/Vue/Svelte examples

Closes #191

## Test plan

- [x] Run typecheck (`pnpm typecheck`) — 0 errors
- [x] Run lint (`pnpm lint`) — clean
- [x] Build docs (`pnpm --filter docs build`) — success
- [x] Verify wiki links sidebar entry in VitePress