### PR TITLE
fix(react): add dependency array to useVizelState useEffect

### DIFF
--- a/packages/react/src/hooks/useVizelState.ts
+++ b/packages/react/src/hooks/useVizelState.ts
@@ -1,5 +1,5 @@
 import type { Editor } from "@vizel/core";
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useReducer } from "react";
 
 /**
  * Hook that forces a re-render whenever the editor's state changes.
@@ -24,27 +24,17 @@ import { useEffect, useReducer, useRef } from "react";
  */
 export function useVizelState(getEditor: () => Editor | null | undefined): number {
   const [updateCount, forceUpdate] = useReducer((x: number) => x + 1, 0);
-  const editorRef = useRef<Editor | null>(null);
+  const editor = getEditor() ?? null;
 
   useEffect(() => {
-    const editor = getEditor() ?? null;
-
-    // Unsubscribe from previous editor if different
-    if (editorRef.current && editorRef.current !== editor) {
-      editorRef.current.off("transaction", forceUpdate);
-    }
-
-    editorRef.current = editor;
-
     if (!editor) return;
 
-    // Subscribe to transaction events to detect state changes
     editor.on("transaction", forceUpdate);
 
     return () => {
       editor.off("transaction", forceUpdate);
     };
-  });
+  }, [editor]);
 
   return updateCount;
 }


### PR DESCRIPTION
## Summary

- `useVizelState` ran its `useEffect` without a dependency array, causing transaction event subscription thrashing on every render
- Simplified by evaluating editor outside the effect and using `[editor]` as dependency
- Removed unnecessary ref tracking — `useEffect` cleanup handles unsubscription

## Changes

| File | Change |
|------|--------|
| `packages/react/src/hooks/useVizelState.ts` | Add `[editor]` dependency, remove `useRef` tracking |

Closes #215

## Test plan

- [x] `pnpm typecheck` passes
- [x] Pre-commit hooks pass (biome-check + typecheck-react)