### PR TITLE
build: add sideEffects field to all package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,9 @@
     "./components.css": "./dist/components.css",
     "./mathematics.css": "./dist/mathematics.css"
   },
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist"
   ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
       "import": "./dist/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -37,6 +37,7 @@
       "import": "./dist/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -35,6 +35,7 @@
       "import": "./dist/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

- Add `sideEffects` field to all 4 package.json files for bundler tree-shaking
- `@vizel/core`: `["*.css"]` — CSS imports are side effects, JS exports are pure
- `@vizel/react`, `@vizel/vue`, `@vizel/svelte`: `false` — all exports are pure

Closes #221

## Test plan

- [x] `pnpm build` passes
- [x] Field placement follows npm package.json convention