### PR TITLE
feat(core): add real-time collaboration support with Yjs integration

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -140,6 +140,7 @@ export default withMermaid({
             { text: "Wiki Links", link: "/guide/wiki-links" },
             { text: "Version History", link: "/guide/version-history" },
             { text: "Comments", link: "/guide/comments" },
+            { text: "Collaboration", link: "/guide/collaboration" },
             { text: "Performance", link: "/guide/performance" },
             { text: "Accessibility", link: "/guide/accessibility" },
             { text: "Troubleshooting", link: "/guide/troubleshooting" },

--- a/docs/guide/collaboration.md
+++ b/docs/guide/collaboration.md
@@ -1,0 +1,338 @@
+# Real-Time Collaboration
+
+Vizel supports real-time collaborative editing using [Yjs](https://yjs.dev/), a CRDT-based framework that enables multiple users to edit the same document simultaneously without conflicts.
+
+## Overview
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Client A   │     │   Client B   │     │   Client C   │
+│  (Vizel +    │     │  (Vizel +    │     │  (Vizel +    │
+│   Yjs)       │     │   Yjs)       │     │   Yjs)       │
+└──────┬───────┘     └──────┬───────┘     └──────┬───────┘
+       │                    │                    │
+       └────────────┬───────┴────────────────────┘
+                    │
+            ┌───────▼───────┐
+            │  Yjs Server   │
+            │ (y-websocket) │
+            └───────────────┘
+```
+
+Vizel provides:
+- **History exclusion** — Automatically disables the built-in History extension when collaboration is enabled (Yjs provides its own undo manager)
+- **State tracking** — Framework hooks/composables/runes for tracking connection status, sync state, and peer count
+- **Lifecycle management** — Automatic setup and cleanup of event listeners
+
+## Prerequisites
+
+Install the required peer dependencies:
+
+```bash
+npm install yjs y-websocket @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor
+```
+
+::: warning Version Compatibility
+Ensure your `@tiptap/extension-collaboration` version is compatible with the `@tiptap/core` version used by Vizel. Check the [Tiptap documentation](https://tiptap.dev/) for version requirements.
+:::
+
+## Setup
+
+### 1. Start a Yjs WebSocket Server
+
+You need a Yjs-compatible WebSocket server for synchronization. The simplest option is `y-websocket`:
+
+```bash
+npx y-websocket
+```
+
+This starts a server on `ws://localhost:1234`. For production, see [Server Setup](#server-setup) below.
+
+### 2. Configure the Editor
+
+::: code-group
+
+```tsx [React]
+import { useState } from "react";
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import Collaboration from "@tiptap/extension-collaboration";
+import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+import {
+  Vizel,
+  useVizelEditor,
+  useVizelCollaboration,
+} from "@vizel/react";
+
+function CollaborativeEditor() {
+  const user = { name: "Alice", color: "#ff0000" };
+
+  // Create Yjs document and WebSocket provider
+  const [doc] = useState(() => new Y.Doc());
+  const [provider] = useState(
+    () => new WebsocketProvider("ws://localhost:1234", "my-document", doc)
+  );
+
+  // Track collaboration state
+  const { isConnected, isSynced, peerCount } = useVizelCollaboration(
+    () => provider,
+    { user }
+  );
+
+  // Create editor with collaboration enabled
+  const editor = useVizelEditor({
+    features: { collaboration: true },
+    extensions: [
+      Collaboration.configure({ document: doc }),
+      CollaborationCursor.configure({ provider, user }),
+    ],
+  });
+
+  return (
+    <div>
+      <div className="status-bar">
+        <span>{isConnected ? "🟢 Connected" : "🔴 Disconnected"}</span>
+        <span>{isSynced ? "Synced" : "Syncing..."}</span>
+        <span>{peerCount} peer(s)</span>
+      </div>
+      <Vizel editor={editor} />
+    </div>
+  );
+}
+```
+
+```vue [Vue]
+<script setup lang="ts">
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import Collaboration from "@tiptap/extension-collaboration";
+import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+import {
+  Vizel,
+  useVizelEditor,
+  useVizelCollaboration,
+} from "@vizel/vue";
+
+const user = { name: "Alice", color: "#ff0000" };
+
+// Create Yjs document and WebSocket provider
+const doc = new Y.Doc();
+const provider = new WebsocketProvider(
+  "ws://localhost:1234",
+  "my-document",
+  doc
+);
+
+// Track collaboration state
+const { isConnected, isSynced, peerCount } = useVizelCollaboration(
+  () => provider,
+  { user }
+);
+
+// Create editor with collaboration enabled
+const editor = useVizelEditor({
+  features: { collaboration: true },
+  extensions: [
+    Collaboration.configure({ document: doc }),
+    CollaborationCursor.configure({ provider, user }),
+  ],
+});
+</script>
+
+<template>
+  <div>
+    <div class="status-bar">
+      <span>{{ isConnected ? "🟢 Connected" : "🔴 Disconnected" }}</span>
+      <span>{{ isSynced ? "Synced" : "Syncing..." }}</span>
+      <span>{{ peerCount }} peer(s)</span>
+    </div>
+    <Vizel :editor="editor" />
+  </div>
+</template>
+```
+
+```svelte [Svelte]
+<script lang="ts">
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import Collaboration from "@tiptap/extension-collaboration";
+import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+import {
+  Vizel,
+  createVizelEditor,
+  createVizelCollaboration,
+} from "@vizel/svelte";
+
+const user = { name: "Alice", color: "#ff0000" };
+
+// Create Yjs document and WebSocket provider
+const doc = new Y.Doc();
+const provider = new WebsocketProvider(
+  "ws://localhost:1234",
+  "my-document",
+  doc
+);
+
+// Track collaboration state
+const collab = createVizelCollaboration(
+  () => provider,
+  { user }
+);
+
+// Create editor with collaboration enabled
+const editor = createVizelEditor({
+  features: { collaboration: true },
+  extensions: [
+    Collaboration.configure({ document: doc }),
+    CollaborationCursor.configure({ provider, user }),
+  ],
+});
+</script>
+
+<div>
+  <div class="status-bar">
+    <span>{collab.isConnected ? "🟢 Connected" : "🔴 Disconnected"}</span>
+    <span>{collab.isSynced ? "Synced" : "Syncing..."}</span>
+    <span>{collab.peerCount} peer(s)</span>
+  </div>
+  <Vizel editor={editor.current} />
+</div>
+```
+
+:::
+
+## API Reference
+
+### Options
+
+The collaboration hooks accept these options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable collaboration state tracking |
+| `user` | `{ name, color }` | Required | Current user info for cursor display |
+| `onConnect` | `() => void` | — | Callback when connected to server |
+| `onDisconnect` | `() => void` | — | Callback when disconnected |
+| `onSynced` | `() => void` | — | Callback when initial sync completes |
+| `onError` | `(error) => void` | — | Callback when an error occurs |
+| `onPeersChange` | `(count) => void` | — | Callback when peer count changes |
+
+### Return Values
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isConnected` | `boolean` | Whether connected to the server |
+| `isSynced` | `boolean` | Whether initial document sync is complete |
+| `peerCount` | `number` | Number of connected peers (including self) |
+| `error` | `Error \| null` | Last error that occurred |
+| `connect()` | `() => void` | Connect to the server |
+| `disconnect()` | `() => void` | Disconnect from the server |
+| `updateUser()` | `(user) => void` | Update cursor information |
+
+### Feature Flag
+
+Setting `features.collaboration` to `true` in the editor options disables the built-in History extension. This is necessary because Yjs provides its own undo/redo mechanism through `Y.UndoManager`.
+
+```ts
+const editor = useVizelEditor({
+  features: {
+    collaboration: true, // Disables History extension
+  },
+});
+```
+
+## Key Concepts
+
+### How Collaboration Works
+
+1. **CRDT (Conflict-free Replicated Data Type)** — Yjs uses CRDTs to merge concurrent edits without conflicts. Each client can edit independently, and changes are automatically merged.
+
+2. **Awareness** — Yjs Awareness protocol tracks ephemeral state like cursor positions, user names, and colors. This is separate from the document and is not persisted.
+
+3. **History** — When collaboration is enabled, the built-in Tiptap History extension must be disabled because Yjs provides `Y.UndoManager` which understands CRDT operations. The standard History extension would conflict with collaborative edits.
+
+### Offline Support
+
+Yjs automatically handles offline scenarios:
+- Edits made offline are stored locally
+- When reconnecting, changes are automatically synced and merged
+- No data loss occurs even with extended offline periods
+
+## Server Setup
+
+### Development Server
+
+For local development, use the built-in `y-websocket` server:
+
+```bash
+npx y-websocket
+```
+
+### Production Server
+
+For production deployments, create a custom server:
+
+```js
+// server.js
+import { WebSocketServer } from "ws";
+import { setupWSConnection } from "y-websocket/bin/utils";
+
+const wss = new WebSocketServer({ port: 1234 });
+
+wss.on("connection", (ws, req) => {
+  setupWSConnection(ws, req);
+});
+
+console.log("Yjs WebSocket server running on ws://localhost:1234");
+```
+
+### Persistence
+
+To persist documents on the server, use `y-websocket` with LevelDB:
+
+```bash
+HOST=0.0.0.0 PORT=1234 YPERSISTENCE=./yjs-docs npx y-websocket
+```
+
+Or configure persistence programmatically:
+
+```js
+import { LeveldbPersistence } from "y-leveldb";
+
+const persistence = new LeveldbPersistence("./yjs-docs");
+// Pass to y-websocket server configuration
+```
+
+### Alternative Providers
+
+Yjs supports multiple transport providers:
+
+| Provider | Package | Use Case |
+|----------|---------|----------|
+| WebSocket | `y-websocket` | Standard server-client setup |
+| WebRTC | `y-webrtc` | Peer-to-peer, no server needed |
+| Hocuspocus | `@hocuspocus/provider` | Feature-rich, authentication support |
+
+## Troubleshooting
+
+### History Extension Conflict
+
+**Problem**: Undo/redo behaves unexpectedly with collaboration enabled.
+
+**Solution**: Ensure `features.collaboration` is set to `true` in your editor options. This disables the built-in History extension that conflicts with Yjs's undo manager.
+
+### Connection Issues
+
+**Problem**: WebSocket connection fails or keeps disconnecting.
+
+**Solution**:
+1. Verify the WebSocket server is running
+2. Check that the server URL is correct (including protocol `ws://` or `wss://`)
+3. For production, ensure your reverse proxy supports WebSocket connections
+4. Check CORS settings if the server is on a different origin
+
+### Cursor Colors Not Showing
+
+**Problem**: Remote cursors appear but without colors.
+
+**Solution**: Ensure you pass the `user` object with both `name` and `color` properties to both `CollaborationCursor.configure()` and the collaboration hook.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,9 @@
     "fuse.js": "^7.1.0",
     "katex": "^0.16.0",
     "lowlight": "^3.0.0",
-    "mermaid": "^11.0.0"
+    "mermaid": "^11.0.0",
+    "yjs": "^13.6.0",
+    "y-websocket": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@hpcc-js/wasm-graphviz": {
@@ -126,6 +128,12 @@
       "optional": true
     },
     "mermaid": {
+      "optional": true
+    },
+    "yjs": {
+      "optional": true
+    },
+    "y-websocket": {
       "optional": true
     }
   },

--- a/packages/core/src/collaboration.ts
+++ b/packages/core/src/collaboration.ts
@@ -1,0 +1,216 @@
+/**
+ * Collaboration module for real-time multi-user editing with Yjs.
+ *
+ * This module provides types, state management, and lifecycle utilities
+ * for integrating Yjs-based collaboration into Vizel editors.
+ *
+ * Users must install their own compatible versions of:
+ * - `yjs` (^13.6.0)
+ * - `y-websocket` (^2.0.0) or another Yjs provider
+ * - `@tiptap/extension-collaboration`
+ * - `@tiptap/extension-collaboration-cursor`
+ */
+
+/**
+ * User information for collaboration cursor display
+ */
+export interface VizelCollaborationUser {
+  /** Display name shown next to the cursor */
+  name: string;
+  /** Cursor and highlight color (CSS color value) */
+  color: string;
+}
+
+/**
+ * Interface matching the Yjs Awareness API.
+ * Compatible with `y-protocols/awareness` Awareness class.
+ */
+export interface VizelYjsAwareness {
+  /** Set a field on the local awareness state */
+  setLocalStateField(field: string, value: unknown): void;
+  /** Get all awareness states from connected peers */
+  getStates(): Map<number, Record<string, unknown>>;
+  /** Subscribe to awareness events */
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  /** Unsubscribe from awareness events */
+  off(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+/**
+ * Interface matching Yjs WebSocket provider API.
+ * Compatible with `y-websocket` WebsocketProvider and similar providers
+ * that emit `"status"` and `"sync"` events.
+ */
+export interface VizelYjsProvider {
+  /** Awareness instance for cursor/presence tracking */
+  awareness: VizelYjsAwareness;
+  /** Connect to the collaboration server */
+  connect(): void;
+  /** Disconnect from the collaboration server */
+  disconnect(): void;
+  /** Destroy the provider and release resources */
+  destroy(): void;
+  /** Subscribe to provider events */
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  /** Unsubscribe from provider events */
+  off(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+/**
+ * Options for collaboration state management
+ */
+export interface VizelCollaborationOptions {
+  /** Whether collaboration tracking is enabled (default: true) */
+  enabled?: boolean;
+  /** Current user info for cursor display */
+  user: VizelCollaborationUser;
+  /** Callback when connected to the collaboration server */
+  onConnect?: () => void;
+  /** Callback when disconnected from the collaboration server */
+  onDisconnect?: () => void;
+  /** Callback when initial document sync completes */
+  onSynced?: () => void;
+  /** Callback when an error occurs */
+  onError?: (error: Error) => void;
+  /** Callback when the number of connected peers changes */
+  onPeersChange?: (count: number) => void;
+}
+
+/**
+ * Collaboration connection state
+ */
+export interface VizelCollaborationState {
+  /** Whether connected to the collaboration server */
+  isConnected: boolean;
+  /** Whether the initial document sync is complete */
+  isSynced: boolean;
+  /** Number of currently connected peers (including self) */
+  peerCount: number;
+  /** Last error that occurred */
+  error: Error | null;
+}
+
+/**
+ * Default collaboration options
+ */
+export const VIZEL_DEFAULT_COLLABORATION_OPTIONS = {
+  enabled: true,
+} as const;
+
+/**
+ * Create collaboration handlers for tracking provider state and managing lifecycle.
+ *
+ * The handlers set up event listeners on the Yjs provider to track connection state,
+ * sync status, and peer count. Call `subscribe()` to start listening and use the
+ * returned cleanup function to stop.
+ *
+ * @param getProvider - Function that returns the Yjs provider instance
+ * @param options - Collaboration options including user info and callbacks
+ * @param onStateChange - Callback to update reactive state
+ * @returns Collaboration control methods
+ *
+ * @example
+ * ```ts
+ * const handlers = createVizelCollaborationHandlers(
+ *   () => wsProvider,
+ *   { user: { name: "Alice", color: "#ff0000" } },
+ *   (partial) => Object.assign(state, partial)
+ * );
+ *
+ * // Start listening to provider events
+ * const unsubscribe = handlers.subscribe();
+ *
+ * // Later, clean up
+ * unsubscribe();
+ * ```
+ */
+export function createVizelCollaborationHandlers(
+  getProvider: () => VizelYjsProvider | null | undefined,
+  options: VizelCollaborationOptions,
+  onStateChange: (state: Partial<VizelCollaborationState>) => void
+): {
+  /** Connect to the collaboration server */
+  connect: () => void;
+  /** Disconnect from the collaboration server */
+  disconnect: () => void;
+  /** Update the current user's cursor information */
+  updateUser: (user: VizelCollaborationUser) => void;
+  /** Subscribe to provider events. Returns an unsubscribe function. */
+  subscribe: () => () => void;
+} {
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COLLABORATION_OPTIONS.enabled;
+
+  function connect(): void {
+    if (!enabled) return;
+    const provider = getProvider();
+    provider?.connect();
+  }
+
+  function disconnect(): void {
+    const provider = getProvider();
+    provider?.disconnect();
+  }
+
+  function updateUser(user: VizelCollaborationUser): void {
+    const provider = getProvider();
+    provider?.awareness.setLocalStateField("user", user);
+  }
+
+  function subscribe(): () => void {
+    const provider = getProvider();
+    if (!(provider && enabled)) {
+      // No provider or disabled — nothing to subscribe to
+      return () => undefined;
+    }
+
+    const handleStatus = (...args: unknown[]) => {
+      const event = args[0] as { status: string } | undefined;
+      if (!event) return;
+      const isConnected = event.status === "connected";
+      onStateChange({ isConnected });
+      if (isConnected) {
+        options.onConnect?.();
+      } else {
+        options.onDisconnect?.();
+      }
+    };
+
+    const handleSync = (...args: unknown[]) => {
+      const isSynced = args[0] as boolean;
+      onStateChange({ isSynced });
+      if (isSynced) {
+        options.onSynced?.();
+      }
+    };
+
+    const handleAwarenessChange = () => {
+      const peerCount = provider.awareness.getStates().size;
+      onStateChange({ peerCount });
+      options.onPeersChange?.(peerCount);
+    };
+
+    // Set initial user info
+    provider.awareness.setLocalStateField("user", options.user);
+
+    // Subscribe to events
+    provider.on("status", handleStatus);
+    provider.on("sync", handleSync);
+    provider.awareness.on("change", handleAwarenessChange);
+
+    // Set initial peer count
+    handleAwarenessChange();
+
+    return () => {
+      provider.off("status", handleStatus);
+      provider.off("sync", handleSync);
+      provider.awareness.off("change", handleAwarenessChange);
+    };
+  }
+
+  return {
+    connect,
+    disconnect,
+    updateUser,
+    subscribe,
+  };
+}

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -67,11 +67,11 @@ export interface VizelExtensionsOptions {
  * to support syntax highlighting when enabled.
  */
 function createBaseExtensions(
-  options: { headingLevels?: (1 | 2 | 3 | 4 | 5 | 6)[] } = {}
+  options: { headingLevels?: (1 | 2 | 3 | 4 | 5 | 6)[]; excludeHistory?: boolean } = {}
 ): Extensions {
-  const { headingLevels = [1, 2, 3] } = options;
+  const { headingLevels = [1, 2, 3], excludeHistory = false } = options;
 
-  return [
+  const extensions: Extensions = [
     // Nodes
     Document,
     Paragraph,
@@ -93,9 +93,15 @@ function createBaseExtensions(
     // Functionality
     Dropcursor.configure({ color: "#3b82f6", width: 2 }),
     Gapcursor,
-    History,
     ListKeymap,
   ];
+
+  // History is excluded when collaboration is enabled (Yjs provides its own undo manager)
+  if (!excludeHistory) {
+    extensions.push(History);
+  }
+
+  return extensions;
 }
 
 /**
@@ -337,8 +343,10 @@ export async function createVizelExtensions(
     features = {},
   } = options;
 
+  const excludeHistory = features.collaboration === true;
+
   const extensions: Extensions = [
-    ...createBaseExtensions({ headingLevels }),
+    ...createBaseExtensions({ headingLevels, excludeHistory }),
     Placeholder.configure({
       placeholder,
       emptyEditorClass: "vizel-editor-empty",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,18 @@ export {
 } from "./auto-save.ts";
 
 // =============================================================================
+// Collaboration
+// =============================================================================
+export {
+  createVizelCollaborationHandlers,
+  VIZEL_DEFAULT_COLLABORATION_OPTIONS,
+  type VizelCollaborationOptions,
+  type VizelCollaborationState,
+  type VizelCollaborationUser,
+  type VizelYjsAwareness,
+  type VizelYjsProvider,
+} from "./collaboration.ts";
+// =============================================================================
 // Comments
 // =============================================================================
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,12 @@ export interface VizelFeatureOptions {
   wikiLink?: VizelWikiLinkOptions | boolean;
   /** Comment/annotation marks for collaborative review workflows */
   comment?: VizelCommentMarkOptions | boolean;
+  /**
+   * Real-time collaboration mode.
+   * When enabled, the History extension is excluded (Yjs provides its own undo manager).
+   * Users must install and configure Yjs collaboration extensions separately.
+   */
+  collaboration?: boolean;
 }
 
 /**

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -5,6 +5,10 @@ export {
   type VizelSlashMenuRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
+export {
+  type UseVizelCollaborationResult,
+  useVizelCollaboration,
+} from "./useVizelCollaboration.ts";
 export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 export { useVizelEditorState } from "./useVizelEditorState.ts";

--- a/packages/react/src/hooks/useVizelCollaboration.ts
+++ b/packages/react/src/hooks/useVizelCollaboration.ts
@@ -1,0 +1,146 @@
+import {
+  createVizelCollaborationHandlers,
+  VIZEL_DEFAULT_COLLABORATION_OPTIONS,
+  type VizelCollaborationOptions,
+  type VizelCollaborationState,
+  type VizelCollaborationUser,
+  type VizelYjsProvider,
+} from "@vizel/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Collaboration hook result
+ */
+export interface UseVizelCollaborationResult {
+  /** Whether connected to the collaboration server */
+  isConnected: boolean;
+  /** Whether the initial document sync is complete */
+  isSynced: boolean;
+  /** Number of currently connected peers (including self) */
+  peerCount: number;
+  /** Last error that occurred */
+  error: Error | null;
+  /** Connect to the collaboration server */
+  connect: () => void;
+  /** Disconnect from the collaboration server */
+  disconnect: () => void;
+  /** Update the current user's cursor information */
+  updateUser: (user: VizelCollaborationUser) => void;
+}
+
+/**
+ * Hook for tracking real-time collaboration state with a Yjs provider.
+ *
+ * This hook manages event listeners on the provider to track connection status,
+ * sync state, and peer count. It does NOT create the Yjs document or provider —
+ * users must create those themselves and pass them in.
+ *
+ * @param getProvider - Function that returns the Yjs provider instance
+ * @param options - Collaboration options including user info and callbacks
+ * @returns Collaboration state and controls
+ *
+ * @example
+ * ```tsx
+ * import * as Y from "yjs";
+ * import { WebsocketProvider } from "y-websocket";
+ * import Collaboration from "@tiptap/extension-collaboration";
+ * import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+ * import { useVizelEditor, useVizelCollaboration } from "@vizel/react";
+ *
+ * function CollaborativeEditor() {
+ *   const [doc] = useState(() => new Y.Doc());
+ *   const [provider] = useState(
+ *     () => new WebsocketProvider("ws://localhost:1234", "my-doc", doc)
+ *   );
+ *
+ *   const { isConnected, peerCount } = useVizelCollaboration(
+ *     () => provider,
+ *     { user: { name: "Alice", color: "#ff0000" } }
+ *   );
+ *
+ *   const editor = useVizelEditor({
+ *     features: { collaboration: true },
+ *     extensions: [
+ *       Collaboration.configure({ document: doc }),
+ *       CollaborationCursor.configure({
+ *         provider,
+ *         user: { name: "Alice", color: "#ff0000" },
+ *       }),
+ *     ],
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <span>{isConnected ? "Connected" : "Disconnected"} ({peerCount} peers)</span>
+ *       <VizelEditor editor={editor} />
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useVizelCollaboration(
+  getProvider: () => VizelYjsProvider | null | undefined,
+  options: VizelCollaborationOptions = { user: { name: "Anonymous", color: "#6366f1" } }
+): UseVizelCollaborationResult {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COLLABORATION_OPTIONS.enabled;
+
+  const [state, setState] = useState<VizelCollaborationState>({
+    isConnected: false,
+    isSynced: false,
+    peerCount: 0,
+    error: null,
+  });
+
+  const getProviderRef = useRef(getProvider);
+  getProviderRef.current = getProvider;
+
+  const handleStateChange = useCallback((partial: Partial<VizelCollaborationState>) => {
+    setState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const handlers = useMemo(
+    () =>
+      createVizelCollaborationHandlers(
+        () => getProviderRef.current(),
+        {
+          enabled,
+          user: options.user,
+          onConnect: () => optionsRef.current.onConnect?.(),
+          onDisconnect: () => optionsRef.current.onDisconnect?.(),
+          onSynced: () => optionsRef.current.onSynced?.(),
+          onError: (error) => optionsRef.current.onError?.(error),
+          onPeersChange: (count) => optionsRef.current.onPeersChange?.(count),
+        },
+        handleStateChange
+      ),
+    [enabled, options.user, handleStateChange]
+  );
+
+  useEffect(() => {
+    const provider = getProvider();
+    if (!(provider && enabled)) {
+      return;
+    }
+    return handlers.subscribe();
+  }, [getProvider, enabled, handlers]);
+
+  const connect = useCallback(() => handlers.connect(), [handlers]);
+  const disconnect = useCallback(() => handlers.disconnect(), [handlers]);
+  const updateUser = useCallback(
+    (user: VizelCollaborationUser) => handlers.updateUser(user),
+    [handlers]
+  );
+
+  return {
+    isConnected: state.isConnected,
+    isSynced: state.isSynced,
+    peerCount: state.peerCount,
+    error: state.error,
+    connect,
+    disconnect,
+    updateUser,
+  };
+}

--- a/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
+++ b/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
@@ -1,0 +1,125 @@
+import {
+  createVizelCollaborationHandlers,
+  VIZEL_DEFAULT_COLLABORATION_OPTIONS,
+  type VizelCollaborationOptions,
+  type VizelCollaborationState,
+  type VizelCollaborationUser,
+  type VizelYjsProvider,
+} from "@vizel/core";
+
+/**
+ * Collaboration rune result
+ */
+export interface CreateVizelCollaborationResult {
+  /** Whether connected to the collaboration server */
+  readonly isConnected: boolean;
+  /** Whether the initial document sync is complete */
+  readonly isSynced: boolean;
+  /** Number of currently connected peers (including self) */
+  readonly peerCount: number;
+  /** Last error that occurred */
+  readonly error: Error | null;
+  /** Connect to the collaboration server */
+  connect: () => void;
+  /** Disconnect from the collaboration server */
+  disconnect: () => void;
+  /** Update the current user's cursor information */
+  updateUser: (user: VizelCollaborationUser) => void;
+}
+
+/**
+ * Rune for tracking real-time collaboration state with a Yjs provider.
+ *
+ * This rune manages event listeners on the provider to track connection status,
+ * sync state, and peer count. It does NOT create the Yjs document or provider —
+ * users must create those themselves and pass them in.
+ *
+ * @param getProvider - Function that returns the Yjs provider instance
+ * @param options - Collaboration options including user info and callbacks
+ * @returns Collaboration state and controls
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ * import * as Y from "yjs";
+ * import { WebsocketProvider } from "y-websocket";
+ * import Collaboration from "@tiptap/extension-collaboration";
+ * import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+ * import { createVizelEditor, createVizelCollaboration } from "@vizel/svelte";
+ *
+ * const doc = new Y.Doc();
+ * const provider = new WebsocketProvider("ws://localhost:1234", "my-doc", doc);
+ *
+ * const collab = createVizelCollaboration(
+ *   () => provider,
+ *   { user: { name: "Alice", color: "#ff0000" } }
+ * );
+ *
+ * const editor = createVizelEditor({
+ *   features: { collaboration: true },
+ *   extensions: [
+ *     Collaboration.configure({ document: doc }),
+ *     CollaborationCursor.configure({
+ *       provider,
+ *       user: { name: "Alice", color: "#ff0000" },
+ *     }),
+ *   ],
+ * });
+ * </script>
+ *
+ * <p>{collab.isConnected ? "Connected" : "Disconnected"} ({collab.peerCount} peers)</p>
+ * ```
+ */
+export function createVizelCollaboration(
+  getProvider: () => VizelYjsProvider | null | undefined,
+  options: VizelCollaborationOptions = { user: { name: "Anonymous", color: "#6366f1" } }
+): CreateVizelCollaborationResult {
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COLLABORATION_OPTIONS.enabled;
+
+  let isConnected = $state(false);
+  let isSynced = $state(false);
+  let peerCount = $state(0);
+  let error = $state<Error | null>(null);
+
+  let handlers: ReturnType<typeof createVizelCollaborationHandlers> | null = null;
+
+  const handleStateChange = (partial: Partial<VizelCollaborationState>) => {
+    if (partial.isConnected !== undefined) isConnected = partial.isConnected;
+    if (partial.isSynced !== undefined) isSynced = partial.isSynced;
+    if (partial.peerCount !== undefined) peerCount = partial.peerCount;
+    if (partial.error !== undefined) error = partial.error;
+  };
+
+  $effect(() => {
+    const provider = getProvider();
+    handlers = createVizelCollaborationHandlers(getProvider, options, handleStateChange);
+
+    let unsubscribe: (() => void) | undefined;
+    if (provider && enabled) {
+      unsubscribe = handlers.subscribe();
+    }
+
+    return () => {
+      unsubscribe?.();
+      handlers = null;
+    };
+  });
+
+  return {
+    get isConnected() {
+      return isConnected;
+    },
+    get isSynced() {
+      return isSynced;
+    },
+    get peerCount() {
+      return peerCount;
+    },
+    get error() {
+      return error;
+    },
+    connect: () => handlers?.connect(),
+    disconnect: () => handlers?.disconnect(),
+    updateUser: (user) => handlers?.updateUser(user),
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -3,6 +3,10 @@ export {
   createVizelAutoSave,
 } from "./createVizelAutoSave.svelte.ts";
 export {
+  type CreateVizelCollaborationResult,
+  createVizelCollaboration,
+} from "./createVizelCollaboration.svelte.ts";
+export {
   type CreateVizelCommentResult,
   createVizelComment,
 } from "./createVizelComment.svelte.ts";

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -3,6 +3,10 @@ export {
   type VizelSlashMenuRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
+export {
+  type UseVizelCollaborationResult,
+  useVizelCollaboration,
+} from "./useVizelCollaboration.ts";
 export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 export { useVizelEditorState } from "./useVizelEditorState.ts";

--- a/packages/vue/src/composables/useVizelCollaboration.ts
+++ b/packages/vue/src/composables/useVizelCollaboration.ts
@@ -1,0 +1,134 @@
+import {
+  createVizelCollaborationHandlers,
+  VIZEL_DEFAULT_COLLABORATION_OPTIONS,
+  type VizelCollaborationOptions,
+  type VizelCollaborationState,
+  type VizelCollaborationUser,
+  type VizelYjsProvider,
+} from "@vizel/core";
+import { type ComputedRef, computed, onBeforeUnmount, onMounted, reactive, watch } from "vue";
+
+/**
+ * Collaboration composable result
+ */
+export interface UseVizelCollaborationResult {
+  /** Whether connected to the collaboration server */
+  isConnected: ComputedRef<boolean>;
+  /** Whether the initial document sync is complete */
+  isSynced: ComputedRef<boolean>;
+  /** Number of currently connected peers (including self) */
+  peerCount: ComputedRef<number>;
+  /** Last error that occurred */
+  error: ComputedRef<Error | null>;
+  /** Connect to the collaboration server */
+  connect: () => void;
+  /** Disconnect from the collaboration server */
+  disconnect: () => void;
+  /** Update the current user's cursor information */
+  updateUser: (user: VizelCollaborationUser) => void;
+}
+
+/**
+ * Composable for tracking real-time collaboration state with a Yjs provider.
+ *
+ * This composable manages event listeners on the provider to track connection status,
+ * sync state, and peer count. It does NOT create the Yjs document or provider —
+ * users must create those themselves and pass them in.
+ *
+ * @param getProvider - Function that returns the Yjs provider instance
+ * @param options - Collaboration options including user info and callbacks
+ * @returns Collaboration state and controls
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import * as Y from "yjs";
+ * import { WebsocketProvider } from "y-websocket";
+ * import Collaboration from "@tiptap/extension-collaboration";
+ * import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+ * import { useVizelEditor, useVizelCollaboration } from "@vizel/vue";
+ *
+ * const doc = new Y.Doc();
+ * const provider = new WebsocketProvider("ws://localhost:1234", "my-doc", doc);
+ *
+ * const { isConnected, peerCount } = useVizelCollaboration(
+ *   () => provider,
+ *   { user: { name: "Alice", color: "#ff0000" } }
+ * );
+ *
+ * const editor = useVizelEditor({
+ *   features: { collaboration: true },
+ *   extensions: [
+ *     Collaboration.configure({ document: doc }),
+ *     CollaborationCursor.configure({
+ *       provider,
+ *       user: { name: "Alice", color: "#ff0000" },
+ *     }),
+ *   ],
+ * });
+ * </script>
+ * ```
+ */
+export function useVizelCollaboration(
+  getProvider: () => VizelYjsProvider | null | undefined,
+  options: VizelCollaborationOptions = { user: { name: "Anonymous", color: "#6366f1" } }
+): UseVizelCollaborationResult {
+  const enabled = options.enabled ?? VIZEL_DEFAULT_COLLABORATION_OPTIONS.enabled;
+
+  const state = reactive<VizelCollaborationState>({
+    isConnected: false,
+    isSynced: false,
+    peerCount: 0,
+    error: null,
+  });
+
+  let handlers: ReturnType<typeof createVizelCollaborationHandlers> | null = null;
+  let unsubscribe: (() => void) | null = null;
+
+  function handleStateChange(partial: Partial<VizelCollaborationState>) {
+    if (partial.isConnected !== undefined) state.isConnected = partial.isConnected;
+    if (partial.isSynced !== undefined) state.isSynced = partial.isSynced;
+    if (partial.peerCount !== undefined) state.peerCount = partial.peerCount;
+    if (partial.error !== undefined) state.error = partial.error;
+  }
+
+  function setup() {
+    cleanup();
+    handlers = createVizelCollaborationHandlers(getProvider, options, handleStateChange);
+    const provider = getProvider();
+    if (provider && enabled) {
+      unsubscribe = handlers.subscribe();
+    }
+  }
+
+  function cleanup() {
+    unsubscribe?.();
+    unsubscribe = null;
+    handlers = null;
+  }
+
+  onMounted(() => {
+    setup();
+  });
+
+  watch(
+    () => getProvider(),
+    () => {
+      setup();
+    }
+  );
+
+  onBeforeUnmount(() => {
+    cleanup();
+  });
+
+  return {
+    isConnected: computed(() => state.isConnected),
+    isSynced: computed(() => state.isSynced),
+    peerCount: computed(() => state.peerCount),
+    error: computed(() => state.error),
+    connect: () => handlers?.connect(),
+    disconnect: () => handlers?.disconnect(),
+    updateUser: (user) => handlers?.updateUser(user),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,12 @@ importers:
       mermaid:
         specifier: ^11.0.0
         version: 11.12.2
+      y-websocket:
+        specifier: ^2.0.0
+        version: 2.1.0(yjs@13.6.29)
+      yjs:
+        specifier: ^13.6.0
+        version: 13.6.29
     devDependencies:
       vite:
         specifier: ^7.3.1
@@ -2344,6 +2350,16 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
+  abstract-leveldown@6.2.3:
+    resolution: {integrity: sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  abstract-leveldown@6.3.0:
+    resolution: {integrity: sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -2407,12 +2423,18 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  async-limiter@1.0.1:
+    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -2428,6 +2450,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   c8@10.1.3:
     resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
@@ -2712,6 +2737,11 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  deferred-leveldown@5.3.0:
+    resolution: {integrity: sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -2751,6 +2781,11 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-down@6.3.0:
+    resolution: {integrity: sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -2758,6 +2793,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  errno@0.1.8:
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
+    hasBin: true
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -2892,12 +2931,21 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immediate@3.3.0:
+    resolution: {integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==}
+
   immutable@5.1.4:
     resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -3054,6 +3102,52 @@ packages:
     resolution: {integrity: sha512-ABs3M5V9c4nqxFnZO509HXuQTu8GM8hmqc9ruV0acQ81yKlxEq70MRoYP5Z1dr5le326X8vA5qj3arJA36yE3A==}
     hasBin: true
 
+  level-codec@9.0.2:
+    resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by level-transcoder (https://github.com/Level/community#faq)
+
+  level-concat-iterator@2.0.1:
+    resolution: {integrity: sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-errors@2.0.1:
+    resolution: {integrity: sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-iterator-stream@4.0.2:
+    resolution: {integrity: sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==}
+    engines: {node: '>=6'}
+
+  level-js@5.0.2:
+    resolution: {integrity: sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==}
+    deprecated: Superseded by browser-level (https://github.com/Level/community#faq)
+
+  level-packager@5.1.1:
+    resolution: {integrity: sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-supports@1.0.1:
+    resolution: {integrity: sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==}
+    engines: {node: '>=6'}
+
+  level@6.0.1:
+    resolution: {integrity: sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==}
+    engines: {node: '>=8.6.0'}
+
+  leveldown@5.6.0:
+    resolution: {integrity: sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==}
+    engines: {node: '>=8.6.0'}
+    deprecated: Superseded by classic-level (https://github.com/Level/community#faq)
+
+  levelup@4.4.0:
+    resolution: {integrity: sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
     engines: {node: '>=16'}
@@ -3082,6 +3176,9 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -3097,6 +3194,9 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  ltgt@2.2.1:
+    resolution: {integrity: sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3182,8 +3282,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-macros@2.0.0:
+    resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
+
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp-build@4.1.1:
+    resolution: {integrity: sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==}
+    hasBin: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3338,6 +3445,9 @@ packages:
   prosemirror-view@1.41.5:
     resolution: {integrity: sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==}
 
+  prr@1.0.1:
+    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -3365,6 +3475,10 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -3422,6 +3536,9 @@ packages:
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3502,6 +3619,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -3630,6 +3750,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -3844,11 +3967,38 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  ws@6.2.3:
+    resolution: {integrity: sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y-leveldb@0.1.2:
+    resolution: {integrity: sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg==}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y-protocols@1.0.7:
     resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       yjs: ^13.0.0
+
+  y-websocket@2.1.0:
+    resolution: {integrity: sha512-WHYDRqomaGkkaujtowCDwL8KYk+t1zQCGIgKyvxvchhjTQlMgWXRHJK+FDEcWmHA7I7o/4fy0eniOrtmz0e4mA==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    peerDependencies:
+      yjs: ^13.5.6
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5518,6 +5668,24 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  abstract-leveldown@6.2.3:
+    dependencies:
+      buffer: 5.7.1
+      immediate: 3.3.0
+      level-concat-iterator: 2.0.1
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
+  abstract-leveldown@6.3.0:
+    dependencies:
+      buffer: 5.7.1
+      immediate: 3.3.0
+      level-concat-iterator: 2.0.1
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
   acorn@8.15.0: {}
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
@@ -5581,9 +5749,15 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  async-limiter@1.0.1:
+    optional: true
+
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  base64-js@1.5.1:
+    optional: true
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -5600,6 +5774,12 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
 
   c8@10.1.3:
     dependencies:
@@ -5905,6 +6085,12 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  deferred-leveldown@5.3.0:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      inherits: 2.0.4
+    optional: true
+
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -5936,9 +6122,22 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-down@6.3.0:
+    dependencies:
+      abstract-leveldown: 6.3.0
+      inherits: 2.0.4
+      level-codec: 9.0.2
+      level-errors: 2.0.1
+    optional: true
+
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  errno@0.1.8:
+    dependencies:
+      prr: 1.0.1
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -6129,9 +6328,18 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1:
+    optional: true
+
+  immediate@3.3.0:
+    optional: true
+
   immutable@5.1.4: {}
 
   import-lazy@4.0.0: {}
+
+  inherits@2.0.4:
+    optional: true
 
   internmap@1.0.1: {}
 
@@ -6265,6 +6473,68 @@ snapshots:
       lefthook-windows-arm64: 2.0.16
       lefthook-windows-x64: 2.0.16
 
+  level-codec@9.0.2:
+    dependencies:
+      buffer: 5.7.1
+    optional: true
+
+  level-concat-iterator@2.0.1:
+    optional: true
+
+  level-errors@2.0.1:
+    dependencies:
+      errno: 0.1.8
+    optional: true
+
+  level-iterator-stream@4.0.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      xtend: 4.0.2
+    optional: true
+
+  level-js@5.0.2:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      buffer: 5.7.1
+      inherits: 2.0.4
+      ltgt: 2.2.1
+    optional: true
+
+  level-packager@5.1.1:
+    dependencies:
+      encoding-down: 6.3.0
+      levelup: 4.4.0
+    optional: true
+
+  level-supports@1.0.1:
+    dependencies:
+      xtend: 4.0.2
+    optional: true
+
+  level@6.0.1:
+    dependencies:
+      level-js: 5.0.2
+      level-packager: 5.1.1
+      leveldown: 5.6.0
+    optional: true
+
+  leveldown@5.6.0:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      napi-macros: 2.0.0
+      node-gyp-build: 4.1.1
+    optional: true
+
+  levelup@4.4.0:
+    dependencies:
+      deferred-leveldown: 5.3.0
+      level-errors: 2.0.1
+      level-iterator-stream: 4.0.2
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
@@ -6291,6 +6561,8 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash@4.17.23: {}
 
   lowlight@3.3.0:
@@ -6308,6 +6580,9 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  ltgt@2.2.1:
+    optional: true
 
   magic-string@0.30.21:
     dependencies:
@@ -6415,7 +6690,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-macros@2.0.0:
+    optional: true
+
   node-addon-api@7.1.1:
+    optional: true
+
+  node-gyp-build@4.1.1:
     optional: true
 
   node-releases@2.0.27: {}
@@ -6608,6 +6889,9 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
 
+  prr@1.0.1:
+    optional: true
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -6624,6 +6908,13 @@ snapshots:
   react-refresh@0.18.0: {}
 
   react@19.2.3: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
 
   readdirp@4.1.2: {}
 
@@ -6703,6 +6994,9 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.2.1:
+    optional: true
+
   safer-buffer@2.1.2: {}
 
   sass@1.97.3:
@@ -6771,6 +7065,11 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -6907,6 +7206,9 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2:
+    optional: true
 
   uuid@11.1.0: {}
 
@@ -7094,10 +7396,38 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
+  ws@6.2.3:
+    dependencies:
+      async-limiter: 1.0.1
+    optional: true
+
+  xtend@4.0.2:
+    optional: true
+
+  y-leveldb@0.1.2(yjs@13.6.29):
+    dependencies:
+      level: 6.0.1
+      lib0: 0.2.117
+      yjs: 13.6.29
+    optional: true
+
   y-protocols@1.0.7(yjs@13.6.29):
     dependencies:
       lib0: 0.2.117
       yjs: 13.6.29
+
+  y-websocket@2.1.0(yjs@13.6.29):
+    dependencies:
+      lib0: 0.2.117
+      lodash.debounce: 4.0.8
+      y-protocols: 1.0.7(yjs@13.6.29)
+      yjs: 13.6.29
+    optionalDependencies:
+      ws: 6.2.3
+      y-leveldb: 0.1.2(yjs@13.6.29)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

- Add Yjs-based real-time collaboration support with provider state tracking
- Add `VizelCollaborationOptions`, `VizelCollaborationState`, and `VizelYjsProvider` types in `@vizel/core`
- Add `createVizelCollaborationHandlers()` factory for managing provider event listeners and tracking connection/sync/peer state
- Add `features.collaboration` flag to `VizelFeatureOptions` that disables History extension (Yjs provides its own undo manager)
- Add framework hooks: `useVizelCollaboration` (React), `useVizelCollaboration` (Vue), `createVizelCollaboration` (Svelte)
- Add optional `yjs` and `y-websocket` peer dependencies
- Add comprehensive documentation with setup guide, API reference, server setup instructions, and troubleshooting

## Design Decisions

- **No hard dependencies on Yjs packages**: Uses interface-based typing (`VizelYjsProvider`, `VizelYjsAwareness`) to avoid version conflicts. Users install their own compatible versions of `yjs`, `y-websocket`, `@tiptap/extension-collaboration`, and `@tiptap/extension-collaboration-cursor`.
- **Subscribe/cleanup pattern**: The handler factory returns a `subscribe()` method that sets up event listeners and returns an unsubscribe function, making it easy for framework hooks to manage lifecycle.
- **History exclusion**: When `features.collaboration` is `true`, the built-in History extension is excluded from `createVizelExtensions()` since Yjs's `Y.UndoManager` must be used instead.

## Test Plan

- [x] `pnpm typecheck` passes (all packages)
- [x] `pnpm lint` passes
- [x] VitePress docs build succeeds
- [x] Pre-commit hooks pass (biome-check, typecheck, commitlint)

Closes #189