### PR TITLE
feat(core): add version history for document snapshots

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -138,6 +138,7 @@ export default withMermaid({
             { text: "Auto-Save", link: "/guide/auto-save" },
             { text: "Plugins", link: "/guide/plugins" },
             { text: "Wiki Links", link: "/guide/wiki-links" },
+            { text: "Version History", link: "/guide/version-history" },
             { text: "Performance", link: "/guide/performance" },
             { text: "Accessibility", link: "/guide/accessibility" },
             { text: "Troubleshooting", link: "/guide/troubleshooting" },

--- a/docs/guide/version-history.md
+++ b/docs/guide/version-history.md
@@ -1,0 +1,237 @@
+# Version History
+
+Vizel provides a version history system that allows users to save, view, and restore document snapshots.
+
+## Overview
+
+Version history enables:
+
+- **Save snapshots** — capture document state at any point
+- **Restore versions** — revert to a previous snapshot
+- **Browse history** — list all saved versions with timestamps
+- **Storage flexibility** — use localStorage or a custom backend
+- **Version limits** — automatic cleanup of old versions
+
+## Quick Start
+
+### React
+
+```tsx
+import { useVizelEditor, useVizelVersionHistory, VizelProvider, VizelEditor } from "@vizel/react";
+
+function Editor() {
+  const editor = useVizelEditor({});
+  const { snapshots, saveVersion, restoreVersion, deleteVersion } =
+    useVizelVersionHistory(() => editor, {
+      maxVersions: 20,
+      key: "my-doc-versions",
+    });
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+      <button onClick={() => saveVersion("Manual save")}>
+        Save Version
+      </button>
+      <ul>
+        {snapshots.map((s) => (
+          <li key={s.id}>
+            {s.description ?? "Untitled"} —{" "}
+            {new Date(s.timestamp).toLocaleString()}
+            <button onClick={() => restoreVersion(s.id)}>Restore</button>
+            <button onClick={() => deleteVersion(s.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </VizelProvider>
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { useVizelEditor, useVizelVersionHistory, VizelProvider, VizelEditor } from "@vizel/vue";
+
+const editor = useVizelEditor({});
+const { snapshots, saveVersion, restoreVersion, deleteVersion } =
+  useVizelVersionHistory(() => editor.value, {
+    maxVersions: 20,
+    key: "my-doc-versions",
+  });
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+    <button @click="saveVersion('Manual save')">Save Version</button>
+    <ul>
+      <li v-for="s in snapshots" :key="s.id">
+        {{ s.description ?? "Untitled" }} —
+        {{ new Date(s.timestamp).toLocaleString() }}
+        <button @click="restoreVersion(s.id)">Restore</button>
+        <button @click="deleteVersion(s.id)">Delete</button>
+      </li>
+    </ul>
+  </VizelProvider>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+import { createVizelEditor, createVizelVersionHistory, VizelProvider, VizelEditor } from "@vizel/svelte";
+
+const editor = createVizelEditor({});
+const history = createVizelVersionHistory(() => editor.current, {
+  maxVersions: 20,
+  key: "my-doc-versions",
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+  <button onclick={() => history.saveVersion("Manual save")}>
+    Save Version
+  </button>
+  <ul>
+    {#each history.snapshots as s}
+      <li>
+        {s.description ?? "Untitled"} —
+        {new Date(s.timestamp).toLocaleString()}
+        <button onclick={() => history.restoreVersion(s.id)}>Restore</button>
+        <button onclick={() => history.deleteVersion(s.id)}>Delete</button>
+      </li>
+    {/each}
+  </ul>
+</VizelProvider>
+```
+
+## Options
+
+```typescript
+interface VizelVersionHistoryOptions {
+  /** Enable version history (default: true) */
+  enabled?: boolean;
+  /** Maximum number of versions to keep (default: 50) */
+  maxVersions?: number;
+  /** Storage backend (default: 'localStorage') */
+  storage?: VizelVersionStorage;
+  /** Storage key for localStorage (default: 'vizel-versions') */
+  key?: string;
+  /** Callback when a version is saved */
+  onSave?: (snapshot: VizelVersionSnapshot) => void;
+  /** Callback when an error occurs */
+  onError?: (error: Error) => void;
+  /** Callback when a version is restored */
+  onRestore?: (snapshot: VizelVersionSnapshot) => void;
+}
+```
+
+### `maxVersions`
+
+Limits the number of stored snapshots. When the limit is reached, the oldest snapshot is removed.
+
+```typescript
+useVizelVersionHistory(() => editor, {
+  maxVersions: 10, // Keep only the last 10 versions
+});
+```
+
+### `storage`
+
+Choose between built-in localStorage or a custom backend.
+
+```typescript
+// localStorage (default)
+useVizelVersionHistory(() => editor, {
+  storage: "localStorage",
+});
+
+// Custom backend (e.g., API)
+useVizelVersionHistory(() => editor, {
+  storage: {
+    save: async (snapshots) => {
+      await fetch("/api/versions", {
+        method: "PUT",
+        body: JSON.stringify(snapshots),
+      });
+    },
+    load: async () => {
+      const res = await fetch("/api/versions");
+      return res.json();
+    },
+  },
+});
+```
+
+## Version Snapshot
+
+Each snapshot contains:
+
+```typescript
+interface VizelVersionSnapshot {
+  /** Unique identifier */
+  id: string;
+  /** Document content as JSON */
+  content: JSONContent;
+  /** Unix timestamp (milliseconds) */
+  timestamp: number;
+  /** Optional description */
+  description?: string;
+  /** Optional author name */
+  author?: string;
+}
+```
+
+## API Reference
+
+### Hook / Composable / Rune
+
+| Framework | Function |
+|-----------|----------|
+| React | `useVizelVersionHistory(getEditor, options)` |
+| Vue | `useVizelVersionHistory(getEditor, options)` |
+| Svelte | `createVizelVersionHistory(getEditor, options)` |
+
+### Return Values
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `snapshots` | `VizelVersionSnapshot[]` | All stored snapshots (newest first) |
+| `isLoading` | `boolean` | Whether history is loading |
+| `error` | `Error \| null` | Last error that occurred |
+| `saveVersion(desc?, author?)` | `Promise<VizelVersionSnapshot \| null>` | Save current state |
+| `restoreVersion(id)` | `Promise<boolean>` | Restore to a version |
+| `loadVersions()` | `Promise<VizelVersionSnapshot[]>` | Reload from storage |
+| `deleteVersion(id)` | `Promise<void>` | Delete a version |
+| `clearVersions()` | `Promise<void>` | Delete all versions |
+
+::: tip
+In Vue, `snapshots`, `isLoading`, and `error` are `ComputedRef` values — access them with `.value` in script or directly in templates.
+:::
+
+## Core Handlers
+
+For advanced use cases, use the core handlers directly:
+
+```typescript
+import {
+  createVizelVersionHistoryHandlers,
+  type VizelVersionHistoryState,
+} from "@vizel/core";
+
+const handlers = createVizelVersionHistoryHandlers(
+  () => editor,
+  { maxVersions: 20, key: "my-versions" },
+  (state: Partial<VizelVersionHistoryState>) => {
+    // Handle state changes
+  }
+);
+
+await handlers.saveVersion("Initial draft", "Alice");
+const versions = await handlers.loadVersions();
+await handlers.restoreVersion(versions[0].id);
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,6 @@ export {
   type VizelSaveStatus,
   type VizelStorageBackend,
 } from "./auto-save.ts";
-
 // =============================================================================
 // Extensions
 // =============================================================================
@@ -236,7 +235,6 @@ export {
   type VizelToolbarAction,
   vizelDefaultToolbarActions,
 } from "./toolbar/index.ts";
-
 // =============================================================================
 // Types
 // =============================================================================
@@ -251,7 +249,6 @@ export type {
   VizelSlashCommandOptions,
   VizelSlashMenuRendererOptions,
 } from "./types.ts";
-
 // =============================================================================
 // Utilities
 // =============================================================================
@@ -315,3 +312,15 @@ export {
   type WrapAsVizelErrorOptions,
   wrapAsVizelError,
 } from "./utils/index.ts";
+// =============================================================================
+// Version History
+// =============================================================================
+export {
+  createVizelVersionHistoryHandlers,
+  getVizelVersionStorageBackend,
+  VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS,
+  type VizelVersionHistoryOptions,
+  type VizelVersionHistoryState,
+  type VizelVersionSnapshot,
+  type VizelVersionStorage,
+} from "./version-history.ts";

--- a/packages/core/src/version-history.ts
+++ b/packages/core/src/version-history.ts
@@ -1,0 +1,283 @@
+import type { Editor, JSONContent } from "@tiptap/core";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A snapshot of the document at a point in time
+ */
+export interface VizelVersionSnapshot {
+  /** Unique identifier */
+  id: string;
+  /** Document content as JSON */
+  content: JSONContent;
+  /** When the snapshot was created */
+  timestamp: number;
+  /** Optional description of changes */
+  description?: string;
+  /** Optional author name */
+  author?: string;
+}
+
+/**
+ * Storage backend for version history.
+ * Use `"localStorage"` for built-in browser storage, or provide a custom backend.
+ */
+export type VizelVersionStorage =
+  | "localStorage"
+  | {
+      save: (snapshots: VizelVersionSnapshot[]) => void | Promise<void>;
+      load: () => VizelVersionSnapshot[] | null | Promise<VizelVersionSnapshot[] | null>;
+    };
+
+/**
+ * Configuration options for version history
+ */
+export interface VizelVersionHistoryOptions {
+  /** Enable version history (default: true) */
+  enabled?: boolean;
+  /** Maximum number of versions to keep (default: 50) */
+  maxVersions?: number;
+  /** Storage backend (default: 'localStorage') */
+  storage?: VizelVersionStorage;
+  /** Storage key for localStorage (default: 'vizel-versions') */
+  key?: string;
+  /** Callback when a version is saved */
+  onSave?: (snapshot: VizelVersionSnapshot) => void;
+  /** Callback when an error occurs */
+  onError?: (error: Error) => void;
+  /** Callback when a version is restored */
+  onRestore?: (snapshot: VizelVersionSnapshot) => void;
+}
+
+/**
+ * Version history state
+ */
+export interface VizelVersionHistoryState {
+  /** All stored snapshots (newest first) */
+  snapshots: VizelVersionSnapshot[];
+  /** Whether the history is loading */
+  isLoading: boolean;
+  /** Last error that occurred */
+  error: Error | null;
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+/**
+ * Default version history options
+ */
+export const VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS = {
+  enabled: true,
+  maxVersions: 50,
+  storage: "localStorage" as const,
+  key: "vizel-versions",
+} satisfies VizelVersionHistoryOptions;
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+/**
+ * Creates a normalized storage backend for version history
+ */
+export function getVizelVersionStorageBackend(
+  storage: VizelVersionStorage,
+  key: string
+): {
+  save: (snapshots: VizelVersionSnapshot[]) => Promise<void>;
+  load: () => Promise<VizelVersionSnapshot[]>;
+} {
+  if (storage === "localStorage") {
+    return {
+      save: (snapshots: VizelVersionSnapshot[]) => {
+        if (typeof localStorage === "undefined") return Promise.resolve();
+        localStorage.setItem(key, JSON.stringify(snapshots));
+        return Promise.resolve();
+      },
+      load: () => {
+        if (typeof localStorage === "undefined") return Promise.resolve([]);
+        const data = localStorage.getItem(key);
+        if (data) {
+          try {
+            const parsed = JSON.parse(data);
+            if (Array.isArray(parsed)) {
+              return Promise.resolve(parsed as VizelVersionSnapshot[]);
+            }
+          } catch {
+            // Invalid data, return empty
+          }
+        }
+        return Promise.resolve([]);
+      },
+    };
+  }
+
+  // Custom storage backend
+  return {
+    save: async (snapshots: VizelVersionSnapshot[]) => {
+      await storage.save(snapshots);
+    },
+    load: async () => {
+      const result = await storage.load();
+      return result ?? [];
+    },
+  };
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Creates version history handlers for an editor.
+ *
+ * @example
+ * ```typescript
+ * const handlers = createVizelVersionHistoryHandlers(
+ *   () => editor,
+ *   { maxVersions: 20 },
+ *   (state) => setState(prev => ({ ...prev, ...state }))
+ * );
+ *
+ * // Save a version
+ * await handlers.saveVersion("Initial draft");
+ *
+ * // List all versions
+ * const versions = await handlers.loadVersions();
+ *
+ * // Restore a version
+ * await handlers.restoreVersion(versions[0].id);
+ * ```
+ */
+export function createVizelVersionHistoryHandlers(
+  getEditor: () => Editor | null | undefined,
+  options: VizelVersionHistoryOptions,
+  onStateChange: (state: Partial<VizelVersionHistoryState>) => void
+): {
+  /** Save current document state as a new version */
+  saveVersion: (description?: string, author?: string) => Promise<VizelVersionSnapshot | null>;
+  /** Restore document to a specific version */
+  restoreVersion: (versionId: string) => Promise<boolean>;
+  /** Load all versions from storage */
+  loadVersions: () => Promise<VizelVersionSnapshot[]>;
+  /** Delete a specific version */
+  deleteVersion: (versionId: string) => Promise<void>;
+  /** Delete all versions */
+  clearVersions: () => Promise<void>;
+} {
+  const opts = { ...VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS, ...options };
+  const storageBackend = getVizelVersionStorageBackend(opts.storage, opts.key);
+
+  let cachedSnapshots: VizelVersionSnapshot[] = [];
+
+  const loadVersions = async (): Promise<VizelVersionSnapshot[]> => {
+    try {
+      onStateChange({ isLoading: true });
+      const snapshots = await storageBackend.load();
+      cachedSnapshots = snapshots;
+      onStateChange({ snapshots, isLoading: false, error: null });
+      return snapshots;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ isLoading: false, error });
+      opts.onError?.(error);
+      return cachedSnapshots;
+    }
+  };
+
+  const saveVersion = async (
+    description?: string,
+    author?: string
+  ): Promise<VizelVersionSnapshot | null> => {
+    const editor = getEditor();
+    if (!editor) return null;
+
+    try {
+      const snapshot: VizelVersionSnapshot = {
+        id: generateId(),
+        content: editor.getJSON(),
+        timestamp: Date.now(),
+        ...(description !== undefined && { description }),
+        ...(author !== undefined && { author }),
+      };
+
+      // Load current snapshots, prepend new one, enforce limit
+      const existing = await storageBackend.load();
+      const updated = [snapshot, ...existing].slice(0, opts.maxVersions);
+
+      await storageBackend.save(updated);
+      cachedSnapshots = updated;
+      onStateChange({ snapshots: updated, error: null });
+
+      opts.onSave?.(snapshot);
+      return snapshot;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return null;
+    }
+  };
+
+  const restoreVersion = async (versionId: string): Promise<boolean> => {
+    const editor = getEditor();
+    if (!editor) return false;
+
+    try {
+      const snapshots = cachedSnapshots.length > 0 ? cachedSnapshots : await storageBackend.load();
+      const snapshot = snapshots.find((s) => s.id === versionId);
+      if (!snapshot) return false;
+
+      editor.commands.setContent(snapshot.content);
+      opts.onRestore?.(snapshot);
+      return true;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return false;
+    }
+  };
+
+  const deleteVersion = async (versionId: string): Promise<void> => {
+    try {
+      const snapshots = cachedSnapshots.length > 0 ? cachedSnapshots : await storageBackend.load();
+      const updated = snapshots.filter((s) => s.id !== versionId);
+      await storageBackend.save(updated);
+      cachedSnapshots = updated;
+      onStateChange({ snapshots: updated, error: null });
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+    }
+  };
+
+  const clearVersions = async (): Promise<void> => {
+    try {
+      await storageBackend.save([]);
+      cachedSnapshots = [];
+      onStateChange({ snapshots: [], error: null });
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+    }
+  };
+
+  return {
+    saveVersion,
+    restoreVersion,
+    loadVersions,
+    deleteVersion,
+    clearVersions,
+  };
+}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -13,3 +13,7 @@ export {
   useVizelMarkdown,
 } from "./useVizelMarkdown.ts";
 export { useVizelState } from "./useVizelState.ts";
+export {
+  type UseVizelVersionHistoryResult,
+  useVizelVersionHistory,
+} from "./useVizelVersionHistory.ts";

--- a/packages/react/src/hooks/useVizelVersionHistory.ts
+++ b/packages/react/src/hooks/useVizelVersionHistory.ts
@@ -1,0 +1,146 @@
+import {
+  createVizelVersionHistoryHandlers,
+  type Editor,
+  VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS,
+  type VizelVersionHistoryOptions,
+  type VizelVersionHistoryState,
+  type VizelVersionSnapshot,
+} from "@vizel/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Version history hook result
+ */
+export interface UseVizelVersionHistoryResult {
+  /** All stored snapshots (newest first) */
+  snapshots: VizelVersionSnapshot[];
+  /** Whether history is loading */
+  isLoading: boolean;
+  /** Last error that occurred */
+  error: Error | null;
+  /** Save current document as a new version */
+  saveVersion: (description?: string, author?: string) => Promise<VizelVersionSnapshot | null>;
+  /** Restore document to a specific version */
+  restoreVersion: (versionId: string) => Promise<boolean>;
+  /** Load all versions from storage */
+  loadVersions: () => Promise<VizelVersionSnapshot[]>;
+  /** Delete a specific version */
+  deleteVersion: (versionId: string) => Promise<void>;
+  /** Delete all versions */
+  clearVersions: () => Promise<void>;
+}
+
+/**
+ * Hook for managing document version history.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Version history configuration options
+ * @returns Version history state and controls
+ *
+ * @example
+ * ```tsx
+ * function Editor() {
+ *   const editor = useVizelEditor({ ... });
+ *   const { snapshots, saveVersion, restoreVersion } = useVizelVersionHistory(
+ *     () => editor,
+ *     { maxVersions: 20, key: 'my-doc-versions' }
+ *   );
+ *
+ *   return (
+ *     <div>
+ *       <VizelEditor editor={editor} />
+ *       <button onClick={() => saveVersion("Manual save")}>Save Version</button>
+ *       <ul>
+ *         {snapshots.map(s => (
+ *           <li key={s.id}>
+ *             {s.description} - {new Date(s.timestamp).toLocaleString()}
+ *             <button onClick={() => restoreVersion(s.id)}>Restore</button>
+ *           </li>
+ *         ))}
+ *       </ul>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useVizelVersionHistory(
+  getEditor: () => Editor | null | undefined,
+  options: VizelVersionHistoryOptions = {}
+): UseVizelVersionHistoryResult {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const enabled = options.enabled ?? VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS.enabled;
+  const maxVersions = options.maxVersions ?? VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS.maxVersions;
+  const storage = options.storage ?? VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS.storage;
+  const key = options.key ?? VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS.key;
+
+  const [state, setState] = useState<VizelVersionHistoryState>({
+    snapshots: [],
+    isLoading: false,
+    error: null,
+  });
+
+  const getEditorRef = useRef(getEditor);
+  getEditorRef.current = getEditor;
+
+  const handleStateChange = useCallback((partial: Partial<VizelVersionHistoryState>) => {
+    setState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const handlers = useMemo(
+    () =>
+      createVizelVersionHistoryHandlers(
+        () => getEditorRef.current(),
+        {
+          enabled,
+          maxVersions,
+          storage,
+          key,
+          onSave: (snapshot) => optionsRef.current.onSave?.(snapshot),
+          onError: (error) => optionsRef.current.onError?.(error),
+          onRestore: (snapshot) => optionsRef.current.onRestore?.(snapshot),
+        },
+        handleStateChange
+      ),
+    [enabled, maxVersions, storage, key, handleStateChange]
+  );
+
+  // Load versions when editor becomes available
+  useEffect(() => {
+    const editor = getEditor();
+    if (editor && enabled) {
+      handlers.loadVersions();
+    }
+  }, [getEditor, enabled, handlers]);
+
+  const saveVersion = useCallback(
+    (description?: string, author?: string) => handlers.saveVersion(description, author),
+    [handlers]
+  );
+
+  const restoreVersion = useCallback(
+    (versionId: string) => handlers.restoreVersion(versionId),
+    [handlers]
+  );
+
+  const loadVersions = useCallback(() => handlers.loadVersions(), [handlers]);
+
+  const deleteVersion = useCallback(
+    (versionId: string) => handlers.deleteVersion(versionId),
+    [handlers]
+  );
+
+  const clearVersions = useCallback(() => handlers.clearVersions(), [handlers]);
+
+  return {
+    snapshots: state.snapshots,
+    isLoading: state.isLoading,
+    error: state.error,
+    saveVersion,
+    restoreVersion,
+    loadVersions,
+    deleteVersion,
+    clearVersions,
+  };
+}

--- a/packages/svelte/src/runes/createVizelVersionHistory.svelte.ts
+++ b/packages/svelte/src/runes/createVizelVersionHistory.svelte.ts
@@ -1,0 +1,126 @@
+import {
+  createVizelVersionHistoryHandlers,
+  type Editor,
+  VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS,
+  type VizelVersionHistoryOptions,
+  type VizelVersionHistoryState,
+  type VizelVersionSnapshot,
+} from "@vizel/core";
+
+/**
+ * Version history rune result
+ */
+export interface CreateVizelVersionHistoryResult {
+  /** All stored snapshots (newest first) */
+  readonly snapshots: VizelVersionSnapshot[];
+  /** Whether history is loading */
+  readonly isLoading: boolean;
+  /** Last error that occurred */
+  readonly error: Error | null;
+  /** Save current document as a new version */
+  saveVersion: (description?: string, author?: string) => Promise<VizelVersionSnapshot | null>;
+  /** Restore document to a specific version */
+  restoreVersion: (versionId: string) => Promise<boolean>;
+  /** Load all versions from storage */
+  loadVersions: () => Promise<VizelVersionSnapshot[]>;
+  /** Delete a specific version */
+  deleteVersion: (versionId: string) => Promise<void>;
+  /** Delete all versions */
+  clearVersions: () => Promise<void>;
+}
+
+/**
+ * Svelte 5 rune for managing document version history.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Version history configuration options
+ * @returns Version history state and controls
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import { createVizelEditor, createVizelVersionHistory } from '@vizel/svelte';
+ *
+ * const editor = createVizelEditor({ ... });
+ * const history = createVizelVersionHistory(() => editor.current, {
+ *   maxVersions: 20,
+ * });
+ * </script>
+ *
+ * <button onclick={() => history.saveVersion("Manual save")}>Save Version</button>
+ * {#each history.snapshots as snapshot}
+ *   <div>{snapshot.description} - {new Date(snapshot.timestamp).toLocaleString()}</div>
+ * {/each}
+ * ```
+ */
+export function createVizelVersionHistory(
+  getEditor: () => Editor | null | undefined,
+  options: VizelVersionHistoryOptions = {}
+): CreateVizelVersionHistoryResult {
+  const opts = { ...VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS, ...options };
+
+  let snapshots = $state<VizelVersionSnapshot[]>([]);
+  let isLoading = $state(false);
+  let error = $state<Error | null>(null);
+
+  let handlers: ReturnType<typeof createVizelVersionHistoryHandlers> | null = null;
+
+  function handleStateChange(partial: Partial<VizelVersionHistoryState>) {
+    if (partial.snapshots !== undefined) snapshots = partial.snapshots;
+    if (partial.isLoading !== undefined) isLoading = partial.isLoading;
+    if (partial.error !== undefined) error = partial.error;
+  }
+
+  $effect(() => {
+    const editor = getEditor();
+    handlers = createVizelVersionHistoryHandlers(getEditor, opts, handleStateChange);
+
+    if (editor && opts.enabled) {
+      handlers.loadVersions();
+    }
+
+    return () => {
+      handlers = null;
+    };
+  });
+
+  async function saveVersion(
+    description?: string,
+    author?: string
+  ): Promise<VizelVersionSnapshot | null> {
+    return (await handlers?.saveVersion(description, author)) ?? null;
+  }
+
+  async function restoreVersion(versionId: string): Promise<boolean> {
+    return (await handlers?.restoreVersion(versionId)) ?? false;
+  }
+
+  async function loadVersions(): Promise<VizelVersionSnapshot[]> {
+    return (await handlers?.loadVersions()) ?? [];
+  }
+
+  async function deleteVersion(versionId: string): Promise<void> {
+    await handlers?.deleteVersion(versionId);
+  }
+
+  async function clearVersions(): Promise<void> {
+    await handlers?.clearVersions();
+  }
+
+  return {
+    get snapshots() {
+      return snapshots;
+    },
+    get isLoading() {
+      return isLoading;
+    },
+    get error() {
+      return error;
+    },
+    saveVersion,
+    restoreVersion,
+    loadVersions,
+    deleteVersion,
+    clearVersions,
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -17,4 +17,8 @@ export {
   type VizelSlashMenuRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { createVizelState } from "./createVizelState.svelte.ts";
+export {
+  type CreateVizelVersionHistoryResult,
+  createVizelVersionHistory,
+} from "./createVizelVersionHistory.svelte.ts";
 export { getVizelTheme, getVizelThemeSafe } from "./getVizelTheme.svelte.ts";

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -12,3 +12,7 @@ export {
 } from "./useVizelMarkdown.ts";
 export { useVizelState } from "./useVizelState.ts";
 export { useVizelTheme, useVizelThemeSafe } from "./useVizelTheme.ts";
+export {
+  type UseVizelVersionHistoryResult,
+  useVizelVersionHistory,
+} from "./useVizelVersionHistory.ts";

--- a/packages/vue/src/composables/useVizelVersionHistory.ts
+++ b/packages/vue/src/composables/useVizelVersionHistory.ts
@@ -1,0 +1,129 @@
+import {
+  createVizelVersionHistoryHandlers,
+  type Editor,
+  VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS,
+  type VizelVersionHistoryOptions,
+  type VizelVersionHistoryState,
+  type VizelVersionSnapshot,
+} from "@vizel/core";
+import { type ComputedRef, computed, onBeforeUnmount, onMounted, reactive, watch } from "vue";
+
+/**
+ * Version history composable result
+ */
+export interface UseVizelVersionHistoryResult {
+  /** All stored snapshots (newest first) */
+  snapshots: ComputedRef<VizelVersionSnapshot[]>;
+  /** Whether history is loading */
+  isLoading: ComputedRef<boolean>;
+  /** Last error that occurred */
+  error: ComputedRef<Error | null>;
+  /** Save current document as a new version */
+  saveVersion: (description?: string, author?: string) => Promise<VizelVersionSnapshot | null>;
+  /** Restore document to a specific version */
+  restoreVersion: (versionId: string) => Promise<boolean>;
+  /** Load all versions from storage */
+  loadVersions: () => Promise<VizelVersionSnapshot[]>;
+  /** Delete a specific version */
+  deleteVersion: (versionId: string) => Promise<void>;
+  /** Delete all versions */
+  clearVersions: () => Promise<void>;
+}
+
+/**
+ * Composable for managing document version history.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Version history configuration options
+ * @returns Version history state and controls
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useVizelEditor, useVizelVersionHistory } from '@vizel/vue';
+ *
+ * const editor = useVizelEditor({ ... });
+ * const { snapshots, saveVersion, restoreVersion } = useVizelVersionHistory(
+ *   () => editor.value,
+ *   { maxVersions: 20 }
+ * );
+ * </script>
+ * ```
+ */
+export function useVizelVersionHistory(
+  getEditor: () => Editor | null | undefined,
+  options: VizelVersionHistoryOptions = {}
+): UseVizelVersionHistoryResult {
+  const opts = { ...VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS, ...options };
+
+  const state = reactive<VizelVersionHistoryState>({
+    snapshots: [],
+    isLoading: false,
+    error: null,
+  });
+
+  let handlers: ReturnType<typeof createVizelVersionHistoryHandlers> | null = null;
+
+  function handleStateChange(partial: Partial<VizelVersionHistoryState>) {
+    if (partial.snapshots !== undefined) state.snapshots = partial.snapshots;
+    if (partial.isLoading !== undefined) state.isLoading = partial.isLoading;
+    if (partial.error !== undefined) state.error = partial.error;
+  }
+
+  function setup() {
+    handlers = createVizelVersionHistoryHandlers(getEditor, opts, handleStateChange);
+    const editor = getEditor();
+    if (editor && opts.enabled) {
+      handlers.loadVersions();
+    }
+  }
+
+  onMounted(() => {
+    setup();
+  });
+
+  watch(
+    () => getEditor(),
+    () => {
+      setup();
+    }
+  );
+
+  onBeforeUnmount(() => {
+    handlers = null;
+  });
+
+  async function saveVersion(
+    description?: string,
+    author?: string
+  ): Promise<VizelVersionSnapshot | null> {
+    return (await handlers?.saveVersion(description, author)) ?? null;
+  }
+
+  async function restoreVersion(versionId: string): Promise<boolean> {
+    return (await handlers?.restoreVersion(versionId)) ?? false;
+  }
+
+  async function loadVersions(): Promise<VizelVersionSnapshot[]> {
+    return (await handlers?.loadVersions()) ?? [];
+  }
+
+  async function deleteVersion(versionId: string): Promise<void> {
+    await handlers?.deleteVersion(versionId);
+  }
+
+  async function clearVersions(): Promise<void> {
+    await handlers?.clearVersions();
+  }
+
+  return {
+    snapshots: computed(() => state.snapshots),
+    isLoading: computed(() => state.isLoading),
+    error: computed(() => state.error),
+    saveVersion,
+    restoreVersion,
+    loadVersions,
+    deleteVersion,
+    clearVersions,
+  };
+}


### PR DESCRIPTION
## Summary

- Add version history system for saving, viewing, and restoring document snapshots
- Core implementation: `VizelVersionSnapshot`, `VizelVersionStorage`, `createVizelVersionHistoryHandlers()`
- React hook: `useVizelVersionHistory()`
- Vue composable: `useVizelVersionHistory()`
- Svelte rune: `createVizelVersionHistory()`
- Support localStorage (default) and custom storage backends
- Configurable max versions, callbacks for save/restore/error events
- Documentation with Quick Start examples for all three frameworks

Closes #190

## Test Plan

- [x] Run typecheck (`pnpm typecheck`) — 0 errors
- [x] Run lint (`pnpm lint`) — clean
- [x] Docs build (`pnpm --filter docs build`) — success
- [x] Pre-commit hooks pass (biome-check, typecheck, commitlint)
- [x] Pre-push hooks pass (lint, typecheck)