### PR TITLE
feat: add onError callback to all Vizel components

### DIFF
--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -1,4 +1,4 @@
-import type { Editor, Extensions, JSONContent, VizelFeatureOptions } from "@vizel/core";
+import type { Editor, Extensions, JSONContent, VizelError, VizelFeatureOptions } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useImperativeHandle } from "react";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
@@ -62,6 +62,8 @@ export interface VizelProps {
   onFocus?: (props: { editor: Editor }) => void;
   /** Callback when editor loses focus */
   onBlur?: (props: { editor: Editor }) => void;
+  /** Callback when an error occurs in the editor */
+  onError?: (error: VizelError) => void;
 }
 
 export interface VizelRef {
@@ -129,6 +131,7 @@ export function Vizel({
   onSelectionUpdate,
   onFocus,
   onBlur,
+  onError,
 }: VizelProps): ReactNode {
   const editor = useVizelEditor({
     ...(initialContent !== undefined && { initialContent }),
@@ -145,6 +148,7 @@ export function Vizel({
     ...(onSelectionUpdate !== undefined && { onSelectionUpdate }),
     ...(onFocus !== undefined && { onFocus }),
     ...(onBlur !== undefined && { onBlur }),
+    ...(onError !== undefined && { onError }),
   });
 
   // Expose editor instance via ref

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-import type { Editor, Extensions, JSONContent, VizelFeatureOptions } from "@vizel/core";
+import type { Editor, Extensions, JSONContent, VizelError, VizelFeatureOptions } from "@vizel/core";
 import type { Snippet } from "svelte";
 
 /**
@@ -70,6 +70,8 @@ export interface VizelProps {
   onFocus?: (props: { editor: Editor }) => void;
   /** Callback when editor loses focus */
   onBlur?: (props: { editor: Editor }) => void;
+  /** Callback when an error occurs in the editor */
+  onError?: (error: VizelError) => void;
 }
 </script>
 
@@ -132,6 +134,7 @@ const editorState = createVizelEditor({
   ...(restProps.onSelectionUpdate !== undefined && { onSelectionUpdate: restProps.onSelectionUpdate }),
   ...(restProps.onFocus !== undefined && { onFocus: restProps.onFocus }),
   ...(restProps.onBlur !== undefined && { onBlur: restProps.onBlur }),
+  ...(restProps.onError !== undefined && { onError: restProps.onError }),
 });
 
 const editor = $derived(editorState.current);

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -9,6 +9,7 @@ import {
   getVizelMarkdown,
   type JSONContent,
   setVizelMarkdown,
+  type VizelError,
   type VizelFeatureOptions,
 } from "@vizel/core";
 import { useSlots, watch } from "vue";
@@ -86,6 +87,8 @@ const emit = defineEmits<{
   focus: [{ editor: Editor }];
   /** Emitted when editor loses focus */
   blur: [{ editor: Editor }];
+  /** Emitted when an error occurs */
+  error: [VizelError];
 }>();
 
 /**
@@ -121,6 +124,7 @@ const editor = useVizelEditor({
   onSelectionUpdate: (e) => emit("selectionUpdate", e),
   onFocus: (e) => emit("focus", e),
   onBlur: (e) => emit("blur", e),
+  onError: (e) => emit("error", e),
 });
 
 // Watch for external markdown changes (v-model:markdown)


### PR DESCRIPTION
## Summary

Expose the `onError` callback (already available in `useVizelEditor` hook options) in the all-in-one `<Vizel>` component across all 3 frameworks:

- **React**: `onError?: (error: VizelError) => void` prop
- **Vue**: `@error` emit event with `VizelError` payload
- **Svelte**: `onError?: (error: VizelError) => void` prop

Closes #248

## Test plan

- [x] `pnpm typecheck` passes (all 4 packages)
- [x] `pnpm lint` passes (379 files)
- [ ] Verify onError is called when an editor error occurs