### PR TITLE
refactor(core): standardize focus ring and disabled opacity with design tokens

### DIFF
--- a/packages/core/src/styles/_tokens.scss
+++ b/packages/core/src/styles/_tokens.scss
@@ -263,6 +263,13 @@ $components: (
   "resize-handle-width": 8px,
   "resize-handle-height": 48px,
 
+  // Focus ring
+  "focus-ring-width": 2px,
+  "focus-ring-offset": -2px,
+
+  // Disabled state
+  "disabled-opacity": 0.5,
+
   // Portal
   "portal-base-z-index": 9999,
 );

--- a/packages/core/src/styles/bubble-menu.scss
+++ b/packages/core/src/styles/bubble-menu.scss
@@ -51,8 +51,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
 
     &.is-active {
@@ -94,8 +94,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
 
     &.has-color[data-action="textColor"] {
@@ -182,8 +182,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: 2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
       z-index: 2;
     }
 
@@ -277,7 +277,7 @@
 
     &:disabled {
       background: v("foreground-muted");
-      opacity: 0.3;
+      opacity: v("disabled-opacity");
       cursor: not-allowed;
     }
   }
@@ -307,8 +307,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
   }
 
@@ -370,8 +370,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
 
     &-icon {

--- a/packages/core/src/styles/components/_find-replace.scss
+++ b/packages/core/src/styles/components/_find-replace.scss
@@ -87,7 +87,7 @@
   }
 
   &:disabled {
-    opacity: 0.5;
+    opacity: v("disabled-opacity");
     cursor: not-allowed;
   }
 

--- a/packages/core/src/styles/slash-menu.scss
+++ b/packages/core/src/styles/slash-menu.scss
@@ -73,8 +73,8 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
   }
 

--- a/packages/core/src/styles/toolbar.scss
+++ b/packages/core/src/styles/toolbar.scss
@@ -52,12 +52,12 @@
     }
 
     &:focus-visible {
-      outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline: v("focus-ring-width") solid v("primary");
+      outline-offset: v("focus-ring-offset");
     }
 
     &:disabled {
-      opacity: 0.35;
+      opacity: v("disabled-opacity");
       cursor: not-allowed;
     }
 


### PR DESCRIPTION
## Summary

- Add `focus-ring-width` (2px), `focus-ring-offset` (-2px), and `disabled-opacity` (0.5) tokens to the design token system
- Replace all hardcoded focus ring styles across toolbar, bubble-menu, slash-menu components
- Fix inconsistent `outline-offset` on color picker swatches (was `2px`, now matches `-2px` standard)
- Unify disabled button opacity from 3 different values (0.35, 0.3, 0.5) to single token (0.5) for better WCAG contrast

Closes #239
Closes #253

## Test plan

- [x] `pnpm build` passes
- [x] All focus ring instances use consistent token values
- [x] All disabled states use unified opacity token