### PR TITLE
feat(core): add Superscript, Subscript, and Typography extensions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,11 +83,14 @@
     "@tiptap/extension-paragraph": "^3.18.0",
     "@tiptap/extension-placeholder": "^3.18.0",
     "@tiptap/extension-strike": "^3.18.0",
+    "@tiptap/extension-subscript": "^3.18.0",
+    "@tiptap/extension-superscript": "^3.18.0",
     "@tiptap/extension-table": "^3.18.0",
     "@tiptap/extension-task-item": "^3.18.0",
     "@tiptap/extension-task-list": "^3.18.0",
     "@tiptap/extension-text": "^3.18.0",
     "@tiptap/extension-text-style": "^3.18.0",
+    "@tiptap/extension-typography": "^3.18.0",
     "@tiptap/extension-underline": "^3.18.0",
     "@tiptap/markdown": "^3.18.0",
     "@tiptap/pm": "^3.18.0",
@@ -96,8 +99,8 @@
     "katex": "^0.16.0",
     "lowlight": "^3.0.0",
     "mermaid": "^11.0.0",
-    "yjs": "^13.6.0",
-    "y-websocket": "^2.0.0"
+    "y-websocket": "^2.0.0",
+    "yjs": "^13.6.0"
   },
   "peerDependenciesMeta": {
     "@hpcc-js/wasm-graphviz": {
@@ -131,6 +134,9 @@
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.89",
     "@iconify/utils": "^3.1.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
+    "@tiptap/extension-typography": "^3.19.0",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -17,7 +17,10 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Strike from "@tiptap/extension-strike";
+import Subscript from "@tiptap/extension-subscript";
+import Superscript from "@tiptap/extension-superscript";
 import Text from "@tiptap/extension-text";
+import Typography from "@tiptap/extension-typography";
 import Underline from "@tiptap/extension-underline";
 import type { VizelFeatureOptions } from "../types.ts";
 import { createVizelCharacterCountExtension } from "./character-count.ts";
@@ -290,6 +293,30 @@ function addCommentExtension(extensions: Extensions, features: VizelFeatureOptio
 }
 
 /**
+ * Add Superscript extension if enabled (enabled by default)
+ */
+function addSuperscriptExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (features.superscript === false) return;
+  extensions.push(Superscript);
+}
+
+/**
+ * Add Subscript extension if enabled (enabled by default)
+ */
+function addSubscriptExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (features.subscript === false) return;
+  extensions.push(Subscript);
+}
+
+/**
+ * Add Typography extension if enabled (enabled by default)
+ */
+function addTypographyExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (features.typography === false) return;
+  extensions.push(Typography);
+}
+
+/**
  * Create the default set of extensions for Vizel editor.
  * All features are enabled by default. Set any feature to `false` to disable it.
  *
@@ -379,6 +406,9 @@ export async function createVizelExtensions(
   addDiagramExtension(extensions, features);
   addWikiLinkExtension(extensions, features);
   addCommentExtension(extensions, features);
+  addSuperscriptExtension(extensions, features);
+  addSubscriptExtension(extensions, features);
+  addTypographyExtension(extensions, features);
 
   // Add code block extension (async - lowlight is loaded dynamically)
   await addCodeBlockExtension(extensions, features);

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -82,6 +82,8 @@ export type VizelBubbleMenuIconName =
   | "strikethrough"
   | "underline"
   | "code"
+  | "superscript"
+  | "subscript"
   | "link"
   | "textColor"
   | "highlighter";
@@ -205,6 +207,8 @@ export const vizelDefaultIconIds: Record<VizelIconName, string> = {
   strikethrough: "lucide:strikethrough",
   underline: "lucide:underline",
   code: "lucide:code",
+  superscript: "lucide:superscript",
+  subscript: "lucide:subscript",
   link: "lucide:link",
   textColor: "lucide:baseline",
   highlighter: "lucide:highlighter",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -72,6 +72,12 @@ export interface VizelFeatureOptions {
   diagram?: VizelDiagramOptions | boolean;
   /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
   wikiLink?: VizelWikiLinkOptions | boolean;
+  /** Superscript text formatting (Mod+.) */
+  superscript?: boolean;
+  /** Subscript text formatting (Mod+,) */
+  subscript?: boolean;
+  /** Typographic auto-conversions (smart quotes, em-dashes, ellipsis, fractions, etc.) */
+  typography?: boolean;
   /** Comment/annotation marks for collaborative review workflows */
   comment?: VizelCommentMarkOptions | boolean;
   /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,18 +51,20 @@
     "react-dom": "^19"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@tiptap/extension-bold": "^3.19.0",
     "@tiptap/extension-code": "^3.19.0",
     "@tiptap/extension-color": "^3.19.0",
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.3",
+    "@vizel/core": "workspace:^",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -89,6 +89,22 @@ export function VizelBubbleMenuDefault({
       >
         <VizelIcon name="code" />
       </VizelBubbleMenuButton>
+      <VizelBubbleMenuButton
+        action="superscript"
+        onClick={() => editor.chain().focus().toggleSuperscript().run()}
+        isActive={editor.isActive("superscript")}
+        title="Superscript (Cmd+.)"
+      >
+        <VizelIcon name="superscript" />
+      </VizelBubbleMenuButton>
+      <VizelBubbleMenuButton
+        action="subscript"
+        onClick={() => editor.chain().focus().toggleSubscript().run()}
+        isActive={editor.isActive("subscript")}
+        title="Subscript (Cmd+,)"
+      >
+        <VizelIcon name="subscript" />
+      </VizelBubbleMenuButton>
       <VizelBubbleMenuDivider />
       <VizelBubbleMenuButton
         action="link"

--- a/packages/react/src/tiptap-extensions.ts
+++ b/packages/react/src/tiptap-extensions.ts
@@ -13,5 +13,7 @@ import "@tiptap/extension-color";
 import "@tiptap/extension-highlight";
 import "@tiptap/extension-italic";
 import "@tiptap/extension-strike";
+import "@tiptap/extension-subscript";
+import "@tiptap/extension-superscript";
 import "@tiptap/extension-text-style";
 import "@tiptap/extension-underline";

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -52,7 +52,6 @@
     "svelte": "^5"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tiptap/extension-bold": "^3.19.0",
@@ -61,8 +60,11 @@
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
+    "@vizel/core": "workspace:^",
     "svelte-check": "^4.3.6"
   }
 }

