### PR TITLE
fix(core): use z-popover token for BubbleMenu z-index

### DIFF
--- a/packages/core/src/styles/bubble-menu.scss
+++ b/packages/core/src/styles/bubble-menu.scss
@@ -12,7 +12,7 @@
   border-radius: v("radius-lg");
   box-shadow: v("shadow-md");
   border: 1px solid v("border");
-  z-index: 50;
+  z-index: v("z-popover");
 
   &-toolbar {
     display: flex;


### PR DESCRIPTION
## Summary

- BubbleMenu used a hardcoded `z-index: 50`, which is lower than the Toolbar's `z-sticky` token (60)
- This caused the BubbleMenu to render behind the Toolbar when selecting text near the top of the editor
- Replace the hardcoded value with the `z-popover` token (100) from the design token system

## Changes

| File | Change |
|------|--------|
| `packages/core/src/styles/bubble-menu.scss` | `z-index: 50` → `z-index: v("z-popover")` |

## z-index Token Reference

| Token | Value | Usage |
|-------|-------|-------|
| `z-dropdown` | 50 | Dropdown menus |
| `z-sticky` | 60 | Toolbar (sticky positioned) |
| `z-fixed` | 70 | Fixed positioned elements |
| `z-popover` | **100** | **BubbleMenu (this fix)** |
| `z-tooltip` | 110 | Tooltips |

Closes #233

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Compiled CSS output verified: `z-index: var(--vizel-z-popover)`
- [ ] Visual verification: BubbleMenu appears above Toolbar when selecting text near top of editor