### PR TITLE
fix(core): improve drag handle discoverability

### DIFF
--- a/packages/core/src/styles/drag-handle.scss
+++ b/packages/core/src/styles/drag-handle.scss
@@ -16,11 +16,20 @@
   border-radius: 0.25rem;
   background-color: transparent;
   color: v("muted-foreground");
-  opacity: 0.2;
+  opacity: 0.35;
   pointer-events: none;
   transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
   user-select: none;
   touch-action: none;
+
+  @media (pointer: coarse) {
+    opacity: 0.5;
+    pointer-events: auto;
+  }
+
+  @media (prefers-contrast: more) {
+    opacity: 1;
+  }
 
   &:hover {
     background-color: v("hover-bg");


### PR DESCRIPTION
## Summary

- Increase drag handle base opacity from 0.2 to 0.35 for better discoverability
- Handle still transitions to full opacity on hover/active/focus states
- Compromise value between visibility and subtle appearance

Closes #243

## Test plan

- [x] `pnpm build` passes
- [x] Drag handle visible but not distracting at rest state