### PR TITLE
docs: fix API documentation errors in core reference

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -43,7 +43,7 @@ This function creates the default set of Vizel extensions.
 ```typescript
 import { createVizelExtensions } from '@vizel/core';
 
-const extensions = createVizelExtensions({
+const extensions = await createVizelExtensions({
   placeholder: 'Start writing...',
   features: {
     markdown: true,
@@ -161,8 +161,11 @@ This function resolves feature options to extension configuration.
 import { resolveVizelFeatures } from '@vizel/core';
 
 const resolved = resolveVizelFeatures({
-  markdown: true,
-  mathematics: { katexOptions: { strict: false } },
+  features: {
+    markdown: true,
+    mathematics: { katexOptions: { strict: false } },
+  },
+  createSlashMenuRenderer: () => ({ /* suggestion options */ }),
 });
 ```
 

--- a/docs/api/types/features.md
+++ b/docs/api/types/features.md
@@ -129,7 +129,7 @@ interface VizelImageFeatureOptions {
   allowedTypes?: string[];
   
   /** Validation error callback */
-  onValidationError?: (error: ImageValidationError) => void;
+  onValidationError?: (error: VizelImageValidationError) => void;
   
   /** Upload error callback */
   onUploadError?: (error: Error, file: File) => void;

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -185,9 +185,9 @@ const { theme, resolvedTheme, systemTheme, setTheme } = useVizelTheme();
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `theme` | `Ref<VizelTheme>` | Current theme setting |
-| `resolvedTheme` | `ComputedRef<VizelResolvedTheme>` | Resolved theme |
-| `systemTheme` | `Ref<VizelResolvedTheme>` | System preference |
+| `theme` | `VizelTheme` | Current theme setting |
+| `resolvedTheme` | `VizelResolvedTheme` | Resolved theme |
+| `systemTheme` | `VizelResolvedTheme` | System preference |
 | `setTheme` | `(theme: VizelTheme) => void` | Set theme function |
 
 ### useVizelCollaboration


### PR DESCRIPTION
## Summary

Fixes #217

- Fix `resolveVizelFeatures` call signature in `docs/api/core.md` to use the correct `{ features, createSlashMenuRenderer }` object parameter instead of passing feature options directly
- Add missing `await` for async `createVizelExtensions` in `docs/api/core.md` which returns `Promise<Extensions>`
- Fix `useVizelTheme` return types in `docs/api/vue.md`: the composable returns plain `VizelThemeState` properties (`VizelTheme`, `VizelResolvedTheme`), not Vue reactive wrappers (`Ref`, `ComputedRef`)
- Fix `ImageValidationError` to `VizelImageValidationError` in `docs/api/types/features.md` to match the actual exported type name

## Test plan

- [x] Verified each fix against the actual source code
- [x] `resolveVizelFeatures` signature matches `packages/core/src/utils/editorHelpers.ts`
- [x] `createVizelExtensions` async signature matches `packages/core/src/extensions/base.ts`
- [x] `useVizelTheme` return type matches `packages/vue/src/composables/useVizelTheme.ts` and `packages/core/src/theme.ts` (`VizelThemeState`)
- [x] `VizelImageValidationError` matches `packages/core/src/plugins/image-upload.ts`