### PR TITLE
docs: improve API completeness and technical writing consistency

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,14 +1,15 @@
 import type { Editor, JSONContent } from "@tiptap/core";
-import { setVizelMarkdown } from "@vizel/core";
+import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
   useVizelAutoSave,
   useVizelEditorState,
   useVizelTheme,
   Vizel,
+  VizelFindReplace,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { initialMarkdown } from "../../shared/content";
 import reactLogo from "../../shared/logos/react.svg";
 import { mockUploadImage } from "../../shared/utils";
@@ -79,6 +80,9 @@ function AppContent() {
     storage: "localStorage",
     key: "vizel-demo-react",
   });
+
+  // Find & Replace extension (stable reference)
+  const findReplaceExtensions = useMemo(() => [createVizelFindReplaceExtension()], []);
 
   // Handle Markdown input change and sync to editor
   const handleMarkdownChange = useCallback(
@@ -172,6 +176,7 @@ function AppContent() {
               className="editor-content"
               showToolbar={features.toolbar}
               enableEmbed
+              extensions={findReplaceExtensions}
               features={{
                 markdown: true,
                 mathematics: true,
@@ -200,7 +205,9 @@ function AppContent() {
                 setJsonInput(JSON.stringify(json, null, 2));
                 setMarkdownInput(updatedEditor.getMarkdown());
               }}
-            />
+            >
+              <VizelFindReplace editor={editor} />
+            </Vizel>
             {(features.autoSave || features.stats) && (
               <div className="status-bar">
                 {features.autoSave && (

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-import { getVizelEditorState, setVizelMarkdown } from "@vizel/core";
+import {
+  createVizelFindReplaceExtension,
+  getVizelEditorState,
+  setVizelMarkdown,
+} from "@vizel/core";
 import {
   createVizelAutoSave,
   createVizelState,
   Vizel,
+  VizelFindReplace,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/svelte";
@@ -46,6 +51,9 @@ const autoSave = createVizelAutoSave(() => (features.autoSave ? editorRef : null
   storage: "localStorage",
   key: "vizel-demo-svelte",
 });
+
+// Find & Replace extension
+const findReplaceExtensions = [createVizelFindReplaceExtension()];
 
 function handleCreate({ editor }: { editor: NonNullable<VizelEditor> }) {
   editorRef = editor;
@@ -140,6 +148,7 @@ function handleJsonChange(event: Event) {
           class="editor-content"
           showToolbar={features.toolbar}
           enableEmbed
+          extensions={findReplaceExtensions}
           features={{
             markdown: true,
             mathematics: true,
@@ -155,7 +164,13 @@ function handleJsonChange(event: Event) {
           }}
           onCreate={handleCreate}
           onUpdate={handleUpdate}
-        />
+        >
+          {#snippet children({ editor: snippetEditor })}
+            {#if snippetEditor}
+              <VizelFindReplace editor={snippetEditor} />
+            {/if}
+          {/snippet}
+        </Vizel>
         {#if features.autoSave || features.stats}
           <div class="status-bar">
             {#if features.autoSave}

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import type { Editor, JSONContent } from "@tiptap/core";
-import { getVizelEditorState, setVizelMarkdown } from "@vizel/core";
+import {
+  createVizelFindReplaceExtension,
+  getVizelEditorState,
+  setVizelMarkdown,
+} from "@vizel/core";
 import {
   useVizelAutoSave,
   useVizelState,
   Vizel,
+  VizelFindReplace,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/vue";
@@ -46,6 +51,9 @@ const { status, lastSaved } = useVizelAutoSave(() => (features.autoSave ? editor
   storage: "localStorage",
   key: "vizel-demo-vue",
 });
+
+// Find & Replace extension
+const findReplaceExtensions = [createVizelFindReplaceExtension()];
 
 function handleCreate({ editor }: { editor: Editor }) {
   editorRef.value = editor;
@@ -139,6 +147,7 @@ function handleJsonChange(event: Event) {
               class="editor-content"
               :show-toolbar="features.toolbar"
               enable-embed
+              :extensions="findReplaceExtensions"
               :features="{
                 markdown: true,
                 mathematics: true,
@@ -154,7 +163,11 @@ function handleJsonChange(event: Event) {
               }"
               @create="handleCreate"
               @update="handleUpdate"
-            />
+            >
+              <template #default="{ editor: slotEditor }">
+                <VizelFindReplace v-if="slotEditor" :editor="slotEditor" />
+              </template>
+            </Vizel>
             <div v-if="features.autoSave || features.stats" class="status-bar">
               <template v-if="features.autoSave">
                 <VizelSaveIndicator :status="status" :lastSaved="lastSaved" />

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -20,7 +20,7 @@ You typically don't need to install this package directly. It's included as a de
 import '@vizel/core/styles.css';
 ```
 
-Includes CSS variables and component styles.
+This stylesheet includes CSS variables and component styles.
 
 ### Components Only
 
@@ -28,7 +28,7 @@ Includes CSS variables and component styles.
 import '@vizel/core/components.css';
 ```
 
-Component styles without CSS variable definitions. Use with custom theming or shadcn/ui.
+This stylesheet provides component styles without CSS variable definitions. Use it with custom theming or shadcn/ui.
 
 ---
 
@@ -38,7 +38,7 @@ Vizel provides pre-configured Tiptap extensions.
 
 ### createVizelExtensions
 
-Creates the default set of Vizel extensions.
+This function creates the default set of Vizel extensions.
 
 ```typescript
 import { createVizelExtensions } from '@vizel/core';
@@ -94,6 +94,8 @@ const extensions = createVizelExtensions({
 | `embed` | `Embed` |
 | `details` | `Details`, `DetailsContent`, `DetailsSummary` |
 | `diagram` | `Diagram` |
+| `wikiLink` | `WikiLink` |
+| `comment` | `CommentMark` |
 
 ---
 
@@ -153,7 +155,7 @@ type VizelResolvedTheme = 'light' | 'dark';
 
 ### resolveVizelFeatures
 
-Resolves feature options to extension configuration.
+This function resolves feature options to extension configuration.
 
 ```typescript
 import { resolveVizelFeatures } from '@vizel/core';
@@ -166,7 +168,7 @@ const resolved = resolveVizelFeatures({
 
 ### getVizelEditorState
 
-Gets the current editor state.
+This function returns the current editor state.
 
 ```typescript
 import { getVizelEditorState } from '@vizel/core';
@@ -184,7 +186,7 @@ const state = getVizelEditorState(editor);
 
 ### formatVizelRelativeTime
 
-Formats a date as relative time.
+This function formats a date as relative time.
 
 ```typescript
 import { formatVizelRelativeTime } from '@vizel/core';
@@ -199,7 +201,7 @@ formatVizelRelativeTime(new Date(Date.now() - 60000));
 
 ### getVizelSystemTheme
 
-Gets the system color scheme preference.
+This function returns the system color scheme preference.
 
 ```typescript
 import { getVizelSystemTheme } from '@vizel/core';
@@ -210,7 +212,7 @@ const theme = getVizelSystemTheme();
 
 ### resolveVizelTheme
 
-Resolves theme setting to actual theme.
+This function resolves a theme setting to an actual theme value.
 
 ```typescript
 import { resolveVizelTheme } from '@vizel/core';
@@ -221,7 +223,7 @@ resolveVizelTheme('system', 'dark');
 
 ### applyVizelTheme
 
-Applies theme to the DOM.
+This function applies a theme to the DOM.
 
 ```typescript
 import { applyVizelTheme } from '@vizel/core';
@@ -231,7 +233,7 @@ applyVizelTheme('dark', document.documentElement);
 
 ### getVizelThemeInitScript
 
-Gets inline script for preventing flash of unstyled content.
+This function returns an inline script that prevents flash of unstyled content.
 
 ```typescript
 import { getVizelThemeInitScript } from '@vizel/core';
@@ -246,7 +248,7 @@ const script = getVizelThemeInitScript('my-theme-key');
 
 ### createVizelImageUploader
 
-Creates an image upload function.
+This function creates an image upload handler.
 
 ```typescript
 import { createVizelImageUploader } from '@vizel/core';
@@ -263,7 +265,7 @@ const upload = createVizelImageUploader({
 
 ### validateVizelImageFile
 
-Validates an image file.
+This function validates an image file against size and type constraints.
 
 ```typescript
 import { validateVizelImageFile } from '@vizel/core';
@@ -284,7 +286,7 @@ if (!result.valid) {
 
 ### getVizelRecentColors
 
-Gets recent colors from localStorage.
+This function retrieves recent colors from localStorage.
 
 ```typescript
 import { getVizelRecentColors } from '@vizel/core';
@@ -295,7 +297,7 @@ const colors = getVizelRecentColors('text');
 
 ### addVizelRecentColor
 
-Adds a color to recent colors.
+This function adds a color to the recent colors list.
 
 ```typescript
 import { addVizelRecentColor } from '@vizel/core';
@@ -309,7 +311,7 @@ addVizelRecentColor('text', '#ff0000');
 
 ### detectVizelEmbedProvider
 
-Detects oEmbed provider from URL.
+This function detects the oEmbed provider from a URL.
 
 ```typescript
 import { detectVizelEmbedProvider } from '@vizel/core';
@@ -324,7 +326,7 @@ const provider = detectVizelEmbedProvider('https://www.youtube.com/watch?v=dQw4w
 
 ### VIZEL_TEXT_COLORS
 
-Default text color palette.
+This constant defines the default text color palette.
 
 ```typescript
 import { VIZEL_TEXT_COLORS } from '@vizel/core';
@@ -333,7 +335,7 @@ import { VIZEL_TEXT_COLORS } from '@vizel/core';
 
 ### VIZEL_HIGHLIGHT_COLORS
 
-Default highlight color palette.
+This constant defines the default highlight color palette.
 
 ```typescript
 import { VIZEL_HIGHLIGHT_COLORS } from '@vizel/core';
@@ -342,7 +344,7 @@ import { VIZEL_HIGHLIGHT_COLORS } from '@vizel/core';
 
 ### vizelDefaultEmbedProviders
 
-Default oEmbed providers.
+This constant defines the default oEmbed providers.
 
 ```typescript
 import { vizelDefaultEmbedProviders } from '@vizel/core';
@@ -355,7 +357,7 @@ import { vizelDefaultEmbedProviders } from '@vizel/core';
 
 ### VizelToolbarAction
 
-Toolbar action type definition.
+Type definition for a toolbar action.
 
 ```typescript
 import type { VizelToolbarAction } from '@vizel/core';
@@ -374,7 +376,7 @@ interface VizelToolbarAction {
 
 ### vizelDefaultToolbarActions
 
-Default toolbar actions including undo/redo, formatting, headings, lists, and blocks.
+This constant provides the default toolbar actions including undo/redo, formatting, headings, lists, and blocks.
 
 ```typescript
 import { vizelDefaultToolbarActions } from '@vizel/core';
@@ -385,13 +387,538 @@ import { vizelDefaultToolbarActions } from '@vizel/core';
 
 ### groupVizelToolbarActions
 
-Groups toolbar actions by their `group` property for rendering with dividers.
+This function groups toolbar actions by their `group` property for rendering with dividers.
 
 ```typescript
 import { groupVizelToolbarActions } from '@vizel/core';
 
 const groups = groupVizelToolbarActions(actions);
 // VizelToolbarAction[][] - each sub-array is a group
+```
+
+---
+
+## Find & Replace
+
+A standalone Tiptap extension for text search and replacement within the editor. This extension is not included in `createVizelExtensions()` — you add it manually.
+
+### createVizelFindReplaceExtension
+
+This function creates the Find & Replace extension.
+
+```typescript
+import { createVizelFindReplaceExtension } from '@vizel/core';
+
+const findReplace = createVizelFindReplaceExtension({
+  caseSensitive: false,
+  onResultsChange: ({ total, current }) => {
+    console.log(`Match ${current} of ${total}`);
+  },
+});
+```
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `caseSensitive` | `boolean` | `false` | Enable case-sensitive search |
+| `onResultsChange` | `(results: { total: number; current: number }) => void` | — | Called when search results change |
+
+### Editor Commands
+
+The extension registers the following commands on the editor:
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `openFindReplace` | `mode?: 'find' \| 'replace'` | Open the Find & Replace panel |
+| `closeFindReplace` | — | Close the panel |
+| `find` | `query: string` | Search for text in the document |
+| `findNext` | — | Navigate to the next match |
+| `findPrevious` | — | Navigate to the previous match |
+| `replace` | `text: string` | Replace the current match |
+| `replaceAll` | `text: string` | Replace all matches |
+| `setFindCaseSensitive` | `caseSensitive: boolean` | Toggle case-sensitive search |
+| `clearFind` | — | Clear the search state |
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Mod-f` | Open Find panel |
+| `Mod-Shift-h` | Open Replace panel |
+
+### getVizelFindReplaceState
+
+This function returns the current Find & Replace plugin state from the editor.
+
+```typescript
+import { getVizelFindReplaceState } from '@vizel/core';
+
+const state = getVizelFindReplaceState(editor.state);
+// {
+//   query: string,
+//   matches: VizelFindMatch[],
+//   activeIndex: number,
+//   caseSensitive: boolean,
+//   isOpen: boolean,
+//   mode: 'find' | 'replace',
+// }
+```
+
+### Types
+
+```typescript
+import type {
+  VizelFindReplaceOptions,
+  VizelFindReplaceState,
+  VizelFindMatch,
+} from '@vizel/core';
+
+import { vizelFindReplacePluginKey } from '@vizel/core';
+```
+
+| Type | Description |
+|------|-------------|
+| `VizelFindReplaceOptions` | Configuration options for the extension |
+| `VizelFindReplaceState` | Plugin state containing query, matches, activeIndex, and more |
+| `VizelFindMatch` | Single match with `from` and `to` positions |
+| `vizelFindReplacePluginKey` | ProseMirror `PluginKey` for accessing the plugin state |
+
+---
+
+## Wiki Link
+
+A mark extension for wiki-style `[[page-name]]` links. Supports display text aliases with `[[page-name|display text]]` syntax.
+
+### createVizelWikiLinkExtension
+
+This function creates a configured Wiki Link extension.
+
+```typescript
+import { createVizelWikiLinkExtension } from '@vizel/core';
+
+const wikiLink = createVizelWikiLinkExtension({
+  resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+  pageExists: (page) => knownPages.has(page),
+  onLinkClick: (page, event) => {
+    event.preventDefault();
+    router.push(`/wiki/${page}`);
+  },
+});
+```
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `resolveLink` | `(pageName: string) => string` | `(p) => '#' + p` | Resolve a page name to a URL |
+| `pageExists` | `(pageName: string) => boolean` | `() => true` | Check whether a page exists (for visual differentiation) |
+| `getPageSuggestions` | `(query: string) => VizelWikiLinkSuggestion[]` | — | Return autocomplete suggestions |
+| `onLinkClick` | `(pageName: string, event: MouseEvent) => void` | — | Called when a wiki link is clicked |
+| `existingClass` | `string` | `'vizel-wiki-link--existing'` | CSS class for existing page links |
+| `newClass` | `string` | `'vizel-wiki-link--new'` | CSS class for non-existing page links |
+| `HTMLAttributes` | `Record<string, unknown>` | `{}` | Additional HTML attributes |
+
+### Editor Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setWikiLink` | `pageName: string, displayText?: string` | Insert a wiki link at the current position |
+| `unsetWikiLink` | — | Remove the wiki link mark from the selection |
+
+### Types
+
+```typescript
+import type { VizelWikiLinkOptions, VizelWikiLinkSuggestion } from '@vizel/core';
+import { VizelWikiLink, vizelWikiLinkPluginKey } from '@vizel/core';
+```
+
+| Type | Description |
+|------|-------------|
+| `VizelWikiLinkOptions` | Configuration options for the extension |
+| `VizelWikiLinkSuggestion` | Page suggestion with `name` and optional `label` |
+| `VizelWikiLink` | Tiptap Mark extension class |
+| `vizelWikiLinkPluginKey` | ProseMirror `PluginKey` for the wiki link plugin |
+
+---
+
+## Comments
+
+Comment management module for adding, resolving, and replying to text annotations. This module provides a handler factory pattern with pluggable storage backends.
+
+### createVizelCommentHandlers
+
+This function creates comment handler methods for an editor.
+
+```typescript
+import { createVizelCommentHandlers } from '@vizel/core';
+import type { VizelCommentState } from '@vizel/core';
+
+const handlers = createVizelCommentHandlers(
+  () => editor,
+  {
+    storage: 'localStorage',
+    key: 'my-comments',
+    onAdd: (comment) => console.log('Added:', comment.id),
+  },
+  (partial) => setState((prev) => ({ ...prev, ...partial }))
+);
+
+// Add a comment to the current text selection
+await handlers.addComment('Needs clarification', 'Alice');
+
+// Resolve a comment
+await handlers.resolveComment(commentId);
+
+// Reply to a comment
+await handlers.replyToComment(commentId, 'Fixed in latest commit', 'Bob');
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor instance |
+| `options` | `VizelCommentOptions` | Configuration options |
+| `onStateChange` | `(state: Partial<VizelCommentState>) => void` | Callback to update reactive state |
+
+#### Return Value
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `addComment` | `(text: string, author?: string) => Promise<VizelComment \| null>` | Add a comment to the current selection |
+| `removeComment` | `(commentId: string) => Promise<void>` | Remove a comment and its mark |
+| `resolveComment` | `(commentId: string) => Promise<boolean>` | Mark a comment as resolved |
+| `reopenComment` | `(commentId: string) => Promise<boolean>` | Reopen a resolved comment |
+| `replyToComment` | `(commentId: string, text: string, author?: string) => Promise<VizelCommentReply \| null>` | Add a reply to a comment |
+| `setActiveComment` | `(commentId: string \| null) => void` | Set the currently active comment |
+| `loadComments` | `() => Promise<VizelComment[]>` | Load all comments from storage |
+| `getCommentById` | `(commentId: string) => VizelComment \| undefined` | Get a comment by its ID |
+
+### getVizelCommentStorageBackend
+
+This function creates a normalized storage backend from the storage option.
+
+```typescript
+import { getVizelCommentStorageBackend } from '@vizel/core';
+
+const backend = getVizelCommentStorageBackend('localStorage', 'my-comments');
+const comments = await backend.load();
+await backend.save(comments);
+```
+
+### Comment Extension
+
+This extension adds a mark to the editor for highlighting commented text.
+
+```typescript
+import { createVizelCommentExtension } from '@vizel/core';
+
+const commentExtension = createVizelCommentExtension();
+```
+
+### Types
+
+```typescript
+import type {
+  VizelComment,
+  VizelCommentReply,
+  VizelCommentState,
+  VizelCommentOptions,
+  VizelCommentStorage,
+} from '@vizel/core';
+
+import {
+  VIZEL_DEFAULT_COMMENT_OPTIONS,
+  vizelCommentPluginKey,
+} from '@vizel/core';
+```
+
+| Type | Description |
+|------|-------------|
+| `VizelComment` | Comment annotation with id, text, author, createdAt, resolved, replies |
+| `VizelCommentReply` | Reply with id, text, author, createdAt |
+| `VizelCommentState` | State object containing comments, activeCommentId, isLoading, error |
+| `VizelCommentOptions` | Configuration for enabled, storage, key, and event callbacks |
+| `VizelCommentStorage` | `'localStorage'` or custom `{ save, load }` backend |
+
+---
+
+## Version History
+
+Version history module for saving, restoring, and managing document snapshots. This module uses the same handler factory pattern and pluggable storage backends as Comments.
+
+### createVizelVersionHistoryHandlers
+
+This function creates version history handler methods for an editor.
+
+```typescript
+import { createVizelVersionHistoryHandlers } from '@vizel/core';
+import type { VizelVersionHistoryState } from '@vizel/core';
+
+const handlers = createVizelVersionHistoryHandlers(
+  () => editor,
+  {
+    maxVersions: 20,
+    storage: 'localStorage',
+    onSave: (snapshot) => console.log('Saved version:', snapshot.id),
+  },
+  (partial) => setState((prev) => ({ ...prev, ...partial }))
+);
+
+// Save the current document state
+await handlers.saveVersion('Initial draft', 'Alice');
+
+// List all versions
+const versions = await handlers.loadVersions();
+
+// Restore a specific version
+await handlers.restoreVersion(versions[0].id);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor instance |
+| `options` | `VizelVersionHistoryOptions` | Configuration options |
+| `onStateChange` | `(state: Partial<VizelVersionHistoryState>) => void` | Callback to update reactive state |
+
+#### Return Value
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `saveVersion` | `(description?: string, author?: string) => Promise<VizelVersionSnapshot \| null>` | Save the current document as a new version |
+| `restoreVersion` | `(versionId: string) => Promise<boolean>` | Restore the document to a specific version |
+| `loadVersions` | `() => Promise<VizelVersionSnapshot[]>` | Load all versions from storage |
+| `deleteVersion` | `(versionId: string) => Promise<void>` | Delete a specific version |
+| `clearVersions` | `() => Promise<void>` | Delete all versions |
+
+### getVizelVersionStorageBackend
+
+This function creates a normalized storage backend from the storage option.
+
+```typescript
+import { getVizelVersionStorageBackend } from '@vizel/core';
+
+const backend = getVizelVersionStorageBackend('localStorage', 'my-versions');
+const snapshots = await backend.load();
+await backend.save(snapshots);
+```
+
+### Types
+
+```typescript
+import type {
+  VizelVersionSnapshot,
+  VizelVersionHistoryState,
+  VizelVersionHistoryOptions,
+  VizelVersionStorage,
+} from '@vizel/core';
+
+import { VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS } from '@vizel/core';
+```
+
+| Type | Description |
+|------|-------------|
+| `VizelVersionSnapshot` | Snapshot with id, content (JSONContent), timestamp, description, author |
+| `VizelVersionHistoryState` | State object containing snapshots, isLoading, error |
+| `VizelVersionHistoryOptions` | Configuration for enabled, maxVersions, storage, key, and callbacks |
+| `VizelVersionStorage` | `'localStorage'` or custom `{ save, load }` backend |
+
+#### Default Options
+
+```typescript
+VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS = {
+  enabled: true,
+  maxVersions: 50,
+  storage: 'localStorage',
+  key: 'vizel-versions',
+};
+```
+
+---
+
+## Collaboration
+
+Real-time multi-user editing module built on Yjs. This module provides types, state management, and lifecycle utilities for integrating Yjs-based collaboration.
+
+::: warning
+You must install your own compatible versions of `yjs`, a Yjs provider (e.g. `y-websocket`), `@tiptap/extension-collaboration`, and `@tiptap/extension-collaboration-cursor`.
+:::
+
+### createVizelCollaborationHandlers
+
+This function creates collaboration handler methods for tracking provider state and managing lifecycle.
+
+```typescript
+import { createVizelCollaborationHandlers } from '@vizel/core';
+import type { VizelCollaborationState } from '@vizel/core';
+
+const handlers = createVizelCollaborationHandlers(
+  () => wsProvider,
+  {
+    user: { name: 'Alice', color: '#ff0000' },
+    onConnect: () => console.log('Connected'),
+    onPeersChange: (count) => console.log('Peers:', count),
+  },
+  (partial) => setState((prev) => ({ ...prev, ...partial }))
+);
+
+// Start listening to provider events
+const unsubscribe = handlers.subscribe();
+
+// Connect to the server
+handlers.connect();
+
+// Later, clean up
+unsubscribe();
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getProvider` | `() => VizelYjsProvider \| null \| undefined` | Getter function for the Yjs provider |
+| `options` | `VizelCollaborationOptions` | Collaboration options including user info |
+| `onStateChange` | `(state: Partial<VizelCollaborationState>) => void` | Callback to update reactive state |
+
+#### Return Value
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `connect` | `() => void` | Connect to the collaboration server |
+| `disconnect` | `() => void` | Disconnect from the server |
+| `updateUser` | `(user: VizelCollaborationUser) => void` | Update the current user's cursor information |
+| `subscribe` | `() => () => void` | Subscribe to provider events; returns an unsubscribe function |
+
+### Types
+
+```typescript
+import type {
+  VizelCollaborationUser,
+  VizelCollaborationOptions,
+  VizelCollaborationState,
+  VizelYjsProvider,
+  VizelYjsAwareness,
+} from '@vizel/core';
+
+import { VIZEL_DEFAULT_COLLABORATION_OPTIONS } from '@vizel/core';
+```
+
+| Type | Description |
+|------|-------------|
+| `VizelCollaborationUser` | User info with `name` and `color` |
+| `VizelCollaborationOptions` | Configuration for enabled, user, and event callbacks |
+| `VizelCollaborationState` | State containing isConnected, isSynced, peerCount, error |
+| `VizelYjsProvider` | Interface matching the Yjs WebSocket provider API |
+| `VizelYjsAwareness` | Interface matching the Yjs Awareness API |
+
+#### VizelCollaborationOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable collaboration tracking |
+| `user` | `VizelCollaborationUser` | — | Current user info for cursor display (required) |
+| `onConnect` | `() => void` | — | Called when connected |
+| `onDisconnect` | `() => void` | — | Called when disconnected |
+| `onSynced` | `() => void` | — | Called when initial document sync completes |
+| `onError` | `(error: Error) => void` | — | Called when an error occurs |
+| `onPeersChange` | `(count: number) => void` | — | Called when the number of connected peers changes |
+
+---
+
+## Plugin System
+
+A plugin architecture for extending Vizel with third-party functionality. The plugin system supports dependency resolution, lifecycle hooks, style injection, and transaction handling.
+
+### VizelPluginManager
+
+The main class for managing plugins.
+
+```typescript
+import { VizelPluginManager } from '@vizel/core';
+import type { VizelPlugin } from '@vizel/core';
+
+const manager = new VizelPluginManager();
+
+// Register a plugin
+manager.register(myPlugin);
+
+// Pass plugin extensions to the editor
+const editor = useVizelEditor({
+  extensions: manager.getExtensions(),
+});
+
+// Connect the editor to enable lifecycle hooks
+if (editor) manager.setEditor(editor);
+
+// Clean up
+manager.destroy();
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `register` | `(plugin: VizelPlugin) => void` | Register a plugin (validates, injects styles, calls `onInstall` if the editor is connected) |
+| `unregister` | `(pluginName: string) => void` | Unregister a plugin (checks dependents, removes styles, calls `onUninstall`) |
+| `setEditor` | `(editor: Editor) => void` | Connect an editor instance and call `onInstall` on all plugins |
+| `destroy` | `() => void` | Disconnect the editor and clean up all plugins |
+| `getExtensions` | `() => Extensions` | Return aggregated extensions from all plugins in dependency order |
+| `getPlugin` | `(name: string) => VizelPlugin \| undefined` | Get a registered plugin by name |
+| `listPlugins` | `() => VizelPlugin[]` | List all registered plugins |
+| `hasPlugin` | `(name: string) => boolean` | Check whether a plugin is registered |
+
+### VizelPlugin Interface
+
+```typescript
+import type { VizelPlugin } from '@vizel/core';
+
+const myPlugin: VizelPlugin = {
+  name: 'my-vizel-plugin',
+  version: '1.0.0',
+  description: 'Adds cool feature to Vizel',
+  extensions: [MyExtension],
+  styles: '.my-plugin { color: red; }',
+  dependencies: ['other-plugin'],
+  onInstall: (editor) => console.log('Installed'),
+  onUninstall: (editor) => console.log('Uninstalled'),
+  onTransaction: ({ editor, transaction }) => { /* handle transaction */ },
+};
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | Unique identifier (kebab-case) |
+| `version` | `string` | Yes | Semver version (e.g. `'1.0.0'`) |
+| `description` | `string` | No | Human-readable description |
+| `extensions` | `Extensions` | No | Tiptap extensions to add |
+| `styles` | `string` | No | CSS styles to inject |
+| `onInstall` | `(editor: Editor) => void` | No | Called when the editor installs the plugin |
+| `onUninstall` | `(editor: Editor) => void` | No | Called when the editor uninstalls the plugin |
+| `onTransaction` | `(props: { editor: Editor; transaction: Transaction }) => void` | No | Called on each editor transaction |
+| `dependencies` | `string[]` | No | Plugin names that you must register first |
+
+### validateVizelPlugin
+
+This function validates a plugin's required fields and format. It throws a descriptive error if validation fails.
+
+```typescript
+import { validateVizelPlugin } from '@vizel/core';
+
+validateVizelPlugin(myPlugin); // throws if invalid
+```
+
+### resolveVizelPluginDependencies
+
+This function resolves plugin dependencies via topological sort. It throws if it detects a circular dependency or a missing dependency.
+
+```typescript
+import { resolveVizelPluginDependencies } from '@vizel/core';
+
+const ordered = resolveVizelPluginDependencies(plugins);
+// Returns plugins in dependency-first order
 ```
 
 ---
@@ -419,3 +946,8 @@ import type { JSONContent, Extensions } from '@tiptap/core';
 - [React API](/api/react) - React-specific APIs
 - [Vue API](/api/vue) - Vue-specific APIs
 - [Svelte API](/api/svelte) - Svelte-specific APIs
+- [Wiki Links Guide](/guide/wiki-links) - Wiki link usage guide
+- [Comments Guide](/guide/comments) - Comment management guide
+- [Version History Guide](/guide/version-history) - Version history guide
+- [Collaboration Guide](/guide/collaboration) - Real-time collaboration guide
+- [Plugins Guide](/guide/plugins) - Plugin system guide

--- a/docs/api/css-variables/colors.md
+++ b/docs/api/css-variables/colors.md
@@ -1,6 +1,6 @@
 # Color Variables
 
-All color values use the OKLCH color space for better perceptual uniformity.
+All color values use the OKLCH color space for perceptual uniformity.
 
 ## Primary Colors
 

--- a/docs/api/css-variables/components.md
+++ b/docs/api/css-variables/components.md
@@ -1,6 +1,6 @@
 # Component Variables
 
-Variables for editor, images, mathematics, and other components.
+CSS variables for the editor, images, mathematics, and other components.
 
 ## Editor
 

--- a/docs/api/css-variables/index.md
+++ b/docs/api/css-variables/index.md
@@ -1,10 +1,10 @@
 # CSS Variables Reference
 
-Reference of CSS custom properties available in Vizel. Color values use the OKLCH color space for perceptual uniformity and wider gamut support.
+This page lists all CSS custom properties available in Vizel. Color values use the OKLCH color space for perceptual uniformity and wider gamut support.
 
 ## Overview
 
-Vizel provides CSS custom properties for theming. Variables are organized into the following categories:
+Vizel provides CSS custom properties for theming. The following categories organize these variables:
 
 | Category | Description |
 |----------|-------------|
@@ -18,16 +18,16 @@ Vizel provides CSS custom properties for theming. Variables are organized into t
 
 Vizel uses the [OKLCH color space](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch) for all color values because:
 
-1. **Perceptual uniformity** - Colors with the same lightness value appear equally bright
-2. **Predictable manipulation** - Adjusting hue, chroma, or lightness produces predictable results
-3. **Wider gamut** - Access to colors beyond sRGB on supported displays
-4. **Dark mode** - Easier to create accessible color variations
+1. **Perceptual uniformity** — Colors with the same lightness value appear equally bright
+2. **Predictable manipulation** — Adjusting hue, chroma, or lightness produces predictable results
+3. **Wider gamut** — Provides access to colors beyond sRGB on supported displays
+4. **Dark mode** — Simplifies creating accessible color variations
 
 OKLCH is supported in all modern browsers (Chrome 111+, Firefox 113+, Safari 15.4+).
 
 ## Theme Selectors
 
-CSS selectors that trigger theme changes:
+These CSS selectors trigger theme changes:
 
 ```css
 /* Light theme (default) */

--- a/docs/api/css-variables/integrations.md
+++ b/docs/api/css-variables/integrations.md
@@ -1,10 +1,10 @@
 # Framework Integrations
 
-Integrate Vizel CSS variables with Tailwind CSS and shadcn/ui.
+This guide explains how to integrate Vizel CSS variables with Tailwind CSS and shadcn/ui.
 
 ## Tailwind CSS
 
-Vizel works with Tailwind CSS. Map Vizel's CSS variables to Tailwind's theme system.
+Vizel works with Tailwind CSS. You can map Vizel's CSS variables to Tailwind's theme system.
 
 ### Configuration
 
@@ -62,11 +62,11 @@ export default {
 
 ## shadcn/ui
 
-Vizel is designed to work with [shadcn/ui](https://ui.shadcn.com/). Both libraries use similar CSS variable naming conventions.
+Vizel works with [shadcn/ui](https://ui.shadcn.com/). Both libraries use similar CSS variable naming conventions.
 
 ### Variable Mapping
 
-Add these CSS variable mappings to your global styles:
+Add the following CSS variable mappings to your global styles:
 
 ```css
 @layer base {

--- a/docs/api/css-variables/spacing.md
+++ b/docs/api/css-variables/spacing.md
@@ -1,6 +1,6 @@
 # Spacing & Layout Variables
 
-Spacing scale, border radius, shadows, transitions, and z-index.
+CSS variables for the spacing scale, border radius, shadows, transitions, and z-index.
 
 ## Spacing
 

--- a/docs/api/css-variables/typography.md
+++ b/docs/api/css-variables/typography.md
@@ -1,6 +1,6 @@
 # Typography Variables
 
-Font families, sizes, weights, line heights, and letter spacing.
+CSS variables for font families, sizes, weights, line heights, and letter spacing.
 
 ## Font Families
 

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -66,7 +66,7 @@ import '@vizel/core/styles.css';
 
 ### useVizelEditor
 
-Creates and manages a Vizel editor instance.
+This hook creates and manages a Vizel editor instance.
 
 ```tsx
 import { useVizelEditor } from '@vizel/react';
@@ -78,7 +78,7 @@ const editor = useVizelEditor(options?: VizelEditorOptions);
 
 ### useVizelState
 
-Forces re-render on editor state changes.
+This hook forces a re-render on editor state changes.
 
 ```tsx
 import { useVizelState } from '@vizel/react';
@@ -90,7 +90,7 @@ const updateCount = useVizelState(() => editor);
 
 ### useVizelEditorState
 
-Tracks specific editor state properties reactively.
+This hook tracks specific editor state properties reactively.
 
 ```tsx
 import { useVizelEditorState } from '@vizel/react';
@@ -105,7 +105,7 @@ const isBold = useVizelEditorState(
 
 ### useVizelAutoSave
 
-Auto-saves editor content with debouncing.
+This hook auto-saves editor content with debouncing.
 
 ```tsx
 import { useVizelAutoSave } from '@vizel/react';
@@ -121,15 +121,15 @@ const result = useVizelAutoSave(
 | Property | Type | Description |
 |----------|------|-------------|
 | `status` | `VizelSaveStatus` | Current save status |
-| `hasUnsavedChanges` | `boolean` | Whether there are unsaved changes |
+| `hasUnsavedChanges` | `boolean` | Whether unsaved changes exist |
 | `lastSaved` | `Date \| null` | Last save timestamp |
 | `error` | `Error \| null` | Last error |
-| `save` | `() => Promise<void>` | Manual save function |
-| `restore` | `() => Promise<JSONContent \| null>` | Manual restore function |
+| `save` | `() => Promise<void>` | Save content manually |
+| `restore` | `() => Promise<JSONContent \| null>` | Restore content manually |
 
 ### useVizelMarkdown
 
-Provides two-way Markdown synchronization with debouncing.
+This hook provides two-way Markdown synchronization with debouncing.
 
 ```tsx
 import { useVizelMarkdown } from '@vizel/react';
@@ -156,7 +156,7 @@ const result = useVizelMarkdown(
 
 ### useVizelTheme
 
-Access theme state within VizelThemeProvider.
+This hook accesses theme state within VizelThemeProvider.
 
 ```tsx
 import { useVizelTheme } from '@vizel/react';
@@ -175,7 +175,7 @@ const { theme, resolvedTheme, systemTheme, setTheme } = useVizelTheme();
 
 ### useVizelContext
 
-Access editor from VizelProvider context.
+This hook accesses the editor from VizelProvider context.
 
 ```tsx
 import { useVizelContext } from '@vizel/react';
@@ -183,13 +183,161 @@ import { useVizelContext } from '@vizel/react';
 const { editor } = useVizelContext();
 ```
 
+### useVizelCollaboration
+
+This hook tracks real-time collaboration state with a Yjs provider.
+
+```tsx
+import { useVizelCollaboration } from '@vizel/react';
+
+const {
+  isConnected,
+  isSynced,
+  peerCount,
+  error,
+  connect,
+  disconnect,
+  updateUser,
+} = useVizelCollaboration(
+  () => wsProvider,
+  { user: { name: 'Alice', color: '#ff0000' } }
+);
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getProvider` | `() => VizelYjsProvider \| null \| undefined` | Getter function for the Yjs provider |
+| `options` | `VizelCollaborationOptions` | Collaboration options including user info |
+
+**Returns:** `UseVizelCollaborationResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isConnected` | `boolean` | Whether the editor is connected to the server |
+| `isSynced` | `boolean` | Whether initial sync is complete |
+| `peerCount` | `number` | Number of connected peers |
+| `error` | `Error \| null` | Last error |
+| `connect` | `() => void` | Connect to the server |
+| `disconnect` | `() => void` | Disconnect from the server |
+| `updateUser` | `(user: VizelCollaborationUser) => void` | Update user cursor info |
+
+### useVizelComment
+
+This hook manages document comments and annotations.
+
+```tsx
+import { useVizelComment } from '@vizel/react';
+
+const {
+  comments,
+  activeCommentId,
+  isLoading,
+  error,
+  addComment,
+  removeComment,
+  resolveComment,
+  reopenComment,
+  replyToComment,
+  setActiveComment,
+  loadComments,
+  getCommentById,
+} = useVizelComment(() => editor, { key: 'my-comments' });
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelCommentOptions` | Comment configuration options |
+
+**Returns:** `UseVizelCommentResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `comments` | `VizelComment[]` | All stored comments (newest first) |
+| `activeCommentId` | `string \| null` | Currently active comment ID |
+| `isLoading` | `boolean` | Whether comments are loading |
+| `error` | `Error \| null` | Last error |
+| `addComment` | `(text: string, author?: string) => Promise<VizelComment \| null>` | Add a comment to the selection |
+| `removeComment` | `(commentId: string) => Promise<void>` | Remove a comment |
+| `resolveComment` | `(commentId: string) => Promise<boolean>` | Resolve a comment |
+| `reopenComment` | `(commentId: string) => Promise<boolean>` | Reopen a comment |
+| `replyToComment` | `(commentId: string, text: string, author?: string) => Promise<VizelCommentReply \| null>` | Reply to a comment |
+| `setActiveComment` | `(commentId: string \| null) => void` | Set the active comment |
+| `loadComments` | `() => Promise<VizelComment[]>` | Load comments from storage |
+| `getCommentById` | `(commentId: string) => VizelComment \| undefined` | Get a comment by ID |
+
+### useVizelVersionHistory
+
+This hook manages document version history with save, restore, and delete operations.
+
+```tsx
+import { useVizelVersionHistory } from '@vizel/react';
+
+const {
+  snapshots,
+  isLoading,
+  error,
+  saveVersion,
+  restoreVersion,
+  loadVersions,
+  deleteVersion,
+  clearVersions,
+} = useVizelVersionHistory(() => editor, { maxVersions: 20 });
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelVersionHistoryOptions` | Version history configuration |
+
+**Returns:** `UseVizelVersionHistoryResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `snapshots` | `VizelVersionSnapshot[]` | All stored snapshots (newest first) |
+| `isLoading` | `boolean` | Whether history is loading |
+| `error` | `Error \| null` | Last error |
+| `saveVersion` | `(description?: string, author?: string) => Promise<VizelVersionSnapshot \| null>` | Save a new version |
+| `restoreVersion` | `(versionId: string) => Promise<boolean>` | Restore a version |
+| `loadVersions` | `() => Promise<VizelVersionSnapshot[]>` | Load versions from storage |
+| `deleteVersion` | `(versionId: string) => Promise<void>` | Delete a version |
+| `clearVersions` | `() => Promise<void>` | Delete all versions |
+
 ---
 
 ## Components
 
+### VizelFindReplace
+
+Find & Replace panel component. This component renders when the Find & Replace extension is open.
+
+```tsx
+import { VizelFindReplace } from '@vizel/react';
+
+<VizelFindReplace
+  editor={editor}
+  className="my-find-replace"
+  onClose={() => console.log('Closed')}
+/>
+```
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `editor` | `Editor \| null` | - | Editor instance |
+| `className` | `string` | - | CSS class name |
+| `onClose` | `() => void` | - | Called when the panel closes |
+
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```tsx
 import { VizelEditor } from '@vizel/react';
@@ -206,7 +354,7 @@ import { VizelEditor } from '@vizel/react';
 
 ### VizelBubbleMenu
 
-Floating formatting bubble menu.
+This component renders a floating formatting bubble menu.
 
 ```tsx
 import { VizelBubbleMenu } from '@vizel/react';
@@ -227,7 +375,7 @@ import { VizelBubbleMenu } from '@vizel/react';
 
 ### VizelBubbleMenuDefault
 
-Default bubble menu with all formatting buttons.
+This component renders the default bubble menu with all formatting buttons.
 
 ```tsx
 import { VizelBubbleMenuDefault } from '@vizel/react';
@@ -247,7 +395,7 @@ import { VizelBubbleMenuDefault } from '@vizel/react';
 
 ### VizelBubbleMenuButton
 
-Individual bubble menu button.
+This component renders an individual bubble menu button.
 
 ```tsx
 import { VizelBubbleMenuButton } from '@vizel/react';
@@ -261,7 +409,7 @@ import { VizelBubbleMenuButton } from '@vizel/react';
 
 ### VizelBubbleMenuDivider
 
-Bubble menu divider.
+This component renders a bubble menu divider.
 
 ```tsx
 import { VizelBubbleMenuDivider } from '@vizel/react';
@@ -271,7 +419,7 @@ import { VizelBubbleMenuDivider } from '@vizel/react';
 
 ### VizelToolbar
 
-Fixed toolbar component.
+This component renders a fixed toolbar.
 
 ```tsx
 import { VizelToolbar } from '@vizel/react';
@@ -290,7 +438,7 @@ import { VizelToolbar } from '@vizel/react';
 
 ### VizelToolbarDefault
 
-Default toolbar content with grouped formatting buttons.
+This component renders the default toolbar content with grouped formatting buttons.
 
 ```tsx
 import { VizelToolbarDefault } from '@vizel/react';
@@ -308,7 +456,7 @@ import { VizelToolbarDefault } from '@vizel/react';
 
 ### VizelToolbarButton
 
-Individual toolbar button.
+This component renders an individual toolbar button.
 
 ```tsx
 import { VizelToolbarButton } from '@vizel/react';
@@ -336,7 +484,7 @@ import { VizelToolbarButton } from '@vizel/react';
 
 ### VizelToolbarDivider
 
-Divider between toolbar button groups.
+This component renders a divider between toolbar button groups.
 
 ```tsx
 import { VizelToolbarDivider } from '@vizel/react';
@@ -346,7 +494,7 @@ import { VizelToolbarDivider } from '@vizel/react';
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context to its children.
 
 ```tsx
 import { VizelThemeProvider } from '@vizel/react';
@@ -372,7 +520,7 @@ import { VizelThemeProvider } from '@vizel/react';
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```tsx
 import { VizelSaveIndicator } from '@vizel/react';
@@ -390,7 +538,7 @@ import { VizelSaveIndicator } from '@vizel/react';
 
 ### VizelPortal
 
-Renders content in a portal.
+This component renders its children in a portal.
 
 ```tsx
 import { VizelPortal } from '@vizel/react';
@@ -407,7 +555,7 @@ import { VizelPortal } from '@vizel/react';
 
 ### VizelColorPicker
 
-Color selection component.
+This component renders a color selection interface.
 
 ```tsx
 import { VizelColorPicker } from '@vizel/react';
@@ -422,7 +570,7 @@ import { VizelColorPicker } from '@vizel/react';
 
 ### VizelIconProvider
 
-Provides custom icons for Vizel components.
+This component provides custom icons for Vizel components.
 
 ```tsx
 import { VizelIconProvider } from '@vizel/react';
@@ -447,7 +595,7 @@ const icons: CustomIconMap = {
 
 ### VizelSlashMenu
 
-Slash command menu component.
+This component renders the slash command menu.
 
 ```tsx
 import { VizelSlashMenu } from '@vizel/react';
@@ -465,7 +613,7 @@ import { VizelSlashMenu } from '@vizel/react';
 
 ### createVizelSlashMenuRenderer
 
-Creates slash menu renderer for the SlashCommand extension.
+This function creates a slash menu renderer for the SlashCommand extension.
 
 ```tsx
 import { createVizelSlashMenuRenderer } from '@vizel/react';
@@ -485,7 +633,7 @@ const editor = useVizelEditor({
 
 ## Importing from @vizel/core and @tiptap/core
 
-Framework packages do not re-export from `@vizel/core`. Import directly:
+Framework packages do not re-export from `@vizel/core`. You must import directly:
 
 ```tsx
 // Framework-specific components and hooks

--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -68,7 +68,7 @@ All-in-one editor component with built-in bubble menu. This is the recommended w
 
 ### createVizelEditor
 
-Creates and manages a Vizel editor instance.
+This rune creates and manages a Vizel editor instance.
 
 ```typescript
 import { createVizelEditor } from '@vizel/svelte';
@@ -81,7 +81,7 @@ const editor = createVizelEditor(options?: VizelEditorOptions);
 
 ### createVizelState
 
-Forces re-render on editor state changes.
+This rune forces a re-render on editor state changes.
 
 ```typescript
 import { createVizelState } from '@vizel/svelte';
@@ -94,7 +94,7 @@ const state = createVizelState(getEditor: () => Editor | null);
 
 ### createVizelAutoSave
 
-Auto-saves editor content with debouncing.
+This rune auto-saves editor content with debouncing.
 
 ```typescript
 import { createVizelAutoSave } from '@vizel/svelte';
@@ -110,15 +110,15 @@ const autoSave = createVizelAutoSave(
 | Property | Type | Description |
 |----------|------|-------------|
 | `status` | `VizelSaveStatus` | Current save status (reactive) |
-| `hasUnsavedChanges` | `boolean` | Has unsaved changes (reactive) |
+| `hasUnsavedChanges` | `boolean` | Whether unsaved changes exist (reactive) |
 | `lastSaved` | `Date \| null` | Last save timestamp (reactive) |
 | `error` | `Error \| null` | Last error (reactive) |
-| `save` | `() => Promise<void>` | Manual save function |
-| `restore` | `() => Promise<JSONContent \| null>` | Manual restore |
+| `save` | `() => Promise<void>` | Save content manually |
+| `restore` | `() => Promise<JSONContent \| null>` | Restore content manually |
 
 ### createVizelMarkdown
 
-Provides two-way Markdown synchronization with debouncing.
+This rune provides two-way Markdown synchronization with debouncing.
 
 ```typescript
 import { createVizelMarkdown } from '@vizel/svelte';
@@ -145,7 +145,7 @@ const md = createVizelMarkdown(
 
 ### getVizelTheme
 
-Access theme state within VizelThemeProvider context.
+This rune accesses theme state within VizelThemeProvider context.
 
 ```typescript
 import { getVizelTheme } from '@vizel/svelte';
@@ -163,13 +163,148 @@ const theme = getVizelTheme();
 | `systemTheme` | `VizelResolvedTheme` | System preference (reactive) |
 | `setTheme` | `(theme: VizelTheme) => void` | Set theme function |
 
+### createVizelCollaboration
+
+This rune tracks real-time collaboration state with a Yjs provider.
+
+```typescript
+import { createVizelCollaboration } from '@vizel/svelte';
+
+const collab = createVizelCollaboration(
+  () => provider,
+  { user: { name: 'Alice', color: '#ff0000' } }
+);
+
+// Access reactive state
+// collab.isConnected, collab.peerCount
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getProvider` | `() => VizelYjsProvider \| null \| undefined` | Getter function for the Yjs provider |
+| `options` | `VizelCollaborationOptions` | Collaboration options including user info |
+
+**Returns:** `CreateVizelCollaborationResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isConnected` | `boolean` | Whether the editor is connected to the server (reactive) |
+| `isSynced` | `boolean` | Whether initial sync is complete (reactive) |
+| `peerCount` | `number` | Number of connected peers (reactive) |
+| `error` | `Error \| null` | Last error (reactive) |
+| `connect` | `() => void` | Connect to the server |
+| `disconnect` | `() => void` | Disconnect from the server |
+| `updateUser` | `(user: VizelCollaborationUser) => void` | Update user cursor info |
+
+### createVizelComment
+
+This rune manages document comments and annotations.
+
+```typescript
+import { createVizelComment } from '@vizel/svelte';
+
+const comment = createVizelComment(
+  () => editor.current,
+  { key: 'my-comments' }
+);
+
+// Access reactive state
+// comment.comments, comment.activeCommentId
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelCommentOptions` | Comment configuration options |
+
+**Returns:** `CreateVizelCommentResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `comments` | `VizelComment[]` | All stored comments (newest first, reactive) |
+| `activeCommentId` | `string \| null` | Currently active comment ID (reactive) |
+| `isLoading` | `boolean` | Whether comments are loading (reactive) |
+| `error` | `Error \| null` | Last error (reactive) |
+| `addComment` | `(text: string, author?: string) => Promise<VizelComment \| null>` | Add a comment to the selection |
+| `removeComment` | `(commentId: string) => Promise<void>` | Remove a comment |
+| `resolveComment` | `(commentId: string) => Promise<boolean>` | Resolve a comment |
+| `reopenComment` | `(commentId: string) => Promise<boolean>` | Reopen a comment |
+| `replyToComment` | `(commentId: string, text: string, author?: string) => Promise<VizelCommentReply \| null>` | Reply to a comment |
+| `setActiveComment` | `(commentId: string \| null) => void` | Set the active comment |
+| `loadComments` | `() => Promise<VizelComment[]>` | Load comments from storage |
+| `getCommentById` | `(commentId: string) => VizelComment \| undefined` | Get a comment by ID |
+
+### createVizelVersionHistory
+
+This rune manages document version history with save, restore, and delete operations.
+
+```typescript
+import { createVizelVersionHistory } from '@vizel/svelte';
+
+const history = createVizelVersionHistory(
+  () => editor.current,
+  { maxVersions: 20 }
+);
+
+// Access reactive state
+// history.snapshots, history.isLoading
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelVersionHistoryOptions` | Version history configuration |
+
+**Returns:** `CreateVizelVersionHistoryResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `snapshots` | `VizelVersionSnapshot[]` | All stored snapshots (newest first, reactive) |
+| `isLoading` | `boolean` | Whether history is loading (reactive) |
+| `error` | `Error \| null` | Last error (reactive) |
+| `saveVersion` | `(description?: string, author?: string) => Promise<VizelVersionSnapshot \| null>` | Save a new version |
+| `restoreVersion` | `(versionId: string) => Promise<boolean>` | Restore a version |
+| `loadVersions` | `() => Promise<VizelVersionSnapshot[]>` | Load versions from storage |
+| `deleteVersion` | `(versionId: string) => Promise<void>` | Delete a version |
+| `clearVersions` | `() => Promise<void>` | Delete all versions |
+
 ---
 
 ## Components
 
+### VizelFindReplace
+
+Find & Replace panel component. This component renders when the Find & Replace extension is open.
+
+```svelte
+<script lang="ts">
+  import { VizelFindReplace } from '@vizel/svelte';
+</script>
+
+<VizelFindReplace
+  editor={editor.current}
+  class="my-find-replace"
+  onClose={() => console.log('Closed')}
+/>
+```
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `editor` | `Editor \| null` | - | Editor instance |
+| `class` | `string` | - | CSS class name |
+| `onClose` | `() => void` | - | Called when the panel closes |
+
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```svelte
 <VizelEditor editor={editor.current} class="my-editor" />
@@ -184,7 +319,7 @@ Renders the editor content area.
 
 ### VizelBubbleMenu
 
-Floating formatting bubble menu.
+This component renders a floating formatting bubble menu.
 
 ```svelte
 <VizelBubbleMenu 
@@ -208,7 +343,7 @@ Floating formatting bubble menu.
 
 ### VizelBubbleMenuDefault
 
-Default bubble menu with all formatting buttons.
+This component renders the default bubble menu with all formatting buttons.
 
 ```svelte
 <VizelBubbleMenuDefault 
@@ -226,7 +361,7 @@ Default bubble menu with all formatting buttons.
 
 ### VizelBubbleMenuButton
 
-Individual bubble menu button.
+This component renders an individual bubble menu button.
 
 ```svelte
 <VizelBubbleMenuButton
@@ -238,7 +373,7 @@ Individual bubble menu button.
 
 ### VizelBubbleMenuDivider
 
-Bubble menu divider.
+This component renders a bubble menu divider.
 
 ```svelte
 <VizelBubbleMenuDivider />
@@ -246,7 +381,7 @@ Bubble menu divider.
 
 ### VizelToolbar
 
-Fixed toolbar component.
+This component renders a fixed toolbar.
 
 ```svelte
 <script lang="ts">
@@ -267,7 +402,7 @@ Fixed toolbar component.
 
 ### VizelToolbarDefault
 
-Default toolbar content with grouped formatting buttons.
+This component renders the default toolbar content with grouped formatting buttons.
 
 ```svelte
 <VizelToolbarDefault editor={editor.current} actions={customActions} />
@@ -283,7 +418,7 @@ Default toolbar content with grouped formatting buttons.
 
 ### VizelToolbarButton
 
-Individual toolbar button.
+This component renders an individual toolbar button.
 
 ```svelte
 <VizelToolbarButton
@@ -309,7 +444,7 @@ Individual toolbar button.
 
 ### VizelToolbarDivider
 
-Divider between toolbar button groups.
+This component renders a divider between toolbar button groups.
 
 ```svelte
 <VizelToolbarDivider />
@@ -317,7 +452,7 @@ Divider between toolbar button groups.
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context to its children.
 
 ```svelte
 <VizelThemeProvider
@@ -340,7 +475,7 @@ Provides theme context.
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```svelte
 <VizelSaveIndicator status={autoSave.status} lastSaved={autoSave.lastSaved} />
@@ -356,7 +491,7 @@ Displays save status.
 
 ### VizelPortal
 
-Renders content in a portal.
+This component renders its children in a portal.
 
 ```svelte
 <VizelPortal container={document.body}>
@@ -372,7 +507,7 @@ Renders content in a portal.
 
 ### VizelColorPicker
 
-Color selection component.
+This component renders a color selection interface.
 
 ```svelte
 <VizelColorPicker
@@ -385,7 +520,7 @@ Color selection component.
 
 ### VizelIconProvider
 
-Provides custom icons for Vizel components.
+This component provides custom icons for Vizel components.
 
 ```svelte
 <script lang="ts">
@@ -412,7 +547,7 @@ const icons: CustomIconMap = {
 
 ### VizelSlashMenu
 
-Slash command menu component.
+This component renders the slash command menu.
 
 ```svelte
 <VizelSlashMenu
@@ -428,7 +563,7 @@ Slash command menu component.
 
 ### createVizelSlashMenuRenderer
 
-Creates slash menu renderer for the SlashCommand extension.
+This function creates a slash menu renderer for the SlashCommand extension.
 
 ```typescript
 import { createVizelSlashMenuRenderer } from '@vizel/svelte';
@@ -490,7 +625,7 @@ const editor = createVizelEditor({
 
 ## Importing from @vizel/core and @tiptap/core
 
-Framework packages do not re-export from `@vizel/core`. Import directly:
+Framework packages do not re-export from `@vizel/core`. You must import directly:
 
 ```typescript
 // Framework-specific components and runes

--- a/docs/api/types/editor.md
+++ b/docs/api/types/editor.md
@@ -96,7 +96,7 @@ const content: JSONContent = {
 
 ## VizelEditorState
 
-Editor state object returned by `getVizelEditorState()`.
+The editor state object that `getVizelEditorState()` returns.
 
 ```typescript
 interface VizelEditorState {
@@ -131,7 +131,7 @@ console.log(`${state.characterCount} characters, ${state.wordCount} words`);
 
 ## VizelRange
 
-Selection range type used in commands.
+Selection range type that commands use.
 
 ```typescript
 interface VizelRange {
@@ -142,7 +142,7 @@ interface VizelRange {
 
 ## VizelEmbedData
 
-Data structure for embedded content.
+Data structure that represents embedded content.
 
 ```typescript
 interface VizelEmbedData {
@@ -170,7 +170,7 @@ interface VizelMarkdownSyncOptions {
 
 ## VizelMarkdownSyncResult
 
-Return type for Markdown synchronization.
+Return type that Markdown synchronization hooks/composables/runes provide.
 
 ```typescript
 interface VizelMarkdownSyncResult {
@@ -187,7 +187,7 @@ interface VizelMarkdownSyncResult {
 
 ## Markdown Utilities
 
-Utility functions for working with Markdown content.
+These utility functions help you work with Markdown content.
 
 ```typescript
 import { 

--- a/docs/api/types/features.md
+++ b/docs/api/types/features.md
@@ -49,6 +49,15 @@ interface VizelFeatureOptions {
   
   /** Diagram support */
   diagram?: VizelDiagramOptions | boolean;
+
+  /** Wiki-style internal links ([[page-name]]) */
+  wikiLink?: VizelWikiLinkOptions | boolean;
+
+  /** Comment/annotation marks */
+  comment?: VizelCommentMarkOptions | boolean;
+
+  /** Real-time collaboration mode (disables History extension) */
+  collaboration?: boolean;
 }
 ```
 
@@ -308,8 +317,77 @@ interface VizelDetailsOptions {
 interface VizelTaskListOptions {
   /** Task list container options */
   taskList?: TaskListOptions;
-  
+
   /** Task item options */
   taskItem?: TaskItemOptions;
 }
 ```
+
+## Wiki Link
+
+```typescript
+interface VizelWikiLinkOptions {
+  /** Resolve a page name to a URL (default: (p) => '#' + p) */
+  resolveLink?: (pageName: string) => string;
+
+  /** Check if a page exists for visual differentiation (default: () => true) */
+  pageExists?: (pageName: string) => boolean;
+
+  /** Get page suggestions for autocomplete */
+  getPageSuggestions?: (query: string) => VizelWikiLinkSuggestion[];
+
+  /** Callback when a wiki link is clicked */
+  onLinkClick?: (pageName: string, event: MouseEvent) => void;
+
+  /** CSS class for existing page links (default: 'vizel-wiki-link--existing') */
+  existingClass?: string;
+
+  /** CSS class for non-existing page links (default: 'vizel-wiki-link--new') */
+  newClass?: string;
+
+  /** Additional HTML attributes */
+  HTMLAttributes?: Record<string, unknown>;
+}
+
+interface VizelWikiLinkSuggestion {
+  /** Page name */
+  name: string;
+
+  /** Optional display label (defaults to name) */
+  label?: string;
+}
+```
+
+## Comment Mark
+
+```typescript
+interface VizelCommentMarkOptions {
+  /** Enable comment marks (default: true) */
+  enabled?: boolean;
+}
+```
+
+::: tip
+Comment mark options control the editor extension for highlighting commented text. For full comment management (storage, replies, resolution), use the `createVizelCommentHandlers` function from `@vizel/core` or the framework-specific hooks/composables/runes.
+:::
+
+## Collaboration
+
+The `collaboration` feature option is a boolean flag. Setting it to `true` disables the built-in History extension (since Yjs handles undo/redo via `y-undo`).
+
+```typescript
+// Enable collaboration mode
+const editor = useVizelEditor({
+  features: {
+    collaboration: true, // disables History extension
+  },
+  extensions: [
+    Collaboration.configure({ document: ydoc }),
+    CollaborationCursor.configure({ provider, user }),
+  ],
+});
+```
+
+::: warning
+You must install and configure `yjs`, a Yjs provider, `@tiptap/extension-collaboration`, and `@tiptap/extension-collaboration-cursor` separately. See the [Collaboration Guide](/guide/collaboration) for details.
+:::

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -68,13 +68,13 @@ import '@vizel/core/styles.css';
 
 | Event | Payload | Description |
 |-------|---------|-------------|
-| `update` | `{ editor: Editor }` | Content updated |
-| `update:markdown` | `string` | Markdown content changed |
-| `create` | `{ editor: Editor }` | Editor created |
-| `destroy` | - | Editor destroyed |
-| `selectionUpdate` | `{ editor: Editor }` | Selection changed |
-| `focus` | `{ editor: Editor }` | Editor focused |
-| `blur` | `{ editor: Editor }` | Editor blurred |
+| `update` | `{ editor: Editor }` | Fires when content changes |
+| `update:markdown` | `string` | Fires when Markdown content changes |
+| `create` | `{ editor: Editor }` | Fires when the editor initializes |
+| `destroy` | - | Fires when the editor destroys |
+| `selectionUpdate` | `{ editor: Editor }` | Fires when the selection changes |
+| `focus` | `{ editor: Editor }` | Fires when the editor gains focus |
+| `blur` | `{ editor: Editor }` | Fires when the editor loses focus |
 
 ---
 
@@ -82,7 +82,7 @@ import '@vizel/core/styles.css';
 
 ### useVizelEditor
 
-Creates and manages a Vizel editor instance.
+This composable creates and manages a Vizel editor instance.
 
 ```typescript
 import { useVizelEditor } from '@vizel/vue';
@@ -94,7 +94,7 @@ const editor = useVizelEditor(options?: VizelEditorOptions);
 
 ### useVizelState
 
-Forces re-render on editor state changes.
+This composable forces a re-render on editor state changes.
 
 ```typescript
 import { useVizelState } from '@vizel/vue';
@@ -106,7 +106,7 @@ const updateCount = useVizelState(() => editor.value);
 
 ### useVizelEditorState
 
-Tracks specific editor state properties reactively.
+This composable tracks specific editor state properties reactively.
 
 ```typescript
 import { useVizelEditorState } from '@vizel/vue';
@@ -121,7 +121,7 @@ const isBold = useVizelEditorState(
 
 ### useVizelAutoSave
 
-Auto-saves editor content with debouncing.
+This composable auto-saves editor content with debouncing.
 
 ```typescript
 import { useVizelAutoSave } from '@vizel/vue';
@@ -137,15 +137,15 @@ const result = useVizelAutoSave(
 | Property | Type | Description |
 |----------|------|-------------|
 | `status` | `ComputedRef<VizelSaveStatus>` | Current save status |
-| `hasUnsavedChanges` | `ComputedRef<boolean>` | Has unsaved changes |
+| `hasUnsavedChanges` | `ComputedRef<boolean>` | Whether unsaved changes exist |
 | `lastSaved` | `ComputedRef<Date \| null>` | Last save timestamp |
 | `error` | `ComputedRef<Error \| null>` | Last error |
-| `save` | `() => Promise<void>` | Manual save function |
-| `restore` | `() => Promise<JSONContent \| null>` | Manual restore |
+| `save` | `() => Promise<void>` | Save content manually |
+| `restore` | `() => Promise<JSONContent \| null>` | Restore content manually |
 
 ### useVizelMarkdown
 
-Provides two-way Markdown synchronization with debouncing.
+This composable provides two-way Markdown synchronization with debouncing.
 
 ```typescript
 import { useVizelMarkdown } from '@vizel/vue';
@@ -172,7 +172,7 @@ const result = useVizelMarkdown(
 
 ### useVizelTheme
 
-Access theme state within VizelThemeProvider.
+This composable accesses theme state within VizelThemeProvider.
 
 ```typescript
 import { useVizelTheme } from '@vizel/vue';
@@ -189,13 +189,170 @@ const { theme, resolvedTheme, systemTheme, setTheme } = useVizelTheme();
 | `systemTheme` | `Ref<VizelResolvedTheme>` | System preference |
 | `setTheme` | `(theme: VizelTheme) => void` | Set theme function |
 
+### useVizelCollaboration
+
+This composable tracks real-time collaboration state with a Yjs provider.
+
+```typescript
+import { useVizelCollaboration } from '@vizel/vue';
+
+const {
+  isConnected,
+  isSynced,
+  peerCount,
+  error,
+  connect,
+  disconnect,
+  updateUser,
+} = useVizelCollaboration(
+  () => provider,
+  { user: { name: 'Alice', color: '#ff0000' } }
+);
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getProvider` | `() => VizelYjsProvider \| null \| undefined` | Getter function for the Yjs provider |
+| `options` | `VizelCollaborationOptions` | Collaboration options including user info |
+
+**Returns:** `UseVizelCollaborationResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isConnected` | `ComputedRef<boolean>` | Whether the editor is connected to the server |
+| `isSynced` | `ComputedRef<boolean>` | Whether initial sync is complete |
+| `peerCount` | `ComputedRef<number>` | Number of connected peers |
+| `error` | `ComputedRef<Error \| null>` | Last error |
+| `connect` | `() => void` | Connect to the server |
+| `disconnect` | `() => void` | Disconnect from the server |
+| `updateUser` | `(user: VizelCollaborationUser) => void` | Update user cursor info |
+
+### useVizelComment
+
+This composable manages document comments and annotations.
+
+```typescript
+import { useVizelComment } from '@vizel/vue';
+
+const {
+  comments,
+  activeCommentId,
+  isLoading,
+  error,
+  addComment,
+  removeComment,
+  resolveComment,
+  reopenComment,
+  replyToComment,
+  setActiveComment,
+  loadComments,
+  getCommentById,
+} = useVizelComment(() => editor.value, { key: 'my-comments' });
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelCommentOptions` | Comment configuration options |
+
+**Returns:** `UseVizelCommentResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `comments` | `ComputedRef<VizelComment[]>` | All stored comments (newest first) |
+| `activeCommentId` | `ComputedRef<string \| null>` | Currently active comment ID |
+| `isLoading` | `ComputedRef<boolean>` | Whether comments are loading |
+| `error` | `ComputedRef<Error \| null>` | Last error |
+| `addComment` | `(text: string, author?: string) => Promise<VizelComment \| null>` | Add a comment to the selection |
+| `removeComment` | `(commentId: string) => Promise<void>` | Remove a comment |
+| `resolveComment` | `(commentId: string) => Promise<boolean>` | Resolve a comment |
+| `reopenComment` | `(commentId: string) => Promise<boolean>` | Reopen a comment |
+| `replyToComment` | `(commentId: string, text: string, author?: string) => Promise<VizelCommentReply \| null>` | Reply to a comment |
+| `setActiveComment` | `(commentId: string \| null) => void` | Set the active comment |
+| `loadComments` | `() => Promise<VizelComment[]>` | Load comments from storage |
+| `getCommentById` | `(commentId: string) => VizelComment \| undefined` | Get a comment by ID |
+
+### useVizelVersionHistory
+
+This composable manages document version history with save, restore, and delete operations.
+
+```typescript
+import { useVizelVersionHistory } from '@vizel/vue';
+
+const {
+  snapshots,
+  isLoading,
+  error,
+  saveVersion,
+  restoreVersion,
+  loadVersions,
+  deleteVersion,
+  clearVersions,
+} = useVizelVersionHistory(() => editor.value, { maxVersions: 20 });
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `options` | `VizelVersionHistoryOptions` | Version history configuration |
+
+**Returns:** `UseVizelVersionHistoryResult`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `snapshots` | `ComputedRef<VizelVersionSnapshot[]>` | All stored snapshots (newest first) |
+| `isLoading` | `ComputedRef<boolean>` | Whether history is loading |
+| `error` | `ComputedRef<Error \| null>` | Last error |
+| `saveVersion` | `(description?: string, author?: string) => Promise<VizelVersionSnapshot \| null>` | Save a new version |
+| `restoreVersion` | `(versionId: string) => Promise<boolean>` | Restore a version |
+| `loadVersions` | `() => Promise<VizelVersionSnapshot[]>` | Load versions from storage |
+| `deleteVersion` | `(versionId: string) => Promise<void>` | Delete a version |
+| `clearVersions` | `() => Promise<void>` | Delete all versions |
+
 ---
 
 ## Components
 
+### VizelFindReplace
+
+Find & Replace panel component. This component renders when the Find & Replace extension is open.
+
+```vue
+<script setup lang="ts">
+import { VizelFindReplace } from '@vizel/vue';
+</script>
+
+<template>
+  <VizelFindReplace
+    :editor="editor"
+    class="my-find-replace"
+    @close="() => console.log('Closed')"
+  />
+</template>
+```
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `editor` | `Editor \| null` | - | Editor instance |
+| `class` | `string` | - | CSS class name |
+
+**Events:**
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `close` | - | Fires when the panel closes |
+
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```vue
 <VizelEditor :editor="editor" class="my-editor" />
@@ -210,7 +367,7 @@ Renders the editor content area.
 
 ### VizelBubbleMenu
 
-Floating formatting bubble menu.
+This component renders a floating formatting bubble menu.
 
 ```vue
 <VizelBubbleMenu 
@@ -234,7 +391,7 @@ Floating formatting bubble menu.
 
 ### VizelBubbleMenuDefault
 
-Default bubble menu with all formatting buttons.
+This component renders the default bubble menu with all formatting buttons.
 
 ```vue
 <VizelBubbleMenuDefault 
@@ -252,7 +409,7 @@ Default bubble menu with all formatting buttons.
 
 ### VizelBubbleMenuButton
 
-Individual bubble menu button.
+This component renders an individual bubble menu button.
 
 ```vue
 <VizelBubbleMenuButton
@@ -264,7 +421,7 @@ Individual bubble menu button.
 
 ### VizelBubbleMenuDivider
 
-Bubble menu divider.
+This component renders a bubble menu divider.
 
 ```vue
 <VizelBubbleMenuDivider />
@@ -272,7 +429,7 @@ Bubble menu divider.
 
 ### VizelToolbar
 
-Fixed toolbar component.
+This component renders a fixed toolbar.
 
 ```vue
 <script setup lang="ts">
@@ -300,7 +457,7 @@ import { VizelToolbar } from '@vizel/vue';
 
 ### VizelToolbarDefault
 
-Default toolbar content with grouped formatting buttons.
+This component renders the default toolbar content with grouped formatting buttons.
 
 ```vue
 <VizelToolbarDefault :editor="editor" :actions="customActions" />
@@ -316,7 +473,7 @@ Default toolbar content with grouped formatting buttons.
 
 ### VizelToolbarButton
 
-Individual toolbar button.
+This component renders an individual toolbar button.
 
 ```vue
 <VizelToolbarButton
@@ -340,7 +497,7 @@ Individual toolbar button.
 
 ### VizelToolbarDivider
 
-Divider between toolbar button groups.
+This component renders a divider between toolbar button groups.
 
 ```vue
 <VizelToolbarDivider />
@@ -348,7 +505,7 @@ Divider between toolbar button groups.
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context to its children.
 
 ```vue
 <VizelThemeProvider
@@ -371,7 +528,7 @@ Provides theme context.
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```vue
 <VizelSaveIndicator :status="status" :lastSaved="lastSaved" />
@@ -387,7 +544,7 @@ Displays save status.
 
 ### VizelPortal
 
-Renders content in a portal.
+This component renders its children in a portal.
 
 ```vue
 <VizelPortal :container="document.body">
@@ -403,7 +560,7 @@ Renders content in a portal.
 
 ### VizelColorPicker
 
-Color selection component.
+This component renders a color selection interface.
 
 ```vue
 <VizelColorPicker
@@ -416,7 +573,7 @@ Color selection component.
 
 ### VizelIconProvider
 
-Provides custom icons for Vizel components.
+This component provides custom icons for Vizel components.
 
 ```vue
 <script setup lang="ts">
@@ -450,7 +607,7 @@ const icons: CustomIconMap = {
 
 ### VizelSlashMenu
 
-Slash command menu component.
+This component renders the slash command menu.
 
 ```vue
 <VizelSlashMenu
@@ -466,7 +623,7 @@ Slash command menu component.
 
 ### createVizelSlashMenuRenderer
 
-Creates slash menu renderer for the SlashCommand extension.
+This function creates a slash menu renderer for the SlashCommand extension.
 
 ```typescript
 import { createVizelSlashMenuRenderer } from '@vizel/vue';
@@ -486,7 +643,7 @@ const editor = useVizelEditor({
 
 ## Importing from @vizel/core and @tiptap/core
 
-Framework packages do not re-export from `@vizel/core`. Import directly:
+Framework packages do not re-export from `@vizel/core`. You must import directly:
 
 ```typescript
 // Framework-specific components and composables

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -1,9 +1,9 @@
 # Accessibility
 
-Vizel is built on Tiptap and ProseMirror, which provide a solid foundation for accessible rich text editing. This guide covers keyboard navigation, screen reader support, and best practices for building accessible applications with Vizel.
+Vizel builds on Tiptap and ProseMirror, which provide a solid foundation for accessible rich text editing. This guide covers keyboard navigation, screen reader support, and best practices for building accessible applications with Vizel.
 
 ::: info Note
-Vizel has not undergone a formal accessibility audit. The information below describes built-in capabilities and recommended practices, but does not constitute a WCAG conformance claim.
+Vizel has not undergone a formal accessibility audit. The information below describes built-in capabilities and recommended practices but does not constitute a WCAG conformance claim.
 :::
 
 ## Keyboard Navigation
@@ -91,7 +91,7 @@ Vizel has not undergone a formal accessibility audit. The information below desc
 
 ### ARIA Attributes
 
-Vizel's editor element uses the `contenteditable` attribute, which modern screen readers recognize as an editable region. For improved screen reader support, set ARIA attributes via `editorProps`:
+Vizel's editor element uses the `contenteditable` attribute, which modern screen readers recognize as an editable region. To improve screen reader support, set ARIA attributes via `editorProps`:
 
 ```typescript
 const editor = useVizelEditor({
@@ -109,7 +109,7 @@ const editor = useVizelEditor({
 Recommended ARIA attributes:
 
 - `role="textbox"` — Identifies the editor as a text input region
-- `aria-multiline="true"` — Indicates multi-line editing
+- `aria-multiline="true"` — Indicates that the editor supports multi-line editing
 - `aria-label` — Provides an accessible name for the editor
 
 ### Live Regions
@@ -127,7 +127,7 @@ For dynamic content like save indicators and slash menu results, use ARIA live r
 
 ### Announcing Content Changes
 
-When programmatically updating content, announce changes to screen readers:
+When you programmatically update content, announce changes to screen readers:
 
 ```typescript
 function announceChange(message: string) {
@@ -151,7 +151,7 @@ announceChange('Document content updated');
 
 ### Editor Focus
 
-The editor can be focused programmatically:
+You can focus the editor programmatically:
 
 ```typescript
 // Focus at the end of the document
@@ -166,7 +166,7 @@ editor.commands.focus(42);
 
 ### Skip Navigation
 
-Add a skip link before the editor for keyboard users:
+You can add a skip link before the editor for keyboard users:
 
 ```html
 <a href="#editor-content" class="sr-only focus:not-sr-only">
@@ -182,7 +182,7 @@ Add a skip link before the editor for keyboard users:
 
 ### Focus Trap Considerations
 
-Vizel does **not** trap focus. Users can `Tab` out of the editor to reach other page elements. If your application wraps the editor in a modal or dialog, implement focus trapping at the dialog level, not the editor level.
+Vizel does **not** trap focus. You can `Tab` out of the editor to reach other page elements. If your application wraps the editor in a modal or dialog, implement focus trapping at the dialog level, not the editor level.
 
 ---
 
@@ -190,7 +190,7 @@ Vizel does **not** trap focus. Users can `Tab` out of the editor to reach other 
 
 ### CSS Custom Properties
 
-Vizel uses CSS custom properties for all colors, which makes it compatible with high contrast modes. Override these variables to adjust contrast:
+Vizel uses CSS custom properties for all colors, which makes it compatible with high contrast modes. You can override these variables to adjust contrast:
 
 ```css
 /* High contrast overrides */
@@ -208,7 +208,7 @@ Vizel uses CSS custom properties for all colors, which makes it compatible with 
 
 ### Focus Indicators
 
-Ensure visible focus indicators are present. Vizel provides default focus styles, but you can enhance them:
+Vizel provides default focus styles, but you can enhance them to ensure visible focus indicators:
 
 ```css
 /* Enhanced focus indicators */
@@ -232,7 +232,7 @@ Vizel supports dark mode through CSS custom properties. See [Theming](/guide/the
 
 ## Custom Component Guidelines
 
-When building custom components that interact with Vizel, follow these accessibility guidelines.
+When you build custom components that interact with Vizel, follow these accessibility guidelines.
 
 ### Toolbar Buttons
 
@@ -250,8 +250,8 @@ When building custom components that interact with Vizel, follow these accessibi
 ```
 
 Key attributes:
-- `aria-pressed` — Reflects toggle state for formatting buttons
-- `aria-label` — Accessible name when button only contains an icon
+- `aria-pressed` — Reflects the toggle state for formatting buttons
+- `aria-label` — Provides an accessible name when the button contains only an icon
 - `title` — Shows the keyboard shortcut on hover
 
 ### Dropdown Menus
@@ -295,10 +295,10 @@ Key attributes:
 
 - [ ] **Keyboard only** — Navigate, edit, and format content using only the keyboard
 - [ ] **Screen reader** — Test with VoiceOver (macOS), NVDA (Windows), or Orca (Linux)
-- [ ] **Zoom** — Ensure the editor is usable at 200% zoom
+- [ ] **Zoom** — Verify the editor is usable at 200% zoom
 - [ ] **High contrast** — Test with the OS high-contrast mode enabled
-- [ ] **Reduced motion** — Verify animations respect `prefers-reduced-motion`
-- [ ] **Color contrast** — Check text and interactive elements meet 4.5:1 contrast ratio
+- [ ] **Reduced motion** — Verify that animations respect `prefers-reduced-motion`
+- [ ] **Color contrast** — Confirm that text and interactive elements meet 4.5:1 contrast ratio
 
 ### Reduced Motion
 
@@ -317,7 +317,7 @@ Respect the user's reduced motion preference:
 
 ### Automated Tools
 
-Use automated accessibility testing tools alongside manual testing:
+You can use automated accessibility testing tools alongside manual testing:
 
 - [axe-core](https://github.com/dequelabs/axe-core) — Automated accessibility testing engine
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/accessibility/) — Chrome DevTools accessibility audit

--- a/docs/guide/auto-save.md
+++ b/docs/guide/auto-save.md
@@ -78,15 +78,15 @@ const { status, lastSaved } = useVizelAutoSave(() => editor.value, {
 | `debounceMs` | `number` | `1000` | Debounce delay in milliseconds |
 | `storage` | `StorageBackend` | `"localStorage"` | Storage backend |
 | `key` | `string` | `"vizel-content"` | Storage key |
-| `onSave` | `(content) => void` | - | Callback after successful save |
-| `onError` | `(error) => void` | - | Callback on save error |
-| `onRestore` | `(content) => void` | - | Callback when content is restored |
+| `onSave` | `(content) => void` | - | Fires after a successful save |
+| `onError` | `(error) => void` | - | Fires on a save error |
+| `onRestore` | `(content) => void` | - | Fires when the system restores content |
 
 ## Storage Backends
 
 ### localStorage (Default)
 
-Persists content in the browser's localStorage:
+This backend persists content in the browser's localStorage:
 
 ```typescript
 const { status } = useVizelAutoSave(() => editor, {
@@ -97,7 +97,7 @@ const { status } = useVizelAutoSave(() => editor, {
 
 ### sessionStorage
 
-Persists content only for the current session:
+This backend persists content only for the current session:
 
 ```typescript
 const { status } = useVizelAutoSave(() => editor, {
@@ -108,7 +108,7 @@ const { status } = useVizelAutoSave(() => editor, {
 
 ### Custom Backend
 
-Implement your own storage backend for server-side persistence:
+You can implement your own storage backend for server-side persistence:
 
 ```typescript
 const { status } = useVizelAutoSave(() => editor, {
@@ -135,10 +135,10 @@ const { status } = useVizelAutoSave(() => editor, {
 
 | Value | Description |
 |-------|-------------|
-| `"saved"` | Content is saved and up to date |
-| `"saving"` | Save operation in progress |
-| `"unsaved"` | Unsaved changes pending |
-| `"error"` | Save failed |
+| `"saved"` | Content has been saved and is up to date |
+| `"saving"` | A save operation is in progress |
+| `"unsaved"` | Unsaved changes exist |
+| `"error"` | The last save attempt failed |
 
 ### Properties
 
@@ -153,8 +153,8 @@ const { status } = useVizelAutoSave(() => editor, {
 
 | Method | Description |
 |--------|-------------|
-| `save()` | Manually trigger save |
-| `restore()` | Manually restore content |
+| `save()` | Triggers a save manually |
+| `restore()` | Restores content manually |
 
 ## Manual Save/Restore
 
@@ -245,7 +245,7 @@ useVizelAutoSave(() => editor, { debounceMs: 5000 });
 
 ## Error Handling
 
-Handle save errors:
+You can handle save errors with the `onError` callback:
 
 ```typescript
 const { status, error } = useVizelAutoSave(() => editor, {
@@ -270,7 +270,7 @@ const { status, error } = useVizelAutoSave(() => editor, {
 
 ## Restoring Content on Load
 
-Restore saved content when the editor initializes:
+You can restore saved content when the editor initializes:
 
 ::: code-group
 
@@ -353,7 +353,7 @@ watch(editor, async (ed) => {
 
 ## Disabling Auto-Save
 
-Temporarily disable auto-save:
+You can temporarily disable auto-save:
 
 ```typescript
 const { status } = useVizelAutoSave(() => editor, {

--- a/docs/guide/collaboration.md
+++ b/docs/guide/collaboration.md
@@ -1,6 +1,6 @@
 # Real-Time Collaboration
 
-Vizel supports real-time collaborative editing using [Yjs](https://yjs.dev/), a CRDT-based framework that enables multiple users to edit the same document simultaneously without conflicts.
+Vizel supports real-time collaborative editing using [Yjs](https://yjs.dev/), a CRDT-based framework that lets multiple users edit the same document simultaneously without conflicts.
 
 ## Overview
 
@@ -20,7 +20,7 @@ Vizel supports real-time collaborative editing using [Yjs](https://yjs.dev/), a 
 ```
 
 Vizel provides:
-- **History exclusion** — Automatically disables the built-in History extension when collaboration is enabled (Yjs provides its own undo manager)
+- **History exclusion** — Automatically disables the built-in History extension when you enable collaboration (Yjs provides its own undo manager)
 - **State tracking** — Framework hooks/composables/runes for tracking connection status, sync state, and peer count
 - **Lifecycle management** — Automatic setup and cleanup of event listeners
 
@@ -40,7 +40,7 @@ Ensure your `@tiptap/extension-collaboration` version is compatible with the `@t
 
 ### 1. Start a Yjs WebSocket Server
 
-You need a Yjs-compatible WebSocket server for synchronization. The simplest option is `y-websocket`:
+You need a Yjs-compatible WebSocket server for synchronization. The simplest option uses `y-websocket`:
 
 ```bash
 npx y-websocket
@@ -205,17 +205,17 @@ const editor = createVizelEditor({
 
 ### Options
 
-The collaboration hooks accept these options:
+The collaboration hook/composable/rune accepts these options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Enable collaboration state tracking |
 | `user` | `{ name, color }` | Required | Current user info for cursor display |
-| `onConnect` | `() => void` | — | Callback when connected to server |
-| `onDisconnect` | `() => void` | — | Callback when disconnected |
-| `onSynced` | `() => void` | — | Callback when initial sync completes |
-| `onError` | `(error) => void` | — | Callback when an error occurs |
-| `onPeersChange` | `(count) => void` | — | Callback when peer count changes |
+| `onConnect` | `() => void` | — | Runs when the client connects to the server |
+| `onDisconnect` | `() => void` | — | Runs when the client disconnects |
+| `onSynced` | `() => void` | — | Runs when initial sync completes |
+| `onError` | `(error) => void` | — | Runs when an error occurs |
+| `onPeersChange` | `(count) => void` | — | Runs when the peer count changes |
 
 ### Return Values
 
@@ -245,17 +245,17 @@ const editor = useVizelEditor({
 
 ### How Collaboration Works
 
-1. **CRDT (Conflict-free Replicated Data Type)** — Yjs uses CRDTs to merge concurrent edits without conflicts. Each client can edit independently, and changes are automatically merged.
+1. **CRDT (Conflict-free Replicated Data Type)** — Yjs uses CRDTs to merge concurrent edits without conflicts. Each client can edit independently, and Yjs automatically merges changes.
 
-2. **Awareness** — Yjs Awareness protocol tracks ephemeral state like cursor positions, user names, and colors. This is separate from the document and is not persisted.
+2. **Awareness** — The Yjs Awareness protocol tracks ephemeral state like cursor positions, user names, and colors. This state is separate from the document and is not persisted.
 
-3. **History** — When collaboration is enabled, the built-in Tiptap History extension must be disabled because Yjs provides `Y.UndoManager` which understands CRDT operations. The standard History extension would conflict with collaborative edits.
+3. **History** — When you enable collaboration, you must disable the built-in Tiptap History extension because Yjs provides `Y.UndoManager`, which understands CRDT operations. The standard History extension would conflict with collaborative edits.
 
 ### Offline Support
 
 Yjs automatically handles offline scenarios:
-- Edits made offline are stored locally
-- When reconnecting, changes are automatically synced and merged
+- Yjs stores edits made offline locally
+- When reconnecting, Yjs automatically syncs and merges changes
 - No data loss occurs even with extended offline periods
 
 ## Server Setup
@@ -319,20 +319,20 @@ Yjs supports multiple transport providers:
 
 **Problem**: Undo/redo behaves unexpectedly with collaboration enabled.
 
-**Solution**: Ensure `features.collaboration` is set to `true` in your editor options. This disables the built-in History extension that conflicts with Yjs's undo manager.
+**Solution**: Set `features.collaboration` to `true` in your editor options. This disables the built-in History extension that conflicts with Yjs's undo manager.
 
 ### Connection Issues
 
 **Problem**: WebSocket connection fails or keeps disconnecting.
 
 **Solution**:
-1. Verify the WebSocket server is running
+1. Verify that the WebSocket server is running
 2. Check that the server URL is correct (including protocol `ws://` or `wss://`)
-3. For production, ensure your reverse proxy supports WebSocket connections
+3. For production, confirm that your reverse proxy supports WebSocket connections
 4. Check CORS settings if the server is on a different origin
 
 ### Cursor Colors Not Showing
 
 **Problem**: Remote cursors appear but without colors.
 
-**Solution**: Ensure you pass the `user` object with both `name` and `color` properties to both `CollaborationCursor.configure()` and the collaboration hook.
+**Solution**: Pass the `user` object with both `name` and `color` properties to both `CollaborationCursor.configure()` and the collaboration hook/composable/rune.

--- a/docs/guide/comments.md
+++ b/docs/guide/comments.md
@@ -1,12 +1,12 @@
 # Comments & Annotations
 
-Vizel provides a comment/annotation system that allows users to add comments to specific text selections in the editor.
+Vizel provides a comment/annotation system that lets you add comments to specific text selections in the editor.
 
 ## Overview
 
 Comments enable:
 
-- **Annotate text** — add comments to any text selection
+- **Text annotation** — add comments to any text selection
 - **Reply threads** — discuss specific passages
 - **Resolve/reopen** — track comment status
 - **Storage flexibility** — use localStorage or a custom backend
@@ -126,7 +126,7 @@ function handleAddComment() {
 
 ## Enabling the Feature
 
-The comment feature is **disabled by default**. Enable it via `features.comment`:
+The comment feature is **disabled by default**. You can enable it via `features.comment`:
 
 ```typescript
 const editor = useVizelEditor({
@@ -258,7 +258,7 @@ In Vue, `comments`, `activeCommentId`, `isLoading`, and `error` are `ComputedRef
 
 ## Styling
 
-Comment highlights use the following CSS classes:
+Comment highlights use these CSS classes:
 
 | Class | Description |
 |-------|-------------|
@@ -283,7 +283,7 @@ Comment highlights use the following CSS classes:
 
 ## Core Handlers
 
-For advanced use cases, use the core handlers directly:
+For advanced use cases, you can use the core handlers directly:
 
 ```typescript
 import {

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -19,12 +19,12 @@ The main configuration object passed to `useVizelEditor` (React/Vue) or `createV
 
 | Callback | Type | Description |
 |----------|------|-------------|
-| `onUpdate` | `({ editor }) => void` | Called when content changes |
-| `onCreate` | `({ editor }) => void` | Called when editor is created |
-| `onDestroy` | `() => void` | Called when editor is destroyed |
-| `onSelectionUpdate` | `({ editor }) => void` | Called when selection changes |
-| `onFocus` | `({ editor }) => void` | Called when editor receives focus |
-| `onBlur` | `({ editor }) => void` | Called when editor loses focus |
+| `onUpdate` | `({ editor }) => void` | Fires when content changes |
+| `onCreate` | `({ editor }) => void` | Fires when the editor initializes |
+| `onDestroy` | `() => void` | Fires when the editor unmounts |
+| `onSelectionUpdate` | `({ editor }) => void` | Fires when selection changes |
+| `onFocus` | `({ editor }) => void` | Fires when the editor receives focus |
+| `onBlur` | `({ editor }) => void` | Fires when the editor loses focus |
 
 ### Example
 
@@ -109,16 +109,16 @@ const editor = createVizelEditor({
 
 ## Autofocus Options
 
-The `autofocus` option controls where the cursor is placed when the editor mounts:
+The `autofocus` option controls where the editor places the cursor on mount:
 
 | Value | Description |
 |-------|-------------|
 | `false` | No autofocus (default) |
-| `true` | Focus at the start |
-| `"start"` | Focus at the start of the document |
-| `"end"` | Focus at the end of the document |
-| `"all"` | Select all content |
-| `number` | Focus at specific position |
+| `true` | Focuses at the start |
+| `"start"` | Focuses at the start of the document |
+| `"end"` | Focuses at the end of the document |
+| `"all"` | Selects all content |
+| `number` | Focuses at a specific position |
 
 ```typescript
 // Focus at end of document
@@ -158,7 +158,7 @@ const isEditable = editor.isEditable;
 
 ## Custom Extensions
 
-Add additional Tiptap extensions alongside Vizel's defaults:
+You can add additional Tiptap extensions alongside Vizel's defaults:
 
 ```typescript
 import { useVizelEditor } from '@vizel/react';
@@ -174,12 +174,12 @@ const editor = useVizelEditor({
 ```
 
 ::: warning Extension Conflicts
-Be careful when adding extensions that might conflict with Vizel's built-in extensions. If you need to customize a built-in extension, disable the feature and add your own configuration.
+Be careful when you add extensions that might conflict with Vizel's built-in extensions. If you need to customize a built-in extension, disable the feature and add your own configuration.
 :::
 
 ## Editor State
 
-Access editor state programmatically:
+You can access editor state programmatically:
 
 ```typescript
 import { getVizelEditorState } from '@vizel/core';

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -1,10 +1,10 @@
 # Features
 
-Each feature can be enabled, disabled, or customized through the `features` option.
+You can enable, disable, or customize each feature through the `features` option.
 
 ## Feature Overview
 
-All features are enabled by default. Set any feature to `false` to disable it.
+Vizel enables all features by default. Set any feature to `false` to disable it.
 
 ```mermaid
 graph TB
@@ -23,6 +23,11 @@ graph TB
         Embed["Embeds"]
         Details["Details"]
         Diagram["Diagrams"]
+        WikiLink["Wiki Links"]
+        Comment["Comments"]
+    end
+    subgraph opt["Opt-in Features"]
+        Collaboration["Collaboration"]
     end
 ```
 
@@ -42,6 +47,9 @@ graph TB
 | `embed` | URL embeds (YouTube, etc.) |
 | `details` | Collapsible content blocks |
 | `diagram` | Mermaid/GraphViz diagrams |
+| `wikiLink` | Wiki-style internal links (`[[page-name]]`) |
+| `comment` | Text annotations and comments |
+| `collaboration` | Real-time collaboration mode (disables History) |
 
 ## Disabling Features
 
@@ -113,7 +121,7 @@ const editor = useVizelEditor({
 
 ## Images
 
-Supports drag and drop, paste, and resize.
+The image feature supports drag and drop, paste, and resize.
 
 ### Options
 
@@ -172,7 +180,7 @@ const editor = useVizelEditor({
 
 ## Code Blocks
 
-Code blocks with syntax highlighting and language selection.
+This feature provides code blocks with syntax highlighting and language selection.
 
 ### Options
 
@@ -204,7 +212,7 @@ const editor = useVizelEditor({
 
 ## Character Count
 
-Track character and word counts.
+This feature tracks character and word counts.
 
 ### Options
 
@@ -237,7 +245,7 @@ const percentage = (chars / limit) * 100;
 
 ## Text Color & Highlight
 
-Text color and background highlight support.
+This feature adds text color and background highlight support.
 
 ### Options
 
@@ -276,7 +284,7 @@ const editor = useVizelEditor({
 
 ## Markdown
 
-Enable Markdown import/export.
+This feature enables Markdown import/export.
 
 ### Options
 
@@ -315,7 +323,7 @@ editor.commands.setContent(
 
 ## Mathematics
 
-LaTeX math equations rendered with KaTeX.
+This feature renders LaTeX math equations with KaTeX.
 
 ### Options
 
@@ -351,7 +359,7 @@ const editor = useVizelEditor({
 
 ## Embeds
 
-Embed content from URLs (YouTube, Vimeo, Twitter).
+This feature embeds content from URLs (YouTube, Vimeo, Twitter).
 
 ### Options
 
@@ -403,7 +411,7 @@ const editor = useVizelEditor({
 
 ## Details
 
-Collapsible content blocks (accordion/disclosure).
+This feature provides collapsible content blocks (accordion/disclosure).
 
 ### Options
 
@@ -431,7 +439,7 @@ Use the slash command `/details` or `/toggle` to insert a collapsible block.
 
 ## Diagrams
 
-Mermaid and GraphViz diagrams.
+This feature supports Mermaid and GraphViz diagrams.
 
 ### Options
 
@@ -474,7 +482,7 @@ const editor = useVizelEditor({
 
 ## Links
 
-Link editing and auto-linking.
+This feature provides link editing and auto-linking.
 
 ### Options
 
@@ -509,7 +517,7 @@ const editor = useVizelEditor({
 
 ## Task Lists
 
-Checkbox task lists.
+This feature adds checkbox task lists.
 
 ### Options
 
@@ -536,7 +544,7 @@ const editor = useVizelEditor({
 
 ## Drag Handle
 
-Handle for drag-and-drop block reordering.
+This feature provides a handle for drag-and-drop block reordering.
 
 ### Options
 
@@ -558,8 +566,93 @@ const editor = useVizelEditor({
 
 ---
 
+## Wiki Links
+
+This feature adds wiki-style `[[page-name]]` links for linking between pages. It supports display text aliases with `[[page-name|display text]]` syntax.
+
+### Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `resolveLink` | `(pageName: string) => string` | `(p) => '#' + p` | Resolves a page name to a URL |
+| `pageExists` | `(pageName: string) => boolean` | `() => true` | Checks if a page exists |
+| `getPageSuggestions` | `(query: string) => VizelWikiLinkSuggestion[]` | - | Autocomplete suggestions |
+| `onLinkClick` | `(pageName: string, event: MouseEvent) => void` | - | Click callback |
+
+### Example
+
+```typescript
+const editor = useVizelEditor({
+  features: {
+    wikiLink: {
+      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+      pageExists: (page) => knownPages.has(page),
+    },
+  },
+});
+```
+
+See the [Wiki Links Guide](/guide/wiki-links) for detailed usage.
+
+---
+
+## Comments
+
+This feature adds text annotation marks for reviewing and discussion.
+
+### Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable comment marks |
+
+### Example
+
+```typescript
+const editor = useVizelEditor({
+  features: {
+    comment: true,
+  },
+});
+```
+
+Comment management (storage, replies, resolution) uses the framework-specific hooks/composables/runes. See the [Comments Guide](/guide/comments) for details.
+
+---
+
+## Collaboration
+
+This feature enables real-time multi-user editing built on Yjs. When you enable it, Vizel disables the built-in History extension (Yjs handles undo/redo).
+
+::: warning
+This opt-in feature requires additional dependencies: `yjs`, a Yjs provider, `@tiptap/extension-collaboration`, and `@tiptap/extension-collaboration-cursor`.
+:::
+
+### Example
+
+```typescript
+const editor = useVizelEditor({
+  features: {
+    collaboration: true, // Disables History
+  },
+  extensions: [
+    Collaboration.configure({ document: ydoc }),
+    CollaborationCursor.configure({ provider, user }),
+  ],
+});
+```
+
+See the [Collaboration Guide](/guide/collaboration) for setup instructions.
+
+---
+
 ## Next Steps
 
+- [Wiki Links](/guide/wiki-links) - Wiki-style internal links
+- [Comments](/guide/comments) - Text annotations and comments
+- [Version History](/guide/version-history) - Document snapshots
+- [Collaboration](/guide/collaboration) - Real-time multi-user editing
+- [Plugins](/guide/plugins) - Extend Vizel with plugins
 - [Theming](/guide/theming) - Customize the appearance
 - [Auto-Save](/guide/auto-save) - Persist content automatically
 - [API Reference](/api/)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ yarn add @vizel/svelte
 :::
 
 ::: info Peer Dependencies
-Each framework package has peer dependencies on its respective framework:
+Each framework package requires its respective framework as a peer dependency:
 - `@vizel/react` requires `react@^19` and `react-dom@^19`
 - `@vizel/vue` requires `vue@^3`
 - `@vizel/svelte` requires `svelte@^5`
@@ -90,7 +90,7 @@ This includes both CSS variables and component styles. For custom theming, see [
 
 ## Advanced Usage
 
-To customize the editor, use individual components:
+To customize the editor, you can use individual components:
 
 ### React
 
@@ -156,7 +156,7 @@ const editor = useVizelEditor({
 
 ## Toolbar
 
-Enable the built-in fixed toolbar for a traditional formatting bar above the editor:
+You can enable the built-in fixed toolbar for a traditional formatting bar above the editor:
 
 ::: code-group
 
@@ -180,11 +180,11 @@ The toolbar includes undo/redo, text formatting, headings, lists, and block acti
 
 ### Initial Content
 
-Initialize the editor with **Markdown** or **JSON** format.
+You can initialize the editor with **Markdown** or **JSON** format.
 
 #### Using Markdown
 
-Initialize with Markdown:
+You can initialize with Markdown:
 
 ::: code-group
 
@@ -240,7 +240,7 @@ const editor = createVizelEditor({
 
 #### Using JSON
 
-Initialize with JSON format:
+You can initialize with JSON format:
 
 ::: code-group
 
@@ -305,7 +305,7 @@ const editor = createVizelEditor({
 
 ### Getting Content
 
-Access the editor content:
+You can access the editor content in multiple formats:
 
 ```typescript
 // Get JSON content
@@ -418,7 +418,7 @@ let markdown = $state('# Hello World');
 
 ## Enabling Features
 
-Enable optional features through the `features` option:
+You can enable optional features through the `features` option:
 
 ::: code-group
 
@@ -476,7 +476,7 @@ See [Features](/guide/features) for detailed configuration of each feature.
 
 ## Image Upload
 
-Configure image uploads with a custom handler:
+You can configure image uploads with a custom handler:
 
 ::: code-group
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -55,10 +55,10 @@ graph LR
 
 ### Development
 
-- **TypeScript** - Written in TypeScript with exported type definitions
-- **Multi-Framework** - Consistent APIs across React, Vue, and Svelte
-- **Extensible** - Built on Tiptap's extension architecture
-- **Tree-shakeable** - Packages support tree-shaking
+- **TypeScript** - Vizel uses TypeScript with exported type definitions
+- **Multi-Framework** - Vizel provides consistent APIs across React, Vue, and Svelte
+- **Extensible** - Vizel builds on Tiptap's extension architecture
+- **Tree-shakeable** - All packages support tree-shaking
 
 ## Package Architecture
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -1,12 +1,12 @@
 # Performance Optimization
 
-Strategies for optimizing Vizel editor performance in production applications.
+This guide covers strategies for optimizing Vizel editor performance in production applications.
 
 ## Bundle Size Optimization
 
 ### Disable Unused Features
 
-All features are enabled by default. Disable features you don't use to reduce bundle size and extension processing:
+Vizel enables all features by default. Disable features you don't use to reduce bundle size and extension processing:
 
 ```typescript
 const editor = useVizelEditor({
@@ -23,7 +23,7 @@ const editor = useVizelEditor({
 
 ### Feature Size Impact
 
-Approximate sizes (minified + gzipped) of optional features:
+The following table shows approximate sizes (minified + gzipped) of optional features:
 
 | Feature | Approximate Size | Dependencies |
 |---------|-----------------|--------------|
@@ -38,7 +38,7 @@ Approximate sizes (minified + gzipped) of optional features:
 | `details` | ~2KB gzipped | Built-in |
 
 ::: tip Measurement
-Actual bundle sizes depend on your bundler configuration and tree-shaking. Use tools like [bundlephobia](https://bundlephobia.com/) or your bundler's analysis output to measure exact sizes:
+Actual bundle sizes depend on your bundler configuration and tree-shaking. You can use tools like [bundlephobia](https://bundlephobia.com/) or your bundler's analysis output to measure exact sizes:
 
 ```bash
 # Vite
@@ -51,9 +51,9 @@ npx webpack-bundle-analyzer
 
 ### Lazy Loading
 
-Vizel uses `createLazyLoader()` internally for optional dependencies like Mermaid. Diagram rendering is lazy-loaded on first use, so simply having the feature enabled doesn't add to initial load time.
+Vizel uses `createLazyLoader()` internally for optional dependencies like Mermaid. Vizel lazy-loads diagram rendering on first use, so simply having the feature enabled does not add to initial load time.
 
-For CSS, you can also lazy-load optional stylesheets:
+You can also lazy-load optional CSS stylesheets:
 
 ```typescript
 // Only import mathematics CSS when the feature is used
@@ -64,7 +64,7 @@ if (useMathematics) {
 
 ### Code Block Language Optimization
 
-By default, code blocks load all common languages. Limit to only the languages you need:
+By default, code blocks load all common languages. You can limit this to only the languages you need:
 
 ```typescript
 import { createLowlight } from 'lowlight';
@@ -99,7 +99,7 @@ const lowlight = createLowlight(common);
 
 ### Character Count Limits
 
-Use the character count feature to enforce document size limits:
+You can use the character count feature to enforce document size limits:
 
 ```typescript
 const editor = useVizelEditor({
@@ -113,7 +113,7 @@ const editor = useVizelEditor({
 
 ### Optimize onUpdate Handlers
 
-Avoid expensive operations on every keystroke:
+You should avoid expensive operations on every keystroke:
 
 ```typescript
 // Bad: Expensive serialization on every keystroke
@@ -223,7 +223,7 @@ const editor = useVizelEditor({
 
 ### Debounce Timing
 
-Choose a debounce value that balances responsiveness with performance:
+Choose a debounce value that balances responsiveness and performance:
 
 | Use Case | Recommended `debounceMs` |
 |----------|-------------------------|
@@ -248,9 +248,9 @@ See [Auto-Save](/guide/auto-save) for detailed configuration.
 
 ### React
 
-- Avoid creating a new `onUpdate` function on every render — use `useCallback` or define outside the component
-- Use `React.memo` for toolbar components that receive the editor instance
-- Do not store the entire editor state in React state — use `useVizelEditorState` for reactive state tracking
+- Avoid creating a new `onUpdate` function on every render. Use `useCallback` or define the function outside the component.
+- Wrap toolbar components that receive the editor instance with `React.memo`
+- Do not store the entire editor state in React state. Use the `useVizelEditorState` hook for reactive state tracking.
 
 ```tsx
 import { useVizelEditor, useVizelEditorState } from '@vizel/react';
@@ -272,8 +272,8 @@ function Editor() {
 
 ### Vue
 
-- Use `shallowRef` for the editor instance (this is done automatically by `useVizelEditor`)
-- Avoid `watch` with `deep: true` on the editor — use `useVizelEditorState` instead
+- Use `shallowRef` for the editor instance (`useVizelEditor` does this automatically)
+- Avoid `watch` with `deep: true` on the editor. Use the `useVizelEditorState` composable instead.
 - Use `computed` for derived values from editor state
 
 ```vue
@@ -290,8 +290,8 @@ const { characterCount, wordCount } = useVizelEditorState(() => editor.value);
 ### Svelte
 
 - Svelte 5 runes handle reactivity efficiently by default
-- Use `createVizelEditorState` for reactive state tracking
-- Avoid frequent `$effect` calls that read the editor state — batch updates
+- Use the `createVizelEditorState` rune for reactive state tracking
+- Avoid frequent `$effect` calls that read the editor state. Batch updates instead.
 
 ```svelte
 <script lang="ts">
@@ -310,15 +310,15 @@ const { characterCount, wordCount } = useVizelEditorState(() => editor.value);
 
 ## Production Checklist
 
-Before deploying to production, verify these optimizations:
+Before deploying to production, verify the following optimizations:
 
-- [ ] **Disable unused features** — Remove features not used in your application
-- [ ] **Optimize code block languages** — Only register languages you need
-- [ ] **Configure auto-save debouncing** — Set appropriate `debounceMs` for your use case
+- [ ] **Disable unused features** — Remove features your application does not use
+- [ ] **Optimize code block languages** — Register only the languages you need
+- [ ] **Configure auto-save debouncing** — Set an appropriate `debounceMs` for your use case
 - [ ] **Debounce onUpdate handlers** — Avoid expensive operations on every keystroke
 - [ ] **Set character count limits** — Prevent excessively large documents if applicable
-- [ ] **Lazy load optional CSS** — Only import `mathematics.css` if using math features
-- [ ] **Enable compression** — Ensure gzip or brotli compression is configured on your server
+- [ ] **Lazy load optional CSS** — Import `mathematics.css` only if you use math features
+- [ ] **Enable compression** — Configure gzip or brotli compression on your server
 - [ ] **Analyze bundle size** — Use bundle analysis tools to identify optimization opportunities
 - [ ] **Test with realistic content** — Profile with documents similar to production usage
 

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,6 +1,6 @@
 # Plugin System
 
-Vizel provides a plugin system that allows third-party developers to extend the editor with custom functionality in a structured and discoverable way.
+Vizel provides a plugin system that lets you extend the editor with custom functionality in a structured and discoverable way.
 
 ## Overview
 
@@ -93,7 +93,7 @@ interface VizelPlugin {
 
 ## Plugin Manager
 
-The `VizelPluginManager` class handles plugin registration, lifecycle, and extension aggregation.
+`VizelPluginManager` handles plugin registration, lifecycle, and extension aggregation.
 
 ### Methods
 
@@ -110,7 +110,7 @@ The `VizelPluginManager` class handles plugin registration, lifecycle, and exten
 
 ### Registration Order
 
-Plugins with dependencies must be registered after their dependencies:
+Register plugins with dependencies after their dependencies:
 
 ```typescript
 const plugins = new VizelPluginManager();
@@ -126,7 +126,7 @@ plugins.register(advancedPlugin); // has dependencies: ["base-plugin"]
 
 ### `onInstall`
 
-Called when the editor is connected via `setEditor()`, or immediately if the editor is already connected when `register()` is called.
+Runs when you connect the editor via `setEditor()`, or immediately if the editor is already connected when you call `register()`.
 
 ```typescript
 const myPlugin: VizelPlugin = {
@@ -141,7 +141,7 @@ const myPlugin: VizelPlugin = {
 
 ### `onUninstall`
 
-Called when the plugin is unregistered or when `destroy()` is called.
+Runs when you unregister the plugin or call `destroy()`.
 
 ```typescript
 const myPlugin: VizelPlugin = {
@@ -155,7 +155,7 @@ const myPlugin: VizelPlugin = {
 
 ### `onTransaction`
 
-Called on every editor transaction. Use this for reactive behavior like tracking changes or updating UI.
+Runs on every editor transaction. Use this for reactive behavior like tracking changes or updating UI.
 
 ```typescript
 const wordCountPlugin: VizelPlugin = {
@@ -170,12 +170,12 @@ const wordCountPlugin: VizelPlugin = {
 ```
 
 ::: warning
-`onTransaction` is called frequently. Keep handlers lightweight to avoid performance issues.
+`onTransaction` runs frequently. Keep handlers lightweight to avoid performance issues.
 :::
 
 ## Style Injection
 
-Plugin styles are automatically injected into `<head>` and cleaned up on unregistration.
+Vizel automatically injects plugin styles into `<head>` and cleans them up on unregistration.
 
 ```typescript
 const themedPlugin: VizelPlugin = {
@@ -194,19 +194,19 @@ const themedPlugin: VizelPlugin = {
 };
 ```
 
-Each plugin's styles are wrapped in a `<style>` element with id `vizel-plugin-style-{name}`, ensuring:
+Vizel wraps each plugin's styles in a `<style>` element with id `vizel-plugin-style-{name}`, ensuring:
 
 - No duplicate style injection
-- Clean removal when the plugin is unregistered
+- Clean removal when you unregister the plugin
 - Compatibility with Vizel's theming system
 
 ## Dependencies
 
 Plugins can declare dependencies on other plugins. The plugin system:
 
-- Verifies dependencies are registered before allowing registration
+- Verifies that dependencies are registered before allowing registration
 - Resolves dependency order when aggregating extensions via `getExtensions()`
-- Prevents unregistering plugins that others depend on
+- Prevents you from unregistering plugins that others depend on
 - Detects circular dependencies
 
 ```typescript
@@ -324,7 +324,7 @@ $effect(() => {
 
 ## Validation
 
-The plugin system validates plugins on registration:
+The plugin system validates each plugin on registration:
 
 | Check | Error |
 |-------|-------|

--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -106,7 +106,7 @@ import { Vizel } from '@vizel/react';
 
 ### useVizelEditor
 
-Creates and manages a Vizel editor instance.
+This hook creates and manages a Vizel editor instance.
 
 ```tsx
 import { useVizelEditor } from '@vizel/react';
@@ -134,11 +134,11 @@ See [Configuration](/guide/configuration) for full options.
 
 #### Return Value
 
-Returns `Editor | null`. The editor instance is `null` during SSR and before initialization.
+Returns `Editor | null`. The editor instance starts as `null` during SSR and before initialization.
 
 ### useVizelState
 
-Forces component re-render on editor state changes.
+This hook forces a component re-render on editor state changes.
 
 ```tsx
 import { useVizelState } from '@vizel/react';
@@ -161,7 +161,7 @@ function EditorStats({ editor }) {
 
 ### useVizelAutoSave
 
-Automatically saves editor content.
+This hook automatically saves editor content.
 
 ```tsx
 import { useVizelAutoSave, VizelEditor, VizelSaveIndicator } from '@vizel/react';
@@ -188,7 +188,7 @@ function Editor() {
 
 ### useVizelMarkdown
 
-Two-way Markdown synchronization with debouncing.
+This hook provides two-way Markdown synchronization with debouncing.
 
 ```tsx
 import { useVizelEditor, useVizelMarkdown, VizelEditor } from '@vizel/react';
@@ -222,7 +222,7 @@ function MarkdownEditor() {
 
 ### useVizelTheme
 
-Access theme state within VizelThemeProvider.
+This hook accesses theme state within `VizelThemeProvider`.
 
 ```tsx
 import { useVizelTheme, VizelThemeProvider } from '@vizel/react';
@@ -251,7 +251,7 @@ function App() {
 
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```tsx
 <VizelEditor 
@@ -269,7 +269,7 @@ Renders the editor content area.
 
 ### VizelBubbleMenu
 
-Floating bubble menu on text selection.
+This component displays a floating bubble menu on text selection.
 
 ```tsx
 <VizelBubbleMenu 
@@ -294,7 +294,7 @@ Floating bubble menu on text selection.
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context.
 
 ```tsx
 <VizelThemeProvider 
@@ -317,7 +317,7 @@ Provides theme context.
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```tsx
 <VizelSaveIndicator 
@@ -329,7 +329,7 @@ Displays save status.
 
 ### VizelPortal
 
-Renders children in a portal.
+This component renders children in a portal.
 
 ```tsx
 <VizelPortal container={document.body}>
@@ -482,7 +482,7 @@ function CustomBubbleMenu({ editor }: { editor: Editor | null }) {
 
 ## SSR Considerations
 
-The editor is client-side only. Use dynamic import or check for browser:
+The editor runs on the client side only. Use dynamic import or check for the browser environment:
 
 ```tsx
 import dynamic from 'next/dynamic';

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -106,7 +106,7 @@ All-in-one editor component with built-in bubble menu.
 
 ### createVizelEditor
 
-Creates and manages a Vizel editor instance using Svelte 5 runes.
+This rune creates and manages a Vizel editor instance using Svelte 5 reactivity.
 
 ```svelte
 <script lang="ts">
@@ -136,7 +136,7 @@ Returns `{ current: Editor | null }`. Access the editor via `editor.current`.
 
 ### createVizelState
 
-Forces component re-render on editor state changes.
+This rune forces a component re-render on editor state changes.
 
 ```svelte
 <script lang="ts">
@@ -158,7 +158,7 @@ Forces component re-render on editor state changes.
 
 ### createVizelAutoSave
 
-Automatically saves editor content.
+This rune automatically saves editor content.
 
 ```svelte
 <script lang="ts">
@@ -181,7 +181,7 @@ Automatically saves editor content.
 
 ### createVizelMarkdown
 
-Two-way Markdown synchronization with debouncing.
+This rune provides two-way Markdown synchronization with debouncing.
 
 ```svelte
 <script lang="ts">
@@ -210,7 +210,7 @@ Two-way Markdown synchronization with debouncing.
 
 ### getVizelTheme
 
-Access theme state within VizelThemeProvider context.
+This rune accesses theme state within `VizelThemeProvider` context.
 
 ```svelte
 <script lang="ts">
@@ -235,7 +235,7 @@ Access theme state within VizelThemeProvider context.
 
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```svelte
 <VizelEditor 
@@ -253,7 +253,7 @@ Renders the editor content area.
 
 ### VizelBubbleMenu
 
-Floating bubble menu on text selection.
+This component displays a floating bubble menu on text selection.
 
 ```svelte
 <VizelBubbleMenu 
@@ -278,7 +278,7 @@ Floating bubble menu on text selection.
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context.
 
 ```svelte
 <VizelThemeProvider 
@@ -301,7 +301,7 @@ Provides theme context.
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```svelte
 <VizelSaveIndicator 
@@ -313,7 +313,7 @@ Displays save status.
 
 ### VizelPortal
 
-Renders children in a portal.
+This component renders children in a portal.
 
 ```svelte
 <VizelPortal container={document.body}>
@@ -496,7 +496,7 @@ Renders children in a portal.
 
 ## SSR/SvelteKit Considerations
 
-The editor is client-side only. Use `browser` check or `onMount`:
+The editor runs on the client side only. Use a `browser` check or `onMount`:
 
 ```svelte
 <script lang="ts">

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -1,12 +1,12 @@
 # Theming
 
-Customize colors, typography, and spacing using CSS variables.
+You can customize colors, typography, and spacing using CSS variables.
 
 ## Importing Styles
 
 ### Default Styles
 
-Import the stylesheet:
+Import the default stylesheet:
 
 ```typescript
 import '@vizel/core/styles.css';
@@ -145,7 +145,7 @@ const { theme, resolvedTheme, setTheme } = useVizelTheme();
 
 ## CSS Variables
 
-Vizel uses CSS custom properties (variables) for all visual styling. Override these to customize the appearance.
+Vizel uses CSS custom properties (variables) for all visual styling. You can override these to customize the appearance.
 
 ### Theme Selectors
 
@@ -423,7 +423,7 @@ Vizel uses the OKLCH color space for all color values. Here's an example of cust
 
 ## shadcn/ui Integration
 
-Map shadcn/ui CSS variables to Vizel. Note that shadcn/ui uses HSL format while Vizel uses OKLCH, but CSS custom properties can reference each other:
+You can map shadcn/ui CSS variables to Vizel. Note that shadcn/ui uses HSL format while Vizel uses OKLCH, but CSS custom properties can reference each other:
 
 ```css
 :root {
@@ -452,7 +452,7 @@ For detailed integration instructions, see the [CSS Variables Reference](/api/cs
 
 ## Preventing Flash of Unstyled Content
 
-Add the theme init script to your HTML `<head>` to prevent flash:
+Add the theme init script to your HTML `<head>` to prevent a flash of unstyled content:
 
 ```typescript
 import { getVizelThemeInitScript } from '@vizel/core';

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -6,7 +6,7 @@ Common issues and solutions when using Vizel.
 
 ### CSS Not Loaded
 
-If the editor appears unstyled or broken, ensure CSS is imported:
+If the editor appears unstyled or broken, ensure you import the CSS:
 
 ```typescript
 // Import Vizel styles
@@ -21,7 +21,7 @@ import '@vizel/core/mathematics.css';
 
 ### Editor Instance is Null
 
-The editor hook/composable returns `null` until initialization completes:
+The editor hook/composable/rune returns `null` until initialization completes:
 
 ::: code-group
 
@@ -71,7 +71,7 @@ const editor = useVizelEditor({});
 
 ### Console Errors
 
-Check the browser console for initialization errors. Common issues include:
+Check your browser console for initialization errors. Common issues include:
 
 - Missing peer dependencies
 - Extension conflicts
@@ -83,7 +83,7 @@ Check the browser console for initialization errors. Common issues include:
 
 ### Upload Handler Not Configured
 
-By default, Vizel converts images to Base64. For production, configure a custom upload handler:
+By default, Vizel converts images to Base64. For production, you should configure a custom upload handler:
 
 ```typescript
 const editor = useVizelEditor({
@@ -112,7 +112,7 @@ const editor = useVizelEditor({
 
 ### File Size Exceeded
 
-Configure `maxFileSize` and handle validation errors:
+You can configure `maxFileSize` and handle validation errors:
 
 ```typescript
 const editor = useVizelEditor({
@@ -131,7 +131,7 @@ const editor = useVizelEditor({
 
 ### Invalid File Type
 
-Configure allowed MIME types:
+You can configure allowed MIME types:
 
 ```typescript
 const editor = useVizelEditor({
@@ -150,7 +150,7 @@ const editor = useVizelEditor({
 
 ### Network Errors
 
-Handle upload failures gracefully:
+You should handle upload failures gracefully:
 
 ```typescript
 const editor = useVizelEditor({
@@ -175,7 +175,7 @@ const editor = useVizelEditor({
 
 ### Auto-Save Too Frequent
 
-Increase debounce time for auto-save:
+You can increase the debounce time for auto-save:
 
 ```typescript
 import { useVizelAutoSave } from '@vizel/react';
@@ -191,9 +191,9 @@ useVizelAutoSave({
 
 ### Large Documents
 
-For large documents, consider:
+For large documents, consider the following approaches:
 
-1. **Disable unused features** to reduce bundle size and processing:
+1. **Disable unused features** to reduce bundle size and processing overhead:
 
 ```typescript
 const editor = useVizelEditor({
@@ -236,7 +236,7 @@ const editor = useVizelEditor({
 If typing feels slow:
 
 1. Check for expensive `onUpdate` handlers
-2. Debounce state updates
+2. Debounce your state updates
 3. Avoid synchronous JSON serialization on every keystroke
 
 ```typescript
@@ -264,7 +264,7 @@ onUpdate: ({ editor }) => {
 
 ### "Cannot read property 'commands' of null"
 
-The editor instance is not initialized. Always check for null:
+The editor instance is not yet initialized. Always check for null:
 
 ```typescript
 // Wrong
@@ -281,9 +281,9 @@ editor?.commands.setContent(content);
 
 ### "Maximum call stack size exceeded"
 
-Usually caused by:
+This error is usually caused by:
 
-1. **Circular content updates**: Avoid updating content inside `onUpdate`:
+1. **Circular content updates**: Do not update content inside `onUpdate`:
 
 ```typescript
 // Wrong: Causes infinite loop
@@ -299,11 +299,11 @@ const handleTransform = () => {
 };
 ```
 
-2. **Recursive component rendering**: Ensure proper dependency arrays in hooks.
+2. **Recursive component rendering**: Verify that you set proper dependency arrays in hooks.
 
 ### "Extension not found"
 
-Check that required features are enabled:
+Verify that you enabled the required features:
 
 ```typescript
 // Error when trying to use disabled feature
@@ -319,7 +319,7 @@ const editor = useVizelEditor({
 
 ### "Adding different instances of a keyed plugin"
 
-This error occurs when multiple instances of ProseMirror plugins are loaded. Common causes:
+This error occurs when multiple instances of the same ProseMirror plugin are loaded. Common causes:
 
 1. **Duplicate Tiptap packages** in dependencies:
 
@@ -331,7 +331,7 @@ npm ls @tiptap/core
 
 2. **Incorrect bundling** of @vizel/core:
 
-Ensure your bundler treats @tiptap/* as external. For Vite:
+Make sure your bundler treats @tiptap/* as external. For Vite:
 
 ```typescript
 // vite.config.ts
@@ -344,7 +344,7 @@ export default defineConfig({
 
 3. **Multiple editor instances** sharing extensions:
 
-Create fresh extension instances for each editor:
+You must create fresh extension instances for each editor:
 
 ```typescript
 // Wrong: Sharing extensions
@@ -367,7 +367,7 @@ const editor2 = useVizelEditor({
 
 ### React Hydration Errors
 
-When using SSR (Next.js, Remix), the editor must render client-side only:
+When you use SSR (Next.js, Remix), you must render the editor client-side only:
 
 ```tsx
 // Next.js
@@ -397,7 +397,7 @@ export default function Page() {
 
 ### Vue Reactivity Caveats
 
-The editor instance is wrapped in `shallowRef` for performance. Access `.value` when needed:
+The composable wraps the editor instance in `shallowRef` for performance. Access `.value` when needed:
 
 ```vue
 <script setup lang="ts">
@@ -428,7 +428,7 @@ const handleSave = () => {
 
 ### Svelte Compilation Errors
 
-Ensure you're using Svelte 5 with the `runes` feature:
+Make sure you use Svelte 5 with the `runes` feature:
 
 ```javascript
 // svelte.config.js
@@ -541,7 +541,7 @@ const editor = useVizelEditor({
 
 ## Getting Help
 
-If you encounter issues not covered here:
+If you encounter an issue not covered here:
 
 1. **Search existing issues**: [GitHub Issues](https://github.com/seijikohara/vizel/issues)
 2. **Check Tiptap documentation**: [Tiptap Docs](https://tiptap.dev/docs)

--- a/docs/guide/version-history.md
+++ b/docs/guide/version-history.md
@@ -1,6 +1,6 @@
 # Version History
 
-Vizel provides a version history system that allows users to save, view, and restore document snapshots.
+Vizel provides a version history system that lets you save, view, and restore document snapshots.
 
 ## Overview
 
@@ -132,7 +132,7 @@ interface VizelVersionHistoryOptions {
 
 ### `maxVersions`
 
-Limits the number of stored snapshots. When the limit is reached, the oldest snapshot is removed.
+Limits the number of stored snapshots. When the limit is reached, Vizel removes the oldest snapshot.
 
 ```typescript
 useVizelVersionHistory(() => editor, {
@@ -142,7 +142,7 @@ useVizelVersionHistory(() => editor, {
 
 ### `storage`
 
-Choose between built-in localStorage or a custom backend.
+You can choose between built-in localStorage or a custom backend.
 
 ```typescript
 // localStorage (default)
@@ -215,7 +215,7 @@ In Vue, `snapshots`, `isLoading`, and `error` are `ComputedRef` values — acces
 
 ## Core Handlers
 
-For advanced use cases, use the core handlers directly:
+For advanced use cases, you can use the core handlers directly:
 
 ```typescript
 import {

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -106,17 +106,17 @@ import { Vizel } from '@vizel/vue';
 
 | Event | Payload | Description |
 |-------|---------|-------------|
-| `update` | `{ editor: Editor }` | Content updated |
-| `update:markdown` | `string` | Markdown content changed |
-| `create` | `{ editor: Editor }` | Editor created |
-| `focus` | `{ editor: Editor }` | Editor focused |
-| `blur` | `{ editor: Editor }` | Editor blurred |
+| `update` | `{ editor: Editor }` | Fires when content changes |
+| `update:markdown` | `string` | Fires when Markdown content changes |
+| `create` | `{ editor: Editor }` | Fires when the editor initializes |
+| `focus` | `{ editor: Editor }` | Fires when the editor gains focus |
+| `blur` | `{ editor: Editor }` | Fires when the editor loses focus |
 
 ## Composables
 
 ### useVizelEditor
 
-Creates and manages a Vizel editor instance.
+This composable creates and manages a Vizel editor instance.
 
 ```vue
 <script setup lang="ts">
@@ -142,11 +142,11 @@ See [Configuration](/guide/configuration) for full options.
 
 #### Return Value
 
-Returns `ShallowRef<Editor | null>`. The editor is `null` during SSR and before initialization.
+Returns `ShallowRef<Editor | null>`. The editor starts as `null` during SSR and before initialization.
 
 ### useVizelState
 
-Forces component re-render on editor state changes.
+This composable forces a component re-render on editor state changes.
 
 ```vue
 <script setup lang="ts">
@@ -168,7 +168,7 @@ useVizelState(() => props.editor);
 
 ### useVizelAutoSave
 
-Automatically saves editor content.
+This composable automatically saves editor content.
 
 ```vue
 <script setup lang="ts">
@@ -195,7 +195,7 @@ const { status, lastSaved, save, restore } = useVizelAutoSave(() => editor.value
 
 ### useVizelMarkdown
 
-Two-way Markdown synchronization with debouncing.
+This composable provides two-way Markdown synchronization with debouncing.
 
 ```vue
 <script setup lang="ts">
@@ -224,7 +224,7 @@ const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor.value
 
 ### useVizelTheme
 
-Access theme state within VizelThemeProvider.
+This composable accesses theme state within `VizelThemeProvider`.
 
 ```vue
 <script setup lang="ts">
@@ -251,7 +251,7 @@ function toggleTheme() {
 
 ### VizelEditor
 
-Renders the editor content area.
+This component renders the editor content area.
 
 ```vue
 <VizelEditor 
@@ -269,7 +269,7 @@ Renders the editor content area.
 
 ### VizelBubbleMenu
 
-Floating bubble menu on text selection.
+This component displays a floating bubble menu on text selection.
 
 ```vue
 <VizelBubbleMenu 
@@ -294,7 +294,7 @@ Floating bubble menu on text selection.
 
 ### VizelThemeProvider
 
-Provides theme context.
+This component provides theme context.
 
 ```vue
 <VizelThemeProvider 
@@ -317,7 +317,7 @@ Provides theme context.
 
 ### VizelSaveIndicator
 
-Displays save status.
+This component displays the save status.
 
 ```vue
 <VizelSaveIndicator 
@@ -329,7 +329,7 @@ Displays save status.
 
 ### VizelPortal
 
-Renders children in a portal.
+This component renders children in a portal.
 
 ```vue
 <VizelPortal :container="document.body">
@@ -499,7 +499,7 @@ const editor = inject<ShallowRef<Editor | null>>('editor');
 
 ## SSR/Nuxt Considerations
 
-The editor is client-side only. Use `<ClientOnly>` in Nuxt:
+The editor runs on the client side only. Use `<ClientOnly>` in Nuxt:
 
 ```vue
 <template>

--- a/docs/guide/wiki-links.md
+++ b/docs/guide/wiki-links.md
@@ -53,7 +53,7 @@ Type double brackets to create a wiki link:
 | `[[My Page]]` | Link to "My Page" with "My Page" as display text |
 | `[[My Page\|Custom Label]]` | Link to "My Page" with "Custom Label" as display text |
 
-The link is automatically created when you close the double brackets (`]]`).
+Vizel automatically creates the link when you close the double brackets (`]]`).
 
 ## Options
 
@@ -78,7 +78,7 @@ interface VizelWikiLinkOptions {
 
 ### `resolveLink`
 
-Converts a page name to a URL. Used for the `href` attribute on rendered links.
+Converts a page name to a URL. Vizel uses this value for the `href` attribute on rendered links.
 
 ```typescript
 {
@@ -90,7 +90,7 @@ Converts a page name to a URL. Used for the `href` attribute on rendered links.
 
 ### `pageExists`
 
-Determines if a linked page exists. Controls visual styling — existing pages get a solid underline, non-existing pages get a dashed underline with muted color.
+Determines if a linked page exists. This function controls visual styling: existing pages display a solid underline, and non-existing pages display a dashed underline with muted color.
 
 ```typescript
 const existingPages = new Set(["Getting Started", "API Reference", "FAQ"]);
@@ -104,7 +104,7 @@ const existingPages = new Set(["Getting Started", "API Reference", "FAQ"]);
 
 ### `onLinkClick`
 
-Intercepts wiki link clicks for client-side navigation. Without this, links follow standard browser navigation using the `href` from `resolveLink`.
+Intercepts wiki link clicks for client-side navigation. Without this callback, links follow standard browser navigation using the `href` from `resolveLink`.
 
 ```typescript
 {
@@ -119,7 +119,7 @@ Intercepts wiki link clicks for client-side navigation. Without this, links foll
 
 ### `getPageSuggestions`
 
-Provides autocomplete suggestions. This callback is available for future autocomplete UI integration.
+Provides autocomplete suggestions. You can use this callback for future autocomplete UI integration.
 
 ```typescript
 {
@@ -134,7 +134,7 @@ Provides autocomplete suggestions. This callback is available for future autocom
 
 ## Commands
 
-The wiki link extension adds two editor commands:
+The wiki link extension provides two editor commands:
 
 ```typescript
 // Insert a wiki link
@@ -149,7 +149,7 @@ editor.commands.unsetWikiLink();
 
 ## Styling
 
-Wiki links use the following CSS classes:
+Wiki links use these CSS classes:
 
 | Class | Description |
 |-------|-------------|
@@ -159,7 +159,7 @@ Wiki links use the following CSS classes:
 
 ### Custom Styling
 
-Override the default styles with CSS custom properties:
+You can override the default styles with CSS custom properties:
 
 ```css
 .vizel-wiki-link {
@@ -261,7 +261,7 @@ const editor = createVizelEditor({
 
 ### Standalone Extension
 
-For advanced setups, use the extension directly instead of the feature option:
+For advanced setups, you can use the extension directly instead of the feature option:
 
 ```typescript
 import { createVizelWikiLinkExtension } from "@vizel/core";
@@ -277,7 +277,7 @@ const editor = useVizelEditor({
 
 ### Backlink Tracking
 
-Track which pages link to a given page by inspecting the editor content:
+You can track which pages link to a given page by inspecting the editor content:
 
 ```typescript
 function getBacklinks(editor: Editor): string[] {

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     linkText: Configuration
 
   - title: Multi-Framework
-    details: Supports React 19, Vue 3, and Svelte 5 with consistent APIs.
+    details: Vizel supports React 19, Vue 3, and Svelte 5 with consistent APIs.
     link: /guide/react
     linkText: Framework Guides
 
@@ -46,7 +46,7 @@ features:
     linkText: Extensions
 
   - title: TypeScript
-    details: Written in TypeScript with exported type definitions.
+    details: Vizel uses TypeScript with exported type definitions.
     link: /api/types
     linkText: Type Definitions
 ---
@@ -166,12 +166,12 @@ Drag blocks by their handle to reorder content.
 
 | Feature | Description |
 |---------|-------------|
-| Multi-framework | React 19, Vue 3, Svelte 5 |
-| TypeScript | Type definitions included |
-| Markdown | Import and export |
-| Theming | CSS variables |
-| Bundle size | Tree-shakeable |
-| Extensions | Modular architecture |
+| Multi-framework | Supports React 19, Vue 3, and Svelte 5 |
+| TypeScript | Includes type definitions |
+| Markdown | Imports and exports Markdown |
+| Theming | Uses CSS variables |
+| Bundle size | Supports tree-shaking |
+| Extensions | Uses modular architecture |
 
 ## Community
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@
 // =============================================================================
 // Tiptap Re-exports (for framework packages)
 // =============================================================================
-export type { Editor, JSONContent } from "@tiptap/core";
+export type { Editor, Extensions, JSONContent } from "@tiptap/core";
 export { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
 export type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -1,4 +1,4 @@
-import type { Editor, JSONContent, VizelFeatureOptions } from "@vizel/core";
+import type { Editor, Extensions, JSONContent, VizelFeatureOptions } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useImperativeHandle } from "react";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
@@ -34,6 +34,8 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /** Additional Tiptap extensions */
+  extensions?: Extensions;
   /** Custom class name for the editor container */
   className?: string;
   /** Whether to show the toolbar (default: false) */
@@ -113,6 +115,7 @@ export function Vizel({
   editable = true,
   autofocus = false,
   features,
+  extensions,
   className,
   showToolbar = false,
   toolbarContent,
@@ -135,6 +138,7 @@ export function Vizel({
     editable,
     autofocus,
     ...(features !== undefined && { features }),
+    ...(extensions !== undefined && { extensions }),
     ...(onUpdate !== undefined && { onUpdate }),
     ...(onCreate !== undefined && { onCreate }),
     ...(onDestroy !== undefined && { onDestroy }),

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-import type { Editor, JSONContent, VizelFeatureOptions } from "@vizel/core";
+import type { Editor, Extensions, JSONContent, VizelFeatureOptions } from "@vizel/core";
 import type { Snippet } from "svelte";
 
 /**
@@ -42,6 +42,8 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /** Additional Tiptap extensions */
+  extensions?: Extensions;
   /** Custom class name for the editor container */
   class?: string;
   /** Whether to show the toolbar (default: false) */
@@ -123,6 +125,7 @@ const editorState = createVizelEditor({
   editable: restProps.editable ?? true,
   autofocus: restProps.autofocus ?? false,
   ...(restProps.features !== undefined && { features: restProps.features }),
+  ...(restProps.extensions !== undefined && { extensions: restProps.extensions }),
   onUpdate: wrappedOnUpdate,
   ...(restProps.onCreate !== undefined && { onCreate: restProps.onCreate }),
   ...(restProps.onDestroy !== undefined && { onDestroy: restProps.onDestroy }),

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -5,6 +5,7 @@
 // This is the recommended way to use Vizel for most use cases.
 import {
   type Editor,
+  type Extensions,
   getVizelMarkdown,
   type JSONContent,
   setVizelMarkdown,
@@ -51,6 +52,8 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /** Additional Tiptap extensions */
+  extensions?: Extensions;
   /** Custom class name for the editor container */
   class?: string;
   /** Whether to show the toolbar (default: false) */
@@ -105,6 +108,7 @@ const editor = useVizelEditor({
   editable: props.editable,
   autofocus: props.autofocus,
   ...(props.features !== undefined && { features: props.features }),
+  ...(props.extensions !== undefined && { extensions: props.extensions }),
   onUpdate: (e) => {
     emit("update", e);
     // Update markdown model if not updating from external change


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for recently added features: Wiki Links, Comments, Collaboration, and Plugins
- Standardize technical writing style across all API and guide documentation to use consistent description patterns ("This function...", "This hook...", "This feature...")
- Export `Extensions` type from `@vizel/core` and add `extensions` prop to `Vizel` component in all three frameworks (React, Vue, Svelte)
- Update all demo applications to demonstrate Find & Replace extension usage via the new `extensions` prop

## Changes

### Documentation (33 files)
- **API docs** (`docs/api/`): Expanded core.md, react.md, vue.md, svelte.md with new feature sections (Wiki Links, Comments, Collaboration, Plugins)
- **Guide docs** (`docs/guide/`): Updated 12 guide files for style consistency
- **Type docs** (`docs/api/types/`): Added new types for WikiLink, CommentMark, Collaboration features
- **CSS variables docs**: Minor style consistency updates

### Code (4 files)
- `packages/core/src/index.ts`: Added `Extensions` type re-export from `@tiptap/core`
- `packages/react/src/components/Vizel.tsx`: Added `extensions?: Extensions` prop
- `packages/vue/src/components/Vizel.vue`: Added `extensions?: Extensions` prop
- `packages/svelte/src/components/Vizel.svelte`: Added `extensions?: Extensions` prop

### Demo (3 files)
- All three framework demos updated to use `extensions` prop for Find & Replace

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test:ct` — 714/720 passed (6 flaky timeouts in Svelte/BubbleMenu on Firefox/WebKit, unrelated to changes)
- [x] Cross-framework consistency verified (all three frameworks have equivalent changes)