### PR TITLE
fix: use direct dist paths in package.json instead of publishConfig

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,29 +27,16 @@
     "block-editor",
     "prosemirror"
   ],
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
-    "./styles.css": "./src/styles/index.scss",
-    "./components.css": "./src/styles/components.scss",
-    "./mathematics.css": "./src/styles/katex-entry.scss"
-  },
-  "publishConfig": {
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      },
-      "./styles.css": "./dist/styles.css",
-      "./components.css": "./dist/components.css",
-      "./mathematics.css": "./dist/mathematics.css"
-    }
+    "./styles.css": "./dist/styles.css",
+    "./components.css": "./dist/components.css",
+    "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [
     "dist"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,22 +27,12 @@
     "rich-text",
     "block-editor"
   ],
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
-  },
-  "publishConfig": {
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
+  "compilerOptions": {},
   "include": ["src/**/*"]
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -27,26 +27,14 @@
     "rich-text",
     "block-editor"
   ],
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
-  "svelte": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "svelte": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "svelte": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
-  },
-  "publishConfig": {
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "svelte": "./dist/index.js",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "svelte": "./dist/index.js",
-        "import": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -78,7 +78,7 @@ export interface VizelProps {
 // A complete editor component that includes EditorContent and BubbleMenu.
 // This is the recommended way to use Vizel for most use cases.
 import { getVizelMarkdown, setVizelMarkdown } from "@vizel/core";
-import { createVizelEditor } from "../runes/createVizelEditor.svelte.ts";
+import { createVizelEditor } from "../runes/createVizelEditor.svelte.js";
 import VizelBubbleMenu from "./VizelBubbleMenu.svelte";
 import VizelEditor from "./VizelEditor.svelte";
 import VizelToolbar from "./VizelToolbar.svelte";

--- a/packages/svelte/src/components/VizelBubbleMenu.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenu.svelte
@@ -25,7 +25,7 @@ export interface VizelBubbleMenuProps {
 <script lang="ts">
 import { BubbleMenuPlugin } from "@vizel/core";
 import VizelBubbleMenuDefault from "./VizelBubbleMenuDefault.svelte";
-import { getVizelContextSafe } from "./VizelContext.ts";
+import { getVizelContextSafe } from "./VizelContext.js";
 
 let {
   editor: editorProp,

--- a/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
@@ -12,7 +12,7 @@ export interface VizelBubbleMenuDefaultProps {
 </script>
 
 <script lang="ts">
-import { createVizelState } from "../runes/createVizelState.svelte.ts";
+import { createVizelState } from "../runes/createVizelState.svelte.js";
 import VizelBubbleMenuButton from "./VizelBubbleMenuButton.svelte";
 import VizelBubbleMenuColorPicker from "./VizelBubbleMenuColorPicker.svelte";
 import VizelBubbleMenuDivider from "./VizelBubbleMenuDivider.svelte";

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -15,7 +15,7 @@ export interface VizelExposed {
 </script>
 
 <script lang="ts">
-import { getVizelContextSafe } from "./VizelContext.ts";
+import { getVizelContextSafe } from "./VizelContext.js";
 
 let { editor: editorProp, class: className }: VizelEditorProps = $props();
 

--- a/packages/svelte/src/components/VizelIcon.svelte
+++ b/packages/svelte/src/components/VizelIcon.svelte
@@ -34,7 +34,7 @@ export interface VizelIconProps {
 import type { IconifyIconProps } from "@iconify/svelte";
 import Icon from "@iconify/svelte";
 import { vizelDefaultIconIds } from "@vizel/core";
-import { getVizelIconContext } from "./VizelIconContext";
+import { getVizelIconContext } from "./VizelIconContext.js";
 
 const { name, customIcons, width, height, color, class: className }: VizelIconProps = $props();
 const { customIcons: contextIcons } = getVizelIconContext();

--- a/packages/svelte/src/components/VizelIconProvider.svelte
+++ b/packages/svelte/src/components/VizelIconProvider.svelte
@@ -30,7 +30,7 @@ export interface VizelIconProviderProps {
 </script>
 
 <script lang="ts">
-  import { setVizelIcons } from "./VizelIconContext.ts";
+  import { setVizelIcons } from "./VizelIconContext.js";
 
   const { icons, children }: VizelIconProviderProps = $props();
 

--- a/packages/svelte/src/components/VizelNodeSelector.svelte
+++ b/packages/svelte/src/components/VizelNodeSelector.svelte
@@ -13,7 +13,7 @@ export interface VizelNodeSelectorProps {
 
 <script lang="ts">
 import { vizelDefaultNodeTypes, getVizelActiveNodeType } from "@vizel/core";
-import { createVizelState } from "../runes/createVizelState.svelte.ts";
+import { createVizelState } from "../runes/createVizelState.svelte.js";
 import VizelIcon from "./VizelIcon.svelte";
 
 let { editor, nodeTypes = vizelDefaultNodeTypes, class: className }: VizelNodeSelectorProps = $props();

--- a/packages/svelte/src/components/VizelProvider.svelte
+++ b/packages/svelte/src/components/VizelProvider.svelte
@@ -14,7 +14,7 @@ export interface VizelProviderProps {
 
 <script lang="ts">
 import { setContext } from "svelte";
-import { VIZEL_CONTEXT_KEY } from "./VizelContext.ts";
+import { VIZEL_CONTEXT_KEY } from "./VizelContext.js";
 
 let { editor, class: className, children }: VizelProviderProps = $props();
 

--- a/packages/svelte/src/components/VizelToolbar.svelte
+++ b/packages/svelte/src/components/VizelToolbar.svelte
@@ -15,7 +15,7 @@ export interface VizelToolbarProps {
 </script>
 
 <script lang="ts">
-import { getVizelContextSafe } from "./VizelContext.ts";
+import { getVizelContextSafe } from "./VizelContext.js";
 import VizelToolbarDefault from "./VizelToolbarDefault.svelte";
 
 let {

--- a/packages/svelte/src/components/VizelToolbarDefault.svelte
+++ b/packages/svelte/src/components/VizelToolbarDefault.svelte
@@ -16,7 +16,7 @@ import {
   groupVizelToolbarActions,
   vizelDefaultToolbarActions,
 } from "@vizel/core";
-import { createVizelState } from "../runes/createVizelState.svelte.ts";
+import { createVizelState } from "../runes/createVizelState.svelte.js";
 import VizelIcon from "./VizelIcon.svelte";
 import VizelToolbarButton from "./VizelToolbarButton.svelte";
 import VizelToolbarDivider from "./VizelToolbarDivider.svelte";

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -35,7 +35,7 @@ export {
 // ============================================================================
 // Vizel Context
 // ============================================================================
-export { getVizelContext, getVizelContextSafe } from "./VizelContext.ts";
+export { getVizelContext, getVizelContextSafe } from "./VizelContext.js";
 // ============================================================================
 // Vizel Editor components
 // ============================================================================
@@ -62,7 +62,7 @@ export {
 // Vizel Icon component
 // ============================================================================
 export { default as VizelIcon, type VizelIconProps } from "./VizelIcon.svelte";
-export { getVizelIconContext, setVizelIcons } from "./VizelIconContext.ts";
+export { getVizelIconContext, setVizelIcons } from "./VizelIconContext.js";
 export {
   default as VizelIconProvider,
   type VizelIconProviderProps,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -5,10 +5,10 @@
  */
 
 // Import Tiptap extension types for ChainedCommands augmentation
-import "./tiptap-extensions.ts";
+import "./tiptap-extensions.js";
 
 // Initialize icon renderer (auto-registers with core)
-import "./iconRenderer.ts";
+import "./iconRenderer.js";
 
 // Components
 export {
@@ -81,7 +81,7 @@ export {
   VizelToolbarDivider,
   type VizelToolbarDividerProps,
   type VizelToolbarProps,
-} from "./components/index.ts";
+} from "./components/index.js";
 
 // Runes (Svelte 5 reactive state)
 export {
@@ -104,4 +104,4 @@ export {
   getVizelTheme,
   getVizelThemeSafe,
   type VizelSlashMenuRendererOptions,
-} from "./runes/index.ts";
+} from "./runes/index.js";

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -5,7 +5,7 @@ import {
   type VizelCreateEditorOptions,
   wrapAsVizelError,
 } from "@vizel/core";
-import { createVizelSlashMenuRenderer } from "./createVizelSlashMenuRenderer.ts";
+import { createVizelSlashMenuRenderer } from "./createVizelSlashMenuRenderer.js";
 
 /**
  * Options for createVizelEditor rune.

--- a/packages/svelte/src/runes/createVizelEditorState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditorState.svelte.ts
@@ -1,5 +1,5 @@
 import { type Editor, getVizelEditorState, type VizelEditorState } from "@vizel/core";
-import { createVizelState } from "./createVizelState.svelte.ts";
+import { createVizelState } from "./createVizelState.svelte.js";
 
 /**
  * Rune that returns the current editor state and updates on state changes.

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -1,32 +1,32 @@
 export {
   type CreateVizelAutoSaveResult,
   createVizelAutoSave,
-} from "./createVizelAutoSave.svelte.ts";
+} from "./createVizelAutoSave.svelte.js";
 export {
   type CreateVizelCollaborationResult,
   createVizelCollaboration,
-} from "./createVizelCollaboration.svelte.ts";
+} from "./createVizelCollaboration.svelte.js";
 export {
   type CreateVizelCommentResult,
   createVizelComment,
-} from "./createVizelComment.svelte.ts";
+} from "./createVizelComment.svelte.js";
 export {
   type CreateVizelEditorOptions,
   createVizelEditor,
-} from "./createVizelEditor.svelte.ts";
-export { createVizelEditorState } from "./createVizelEditorState.svelte.ts";
+} from "./createVizelEditor.svelte.js";
+export { createVizelEditorState } from "./createVizelEditorState.svelte.js";
 export {
   type CreateVizelMarkdownOptions,
   type CreateVizelMarkdownResult,
   createVizelMarkdown,
-} from "./createVizelMarkdown.svelte.ts";
+} from "./createVizelMarkdown.svelte.js";
 export {
   createVizelSlashMenuRenderer,
   type VizelSlashMenuRendererOptions,
-} from "./createVizelSlashMenuRenderer.ts";
-export { createVizelState } from "./createVizelState.svelte.ts";
+} from "./createVizelSlashMenuRenderer.js";
+export { createVizelState } from "./createVizelState.svelte.js";
 export {
   type CreateVizelVersionHistoryResult,
   createVizelVersionHistory,
-} from "./createVizelVersionHistory.svelte.ts";
-export { getVizelTheme, getVizelThemeSafe } from "./getVizelTheme.svelte.ts";
+} from "./createVizelVersionHistory.svelte.js";
+export { getVizelTheme, getVizelThemeSafe } from "./getVizelTheme.svelte.js";

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
+  "compilerOptions": {},
   "include": ["src/**/*", "src/**/*.svelte"]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,22 +27,12 @@
     "rich-text",
     "block-editor"
   ],
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
-  },
-  "publishConfig": {
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
+  "compilerOptions": {},
   "include": ["src/**/*", "src/**/*.vue"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,17 @@
 
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+
+    "paths": {
+      "@vizel/core": ["./packages/core/src/index.ts"],
+      "@vizel/core/*": ["./packages/core/src/*"],
+      "@vizel/react": ["./packages/react/src/index.ts"],
+      "@vizel/react/*": ["./packages/react/src/*"],
+      "@vizel/vue": ["./packages/vue/src/index.ts"],
+      "@vizel/vue/*": ["./packages/vue/src/*"],
+      "@vizel/svelte": ["./packages/svelte/src/index.ts"],
+      "@vizel/svelte/*": ["./packages/svelte/src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Remove `publishConfig`** from all 4 package.json files — npm CLI does not support field overrides for `main`/`types`/`exports` (npm/cli#7586), causing published packages to point to `./src/index.ts` instead of `./dist/index.js`
- **Use direct `dist/` paths** in `main`, `types`, and `exports` fields (industry standard pattern used by tRPC, Tiptap, TanStack Query, etc.)
- **Add `tsconfig.json` paths** for dev-time module resolution (`@vizel/*` → `packages/*/src`)
- **Fix `.ts` import extensions** in `@vizel/svelte` source (27 changes across 15 files: `.ts` → `.js`, `.svelte.ts` → `.svelte.js`)
- **Fix extensionless import** in `VizelIcon.svelte` (`./VizelIconContext` → `./VizelIconContext.js`)

## Context

`npm view @vizel/core@1.1.0 main` returns `./src/index.ts` (broken), should return `./dist/index.js`. This affects all published versions (v1.0.0, v1.1.0) across all 4 packages.

After this fix, v1.1.1 should be published and v1.0.0/v1.1.0 deprecated.

## Test plan

- [x] `pnpm typecheck` — 0 errors (1 known svelte warning)
- [x] `pnpm lint` — 377 files, no fixes
- [x] `pnpm build` — all 4 packages built successfully
- [x] `grep -r '.ts"' packages/svelte/dist/ --include="*.js"` — 0 matches
- [x] `grep -r 'publishConfig' packages/*/package.json` — 0 matches
- [x] `npm pack --dry-run` — all 4 packages show correct dist/ contents
- [x] `pnpm test:ct:react -- --project=chromium` — 240/240 passed