### PR TITLE
fix(core): add HTML sanitization for oEmbed rendering

### DIFF
--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -57,6 +57,7 @@ export {
   createVizelDefaultFetchEmbedData,
   createVizelEmbedExtension,
   detectVizelEmbedProvider,
+  sanitizeVizelOembedHtml,
   VizelEmbed,
   type VizelEmbedData,
   type VizelEmbedOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   groupVizelSlashCommands,
   handleVizelImageDrop,
   handleVizelImagePaste,
+  sanitizeVizelOembedHtml,
   searchVizelSlashCommands,
   VIZEL_DEFAULT_FILE_MIME_TYPES,
   VIZEL_DEFAULT_IMAGE_MAX_FILE_SIZE,


### PR DESCRIPTION
## Summary

- Add built-in HTML sanitization for oEmbed content using DOMParser-based allowlist
- Strips `<script>`, `<style>`, `<object>`, event handlers (`on*`), and dangerous URLs (`javascript:`, `data:text/html`)
- Preserves `<iframe>` and other elements needed by oEmbed providers (YouTube, Vimeo, etc.)
- Add `sanitize` option to `VizelEmbedOptions` for custom sanitizers or opt-out

## Changes

| File | Change |
|------|--------|
| `packages/core/src/extensions/embed.ts` | Add `sanitizeVizelOembedHtml()`, `sanitize` option, update `renderOembed()` |
| `packages/core/src/extensions/index.ts` | Export `sanitizeVizelOembedHtml` |
| `packages/core/src/index.ts` | Re-export `sanitizeVizelOembedHtml` |

## API

```typescript
// Default: built-in sanitizer (strips scripts, event handlers, dangerous URLs)
const editor = useVizelEditor({ features: { embed: {} } });

// Custom sanitizer (e.g., DOMPurify for maximum security)
import DOMPurify from 'dompurify';
const editor = useVizelEditor({
  features: {
    embed: {
      sanitize: (html) => DOMPurify.sanitize(html, {
        ADD_TAGS: ['iframe'],
        ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder'],
      }),
    },
  },
});

// Opt-out (not recommended)
const editor = useVizelEditor({
  features: { embed: { sanitize: false } },
});
```

Closes #213

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] Pre-commit hooks pass