### PR TITLE
feat(core): add copy-to-clipboard button for code blocks

### DIFF
--- a/packages/core/src/extensions/code-block-lowlight.ts
+++ b/packages/core/src/extensions/code-block-lowlight.ts
@@ -266,10 +266,35 @@ export async function createVizelCodeBlockExtension(
         }
         lineNumbersBtn.title = node.attrs.lineNumbers ? "Hide line numbers" : "Show line numbers";
 
-        // Append in order: toggle button, language input, datalist
+        // Copy to clipboard button
+        const copyBtn = document.createElement("button");
+        copyBtn.type = "button";
+        copyBtn.classList.add("vizel-code-block-copy-button");
+        copyBtn.title = "Copy code";
+        copyBtn.textContent = "Copy";
+
+        copyBtn.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const text = code.textContent || "";
+          navigator.clipboard.writeText(text).then(() => {
+            copyBtn.textContent = "Copied!";
+            copyBtn.classList.add("copied");
+            setTimeout(() => {
+              copyBtn.textContent = "Copy";
+              copyBtn.classList.remove("copied");
+            }, 2000);
+          });
+        });
+
+        // Append in order: toggle button, language input, datalist, spacer, copy button
         toolbar.appendChild(lineNumbersBtn);
         toolbar.appendChild(languageInput);
         toolbar.appendChild(datalist);
+        const spacer = document.createElement("div");
+        spacer.style.flex = "1";
+        toolbar.appendChild(spacer);
+        toolbar.appendChild(copyBtn);
 
         // Code container with gutter and pre
         const codeContainer = document.createElement("div");

--- a/packages/core/src/styles/code-block.scss
+++ b/packages/core/src/styles/code-block.scss
@@ -77,6 +77,32 @@
     }
   }
 
+  &-copy-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-family: v("font-mono");
+    background-color: transparent;
+    border: 1px solid v("code-block-button-border");
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+    color: v("code-block-button-color");
+    white-space: nowrap;
+
+    &:hover {
+      background-color: v("code-block-button-hover-bg");
+      color: v("code-block-button-hover-color");
+    }
+
+    &.copied {
+      border-color: v("primary");
+      color: v("primary");
+    }
+  }
+
   &-container {
     display: flex;
     overflow-x: auto;
@@ -241,6 +267,10 @@
       svg {
         transition: none;
       }
+    }
+
+    &-copy-button {
+      transition: none;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add a "Copy" button to the code block toolbar (right-aligned, after language input)
- Uses `navigator.clipboard.writeText()` for modern clipboard API
- Shows "Copied!" text feedback with accent color for 2 seconds
- Styled consistently with existing line numbers toggle button
- Includes `prefers-reduced-motion` support

Closes #246

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (379 files)
- [x] `pnpm typecheck` passes
- [ ] Click "Copy" on a code block and verify clipboard content
- [ ] Verify "Copied!" feedback appears and resets after 2s
- [ ] Verify button styles match existing toolbar buttons