### PR TITLE
fix(core): increase disabled toolbar button opacity from 0.35 to 0.5

### DIFF
--- a/packages/core/src/styles/toolbar.scss
+++ b/packages/core/src/styles/toolbar.scss
@@ -57,7 +57,7 @@
     }
 
     &:disabled {
-      opacity: 0.35;
+      opacity: 0.5;
       cursor: not-allowed;
     }
 


### PR DESCRIPTION
## Summary

- Increase disabled toolbar button opacity from 0.35 to 0.5 for better visual distinction

## Test plan

- [x] Visual check: disabled buttons are clearly visible but distinctly different from enabled

Closes #253