### PR TITLE
refactor(core): replace magic number spacing in editor.scss with design tokens

### DIFF
--- a/packages/core/src/styles/_tokens.scss
+++ b/packages/core/src/styles/_tokens.scss
@@ -257,6 +257,8 @@ $z-index: (
 $components: (
   // Editor
   "editor-min-height": 350px,
+  "editor-block-spacing": 0.75em,
+  "editor-list-indent": 1.5em,
 
   // Image
   "image-outline-width": 2px,

--- a/packages/core/src/styles/editor.scss
+++ b/packages/core/src/styles/editor.scss
@@ -20,7 +20,7 @@
   padding: v("editor-padding");
 
   > * + * {
-    margin-top: 0.75em;
+    margin-top: v("editor-block-spacing");
   }
 
   h1 {
@@ -47,7 +47,7 @@
 
   ul,
   ol {
-    padding-left: 1.5em;
+    padding-left: v("editor-list-indent");
   }
 
   li {


### PR DESCRIPTION
## Summary

- Add `editor-block-spacing` (0.75em) and `editor-list-indent` (1.5em) tokens to `_tokens.scss`
- Replace hardcoded values in `editor.scss` with token references via `v()` function
- Enables consumers to override editor spacing through CSS custom properties

Closes #240

## Test plan

- [x] `pnpm build` passes
- [x] Token validation ensures compile-time safety