### PR TITLE
fix: cancel requestAnimationFrame polling on cleanup in useVizelMarkdown

### DIFF
--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -117,26 +117,33 @@ export function useVizelMarkdown(
     const handlers = handlersRef.current;
     if (!handlers) return;
 
+    let rafId: number | null = null;
+
     const handleUpdate = () => {
       handlers.handleUpdate(editor);
       setIsPending(handlers.isPending());
 
+      // Cancel any existing rAF to prevent multiple concurrent loops
+      if (rafId !== null) cancelAnimationFrame(rafId);
+
       // Schedule state update after debounce
       const checkPending = () => {
         if (handlers.isPending()) {
-          requestAnimationFrame(checkPending);
+          rafId = requestAnimationFrame(checkPending);
         } else {
+          rafId = null;
           setMarkdownState(handlers.getMarkdown());
           setIsPending(false);
         }
       };
-      requestAnimationFrame(checkPending);
+      rafId = requestAnimationFrame(checkPending);
     };
 
     editor.on("update", handleUpdate);
 
     return () => {
       editor.off("update", handleUpdate);
+      if (rafId !== null) cancelAnimationFrame(rafId);
     };
   }, [getEditor]);
 


### PR DESCRIPTION
## Summary

- rAF polling loop in `useVizelMarkdown` lacked cancellation on component unmount
- Rapid typing could spawn multiple concurrent rAF loops (each editor update started a new loop without cancelling the previous)
- State updates on unmounted components caused React warnings and CPU waste

## Changes

| File | Change |
|------|--------|
| `packages/react/src/hooks/useVizelMarkdown.ts` | Track rAF ID, cancel on cleanup and before new loop |
| `packages/vue/src/composables/useVizelMarkdown.ts` | Same fix in Vue watch cleanup |
| `packages/svelte/src/runes/createVizelMarkdown.svelte.ts` | Same fix in Svelte $effect cleanup |

## Fix Details

1. Store `rafId` returned by `requestAnimationFrame`
2. Cancel existing rAF before starting a new polling loop (prevents concurrent loops)
3. Cancel rAF in cleanup function (prevents updates after unmount)
4. Reset `rafId` to `null` when polling completes naturally

Closes #214

## Test plan

- [x] `pnpm typecheck` passes (all 4 packages)
- [x] `pnpm build` passes
- [x] Pre-commit hooks pass (biome-check + typecheck)