--- a/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
@@ -47,6 +47,14 @@ const isCodeActive = $derived.by(() => {
   void editorState.current;
   return editor.isActive("code");
 });
+const isSuperscriptActive = $derived.by(() => {
+  void editorState.current;
+  return editor.isActive("superscript");
+});
+const isSubscriptActive = $derived.by(() => {
+  void editorState.current;
+  return editor.isActive("subscript");
+});
 const isLinkActive = $derived.by(() => {
   void editorState.current;
   return editor.isActive("link");
@@ -98,6 +106,22 @@ const isLinkActive = $derived.by(() => {
       onclick={() => editor.chain().focus().toggleCode().run()}
     >
       <VizelIcon name="code" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      action="superscript"
+      isActive={isSuperscriptActive}
+      title="Superscript (Cmd+.)"
+      onclick={() => editor.chain().focus().toggleSuperscript().run()}
+    >
+      <VizelIcon name="superscript" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      action="subscript"
+      isActive={isSubscriptActive}
+      title="Subscript (Cmd+,)"
+      onclick={() => editor.chain().focus().toggleSubscript().run()}
+    >
+      <VizelIcon name="subscript" />
     </VizelBubbleMenuButton>
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuButton

--- a/packages/svelte/src/tiptap-extensions.ts
+++ b/packages/svelte/src/tiptap-extensions.ts
@@ -16,6 +16,8 @@
 /// <reference types="@tiptap/extension-highlight" />
 /// <reference types="@tiptap/extension-italic" />
 /// <reference types="@tiptap/extension-strike" />
+/// <reference types="@tiptap/extension-subscript" />
+/// <reference types="@tiptap/extension-superscript" />
 /// <reference types="@tiptap/extension-text-style" />
 /// <reference types="@tiptap/extension-underline" />
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -50,16 +50,18 @@
     "vue": "^3.4"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@tiptap/extension-bold": "^3.19.0",
     "@tiptap/extension-code": "^3.19.0",
     "@tiptap/extension-color": "^3.19.0",
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@vitejs/plugin-vue": "^6.0.4",
+    "@vizel/core": "workspace:^",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",
     "vue-tsc": "^3.2.4"

--- a/packages/vue/src/components/VizelBubbleMenuDefault.vue
+++ b/packages/vue/src/components/VizelBubbleMenuDefault.vue
@@ -44,6 +44,14 @@ const isCodeActive = computed(() => {
   void editorStateVersion.value;
   return props.editor.isActive("code");
 });
+const isSuperscriptActive = computed(() => {
+  void editorStateVersion.value;
+  return props.editor.isActive("superscript");
+});
+const isSubscriptActive = computed(() => {
+  void editorStateVersion.value;
+  return props.editor.isActive("subscript");
+});
 const isLinkActive = computed(() => {
   void editorStateVersion.value;
   return props.editor.isActive("link");
@@ -101,6 +109,22 @@ const showLinkEditor = ref(false);
       @click="props.editor.chain().focus().toggleCode().run()"
     >
       <VizelIcon name="code" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      action="superscript"
+      :is-active="isSuperscriptActive"
+      title="Superscript (Cmd+.)"
+      @click="props.editor.chain().focus().toggleSuperscript().run()"
+    >
+      <VizelIcon name="superscript" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      action="subscript"
+      :is-active="isSubscriptActive"
+      title="Subscript (Cmd+,)"
+      @click="props.editor.chain().focus().toggleSubscript().run()"
+    >
+      <VizelIcon name="subscript" />
     </VizelBubbleMenuButton>
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuButton

--- a/packages/vue/src/tiptap-extensions.ts
+++ b/packages/vue/src/tiptap-extensions.ts
@@ -13,5 +13,7 @@ import "@tiptap/extension-color";
 import "@tiptap/extension-highlight";
 import "@tiptap/extension-italic";
 import "@tiptap/extension-strike";
+import "@tiptap/extension-subscript";
+import "@tiptap/extension-superscript";
 import "@tiptap/extension-text-style";
 import "@tiptap/extension-underline";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,15 @@ importers:
       '@iconify/utils':
         specifier: ^3.1.0
         version: 3.1.0
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-typography':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
@@ -515,6 +524,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -544,17 +559,17 @@ importers:
     dependencies:
       '@iconify/svelte':
         specifier: ^5.2.1
-        version: 5.2.1(svelte@5.49.0)
+        version: 5.2.1(svelte@5.50.0)
       svelte:
         specifier: ^5
-        version: 5.49.0
+        version: 5.50.0
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(svelte@5.49.0)(typescript@5.9.3)
+        version: 2.5.7(svelte@5.50.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
+        version: 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
       '@tiptap/extension-bold':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -573,6 +588,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -584,7 +605,7 @@ importers:
         version: link:../core
       svelte-check:
         specifier: ^4.3.6
-        version: 4.3.6(picomatch@4.0.3)(svelte@5.49.0)(typescript@5.9.3)
+        version: 4.3.6(picomatch@4.0.3)(svelte@5.50.0)(typescript@5.9.3)
 
   packages/vue:
     dependencies:
@@ -613,6 +634,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -2174,6 +2201,18 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.19.0
 
+  '@tiptap/extension-subscript@3.19.0':
+    resolution: {integrity: sha512-RchUOSIDprlnuzmA/znZIBKMONIlCAXHuR6XkoNX2jFJ/9OHk/si+jEeY8jJfpPDpVqZ3KrwS/zJrqhU/pT+hQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-superscript@3.19.0':
+    resolution: {integrity: sha512-PjLUGjM23/7hqFP5HS1DbdywRm63GhjJ5SD6KqNgyZQwcwDZeJTAW2b/LYTHAP+k07OxOLPdj/k4ntQKtgKNow==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
   '@tiptap/extension-table@3.18.0':
     resolution: {integrity: sha512-04BQYiSKxhy33Pd7UFZchW8UYH0FOts8LCwel11n507w2lNd/wbYMTI2A5AfOEOXvr6Xwx/jOWX4MWuhMqiZwQ==}
     peerDependencies:
@@ -2223,6 +2262,11 @@ packages:
 
   '@tiptap/extension-text@3.19.0':
     resolution: {integrity: sha512-K95+SnbZy0h6hNFtfy23n8t/nOcTFEf69In9TSFVVmwn/Nwlke+IfiESAkqbt1/7sKJeegRXYO7WzFEmFl9Q/g==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-typography@3.19.0':
+    resolution: {integrity: sha512-2Rwwz1ErNhqUcXPzPX2u4frdyrK4Yj6ZMvCLPxLt5lQXj9Eq9YEoD9isw8abR105ko3BCidvfElQYSFu6dWPSw==}
     peerDependencies:
       '@tiptap/core': ^3.19.0
 
@@ -3892,10 +3936,6 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.49.0:
-    resolution: {integrity: sha512-Fn2mCc3XX0gnnbBYzWOTrZHi5WnF9KvqmB1+KGlUWoJkdioPmFYtg2ALBr6xl2dcnFTz3Vi7/mHpbKSVg/imVg==}
-    engines: {node: '>=18'}
-
   svelte@5.50.0:
     resolution: {integrity: sha512-FR9kTLmX5i0oyeQ5j/+w8DuagIkQ7MWMuPpPVioW2zx9Dw77q+1ufLzF1IqNtcTXPRnIIio4PlasliVn43OnbQ==}
     engines: {node: '>=18'}
@@ -4841,10 +4881,10 @@ snapshots:
       '@iconify/types': 2.0.0
       react: 19.2.3
 
-  '@iconify/svelte@5.2.1(svelte@5.49.0)':
+  '@iconify/svelte@5.2.1(svelte@5.50.0)':
     dependencies:
       '@iconify/types': 2.0.0
-      svelte: 5.49.0
+      svelte: 5.50.0
 
   '@iconify/types@2.0.0': {}
 
@@ -5262,14 +5302,14 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/package@2.5.7(svelte@5.49.0)(typescript@5.9.3)':
+  '@sveltejs/package@2.5.7(svelte@5.50.0)(typescript@5.9.3)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.3
-      svelte: 5.49.0
-      svelte2tsx: 0.7.46(svelte@5.49.0)(typescript@5.9.3)
+      svelte: 5.50.0
+      svelte2tsx: 0.7.46(svelte@5.50.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -5281,13 +5321,6 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
-      obug: 2.1.1
-      svelte: 5.49.0
-      vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
     dependencies:
@@ -5308,16 +5341,6 @@ snapshots:
       vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.49.0
-      vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
     dependencies:
@@ -5625,6 +5648,16 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
 
+  '@tiptap/extension-subscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-superscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
   '@tiptap/extension-table@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
@@ -5664,6 +5697,10 @@ snapshots:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
 
   '@tiptap/extension-text@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-typography@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
 
@@ -7530,42 +7567,24 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.49.0)(typescript@5.9.3):
+  svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.50.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.49.0
+      svelte: 5.50.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte2tsx@0.7.46(svelte@5.49.0)(typescript@5.9.3):
+  svelte2tsx@0.7.46(svelte@5.50.0)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.49.0
+      svelte: 5.50.0
       typescript: 5.9.3
-
-  svelte@5.49.0:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@types/estree': 1.0.8
-      acorn: 8.15.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      clsx: 2.1.1
-      devalue: 5.6.2
-      esm-env: 1.2.2
-      esrap: 2.2.2
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
 
   svelte@5.50.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@tiptap/extension-superscript`, `@tiptap/extension-subscript`, `@tiptap/extension-typography` as new features
- Add `superscript`, `subscript`, `typography` boolean fields to `VizelFeatureOptions` (all enabled by default)
- Add bubble menu buttons for Superscript (Mod+.) and Subscript (Mod+,) across React, Vue, and Svelte
- Typography enables auto-conversion of smart quotes, em-dashes, ellipsis, fractions, etc.
- Add `superscript` and `subscript` icon names to `VizelBubbleMenuIconName` (mapped to `lucide:superscript`/`lucide:subscript`)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes (0 errors, 1 known warning)
- [x] `pnpm lint` passes (379 files)
- [x] lefthook pre-commit and pre-push hooks pass

Closes #223