### PR TITLE
chore: clean up unused root devDependencies and Biome config remnant

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -300,14 +300,6 @@
       }
     },
     {
-      "includes": ["packages/tailwind/src/**/*.css"],
-      "css": {
-        "parser": {
-          "cssModules": false
-        }
-      }
-    },
-    {
       "includes": [
         "**/vite.config.ts",
         "**/svelte.config.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
-    "@braintree/sanitize-url": "^7.1.2",
     "@playwright/experimental-ct-react": "~1.57.0",
     "@playwright/experimental-ct-svelte": "~1.57.0",
     "@playwright/experimental-ct-vue": "~1.57.0",
@@ -98,10 +97,6 @@
     "@vue/compiler-dom": "^3.5.27",
     "c8": "^10.1.3",
     "concurrently": "^9.2.1",
-    "cytoscape": "^3.33.1",
-    "cytoscape-cose-bilkent": "^4.1.0",
-    "dayjs": "^1.11.19",
-    "debug": "^4.4.3",
     "fuse.js": "^7.1.0",
     "lefthook": "^2.1.0",
     "mermaid": "^11.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.14
         version: 2.3.14
-      '@braintree/sanitize-url':
-        specifier: ^7.1.2
-        version: 7.1.2
       '@playwright/experimental-ct-react':
         specifier: ~1.57.0
         version: 1.57.0(@types/node@25.2.2)(sass@1.97.3)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
@@ -174,18 +171,6 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
-      cytoscape:
-        specifier: ^3.33.1
-        version: 3.33.1
-      cytoscape-cose-bilkent:
-        specifier: ^4.1.0
-        version: 4.1.0(cytoscape@3.33.1)
-      dayjs:
-        specifier: ^1.11.19
-        version: 1.11.19
-      debug:
-        specifier: ^4.4.3
-        version: 4.4.3
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0


### PR DESCRIPTION
## Summary

- Remove 5 transitive mermaid dependencies from root devDependencies: `@braintree/sanitize-url`, `cytoscape`, `cytoscape-cose-bilkent`, `dayjs`, `debug`
- Remove stale `packages/tailwind/` CSS override from `biome.json` (directory no longer exists)

Verified with `pnpm why` that all removed packages are only used as transitive dependencies of `mermaid`.

## Test plan

- [x] `pnpm install` — completes without errors
- [x] `pnpm build` — passes
- [x] `pnpm lint` — passes (379 files)

Closes #222