### PR TITLE
feat(core): add comment/annotation system for text annotations

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -139,6 +139,7 @@ export default withMermaid({
             { text: "Plugins", link: "/guide/plugins" },
             { text: "Wiki Links", link: "/guide/wiki-links" },
             { text: "Version History", link: "/guide/version-history" },
+            { text: "Comments", link: "/guide/comments" },
             { text: "Performance", link: "/guide/performance" },
             { text: "Accessibility", link: "/guide/accessibility" },
             { text: "Troubleshooting", link: "/guide/troubleshooting" },

--- a/docs/guide/comments.md
+++ b/docs/guide/comments.md
@@ -1,0 +1,305 @@
+# Comments & Annotations
+
+Vizel provides a comment/annotation system that allows users to add comments to specific text selections in the editor.
+
+## Overview
+
+Comments enable:
+
+- **Annotate text** — add comments to any text selection
+- **Reply threads** — discuss specific passages
+- **Resolve/reopen** — track comment status
+- **Storage flexibility** — use localStorage or a custom backend
+- **Active highlighting** — click a comment to highlight its text
+
+## Quick Start
+
+### React
+
+```tsx
+import { useVizelEditor, useVizelComment, VizelProvider, VizelEditor } from "@vizel/react";
+
+function Editor() {
+  const editor = useVizelEditor({
+    features: { comment: true },
+  });
+  const { comments, addComment, resolveComment, removeComment, setActiveComment } =
+    useVizelComment(() => editor, {
+      key: "my-doc-comments",
+    });
+
+  const handleAddComment = () => {
+    const text = prompt("Enter comment:");
+    if (text) addComment(text, "Author");
+  };
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+      <button onClick={handleAddComment}>Add Comment</button>
+      <ul>
+        {comments.map((c) => (
+          <li key={c.id} onClick={() => setActiveComment(c.id)}>
+            {c.text} {c.resolved ? "(resolved)" : ""}
+            <button onClick={() => resolveComment(c.id)}>Resolve</button>
+            <button onClick={() => removeComment(c.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </VizelProvider>
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { useVizelEditor, useVizelComment, VizelProvider, VizelEditor } from "@vizel/vue";
+
+const editor = useVizelEditor({
+  features: { comment: true },
+});
+const { comments, addComment, resolveComment, removeComment, setActiveComment } =
+  useVizelComment(() => editor.value, {
+    key: "my-doc-comments",
+  });
+
+function handleAddComment() {
+  const text = prompt("Enter comment:");
+  if (text) addComment(text, "Author");
+}
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+    <button @click="handleAddComment">Add Comment</button>
+    <ul>
+      <li
+        v-for="c in comments"
+        :key="c.id"
+        @click="setActiveComment(c.id)"
+      >
+        {{ c.text }} {{ c.resolved ? "(resolved)" : "" }}
+        <button @click="resolveComment(c.id)">Resolve</button>
+        <button @click="removeComment(c.id)">Delete</button>
+      </li>
+    </ul>
+  </VizelProvider>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+import { createVizelEditor, createVizelComment, VizelProvider, VizelEditor } from "@vizel/svelte";
+
+const editor = createVizelEditor({
+  features: { comment: true },
+});
+const comment = createVizelComment(() => editor.current, {
+  key: "my-doc-comments",
+});
+
+function handleAddComment() {
+  const text = prompt("Enter comment:");
+  if (text) comment.addComment(text, "Author");
+}
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+  <button onclick={handleAddComment}>Add Comment</button>
+  <ul>
+    {#each comment.comments as c}
+      <li onclick={() => comment.setActiveComment(c.id)}>
+        {c.text} {c.resolved ? "(resolved)" : ""}
+        <button onclick={() => comment.resolveComment(c.id)}>Resolve</button>
+        <button onclick={() => comment.removeComment(c.id)}>Delete</button>
+      </li>
+    {/each}
+  </ul>
+</VizelProvider>
+```
+
+## Enabling the Feature
+
+The comment feature is **disabled by default**. Enable it via `features.comment`:
+
+```typescript
+const editor = useVizelEditor({
+  features: {
+    comment: true, // Enable with defaults
+  },
+});
+
+// Or with options
+const editor = useVizelEditor({
+  features: {
+    comment: {
+      onCommentClick: (commentId) => {
+        console.log("Clicked comment:", commentId);
+      },
+    },
+  },
+});
+```
+
+## Comment Options
+
+```typescript
+interface VizelCommentOptions {
+  /** Enable comments (default: true) */
+  enabled?: boolean;
+  /** Storage backend (default: 'localStorage') */
+  storage?: VizelCommentStorage;
+  /** Storage key for localStorage (default: 'vizel-comments') */
+  key?: string;
+  /** Callback when a comment is added */
+  onAdd?: (comment: VizelComment) => void;
+  /** Callback when a comment is removed */
+  onRemove?: (commentId: string) => void;
+  /** Callback when a comment is resolved */
+  onResolve?: (comment: VizelComment) => void;
+  /** Callback when a comment is reopened */
+  onReopen?: (comment: VizelComment) => void;
+  /** Callback when an error occurs */
+  onError?: (error: Error) => void;
+}
+```
+
+### Custom Storage Backend
+
+```typescript
+useVizelComment(() => editor, {
+  storage: {
+    save: async (comments) => {
+      await fetch("/api/comments", {
+        method: "PUT",
+        body: JSON.stringify(comments),
+      });
+    },
+    load: async () => {
+      const res = await fetch("/api/comments");
+      return res.json();
+    },
+  },
+});
+```
+
+## Data Model
+
+### Comment
+
+```typescript
+interface VizelComment {
+  /** Unique identifier */
+  id: string;
+  /** Comment text */
+  text: string;
+  /** Optional author name */
+  author?: string;
+  /** Unix timestamp (milliseconds) */
+  createdAt: number;
+  /** Whether the comment is resolved */
+  resolved: boolean;
+  /** Replies to this comment */
+  replies: VizelCommentReply[];
+}
+```
+
+### Reply
+
+```typescript
+interface VizelCommentReply {
+  /** Unique identifier */
+  id: string;
+  /** Reply text */
+  text: string;
+  /** Optional author name */
+  author?: string;
+  /** Unix timestamp (milliseconds) */
+  createdAt: number;
+}
+```
+
+## API Reference
+
+### Hook / Composable / Rune
+
+| Framework | Function |
+|-----------|----------|
+| React | `useVizelComment(getEditor, options)` |
+| Vue | `useVizelComment(getEditor, options)` |
+| Svelte | `createVizelComment(getEditor, options)` |
+
+### Return Values
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `comments` | `VizelComment[]` | All stored comments (newest first) |
+| `activeCommentId` | `string \| null` | Currently active comment ID |
+| `isLoading` | `boolean` | Whether comments are loading |
+| `error` | `Error \| null` | Last error that occurred |
+| `addComment(text, author?)` | `Promise<VizelComment \| null>` | Add a comment to the selection |
+| `removeComment(id)` | `Promise<void>` | Remove a comment and its mark |
+| `resolveComment(id)` | `Promise<boolean>` | Mark a comment as resolved |
+| `reopenComment(id)` | `Promise<boolean>` | Reopen a resolved comment |
+| `replyToComment(id, text, author?)` | `Promise<VizelCommentReply \| null>` | Add a reply |
+| `setActiveComment(id)` | `void` | Set the active comment |
+| `loadComments()` | `Promise<VizelComment[]>` | Reload from storage |
+| `getCommentById(id)` | `VizelComment \| undefined` | Get a comment by ID |
+
+::: tip
+In Vue, `comments`, `activeCommentId`, `isLoading`, and `error` are `ComputedRef` values — access them with `.value` in script or directly in templates.
+:::
+
+## Styling
+
+Comment highlights use the following CSS classes:
+
+| Class | Description |
+|-------|-------------|
+| `.vizel-comment-marker` | Base highlight for commented text |
+| `.vizel-comment-marker--active` | Highlight for the active comment |
+
+### CSS Custom Properties
+
+```css
+:root {
+  /* Comment highlight */
+  --vizel-comment-bg: rgba(255, 212, 100, 0.3);
+  --vizel-comment-border: rgba(255, 180, 50, 0.6);
+  --vizel-comment-hover-bg: rgba(255, 212, 100, 0.5);
+
+  /* Active comment */
+  --vizel-comment-active-bg: rgba(255, 180, 50, 0.5);
+  --vizel-comment-active-border: rgba(255, 150, 0, 0.8);
+  --vizel-comment-active-outline: rgba(255, 150, 0, 0.4);
+}
+```
+
+## Core Handlers
+
+For advanced use cases, use the core handlers directly:
+
+```typescript
+import {
+  createVizelCommentHandlers,
+  type VizelCommentState,
+} from "@vizel/core";
+
+const handlers = createVizelCommentHandlers(
+  () => editor,
+  { key: "my-comments" },
+  (state: Partial<VizelCommentState>) => {
+    // Handle state changes
+  }
+);
+
+await handlers.addComment("Needs review", "Alice");
+await handlers.replyToComment(commentId, "Fixed!", "Bob");
+await handlers.resolveComment(commentId);
+```

--- a/packages/core/src/comment.ts
+++ b/packages/core/src/comment.ts
@@ -1,0 +1,373 @@
+import type { Editor } from "@tiptap/core";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A reply to a comment
+ */
+export interface VizelCommentReply {
+  /** Unique identifier */
+  id: string;
+  /** Reply text */
+  text: string;
+  /** Optional author name */
+  author?: string;
+  /** Unix timestamp (milliseconds) */
+  createdAt: number;
+}
+
+/**
+ * A comment annotation on the document
+ */
+export interface VizelComment {
+  /** Unique identifier */
+  id: string;
+  /** Comment text */
+  text: string;
+  /** Optional author name */
+  author?: string;
+  /** Unix timestamp (milliseconds) */
+  createdAt: number;
+  /** Whether the comment is resolved */
+  resolved: boolean;
+  /** Replies to this comment */
+  replies: VizelCommentReply[];
+}
+
+/**
+ * Storage backend for comments.
+ * Use `"localStorage"` for built-in browser storage, or provide a custom backend.
+ */
+export type VizelCommentStorage =
+  | "localStorage"
+  | {
+      save: (comments: VizelComment[]) => void | Promise<void>;
+      load: () => VizelComment[] | null | Promise<VizelComment[] | null>;
+    };
+
+/**
+ * Configuration options for comment management
+ */
+export interface VizelCommentOptions {
+  /** Enable comments (default: true) */
+  enabled?: boolean;
+  /** Storage backend (default: 'localStorage') */
+  storage?: VizelCommentStorage;
+  /** Storage key for localStorage (default: 'vizel-comments') */
+  key?: string;
+  /** Callback when a comment is added */
+  onAdd?: (comment: VizelComment) => void;
+  /** Callback when a comment is removed */
+  onRemove?: (commentId: string) => void;
+  /** Callback when a comment is resolved */
+  onResolve?: (comment: VizelComment) => void;
+  /** Callback when a comment is reopened */
+  onReopen?: (comment: VizelComment) => void;
+  /** Callback when an error occurs */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Comment state
+ */
+export interface VizelCommentState {
+  /** All stored comments (newest first) */
+  comments: VizelComment[];
+  /** Currently active comment ID */
+  activeCommentId: string | null;
+  /** Whether comments are loading */
+  isLoading: boolean;
+  /** Last error that occurred */
+  error: Error | null;
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+/**
+ * Default comment options
+ */
+export const VIZEL_DEFAULT_COMMENT_OPTIONS = {
+  enabled: true,
+  storage: "localStorage" as const,
+  key: "vizel-comments",
+} satisfies VizelCommentOptions;
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+/**
+ * Creates a normalized storage backend for comments
+ */
+export function getVizelCommentStorageBackend(
+  storage: VizelCommentStorage,
+  key: string
+): {
+  save: (comments: VizelComment[]) => Promise<void>;
+  load: () => Promise<VizelComment[]>;
+} {
+  if (storage === "localStorage") {
+    return {
+      save: (comments: VizelComment[]) => {
+        if (typeof localStorage === "undefined") return Promise.resolve();
+        localStorage.setItem(key, JSON.stringify(comments));
+        return Promise.resolve();
+      },
+      load: () => {
+        if (typeof localStorage === "undefined") return Promise.resolve([]);
+        const data = localStorage.getItem(key);
+        if (data) {
+          try {
+            const parsed = JSON.parse(data);
+            if (Array.isArray(parsed)) {
+              return Promise.resolve(parsed as VizelComment[]);
+            }
+          } catch {
+            // Invalid data, return empty
+          }
+        }
+        return Promise.resolve([]);
+      },
+    };
+  }
+
+  return {
+    save: async (comments: VizelComment[]) => {
+      await storage.save(comments);
+    },
+    load: async () => {
+      return (await storage.load()) ?? [];
+    },
+  };
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Creates comment handlers for an editor.
+ *
+ * @example
+ * ```typescript
+ * const handlers = createVizelCommentHandlers(
+ *   () => editor,
+ *   { key: "my-comments" },
+ *   (state) => setState(prev => ({ ...prev, ...state }))
+ * );
+ *
+ * // Add a comment to the current selection
+ * await handlers.addComment("Needs clarification", "Alice");
+ *
+ * // Resolve a comment
+ * await handlers.resolveComment(commentId);
+ *
+ * // Reply to a comment
+ * await handlers.replyToComment(commentId, "Fixed in latest commit", "Bob");
+ * ```
+ */
+export function createVizelCommentHandlers(
+  getEditor: () => Editor | null | undefined,
+  options: VizelCommentOptions,
+  onStateChange: (state: Partial<VizelCommentState>) => void
+): {
+  /** Add a comment to the current selection */
+  addComment: (text: string, author?: string) => Promise<VizelComment | null>;
+  /** Remove a comment and its mark */
+  removeComment: (commentId: string) => Promise<void>;
+  /** Mark a comment as resolved */
+  resolveComment: (commentId: string) => Promise<boolean>;
+  /** Reopen a resolved comment */
+  reopenComment: (commentId: string) => Promise<boolean>;
+  /** Add a reply to a comment */
+  replyToComment: (
+    commentId: string,
+    text: string,
+    author?: string
+  ) => Promise<VizelCommentReply | null>;
+  /** Set the active comment */
+  setActiveComment: (commentId: string | null) => void;
+  /** Load all comments from storage */
+  loadComments: () => Promise<VizelComment[]>;
+  /** Get a comment by its ID */
+  getCommentById: (commentId: string) => VizelComment | undefined;
+} {
+  const opts = { ...VIZEL_DEFAULT_COMMENT_OPTIONS, ...options };
+  const storageBackend = getVizelCommentStorageBackend(opts.storage, opts.key);
+
+  let cachedComments: VizelComment[] = [];
+
+  const loadComments = async (): Promise<VizelComment[]> => {
+    try {
+      onStateChange({ isLoading: true });
+      const comments = await storageBackend.load();
+      cachedComments = comments;
+      onStateChange({ comments, isLoading: false, error: null });
+      return comments;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ isLoading: false, error });
+      opts.onError?.(error);
+      return cachedComments;
+    }
+  };
+
+  const addComment = async (text: string, author?: string): Promise<VizelComment | null> => {
+    const editor = getEditor();
+    if (!editor) return null;
+
+    const { from, to } = editor.state.selection;
+    if (from === to) return null;
+
+    try {
+      const comment: VizelComment = {
+        id: generateId(),
+        text,
+        createdAt: Date.now(),
+        resolved: false,
+        replies: [],
+        ...(author !== undefined && { author }),
+      };
+
+      editor.commands.addCommentMark(comment.id);
+
+      const updated = [comment, ...cachedComments];
+      await storageBackend.save(updated);
+      cachedComments = updated;
+      onStateChange({ comments: updated, activeCommentId: comment.id, error: null });
+
+      opts.onAdd?.(comment);
+      return comment;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return null;
+    }
+  };
+
+  const removeComment = async (commentId: string): Promise<void> => {
+    const editor = getEditor();
+
+    try {
+      if (editor) {
+        editor.commands.removeCommentMark(commentId);
+      }
+
+      const updated = cachedComments.filter((c) => c.id !== commentId);
+      await storageBackend.save(updated);
+      cachedComments = updated;
+      onStateChange({ comments: updated, activeCommentId: null, error: null });
+
+      opts.onRemove?.(commentId);
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+    }
+  };
+
+  const resolveComment = async (commentId: string): Promise<boolean> => {
+    try {
+      const comment = cachedComments.find((c) => c.id === commentId);
+      if (!comment) return false;
+
+      const updatedComment = { ...comment, resolved: true };
+      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      await storageBackend.save(updated);
+      cachedComments = updated;
+      onStateChange({ comments: updated, error: null });
+
+      opts.onResolve?.(updatedComment);
+      return true;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return false;
+    }
+  };
+
+  const reopenComment = async (commentId: string): Promise<boolean> => {
+    try {
+      const comment = cachedComments.find((c) => c.id === commentId);
+      if (!comment) return false;
+
+      const updatedComment = { ...comment, resolved: false };
+      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      await storageBackend.save(updated);
+      cachedComments = updated;
+      onStateChange({ comments: updated, error: null });
+
+      opts.onReopen?.(updatedComment);
+      return true;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return false;
+    }
+  };
+
+  const replyToComment = async (
+    commentId: string,
+    text: string,
+    author?: string
+  ): Promise<VizelCommentReply | null> => {
+    try {
+      const comment = cachedComments.find((c) => c.id === commentId);
+      if (!comment) return null;
+
+      const reply: VizelCommentReply = {
+        id: generateId(),
+        text,
+        createdAt: Date.now(),
+        ...(author !== undefined && { author }),
+      };
+
+      const updatedComment = { ...comment, replies: [...comment.replies, reply] };
+      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      await storageBackend.save(updated);
+      cachedComments = updated;
+      onStateChange({ comments: updated, error: null });
+
+      return reply;
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      onStateChange({ error });
+      opts.onError?.(error);
+      return null;
+    }
+  };
+
+  const setActiveComment = (commentId: string | null): void => {
+    const editor = getEditor();
+    if (editor) {
+      editor.commands.setActiveComment(commentId);
+    }
+    onStateChange({ activeCommentId: commentId });
+  };
+
+  const getCommentById = (commentId: string): VizelComment | undefined => {
+    return cachedComments.find((c) => c.id === commentId);
+  };
+
+  return {
+    addComment,
+    removeComment,
+    resolveComment,
+    reopenComment,
+    replyToComment,
+    setActiveComment,
+    loadComments,
+    getCommentById,
+  };
+}

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -22,6 +22,7 @@ import Underline from "@tiptap/extension-underline";
 import type { VizelFeatureOptions } from "../types.ts";
 import { createVizelCharacterCountExtension } from "./character-count.ts";
 import type { VizelCodeBlockOptions } from "./code-block-lowlight.ts";
+import { createVizelCommentExtension } from "./comment.ts";
 import { createVizelDetailsExtensions } from "./details.ts";
 import { createVizelDiagramExtension } from "./diagram.ts";
 import { createVizelDragHandleExtensions } from "./drag-handle.ts";
@@ -273,6 +274,16 @@ function addWikiLinkExtension(extensions: Extensions, features: VizelFeatureOpti
 }
 
 /**
+ * Add Comment extension if enabled (disabled by default)
+ */
+function addCommentExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (!features.comment) return;
+
+  const commentOptions = typeof features.comment === "object" ? features.comment : {};
+  extensions.push(createVizelCommentExtension(commentOptions));
+}
+
+/**
  * Create the default set of extensions for Vizel editor.
  * All features are enabled by default. Set any feature to `false` to disable it.
  *
@@ -359,6 +370,7 @@ export async function createVizelExtensions(
   addEmbedExtension(extensions, features);
   addDiagramExtension(extensions, features);
   addWikiLinkExtension(extensions, features);
+  addCommentExtension(extensions, features);
 
   // Add code block extension (async - lowlight is loaded dynamically)
   await addCodeBlockExtension(extensions, features);

--- a/packages/core/src/extensions/comment.ts
+++ b/packages/core/src/extensions/comment.ts
@@ -1,0 +1,246 @@
+import { Mark } from "@tiptap/core";
+import type { MarkType } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Options for the comment mark extension
+ */
+export interface VizelCommentMarkOptions {
+  /** Additional HTML attributes for comment marks */
+  HTMLAttributes?: Record<string, string>;
+  /** Callback when a comment mark is clicked */
+  onCommentClick?: (commentId: string) => void;
+}
+
+/**
+ * Plugin state for tracking the active comment
+ */
+export interface VizelCommentPluginState {
+  /** Currently active (selected) comment ID */
+  activeCommentId: string | null;
+}
+
+type VizelCommentMeta = { type: "setActive"; commentId: string | null };
+
+/**
+ * Plugin key for accessing comment plugin state
+ */
+export const vizelCommentPluginKey = new PluginKey<VizelCommentPluginState>("vizelComment");
+
+/**
+ * Get the current comment plugin state from the editor
+ */
+export function getVizelCommentPluginState(state: EditorState): VizelCommentPluginState | null {
+  return vizelCommentPluginKey.getState(state) ?? null;
+}
+
+function isCommentMeta(value: unknown): value is VizelCommentMeta {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
+/**
+ * Find all text ranges with a specific comment mark
+ */
+function findCommentMarkPositions(
+  state: EditorState,
+  commentId: string,
+  markType: MarkType
+): { from: number; to: number }[] {
+  const positions: { from: number; to: number }[] = [];
+
+  state.doc.descendants((node, pos) => {
+    if (!node.isText) return true;
+
+    for (const mark of node.marks) {
+      if (mark.type === markType && mark.attrs.commentId === commentId) {
+        positions.push({ from: pos, to: pos + node.nodeSize });
+        break;
+      }
+    }
+    return true;
+  });
+
+  return positions;
+}
+
+/**
+ * Comment mark extension for highlighting annotated text.
+ *
+ * @example
+ * ```typescript
+ * import { VizelCommentMark } from "@vizel/core";
+ *
+ * const extensions = [
+ *   VizelCommentMark.configure({
+ *     onCommentClick: (commentId) => console.log("Clicked:", commentId),
+ *   }),
+ * ];
+ * ```
+ */
+export const VizelCommentMark = Mark.create<VizelCommentMarkOptions>({
+  name: "vizelComment",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      commentId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-vizel-comment-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.commentId) return {};
+          return { "data-vizel-comment-id": attributes.commentId as string };
+        },
+      },
+    };
+  },
+
+  inclusive: false,
+  spanning: true,
+
+  parseHTML() {
+    return [{ tag: "span[data-vizel-comment-id]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      {
+        ...this.options.HTMLAttributes,
+        ...HTMLAttributes,
+        class: "vizel-comment-marker",
+      },
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      addCommentMark:
+        (commentId: string) =>
+        ({ commands }) => {
+          return commands.setMark(this.name, { commentId });
+        },
+
+      removeCommentMark:
+        (commentId: string) =>
+        ({ state, dispatch }) => {
+          if (!dispatch) return true;
+
+          const markType = state.schema.marks[this.name];
+          if (!markType) return false;
+
+          const positions = findCommentMarkPositions(state, commentId, markType);
+          if (positions.length === 0) return false;
+
+          let tr = state.tr;
+          for (let i = positions.length - 1; i >= 0; i -= 1) {
+            const pos = positions[i];
+            if (pos) {
+              tr = tr.removeMark(pos.from, pos.to, markType.create({ commentId }));
+            }
+          }
+
+          dispatch(tr);
+          return true;
+        },
+
+      setActiveComment:
+        (commentId: string | null) =>
+        ({ tr, dispatch }) => {
+          if (dispatch) {
+            dispatch(tr.setMeta(vizelCommentPluginKey, { type: "setActive", commentId }));
+          }
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const extensionOptions = this.options;
+    const markName = this.name;
+
+    return [
+      new Plugin<VizelCommentPluginState>({
+        key: vizelCommentPluginKey,
+
+        state: {
+          init: () => ({ activeCommentId: null }),
+          apply: (tr, value) => {
+            const meta = tr.getMeta(vizelCommentPluginKey);
+            if (isCommentMeta(meta)) {
+              return { ...value, activeCommentId: meta.commentId };
+            }
+            return value;
+          },
+        },
+
+        props: {
+          handleClick: (_view, _pos, event) => {
+            const target = event.target as HTMLElement;
+            const commentEl = target.closest("[data-vizel-comment-id]");
+            if (commentEl) {
+              const commentId = commentEl.getAttribute("data-vizel-comment-id");
+              if (commentId) {
+                extensionOptions.onCommentClick?.(commentId);
+                return false;
+              }
+            }
+            return false;
+          },
+
+          decorations(state) {
+            const pluginState = vizelCommentPluginKey.getState(state);
+            if (!pluginState?.activeCommentId) return DecorationSet.empty;
+
+            const markType = state.schema.marks[markName];
+            if (!markType) return DecorationSet.empty;
+
+            const positions = findCommentMarkPositions(
+              state,
+              pluginState.activeCommentId,
+              markType
+            );
+            if (positions.length === 0) return DecorationSet.empty;
+
+            const decorations = positions.map((pos) =>
+              Decoration.inline(pos.from, pos.to, {
+                class: "vizel-comment-marker--active",
+              })
+            );
+
+            return DecorationSet.create(state.doc, decorations);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/**
+ * Create the comment mark extension with configured options
+ */
+export function createVizelCommentExtension(
+  options: VizelCommentMarkOptions = {}
+): ReturnType<typeof VizelCommentMark.configure> {
+  return VizelCommentMark.configure(options);
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    vizelComment: {
+      /** Add a comment mark to the current selection */
+      addCommentMark: (commentId: string) => ReturnType;
+      /** Remove all comment marks with the given ID */
+      removeCommentMark: (commentId: string) => ReturnType;
+      /** Set the active (highlighted) comment */
+      setActiveComment: (commentId: string | null) => ReturnType;
+    };
+  }
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -1,13 +1,11 @@
 // Base extensions
 export { createVizelExtensions, type VizelExtensionsOptions } from "./base.ts";
-
 // Character count
 export {
   createVizelCharacterCountExtension,
   type VizelCharacterCountOptions,
   type VizelCharacterCountStorage,
 } from "./character-count.ts";
-
 // Code block with syntax highlighting
 export {
   createVizelCodeBlockExtension,
@@ -17,6 +15,15 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
 } from "./code-block-lowlight.ts";
+// Comment
+export {
+  createVizelCommentExtension,
+  getVizelCommentPluginState,
+  VizelCommentMark,
+  type VizelCommentMarkOptions,
+  type VizelCommentPluginState,
+  vizelCommentPluginKey,
+} from "./comment.ts";
 
 // Details (collapsible content)
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,21 @@ export {
   type VizelSaveStatus,
   type VizelStorageBackend,
 } from "./auto-save.ts";
+
+// =============================================================================
+// Comments
+// =============================================================================
+export {
+  createVizelCommentHandlers,
+  getVizelCommentStorageBackend,
+  VIZEL_DEFAULT_COMMENT_OPTIONS,
+  type VizelComment,
+  type VizelCommentOptions,
+  type VizelCommentReply,
+  type VizelCommentState,
+  type VizelCommentStorage,
+} from "./comment.ts";
+
 // =============================================================================
 // Extensions
 // =============================================================================
@@ -35,6 +50,8 @@ export {
   createVizelCharacterCountExtension,
   // Code block with syntax highlighting
   createVizelCodeBlockExtension,
+  // Comment
+  createVizelCommentExtension,
   // Embed (oEmbed, OGP)
   createVizelDefaultFetchEmbedData,
   // Details (collapsible content)
@@ -80,6 +97,7 @@ export {
   getAllVizelLanguageIds,
   // Node types
   getVizelActiveNodeType,
+  getVizelCommentPluginState,
   getVizelFindReplaceState,
   getVizelImageUploadPluginKey,
   getVizelRecentColors,
@@ -99,6 +117,9 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
   type VizelColorDefinition,
+  VizelCommentMark,
+  type VizelCommentMarkOptions,
+  type VizelCommentPluginState,
   type VizelDetailsContentOptions,
   type VizelDetailsNodeOptions,
   type VizelDetailsOptions,
@@ -166,6 +187,7 @@ export {
   type VizelWikiLinkOptions,
   type VizelWikiLinkSuggestion,
   validateVizelImageFile,
+  vizelCommentPluginKey,
   vizelDefaultBase64Upload,
   vizelDefaultEmbedProviders,
   vizelDefaultGroupOrder,

--- a/packages/core/src/styles/components.scss
+++ b/packages/core/src/styles/components.scss
@@ -43,4 +43,5 @@
 @use "save-indicator";
 @use "diagram";
 @use "wiki-link";
+@use "components/comment";
 @use "components/find-replace";

--- a/packages/core/src/styles/components/_comment.scss
+++ b/packages/core/src/styles/components/_comment.scss
@@ -1,0 +1,47 @@
+// Comment annotation styles
+// Highlight styles for commented text
+
+.vizel-comment-marker {
+  background-color: var(--vizel-comment-bg, rgba(255, 212, 100, 0.3));
+  border-bottom: 2px solid var(--vizel-comment-border, rgba(255, 180, 50, 0.6));
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--vizel-comment-hover-bg, rgba(255, 212, 100, 0.5));
+  }
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-comment-bg, rgba(255, 212, 100, 0.15));
+    border-bottom-color: var(--vizel-comment-border, rgba(255, 180, 50, 0.4));
+
+    &:hover {
+      background-color: var(--vizel-comment-hover-bg, rgba(255, 212, 100, 0.25));
+    }
+  }
+}
+
+// Active comment highlight (decoration overlay)
+.vizel-comment-marker--active {
+  background-color: var(--vizel-comment-active-bg, rgba(255, 180, 50, 0.5));
+  border-bottom: 2px solid var(--vizel-comment-active-border, rgba(255, 150, 0, 0.8));
+  outline: 1px solid var(--vizel-comment-active-outline, rgba(255, 150, 0, 0.4));
+  outline-offset: -1px;
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-comment-active-bg, rgba(255, 180, 50, 0.3));
+    border-bottom-color: var(--vizel-comment-active-border, rgba(255, 150, 0, 0.6));
+    outline-color: var(--vizel-comment-active-outline, rgba(255, 150, 0, 0.3));
+  }
+}
+
+// Resolved comment (dimmed)
+.vizel-comment-marker[data-vizel-comment-resolved] {
+  background-color: var(--vizel-comment-resolved-bg, rgba(200, 200, 200, 0.2));
+  border-bottom-color: var(--vizel-comment-resolved-border, rgba(160, 160, 160, 0.4));
+
+  [data-vizel-theme="dark"] & {
+    background-color: var(--vizel-comment-resolved-bg, rgba(200, 200, 200, 0.1));
+    border-bottom-color: var(--vizel-comment-resolved-border, rgba(160, 160, 160, 0.2));
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import type { Editor, Extensions, JSONContent } from "@tiptap/core";
 import type { SuggestionOptions } from "@tiptap/suggestion";
 import type { VizelCharacterCountOptions } from "./extensions/character-count.ts";
 import type { VizelCodeBlockOptions } from "./extensions/code-block-lowlight.ts";
+import type { VizelCommentMarkOptions } from "./extensions/comment.ts";
 import type { VizelDetailsOptions } from "./extensions/details.ts";
 import type { VizelDiagramOptions } from "./extensions/diagram.ts";
 import type { VizelDragHandleOptions } from "./extensions/drag-handle.ts";
@@ -71,6 +72,8 @@ export interface VizelFeatureOptions {
   diagram?: VizelDiagramOptions | boolean;
   /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
   wikiLink?: VizelWikiLinkOptions | boolean;
+  /** Comment/annotation marks for collaborative review workflows */
+  comment?: VizelCommentMarkOptions | boolean;
 }
 
 /**

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -5,6 +5,7 @@ export {
   type VizelSlashMenuRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
+export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 export { useVizelEditorState } from "./useVizelEditorState.ts";
 export {

--- a/packages/react/src/hooks/useVizelComment.ts
+++ b/packages/react/src/hooks/useVizelComment.ts
@@ -1,0 +1,187 @@
+import {
+  createVizelCommentHandlers,
+  type Editor,
+  VIZEL_DEFAULT_COMMENT_OPTIONS,
+  type VizelComment,
+  type VizelCommentOptions,
+  type VizelCommentReply,
+  type VizelCommentState,
+} from "@vizel/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Comment hook result
+ */
+export interface UseVizelCommentResult {
+  /** All stored comments (newest first) */
+  comments: VizelComment[];
+  /** Currently active comment ID */
+  activeCommentId: string | null;
+  /** Whether comments are loading */
+  isLoading: boolean;
+  /** Last error that occurred */
+  error: Error | null;
+  /** Add a comment to the current selection */
+  addComment: (text: string, author?: string) => Promise<VizelComment | null>;
+  /** Remove a comment and its mark */
+  removeComment: (commentId: string) => Promise<void>;
+  /** Mark a comment as resolved */
+  resolveComment: (commentId: string) => Promise<boolean>;
+  /** Reopen a resolved comment */
+  reopenComment: (commentId: string) => Promise<boolean>;
+  /** Add a reply to a comment */
+  replyToComment: (
+    commentId: string,
+    text: string,
+    author?: string
+  ) => Promise<VizelCommentReply | null>;
+  /** Set the active comment */
+  setActiveComment: (commentId: string | null) => void;
+  /** Load all comments from storage */
+  loadComments: () => Promise<VizelComment[]>;
+  /** Get a comment by its ID */
+  getCommentById: (commentId: string) => VizelComment | undefined;
+}
+
+/**
+ * Hook for managing document comments and annotations.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Comment configuration options
+ * @returns Comment state and controls
+ *
+ * @example
+ * ```tsx
+ * function Editor() {
+ *   const editor = useVizelEditor({
+ *     features: { comment: true },
+ *   });
+ *   const { comments, addComment, resolveComment, setActiveComment } =
+ *     useVizelComment(() => editor, { key: "my-comments" });
+ *
+ *   const handleAddComment = () => {
+ *     const text = prompt("Enter comment:");
+ *     if (text) addComment(text, "Author");
+ *   };
+ *
+ *   return (
+ *     <div>
+ *       <VizelEditor editor={editor} />
+ *       <button onClick={handleAddComment}>Add Comment</button>
+ *       <ul>
+ *         {comments.map((c) => (
+ *           <li key={c.id} onClick={() => setActiveComment(c.id)}>
+ *             {c.text} {c.resolved ? "(resolved)" : ""}
+ *             <button onClick={() => resolveComment(c.id)}>Resolve</button>
+ *           </li>
+ *         ))}
+ *       </ul>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useVizelComment(
+  getEditor: () => Editor | null | undefined,
+  options: VizelCommentOptions = {}
+): UseVizelCommentResult {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COMMENT_OPTIONS.enabled;
+  const storage = options.storage ?? VIZEL_DEFAULT_COMMENT_OPTIONS.storage;
+  const key = options.key ?? VIZEL_DEFAULT_COMMENT_OPTIONS.key;
+
+  const [state, setState] = useState<VizelCommentState>({
+    comments: [],
+    activeCommentId: null,
+    isLoading: false,
+    error: null,
+  });
+
+  const getEditorRef = useRef(getEditor);
+  getEditorRef.current = getEditor;
+
+  const handleStateChange = useCallback((partial: Partial<VizelCommentState>) => {
+    setState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const handlers = useMemo(
+    () =>
+      createVizelCommentHandlers(
+        () => getEditorRef.current(),
+        {
+          enabled,
+          storage,
+          key,
+          onAdd: (comment) => optionsRef.current.onAdd?.(comment),
+          onRemove: (id) => optionsRef.current.onRemove?.(id),
+          onResolve: (comment) => optionsRef.current.onResolve?.(comment),
+          onReopen: (comment) => optionsRef.current.onReopen?.(comment),
+          onError: (error) => optionsRef.current.onError?.(error),
+        },
+        handleStateChange
+      ),
+    [enabled, storage, key, handleStateChange]
+  );
+
+  useEffect(() => {
+    const editor = getEditor();
+    if (editor && enabled) {
+      handlers.loadComments();
+    }
+  }, [getEditor, enabled, handlers]);
+
+  const addComment = useCallback(
+    (text: string, author?: string) => handlers.addComment(text, author),
+    [handlers]
+  );
+
+  const removeComment = useCallback(
+    (commentId: string) => handlers.removeComment(commentId),
+    [handlers]
+  );
+
+  const resolveComment = useCallback(
+    (commentId: string) => handlers.resolveComment(commentId),
+    [handlers]
+  );
+
+  const reopenComment = useCallback(
+    (commentId: string) => handlers.reopenComment(commentId),
+    [handlers]
+  );
+
+  const replyToComment = useCallback(
+    (commentId: string, text: string, author?: string) =>
+      handlers.replyToComment(commentId, text, author),
+    [handlers]
+  );
+
+  const setActiveComment = useCallback(
+    (commentId: string | null) => handlers.setActiveComment(commentId),
+    [handlers]
+  );
+
+  const loadComments = useCallback(() => handlers.loadComments(), [handlers]);
+
+  const getCommentById = useCallback(
+    (commentId: string) => handlers.getCommentById(commentId),
+    [handlers]
+  );
+
+  return {
+    comments: state.comments,
+    activeCommentId: state.activeCommentId,
+    isLoading: state.isLoading,
+    error: state.error,
+    addComment,
+    removeComment,
+    resolveComment,
+    reopenComment,
+    replyToComment,
+    setActiveComment,
+    loadComments,
+    getCommentById,
+  };
+}

--- a/packages/svelte/src/runes/createVizelComment.svelte.ts
+++ b/packages/svelte/src/runes/createVizelComment.svelte.ts
@@ -1,0 +1,140 @@
+import {
+  createVizelCommentHandlers,
+  type Editor,
+  VIZEL_DEFAULT_COMMENT_OPTIONS,
+  type VizelComment,
+  type VizelCommentOptions,
+  type VizelCommentReply,
+  type VizelCommentState,
+} from "@vizel/core";
+
+/**
+ * Comment rune result
+ */
+export interface CreateVizelCommentResult {
+  /** All stored comments (newest first) */
+  readonly comments: VizelComment[];
+  /** Currently active comment ID */
+  readonly activeCommentId: string | null;
+  /** Whether comments are loading */
+  readonly isLoading: boolean;
+  /** Last error that occurred */
+  readonly error: Error | null;
+  /** Add a comment to the current selection */
+  addComment: (text: string, author?: string) => Promise<VizelComment | null>;
+  /** Remove a comment and its mark */
+  removeComment: (commentId: string) => Promise<void>;
+  /** Mark a comment as resolved */
+  resolveComment: (commentId: string) => Promise<boolean>;
+  /** Reopen a resolved comment */
+  reopenComment: (commentId: string) => Promise<boolean>;
+  /** Add a reply to a comment */
+  replyToComment: (
+    commentId: string,
+    text: string,
+    author?: string
+  ) => Promise<VizelCommentReply | null>;
+  /** Set the active comment */
+  setActiveComment: (commentId: string | null) => void;
+  /** Load all comments from storage */
+  loadComments: () => Promise<VizelComment[]>;
+  /** Get a comment by its ID */
+  getCommentById: (commentId: string) => VizelComment | undefined;
+}
+
+/**
+ * Rune for managing document comments and annotations.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Comment configuration options
+ * @returns Comment state and controls
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import { createVizelEditor, createVizelComment } from "@vizel/svelte";
+ *
+ * const editor = createVizelEditor({ features: { comment: true } });
+ * const comment = createVizelComment(() => editor.current, { key: "my-comments" });
+ * </script>
+ *
+ * <button onclick={() => comment.addComment("Needs review", "Author")}>
+ *   Add Comment
+ * </button>
+ * {#each comment.comments as c}
+ *   <div onclick={() => comment.setActiveComment(c.id)}>
+ *     {c.text} {c.resolved ? "(resolved)" : ""}
+ *   </div>
+ * {/each}
+ * ```
+ */
+export function createVizelComment(
+  getEditor: () => Editor | null | undefined,
+  options: VizelCommentOptions = {}
+): CreateVizelCommentResult {
+  const opts = { ...VIZEL_DEFAULT_COMMENT_OPTIONS, ...options };
+
+  let comments = $state<VizelComment[]>([]);
+  let activeCommentId = $state<string | null>(null);
+  let isLoading = $state(false);
+  let error = $state<Error | null>(null);
+
+  const handleStateChange = (partial: Partial<VizelCommentState>) => {
+    if (partial.comments !== undefined) comments = partial.comments;
+    if (partial.activeCommentId !== undefined) activeCommentId = partial.activeCommentId;
+    if (partial.isLoading !== undefined) isLoading = partial.isLoading;
+    if (partial.error !== undefined) error = partial.error;
+  };
+
+  let handlers: ReturnType<typeof createVizelCommentHandlers> | null = null;
+
+  $effect(() => {
+    handlers = createVizelCommentHandlers(
+      getEditor,
+      {
+        enabled: opts.enabled,
+        storage: opts.storage,
+        key: opts.key,
+        onAdd: (comment) => options.onAdd?.(comment),
+        onRemove: (id) => options.onRemove?.(id),
+        onResolve: (comment) => options.onResolve?.(comment),
+        onReopen: (comment) => options.onReopen?.(comment),
+        onError: (err) => options.onError?.(err),
+      },
+      handleStateChange
+    );
+
+    const editor = getEditor();
+    if (editor && opts.enabled) {
+      handlers.loadComments();
+    }
+
+    return () => {
+      handlers = null;
+    };
+  });
+
+  return {
+    get comments() {
+      return comments;
+    },
+    get activeCommentId() {
+      return activeCommentId;
+    },
+    get isLoading() {
+      return isLoading;
+    },
+    get error() {
+      return error;
+    },
+    addComment: (text, author?) => handlers?.addComment(text, author) ?? Promise.resolve(null),
+    removeComment: (commentId) => handlers?.removeComment(commentId) ?? Promise.resolve(),
+    resolveComment: (commentId) => handlers?.resolveComment(commentId) ?? Promise.resolve(false),
+    reopenComment: (commentId) => handlers?.reopenComment(commentId) ?? Promise.resolve(false),
+    replyToComment: (commentId, text, author?) =>
+      handlers?.replyToComment(commentId, text, author) ?? Promise.resolve(null),
+    setActiveComment: (commentId) => handlers?.setActiveComment(commentId),
+    loadComments: () => handlers?.loadComments() ?? Promise.resolve([]),
+    getCommentById: (commentId) => handlers?.getCommentById(commentId),
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -3,6 +3,10 @@ export {
   createVizelAutoSave,
 } from "./createVizelAutoSave.svelte.ts";
 export {
+  type CreateVizelCommentResult,
+  createVizelComment,
+} from "./createVizelComment.svelte.ts";
+export {
   type CreateVizelEditorOptions,
   createVizelEditor,
 } from "./createVizelEditor.svelte.ts";

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -3,6 +3,7 @@ export {
   type VizelSlashMenuRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
+export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 export { useVizelEditorState } from "./useVizelEditorState.ts";
 export {

--- a/packages/vue/src/composables/useVizelComment.ts
+++ b/packages/vue/src/composables/useVizelComment.ts
@@ -1,0 +1,145 @@
+import {
+  createVizelCommentHandlers,
+  type Editor,
+  VIZEL_DEFAULT_COMMENT_OPTIONS,
+  type VizelComment,
+  type VizelCommentOptions,
+  type VizelCommentReply,
+  type VizelCommentState,
+} from "@vizel/core";
+import { type ComputedRef, computed, onMounted, reactive, watch } from "vue";
+
+/**
+ * Comment composable result
+ */
+export interface UseVizelCommentResult {
+  /** All stored comments (newest first) */
+  comments: ComputedRef<VizelComment[]>;
+  /** Currently active comment ID */
+  activeCommentId: ComputedRef<string | null>;
+  /** Whether comments are loading */
+  isLoading: ComputedRef<boolean>;
+  /** Last error that occurred */
+  error: ComputedRef<Error | null>;
+  /** Add a comment to the current selection */
+  addComment: (text: string, author?: string) => Promise<VizelComment | null>;
+  /** Remove a comment and its mark */
+  removeComment: (commentId: string) => Promise<void>;
+  /** Mark a comment as resolved */
+  resolveComment: (commentId: string) => Promise<boolean>;
+  /** Reopen a resolved comment */
+  reopenComment: (commentId: string) => Promise<boolean>;
+  /** Add a reply to a comment */
+  replyToComment: (
+    commentId: string,
+    text: string,
+    author?: string
+  ) => Promise<VizelCommentReply | null>;
+  /** Set the active comment */
+  setActiveComment: (commentId: string | null) => void;
+  /** Load all comments from storage */
+  loadComments: () => Promise<VizelComment[]>;
+  /** Get a comment by its ID */
+  getCommentById: (commentId: string) => VizelComment | undefined;
+}
+
+/**
+ * Composable for managing document comments and annotations.
+ *
+ * @param getEditor - Function that returns the editor instance
+ * @param options - Comment configuration options
+ * @returns Comment state and controls
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useVizelEditor, useVizelComment } from "@vizel/vue";
+ *
+ * const editor = useVizelEditor({ features: { comment: true } });
+ * const { comments, addComment, resolveComment, setActiveComment } =
+ *   useVizelComment(() => editor.value, { key: "my-comments" });
+ * </script>
+ * ```
+ */
+export function useVizelComment(
+  getEditor: () => Editor | null | undefined,
+  options: VizelCommentOptions = {}
+): UseVizelCommentResult {
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COMMENT_OPTIONS.enabled;
+  const storage = options.storage ?? VIZEL_DEFAULT_COMMENT_OPTIONS.storage;
+  const key = options.key ?? VIZEL_DEFAULT_COMMENT_OPTIONS.key;
+
+  const state = reactive<VizelCommentState>({
+    comments: [],
+    activeCommentId: null,
+    isLoading: false,
+    error: null,
+  });
+
+  const handleStateChange = (partial: Partial<VizelCommentState>) => {
+    Object.assign(state, partial);
+  };
+
+  let handlers = createVizelCommentHandlers(
+    getEditor,
+    {
+      enabled,
+      storage,
+      key,
+      onAdd: (comment) => options.onAdd?.(comment),
+      onRemove: (id) => options.onRemove?.(id),
+      onResolve: (comment) => options.onResolve?.(comment),
+      onReopen: (comment) => options.onReopen?.(comment),
+      onError: (error) => options.onError?.(error),
+    },
+    handleStateChange
+  );
+
+  watch(
+    () => ({ enabled, storage, key }),
+    () => {
+      handlers = createVizelCommentHandlers(
+        getEditor,
+        {
+          enabled,
+          storage,
+          key,
+          onAdd: (comment) => options.onAdd?.(comment),
+          onRemove: (id) => options.onRemove?.(id),
+          onResolve: (comment) => options.onResolve?.(comment),
+          onReopen: (comment) => options.onReopen?.(comment),
+          onError: (error) => options.onError?.(error),
+        },
+        handleStateChange
+      );
+    }
+  );
+
+  onMounted(() => {
+    const editor = getEditor();
+    if (editor && enabled) {
+      void handlers.loadComments();
+    }
+  });
+
+  watch(getEditor, (editor) => {
+    if (editor && enabled) {
+      void handlers.loadComments();
+    }
+  });
+
+  return {
+    comments: computed(() => state.comments),
+    activeCommentId: computed(() => state.activeCommentId),
+    isLoading: computed(() => state.isLoading),
+    error: computed(() => state.error),
+    addComment: (text, author?) => handlers.addComment(text, author),
+    removeComment: (commentId) => handlers.removeComment(commentId),
+    resolveComment: (commentId) => handlers.resolveComment(commentId),
+    reopenComment: (commentId) => handlers.reopenComment(commentId),
+    replyToComment: (commentId, text, author?) => handlers.replyToComment(commentId, text, author),
+    setActiveComment: (commentId) => handlers.setActiveComment(commentId),
+    loadComments: () => handlers.loadComments(),
+    getCommentById: (commentId) => handlers.getCommentById(commentId),
+  };
+}


### PR DESCRIPTION
## Summary

- Add comment/annotation system with Mark extension for inline text highlighting
- Core handlers: `createVizelCommentHandlers()` for CRUD operations with configurable storage
- React hook: `useVizelComment()`
- Vue composable: `useVizelComment()`
- Svelte rune: `createVizelComment()`
- Support for replies, resolve/reopen, and active comment highlighting
- Feature toggle via `features.comment` (disabled by default)
- Documentation with Quick Start examples for all three frameworks

Closes #188

## Test Plan

- [x] Run typecheck (`pnpm typecheck`) — 0 errors
- [x] Run lint (`pnpm lint`) — clean
- [x] Docs build — success
- [x] Pre-commit hooks pass (biome-check, typecheck, commitlint)
- [x] Pre-push hooks pass (lint, typecheck)