### PR TITLE
chore: add sideEffects field to all package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,9 @@
   },
   "description": "Framework-agnostic core for Vizel block-based Markdown editor built on Tiptap",
   "license": "MIT",
+  "sideEffects": [
+    "*.css"
+  ],
   "author": "Seiji Kohara",
   "homepage": "https://seijikohara.github.io/vizel/",
   "bugs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,6 +9,10 @@
   },
   "description": "React 19 components and hooks for Vizel block-based Markdown editor",
   "license": "MIT",
+  "sideEffects": [
+    "./dist/iconRenderer.js",
+    "./dist/tiptap-extensions.js"
+  ],
   "author": "Seiji Kohara",
   "homepage": "https://seijikohara.github.io/vizel/",
   "bugs": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -9,6 +9,9 @@
   },
   "description": "Svelte 5 components and runes for Vizel block-based Markdown editor",
   "license": "MIT",
+  "sideEffects": [
+    "./dist/iconRenderer.js"
+  ],
   "author": "Seiji Kohara",
   "homepage": "https://seijikohara.github.io/vizel/",
   "bugs": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -9,6 +9,10 @@
   },
   "description": "Vue 3 components and composables for Vizel block-based Markdown editor",
   "license": "MIT",
+  "sideEffects": [
+    "./dist/iconRenderer.js",
+    "./dist/tiptap-extensions.js"
+  ],
   "author": "Seiji Kohara",
   "homepage": "https://seijikohara.github.io/vizel/",
   "bugs": {


### PR DESCRIPTION
## Summary

- Add explicit `sideEffects` field to all 4 package.json files for better tree-shaking
- core: `["*.css"]` — only CSS files have side effects
- react/vue: `["./dist/iconRenderer.js", "./dist/tiptap-extensions.js"]` — icon renderer registration + type augmentation imports
- svelte: `["./dist/iconRenderer.js"]` — icon renderer only (tiptap-extensions uses `///` references)

## Test plan

- [x] `pnpm lint` — passes
- [x] Pre-commit hooks pass

Closes #221