### PR TITLE
docs: fix wikiLink incorrectly documented as enabled-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ const editor = useVizelEditor({
     embed: true,           // enabled by default
     details: true,         // enabled by default
     diagram: true,         // enabled by default
-    wikiLink: true,        // enabled by default
+    wikiLink: true,        // opt-in: must be explicitly enabled
     comment: true,         // opt-in: must be explicitly enabled
     // collaboration: true, // opt-in: must be explicitly enabled
   },

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -4,7 +4,7 @@ You can enable, disable, or customize each feature through the `features` option
 
 ## Feature Overview
 
-Vizel enables all features by default. Set any feature to `false` to disable it.
+Vizel enables most features by default. `collaboration`, `comment`, and `wikiLink` are opt-in and must be explicitly enabled.
 
 ```mermaid
 graph TB
@@ -23,10 +23,10 @@ graph TB
         Embed["Embeds"]
         Details["Details"]
         Diagram["Diagrams"]
-        WikiLink["Wiki Links"]
-        Comment["Comments"]
     end
     subgraph opt["Opt-in Features"]
+        WikiLink["Wiki Links"]
+        Comment["Comments"]
         Collaboration["Collaboration"]
     end
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -417,7 +417,7 @@ let markdown = $state('# Hello World');
 
 ## Enabling Features
 
-All features are enabled by default except `collaboration` and `comment`. You can disable specific features by setting them to `false`, or pass an options object to configure them:
+All features are enabled by default except `collaboration`, `comment`, and `wikiLink`. You can disable specific features by setting them to `false`, or pass an options object to configure them:
 
 ::: code-group
 
@@ -440,9 +440,9 @@ const editor = useVizelEditor({
     embed: true,
     details: true,
     diagram: true,
-    wikiLink: true,
 
     // Opt-in: must be explicitly enabled
+    wikiLink: true,
     comment: true,
     collaboration: true,
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,7 +44,7 @@ This package provides:
 
 ## Extensions
 
-All extensions are enabled by default except `collaboration` and `comment`:
+All extensions are enabled by default except `collaboration`, `comment`, and `wikiLink`:
 
 | Extension | Description |
 |-----------|-------------|


### PR DESCRIPTION
## Summary

- Move `wikiLink` from "enabled by default" to "opt-in" section in README.md, features.md, getting-started.md, and core/README.md
- Fix Mermaid diagram in features.md to show `wikiLink` and `comment` under "Opt-in Features" subgraph
- Update prose descriptions to list all three opt-in features: `collaboration`, `comment`, and `wikiLink`

Closes #216

## Test plan

- [x] Verify all 4 doc files consistently describe wikiLink as opt-in
- [x] Verify Mermaid diagram groups wikiLink/comment with collaboration under opt-in