### PR TITLE
feat(core): add @mention autocomplete extension

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,9 +98,10 @@
     "fuse.js": "^7.1.0",
     "katex": "^0.16.0",
     "lowlight": "^3.0.0",
+    "@tiptap/extension-mention": "^3.18.0",
     "mermaid": "^11.0.0",
-    "yjs": "^13.6.0",
-    "y-websocket": "^2.0.0"
+    "y-websocket": "^2.0.0",
+    "yjs": "^13.6.0"
   },
   "peerDependenciesMeta": {
     "@hpcc-js/wasm-graphviz": {
@@ -127,6 +128,9 @@
     "yjs": {
       "optional": true
     },
+    "@tiptap/extension-mention": {
+      "optional": true
+    },
     "y-websocket": {
       "optional": true
     }
@@ -134,6 +138,7 @@
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.89",
     "@iconify/utils": "^3.1.0",
+    "@tiptap/extension-mention": "^3.19.0",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -36,6 +36,7 @@ import {
 import { createVizelLinkExtension } from "./link.ts";
 import { createVizelMarkdownExtension } from "./markdown.ts";
 import { createVizelMathematicsExtensions } from "./mathematics.ts";
+import { createVizelMentionExtension } from "./mention.ts";
 import {
   VizelSlashCommand,
   type VizelSlashCommandItem,
@@ -291,6 +292,16 @@ function addCalloutExtension(extensions: Extensions, features: VizelFeatureOptio
 }
 
 /**
+ * Add Mention extension if enabled (disabled by default)
+ */
+function addMentionExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (!features.mention) return;
+
+  const mentionOptions = typeof features.mention === "object" ? features.mention : {};
+  extensions.push(createVizelMentionExtension(mentionOptions));
+}
+
+/**
  * Add Comment extension if enabled (disabled by default)
  */
 function addCommentExtension(extensions: Extensions, features: VizelFeatureOptions): void {
@@ -390,6 +401,7 @@ export async function createVizelExtensions(
   addEmbedExtension(extensions, features);
   addDiagramExtension(extensions, features);
   addWikiLinkExtension(extensions, features);
+  addMentionExtension(extensions, features);
   addCommentExtension(extensions, features);
 
   // Add code block extension (async - lowlight is loaded dynamically)

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -130,14 +130,12 @@ export {
 
 // Link
 export { createVizelLinkExtension, type VizelLinkOptions } from "./link.ts";
-
 // Markdown
 export {
   createVizelMarkdownExtension,
   VizelMarkdown,
   type VizelMarkdownOptions,
 } from "./markdown.ts";
-
 // Mathematics (KaTeX)
 export {
   createVizelMathematicsExtensions,
@@ -145,6 +143,12 @@ export {
   type VizelMathematicsOptions,
   VizelMathInline,
 } from "./mathematics.ts";
+// Mention
+export {
+  createVizelMentionExtension,
+  type VizelMentionItem,
+  type VizelMentionOptions,
+} from "./mention.ts";
 
 // Node types
 export {

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -41,7 +41,8 @@ export type VizelSlashCommandIconName =
   | "mathBlock"
   | "mathInline"
   | "mermaid"
-  | "graphviz";
+  | "graphviz"
+  | "mention";
 
 /**
  * Icon names used in node type selector.
@@ -196,6 +197,7 @@ export const vizelDefaultIconIds: Record<VizelIconName, string> = {
   mathInline: "lucide:superscript",
   mermaid: "lucide:git-graph",
   graphviz: "lucide:workflow",
+  mention: "lucide:at-sign",
   // Table controls
   arrowUp: "lucide:arrow-up",
   arrowDown: "lucide:arrow-down",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,8 @@ export {
   createVizelMarkdownExtension,
   // Mathematics (KaTeX)
   createVizelMathematicsExtensions,
+  // Mention
+  createVizelMentionExtension,
   // Table
   createVizelTableExtensions,
   // Task list
@@ -173,6 +175,8 @@ export {
   VizelMathBlock,
   type VizelMathematicsOptions,
   VizelMathInline,
+  type VizelMentionItem,
+  type VizelMentionOptions,
   type VizelNodeTypeOption,
   VizelResizableImage,
   type VizelResizableImageOptions,

--- a/packages/core/src/styles/index.scss
+++ b/packages/core/src/styles/index.scss
@@ -35,6 +35,7 @@
 @use "mathematics";
 @use "drag-handle";
 @use "callout";
+@use "mention";
 @use "details";
 @use "embed";
 @use "save-indicator";

--- a/packages/core/src/styles/mention.scss
+++ b/packages/core/src/styles/mention.scss
@@ -1,0 +1,108 @@
+/**
+ * Mention Styles
+ */
+
+@use "tokens" as *;
+
+.vizel-mention {
+  display: inline;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  background-color: v("primary-bg");
+  color: v("primary");
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background-color: v("primary");
+    color: v("primary-foreground");
+  }
+}
+
+.vizel-mention-menu {
+  width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid v("border");
+  border-radius: v("radius-md");
+  background: v("background");
+  box-shadow: 0 4px 12px oklch(0 0 0 / 0.12);
+  padding: 0.25rem;
+
+  &-empty {
+    padding: 0.75rem 1rem;
+    color: v("muted-foreground");
+    font-size: 0.875rem;
+    text-align: center;
+  }
+
+  &-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: v("radius-sm");
+    cursor: pointer;
+    transition: background-color 0.1s ease;
+
+    &:hover,
+    &.is-selected {
+      background-color: v("hover-bg");
+    }
+
+    &-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background-color: v("primary-bg");
+      color: v("primary");
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 600;
+      flex-shrink: 0;
+      overflow: hidden;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+
+    &-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    &-label {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: v("foreground");
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &-description {
+      font-size: 0.75rem;
+      color: v("muted-foreground");
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vizel-mention {
+    transition: none;
+  }
+
+  .vizel-mention-menu-item {
+    transition: none;
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,7 @@ import type { VizelEmbedOptions } from "./extensions/embed.ts";
 import type { VizelLinkOptions } from "./extensions/link.ts";
 import type { VizelMarkdownOptions } from "./extensions/markdown.ts";
 import type { VizelMathematicsOptions } from "./extensions/mathematics.ts";
+import type { VizelMentionOptions } from "./extensions/mention.ts";
 import type { VizelSlashCommandItem } from "./extensions/slash-command.ts";
 import type { VizelTableOptions } from "./extensions/table.ts";
 import type { VizelTaskListExtensionsOptions } from "./extensions/task-list.ts";
@@ -75,6 +76,17 @@ export interface VizelFeatureOptions {
   diagram?: VizelDiagramOptions | boolean;
   /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
   wikiLink?: VizelWikiLinkOptions | boolean;
+  /**
+   * @mention autocomplete for user mentions.
+   * Disabled by default — requires user-provided items function.
+   * @example
+   * ```ts
+   * mention: {
+   *   items: async (query) => users.filter(u => u.label.includes(query)),
+   * }
+   * ```
+   */
+  mention?: VizelMentionOptions | boolean;
   /** Comment/annotation marks for collaborative review workflows */
   comment?: VizelCommentMarkOptions | boolean;
   /**

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -1,0 +1,136 @@
+import type { VizelMentionItem } from "@vizel/core";
+import type { ReactNode, Ref } from "react";
+import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+
+export interface VizelMentionMenuRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+}
+
+export interface VizelMentionMenuProps {
+  /** Ref to access menu methods */
+  ref?: Ref<VizelMentionMenuRef>;
+  /** Mention items to display */
+  items: VizelMentionItem[];
+  /** Callback when an item is selected */
+  command: (item: VizelMentionItem) => void;
+  /** Custom class name for the menu container */
+  className?: string;
+}
+
+/**
+ * Mention autocomplete menu component.
+ * Displays a list of mention suggestions with keyboard navigation.
+ */
+export function VizelMentionMenu({
+  ref,
+  items,
+  command,
+  className,
+}: VizelMentionMenuProps): ReactNode {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    if (itemRefs.current.length > items.length) {
+      itemRefs.current.length = items.length;
+    }
+  }, [items.length]);
+
+  useEffect(() => {
+    const selectedElement = itemRefs.current[selectedIndex];
+    if (selectedElement) {
+      selectedElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [selectedIndex]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when items change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [items]);
+
+  const selectItem = useCallback(
+    (index: number) => {
+      const item = items[index];
+      if (item) {
+        command(item);
+      }
+    },
+    [items, command]
+  );
+
+  const upHandler = useCallback(() => {
+    setSelectedIndex((index) => (index + items.length - 1) % items.length);
+  }, [items.length]);
+
+  const downHandler = useCallback(() => {
+    setSelectedIndex((index) => (index + 1) % items.length);
+  }, [items.length]);
+
+  const enterHandler = useCallback(() => {
+    selectItem(selectedIndex);
+  }, [selectItem, selectedIndex]);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === "ArrowUp") {
+        upHandler();
+        return true;
+      }
+      if (event.key === "ArrowDown") {
+        downHandler();
+        return true;
+      }
+      if (event.key === "Enter") {
+        enterHandler();
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  if (items.length === 0) {
+    return (
+      <div className={`vizel-mention-menu ${className ?? ""}`} data-vizel-mention-menu="">
+        <div className="vizel-mention-menu-empty">No results</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`vizel-mention-menu ${className ?? ""}`} data-vizel-mention-menu="">
+      {items.map((item, index) => {
+        const isSelected = index === selectedIndex;
+        return (
+          <div
+            key={item.id}
+            ref={(el) => {
+              itemRefs.current[index] = el;
+            }}
+            className={`vizel-mention-menu-item ${isSelected ? "is-selected" : ""}`}
+            onClick={() => selectItem(index)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") selectItem(index);
+            }}
+            tabIndex={-1}
+            role="option"
+            aria-selected={isSelected}
+          >
+            <div className="vizel-mention-menu-item-avatar">
+              {item.avatar ? (
+                <img src={item.avatar} alt={item.label} />
+              ) : (
+                item.label.charAt(0).toUpperCase()
+              )}
+            </div>
+            <div className="vizel-mention-menu-item-content">
+              <div className="vizel-mention-menu-item-label">{item.label}</div>
+              {item.description && (
+                <div className="vizel-mention-menu-item-description">{item.description}</div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -38,6 +38,12 @@ export {
   VizelLinkEditor,
   type VizelLinkEditorProps,
 } from "./VizelLinkEditor.tsx";
+// VizelMentionMenu component
+export {
+  VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
+} from "./VizelMentionMenu.tsx";
 // VizelNodeSelector component
 export { VizelNodeSelector, type VizelNodeSelectorProps } from "./VizelNodeSelector.tsx";
 // Portal component

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -1,0 +1,88 @@
+import {
+  createVizelSuggestionContainer,
+  handleVizelSuggestionEscape,
+  type SuggestionOptions,
+  type SuggestionProps,
+  type VizelMentionItem,
+  type VizelSlashMenuRendererOptions,
+} from "@vizel/core";
+import { createElement, type RefObject } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { VizelMentionMenu, type VizelMentionMenuRef } from "../components/VizelMentionMenu.tsx";
+
+/**
+ * Creates a suggestion render configuration for the Mention extension.
+ * This handles the popup positioning and React component lifecycle.
+ *
+ * @example
+ * ```tsx
+ * import { createVizelMentionMenuRenderer } from '@vizel/react';
+ *
+ * const editor = useVizelEditor({
+ *   features: {
+ *     mention: {
+ *       items: async (query) => fetchUsers(query),
+ *       suggestion: createVizelMentionMenuRenderer(),
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function createVizelMentionMenuRenderer(
+  options: VizelSlashMenuRendererOptions = {}
+): Partial<SuggestionOptions<VizelMentionItem>> {
+  return {
+    render: () => {
+      let root: Root | null = null;
+      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
+      let items: VizelMentionItem[] = [];
+      let commandFn: ((item: VizelMentionItem) => void) | null = null;
+      const menuRef: RefObject<VizelMentionMenuRef | null> = { current: null };
+
+      const renderMenu = () => {
+        if (!(root && commandFn)) return;
+        root.render(
+          createElement(VizelMentionMenu, {
+            items,
+            command: commandFn,
+            ...(options.className !== undefined && { className: options.className }),
+            ref: menuRef,
+          })
+        );
+      };
+
+      return {
+        onStart: (props: SuggestionProps<VizelMentionItem>) => {
+          items = props.items;
+          commandFn = props.command;
+
+          suggestionContainer = createVizelSuggestionContainer();
+          root = createRoot(suggestionContainer.menuContainer);
+          renderMenu();
+          suggestionContainer.updatePosition(props.clientRect);
+        },
+
+        onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
+          items = props.items;
+          commandFn = props.command;
+          renderMenu();
+          suggestionContainer?.updatePosition(props.clientRect);
+        },
+
+        onKeyDown: (props: { event: KeyboardEvent }) => {
+          if (handleVizelSuggestionEscape(props.event)) {
+            return true;
+          }
+          return menuRef.current?.onKeyDown(props) ?? false;
+        },
+
+        onExit: () => {
+          root?.unmount();
+          suggestionContainer?.destroy();
+          root = null;
+          suggestionContainer = null;
+        },
+      };
+    },
+  };
+}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,5 +1,6 @@
 // Re-export theme hooks for convenience (primary export is from components)
 export { useVizelTheme, useVizelThemeSafe } from "../components/VizelThemeProvider.tsx";
+export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.ts";
 export {
   createVizelSlashMenuRenderer,
   type VizelSlashMenuRendererOptions,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -52,6 +52,10 @@ export {
   type VizelIconProviderProps,
   VizelLinkEditor,
   type VizelLinkEditorProps,
+  // MentionMenu
+  VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
@@ -89,6 +93,7 @@ export {
 
 // Hooks
 export {
+  createVizelMentionMenuRenderer,
   createVizelSlashMenuRenderer,
   type UseVizelAutoSaveResult,
   type UseVizelCollaborationResult,

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -1,0 +1,105 @@
+<script lang="ts" module>
+import type { VizelMentionItem } from "@vizel/core";
+
+export interface VizelMentionMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+export interface VizelMentionMenuProps {
+  items: VizelMentionItem[];
+  class?: string;
+  oncommand?: (item: VizelMentionItem) => void;
+}
+</script>
+
+<script lang="ts">
+import { tick } from "svelte";
+
+let {
+  items,
+  class: className,
+  oncommand,
+}: VizelMentionMenuProps = $props();
+
+let selectedIndex = $state(0);
+let itemRefs: (HTMLElement | null)[] = $state([]);
+
+$effect(() => {
+  if (itemRefs.length > items.length) {
+    itemRefs.length = items.length;
+  }
+});
+
+// Reset selection when items change
+$effect(() => {
+  // Access items to track changes
+  void items.length;
+  selectedIndex = 0;
+});
+
+function scrollToSelected() {
+  tick().then(() => {
+    const el = itemRefs[selectedIndex];
+    if (el) {
+      el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  });
+}
+
+function selectItem(index: number) {
+  const item = items[index];
+  if (item) {
+    oncommand?.(item);
+  }
+}
+
+export function onKeyDown(event: KeyboardEvent): boolean {
+  if (event.key === "ArrowUp") {
+    selectedIndex = (selectedIndex + items.length - 1) % items.length;
+    scrollToSelected();
+    return true;
+  }
+  if (event.key === "ArrowDown") {
+    selectedIndex = (selectedIndex + 1) % items.length;
+    scrollToSelected();
+    return true;
+  }
+  if (event.key === "Enter") {
+    selectItem(selectedIndex);
+    return true;
+  }
+  return false;
+}
+</script>
+
+<div class="vizel-mention-menu {className ?? ''}" data-vizel-mention-menu>
+  {#if items.length === 0}
+    <div class="vizel-mention-menu-empty">No results</div>
+  {:else}
+    {#each items as item, index (item.id)}
+      <div
+        bind:this={itemRefs[index]}
+        class="vizel-mention-menu-item {index === selectedIndex ? 'is-selected' : ''}"
+        role="option"
+        aria-selected={index === selectedIndex}
+        onclick={() => selectItem(index)}
+        onkeydown={(e) => { if (e.key === "Enter") selectItem(index); }}
+        tabindex={-1}
+      >
+        <div class="vizel-mention-menu-item-avatar">
+          {#if item.avatar}
+            <img src={item.avatar} alt={item.label} />
+          {:else}
+            {item.label.charAt(0).toUpperCase()}
+          {/if}
+        </div>
+        <div class="vizel-mention-menu-item-content">
+          <div class="vizel-mention-menu-item-label">{item.label}</div>
+          {#if item.description}
+            <div class="vizel-mention-menu-item-description">{item.description}</div>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  {/if}
+</div>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -75,6 +75,14 @@ export {
   type VizelLinkEditorProps,
 } from "./VizelLinkEditor.svelte";
 // ============================================================================
+// Vizel MentionMenu component
+// ============================================================================
+export {
+  default as VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
+} from "./VizelMentionMenu.svelte";
+// ============================================================================
 // Vizel NodeSelector component
 // ============================================================================
 export {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -49,6 +49,10 @@ export {
   type VizelIconProviderProps,
   VizelLinkEditor,
   type VizelLinkEditorProps,
+  // MentionMenu
+  VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
@@ -98,6 +102,7 @@ export {
   createVizelEditor,
   createVizelEditorState,
   createVizelMarkdown,
+  createVizelMentionMenuRenderer,
   createVizelSlashMenuRenderer,
   createVizelState,
   createVizelVersionHistory,

--- a/packages/svelte/src/runes/createVizelMentionMenuRenderer.ts
+++ b/packages/svelte/src/runes/createVizelMentionMenuRenderer.ts
@@ -1,0 +1,106 @@
+import {
+  createVizelSuggestionContainer,
+  handleVizelSuggestionEscape,
+  type SuggestionOptions,
+  type SuggestionProps,
+  type VizelMentionItem,
+  type VizelSlashMenuRendererOptions,
+} from "@vizel/core";
+import { mount, unmount } from "svelte";
+import VizelMentionMenu from "../components/VizelMentionMenu.svelte";
+
+export type { VizelSlashMenuRendererOptions };
+
+interface MentionMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+const isMentionMenuRef = (value: unknown): value is MentionMenuRef =>
+  typeof value === "object" && value !== null && "onKeyDown" in value;
+
+/**
+ * Creates a suggestion render configuration for the Mention extension.
+ * This handles the popup positioning and Svelte component lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { createVizelMentionMenuRenderer } from '@vizel/svelte';
+ *
+ * const editor = createVizelEditor({
+ *   features: {
+ *     mention: {
+ *       items: async (query) => fetchUsers(query),
+ *       suggestion: createVizelMentionMenuRenderer(),
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function createVizelMentionMenuRenderer(
+  options: VizelSlashMenuRendererOptions = {}
+): Partial<SuggestionOptions<VizelMentionItem>> {
+  return {
+    render: () => {
+      let component: ReturnType<typeof mount> | null = null;
+      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
+      let items: VizelMentionItem[] = [];
+      let commandFn: ((item: VizelMentionItem) => void) | null = null;
+
+      const mountComponent = () => {
+        if (!suggestionContainer) return;
+        component = mount(VizelMentionMenu, {
+          target: suggestionContainer.menuContainer,
+          props: {
+            items,
+            ...(options.className !== undefined && { class: options.className }),
+            oncommand: (item: VizelMentionItem) => {
+              commandFn?.(item);
+            },
+          },
+        });
+      };
+
+      return {
+        onStart: (props: SuggestionProps<VizelMentionItem>) => {
+          items = props.items;
+          commandFn = props.command;
+
+          suggestionContainer = createVizelSuggestionContainer();
+          mountComponent();
+          suggestionContainer.updatePosition(props.clientRect);
+        },
+
+        onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
+          items = props.items;
+          commandFn = props.command;
+
+          if (component && suggestionContainer) {
+            unmount(component);
+            mountComponent();
+          }
+
+          suggestionContainer?.updatePosition(props.clientRect);
+        },
+
+        onKeyDown: (props: { event: KeyboardEvent }) => {
+          if (handleVizelSuggestionEscape(props.event)) {
+            return true;
+          }
+          if (component && isMentionMenuRef(component)) {
+            return component.onKeyDown(props.event);
+          }
+          return false;
+        },
+
+        onExit: () => {
+          if (component) {
+            unmount(component);
+          }
+          suggestionContainer?.destroy();
+          component = null;
+          suggestionContainer = null;
+        },
+      };
+    },
+  };
+}

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -20,6 +20,7 @@ export {
   type CreateVizelMarkdownResult,
   createVizelMarkdown,
 } from "./createVizelMarkdown.svelte.js";
+export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.js";
 export {
   createVizelSlashMenuRenderer,
   type VizelSlashMenuRendererOptions,

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import type { VizelMentionItem } from "@vizel/core";
+import { nextTick, ref, watch } from "vue";
+
+export interface VizelMentionMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+export interface VizelMentionMenuProps {
+  items: VizelMentionItem[];
+  class?: string;
+}
+
+const props = defineProps<VizelMentionMenuProps>();
+
+const emit = defineEmits<{
+  command: [item: VizelMentionItem];
+}>();
+
+const selectedIndex = ref(0);
+const itemRefs = ref<(HTMLElement | null)[]>([]);
+
+watch(
+  () => props.items,
+  () => {
+    selectedIndex.value = 0;
+    itemRefs.value = new Array(props.items.length).fill(null);
+  }
+);
+
+function scrollToSelected() {
+  void nextTick(() => {
+    const el = itemRefs.value[selectedIndex.value];
+    if (el) {
+      el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  });
+}
+
+function selectItem(index: number) {
+  const item = props.items[index];
+  if (item) {
+    emit("command", item);
+  }
+}
+
+function onKeyDown(event: KeyboardEvent): boolean {
+  if (event.key === "ArrowUp") {
+    selectedIndex.value = (selectedIndex.value + props.items.length - 1) % props.items.length;
+    scrollToSelected();
+    return true;
+  }
+  if (event.key === "ArrowDown") {
+    selectedIndex.value = (selectedIndex.value + 1) % props.items.length;
+    scrollToSelected();
+    return true;
+  }
+  if (event.key === "Enter") {
+    selectItem(selectedIndex.value);
+    return true;
+  }
+  return false;
+}
+
+defineExpose<VizelMentionMenuRef>({ onKeyDown });
+</script>
+
+<template>
+  <div
+    :class="['vizel-mention-menu', props.class]"
+    data-vizel-mention-menu
+  >
+    <div v-if="items.length === 0" class="vizel-mention-menu-empty">
+      No results
+    </div>
+    <template v-else>
+      <div
+        v-for="(item, index) in items"
+        :key="item.id"
+        :ref="(el) => { itemRefs[index] = el as HTMLElement | null }"
+        :class="['vizel-mention-menu-item', { 'is-selected': index === selectedIndex }]"
+        role="option"
+        :aria-selected="index === selectedIndex"
+        :tabindex="-1"
+        @click="selectItem(index)"
+        @keydown.enter="selectItem(index)"
+      >
+        <div class="vizel-mention-menu-item-avatar">
+          <img v-if="item.avatar" :src="item.avatar" :alt="item.label" />
+          <template v-else>{{ item.label.charAt(0).toUpperCase() }}</template>
+        </div>
+        <div class="vizel-mention-menu-item-content">
+          <div class="vizel-mention-menu-item-label">{{ item.label }}</div>
+          <div v-if="item.description" class="vizel-mention-menu-item-description">
+            {{ item.description }}
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -48,6 +48,12 @@ export {
   default as VizelLinkEditor,
   type VizelLinkEditorProps,
 } from "./VizelLinkEditor.vue";
+// VizelMentionMenu component
+export {
+  default as VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
+} from "./VizelMentionMenu.vue";
 // VizelNodeSelector component
 export {
   default as VizelNodeSelector,

--- a/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
@@ -1,0 +1,92 @@
+import {
+  createVizelSuggestionContainer,
+  handleVizelSuggestionEscape,
+  type SuggestionOptions,
+  type SuggestionProps,
+  type VizelMentionItem,
+  type VizelSlashMenuRendererOptions,
+} from "@vizel/core";
+import { type App, createApp, h, ref } from "vue";
+import { VizelMentionMenu } from "../components/index.ts";
+
+interface VizelMentionMenuRef {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Creates a suggestion render configuration for the Mention extension.
+ * This handles the popup positioning and Vue component lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { createVizelMentionMenuRenderer } from '@vizel/vue';
+ *
+ * const editor = useVizelEditor({
+ *   features: {
+ *     mention: {
+ *       items: async (query) => fetchUsers(query),
+ *       suggestion: createVizelMentionMenuRenderer(),
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function createVizelMentionMenuRenderer(
+  options: VizelSlashMenuRendererOptions = {}
+): Partial<SuggestionOptions<VizelMentionItem>> {
+  return {
+    render: () => {
+      let app: App | null = null;
+      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
+      const componentRef = ref<VizelMentionMenuRef | null>(null);
+      const items = ref<VizelMentionItem[]>([]);
+      const commandFn = ref<((item: VizelMentionItem) => void) | null>(null);
+
+      return {
+        onStart: (props: SuggestionProps<VizelMentionItem>) => {
+          items.value = props.items;
+          commandFn.value = props.command;
+
+          suggestionContainer = createVizelSuggestionContainer();
+
+          app = createApp({
+            setup() {
+              return () =>
+                h(VizelMentionMenu, {
+                  items: items.value,
+                  ...(options.className !== undefined && { class: options.className }),
+                  ref: componentRef,
+                  onCommand: (item: VizelMentionItem) => {
+                    commandFn.value?.(item);
+                  },
+                });
+            },
+          });
+
+          app.mount(suggestionContainer.menuContainer);
+          suggestionContainer.updatePosition(props.clientRect);
+        },
+
+        onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
+          items.value = props.items;
+          commandFn.value = props.command;
+          suggestionContainer?.updatePosition(props.clientRect);
+        },
+
+        onKeyDown: (props: { event: KeyboardEvent }) => {
+          if (handleVizelSuggestionEscape(props.event)) {
+            return true;
+          }
+          return componentRef.value?.onKeyDown(props.event) ?? false;
+        },
+
+        onExit: () => {
+          app?.unmount();
+          suggestionContainer?.destroy();
+          app = null;
+          suggestionContainer = null;
+        },
+      };
+    },
+  };
+}

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -1,3 +1,4 @@
+export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.ts";
 export {
   createVizelSlashMenuRenderer,
   type VizelSlashMenuRendererOptions,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -49,6 +49,10 @@ export {
   type VizelIconProviderProps,
   VizelLinkEditor,
   type VizelLinkEditorProps,
+  // MentionMenu
+  VizelMentionMenu,
+  type VizelMentionMenuProps,
+  type VizelMentionMenuRef,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
@@ -85,6 +89,7 @@ export {
 
 // Composables
 export {
+  createVizelMentionMenuRenderer,
   createVizelSlashMenuRenderer,
   type UseVizelAutoSaveResult,
   type UseVizelCollaborationResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ importers:
         version: 3.19.0
       '@tiptap/suggestion':
         specifier: ^3.18.0
-        version: 3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0
@@ -463,6 +463,9 @@ importers:
       '@iconify/utils':
         specifier: ^3.1.0
         version: 3.1.0
+      '@tiptap/extension-mention':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
@@ -2113,6 +2116,13 @@ packages:
       '@tiptap/core': ^3.19.0
       '@tiptap/pm': ^3.19.0
 
+  '@tiptap/extension-mention@3.19.0':
+    resolution: {integrity: sha512-iBWX6mUouvDe9F75C2fJnFzvBFYVF8fcOa7UvzqWHRSCt8WxqSIp6C1B9Y0npP4TbIZySHzPV4NQQJhtmWwKww==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+      '@tiptap/suggestion': ^3.19.0
+
   '@tiptap/extension-node-range@3.16.0':
     resolution: {integrity: sha512-jCDyc/K+0Oe2TIdk3USKgFkkC1M9j/SenOl5JzbLU37dOuxn8umTTw2wUjRu+CKSUiG9RUxqfkUYNUhc0F+GPw==}
     peerDependencies:
@@ -2241,12 +2251,6 @@ packages:
 
   '@tiptap/pm@3.19.0':
     resolution: {integrity: sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==}
-
-  '@tiptap/suggestion@3.18.0':
-    resolution: {integrity: sha512-AxJfM34e6wFPKVsfyXSvHN1wBBiXIm65hUmY+newop+DMeOjsvkO7M6j7tzUR2Nnrh1AQEsVr6iR0UzO91PBSA==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
 
   '@tiptap/suggestion@3.19.0':
     resolution: {integrity: sha512-tUZwMRFqTVPIo566ZmHNRteyZxJy2EE4FA+S3IeIUOOvY6AW0h1imhbpBO7sXV8CeEQvpa+2DWwLvy7L3vmstA==}
@@ -5573,6 +5577,12 @@ snapshots:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
 
+  '@tiptap/extension-mention@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
   '@tiptap/extension-node-range@3.16.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
@@ -5697,11 +5707,6 @@ snapshots:
       prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.5
-
-  '@tiptap/suggestion@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
 
   '@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@mention` autocomplete functionality using `@tiptap/extension-mention`
- Core: `VizelMentionItem`/`VizelMentionOptions` types, `createVizelMentionExtension()` factory
- React: `VizelMentionMenu` component + `createVizelMentionMenuRenderer` hook
- Vue: `VizelMentionMenu` component + `createVizelMentionMenuRenderer` composable
- Svelte: `VizelMentionMenu` component + `createVizelMentionMenuRenderer` rune
- Styles: `mention.scss` with avatar, label, description, keyboard navigation
- Feature flag: `mention` option in `VizelFeatureOptions` (opt-in, disabled by default)
- Added `"mention"` icon (`lucide:at-sign`) to icon system

Closes #224

## Test Plan

- [x] `pnpm lint` — no errors (warnings only from generated .d.ts files)
- [x] `pnpm typecheck` — all 4 packages pass
- [x] Pre-commit hooks pass (biome-check, typecheck, commitlint)
- [ ] `pnpm build` — verify dist output
- [ ] `pnpm test:ct` — run Playwright component tests