### PR TITLE
refactor(core): standardize focus ring outline-offset with design tokens

### DIFF
--- a/packages/core/src/styles/_tokens.scss
+++ b/packages/core/src/styles/_tokens.scss
@@ -263,6 +263,10 @@ $components: (
   "resize-handle-width": 8px,
   "resize-handle-height": 48px,
 
+  // Focus ring
+  "focus-ring-offset-inset": -2px,
+  "focus-ring-offset-outset": 2px,
+
   // Portal
   "portal-base-z-index": 9999,
 );

--- a/packages/core/src/styles/bubble-menu.scss
+++ b/packages/core/src/styles/bubble-menu.scss
@@ -52,7 +52,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
 
     &.is-active {
@@ -95,7 +95,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
 
     &.has-color[data-action="textColor"] {
@@ -183,7 +183,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: 2px;
+      outline-offset: v("focus-ring-offset-outset");
       z-index: 2;
     }
 
@@ -308,7 +308,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
   }
 
@@ -371,7 +371,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
 
     &-icon {

--- a/packages/core/src/styles/details.scss
+++ b/packages/core/src/styles/details.scss
@@ -64,7 +64,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
   }
 

--- a/packages/core/src/styles/diagram.scss
+++ b/packages/core/src/styles/diagram.scss
@@ -26,7 +26,7 @@
     background-color: var(--vizel-diagram-selected-bg, v("primary-bg"));
     border-color: v("primary");
     outline: 2px solid v("primary");
-    outline-offset: 2px;
+    outline-offset: v("focus-ring-offset-outset");
   }
 
   &-editing {

--- a/packages/core/src/styles/drag-handle.scss
+++ b/packages/core/src/styles/drag-handle.scss
@@ -40,7 +40,7 @@
     opacity: 1;
     pointer-events: auto;
     outline: 2px solid v("primary");
-    outline-offset: 1px;
+    outline-offset: v("focus-ring-offset-outset");
   }
 
   &.is-visible,

--- a/packages/core/src/styles/embed.scss
+++ b/packages/core/src/styles/embed.scss
@@ -23,7 +23,7 @@
 
   &.ProseMirror-selectednode {
     outline: 2px solid v("primary");
-    outline-offset: 2px;
+    outline-offset: v("focus-ring-offset-outset");
     border-radius: v("radius-md");
   }
 

--- a/packages/core/src/styles/mathematics.scss
+++ b/packages/core/src/styles/mathematics.scss
@@ -87,7 +87,7 @@
     &.vizel-math-selected {
       background-color: v("math-block-selected-bg");
       outline: 2px solid v("primary");
-      outline-offset: 2px;
+      outline-offset: v("focus-ring-offset-outset");
     }
 
     .vizel-math-render {

--- a/packages/core/src/styles/slash-menu.scss
+++ b/packages/core/src/styles/slash-menu.scss
@@ -74,7 +74,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
   }
 

--- a/packages/core/src/styles/task-list.scss
+++ b/packages/core/src/styles/task-list.scss
@@ -64,7 +64,7 @@
 
       &:focus-visible {
         outline: 2px solid v("primary");
-        outline-offset: 2px;
+        outline-offset: v("focus-ring-offset-outset");
       }
     }
   }

--- a/packages/core/src/styles/toolbar.scss
+++ b/packages/core/src/styles/toolbar.scss
@@ -53,7 +53,7 @@
 
     &:focus-visible {
       outline: 2px solid v("primary");
-      outline-offset: -2px;
+      outline-offset: v("focus-ring-offset-inset");
     }
 
     &:disabled {


### PR DESCRIPTION
## Summary

- Add `focus-ring-offset-inset` (-2px) and `focus-ring-offset-outset` (2px) tokens to `_tokens.scss`
- Replace all hardcoded `outline-offset` values across 10 SCSS files
- Standardize drag-handle from 1px to outset token (2px)
- Special cases (`1px` in mathematics, `3px` in image, `-1px` in comment/find-replace) left as-is

Closes #239

## Test plan

- [x] `pnpm build` passes — CSS compiles correctly
- [ ] Visual: focus rings appear correctly on all interactive elements