### PR TITLE
feat(core): add Table of Contents extension

### DIFF
--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -302,6 +302,20 @@ export const defaultSlashCommands: SlashCommandItem[] = [
       }
     },
   },
+  // Navigation group
+  {
+    title: "Table of Contents",
+    description: "Auto-generated list of headings",
+    icon: "tableOfContents",
+    group: "Navigation",
+    keywords: ["toc", "navigation", "outline", "headings", "contents", "index"],
+    command: ({ editor, range }) => {
+      if (typeof editor.commands.insertTableOfContents !== "function") {
+        return;
+      }
+      editor.chain().focus().deleteRange(range).insertTableOfContents().run();
+    },
+  },
   // Advanced group
   {
     title: "Math Equation",
@@ -364,7 +378,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
 /**
  * Default group order for display
  */
-export const defaultGroupOrder = ["Text", "Lists", "Blocks", "Media", "Advanced"];
+export const defaultGroupOrder = ["Text", "Lists", "Blocks", "Media", "Navigation", "Advanced"];
 
 /**
  * Fuse.js configuration for fuzzy search

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -43,6 +43,7 @@ import {
   vizelDefaultSlashCommands,
 } from "./slash-command.ts";
 import { createVizelTableExtensions } from "./table.ts";
+import { createVizelTableOfContentsExtension } from "./table-of-contents.ts";
 import { createVizelTaskListExtensions } from "./task-list.ts";
 import { createVizelTextColorExtensions } from "./text-color.ts";
 import { createVizelWikiLinkExtension } from "./wiki-link.ts";
@@ -272,6 +273,16 @@ function addDiagramExtension(extensions: Extensions, features: VizelFeatureOptio
 }
 
 /**
+ * Add Table of Contents extension if enabled
+ */
+function addTableOfContentsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  if (features.tableOfContents === false) return;
+
+  const tocOptions = typeof features.tableOfContents === "object" ? features.tableOfContents : {};
+  extensions.push(createVizelTableOfContentsExtension(tocOptions));
+}
+
+/**
  * Add Wiki Link extension if enabled (disabled by default)
  */
 function addWikiLinkExtension(extensions: Extensions, features: VizelFeatureOptions): void {
@@ -400,6 +411,7 @@ export async function createVizelExtensions(
   addCalloutExtension(extensions, features);
   addEmbedExtension(extensions, features);
   addDiagramExtension(extensions, features);
+  addTableOfContentsExtension(extensions, features);
   addWikiLinkExtension(extensions, features);
   addMentionExtension(extensions, features);
   addCommentExtension(extensions, features);

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -191,7 +191,12 @@ export {
   type VizelTableMenuItem,
   VizelTableWithControls,
 } from "./table-controls.ts";
-
+// Table of Contents
+export {
+  createVizelTableOfContentsExtension,
+  type VizelTableOfContentsOptions,
+  type VizelTOCHeading,
+} from "./table-of-contents.ts";
 // Task list
 export {
   createVizelTaskListExtensions,
@@ -209,6 +214,7 @@ export {
   type VizelColorDefinition,
   type VizelTextColorOptions,
 } from "./text-color.ts";
+
 // Wiki link
 export {
   createVizelWikiLinkExtension,

--- a/packages/core/src/extensions/table-of-contents.ts
+++ b/packages/core/src/extensions/table-of-contents.ts
@@ -1,0 +1,220 @@
+/**
+ * Table of Contents Extension
+ *
+ * Provides a Table of Contents (TOC) block that automatically collects
+ * headings from the document and renders navigation links with
+ * click-to-scroll behavior.
+ */
+
+import { type Editor, Node } from "@tiptap/core";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    tableOfContents: {
+      /** Insert a Table of Contents block */
+      insertTableOfContents: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * A heading entry in the Table of Contents.
+ */
+export interface VizelTOCHeading {
+  /** Heading text content */
+  text: string;
+  /** Heading level (1-6) */
+  level: number;
+  /** Position in the document */
+  pos: number;
+}
+
+/**
+ * Options for the Table of Contents extension.
+ */
+export interface VizelTableOfContentsOptions {
+  /**
+   * Maximum heading depth to include.
+   * @default 6
+   */
+  maxDepth?: 1 | 2 | 3 | 4 | 5 | 6;
+
+  /**
+   * Custom HTML attributes for the TOC container.
+   */
+  HTMLAttributes?: Record<string, string>;
+}
+
+/**
+ * Collect all headings from the editor document.
+ */
+function collectHeadings(editor: Editor, maxDepth: number): VizelTOCHeading[] {
+  const headings: VizelTOCHeading[] = [];
+  const { doc } = editor.state;
+
+  doc.descendants((node, pos) => {
+    if (node.type.name === "heading") {
+      const level = node.attrs.level as number;
+      if (level <= maxDepth) {
+        headings.push({
+          text: node.textContent,
+          level,
+          pos,
+        });
+      }
+    }
+  });
+
+  return headings;
+}
+
+/**
+ * Scroll to a heading at the given document position.
+ */
+function scrollToHeading(editor: Editor, pos: number): void {
+  try {
+    const domAtPos = editor.view.domAtPos(pos + 1);
+    const node = domAtPos.node;
+    const element = node instanceof HTMLElement ? node : node.parentElement;
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+      editor.commands.setTextSelection(pos + 1);
+    }
+  } catch {
+    // Position may be invalid if document changed
+  }
+}
+
+/**
+ * Remove all child nodes from an element.
+ */
+function clearElement(element: HTMLElement): void {
+  while (element.firstChild) {
+    element.removeChild(element.firstChild);
+  }
+}
+
+/**
+ * Render the TOC list into a DOM element.
+ */
+function renderTOC(dom: HTMLElement, editor: Editor, maxDepth: number): void {
+  clearElement(dom);
+
+  const headings = collectHeadings(editor, maxDepth);
+
+  if (headings.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "vizel-toc-empty";
+    empty.textContent = "No headings found";
+    dom.appendChild(empty);
+    return;
+  }
+
+  const nav = document.createElement("nav");
+  nav.setAttribute("aria-label", "Table of contents");
+
+  const list = document.createElement("ul");
+  list.className = "vizel-toc-list";
+
+  for (const heading of headings) {
+    const li = document.createElement("li");
+    li.className = `vizel-toc-item vizel-toc-item--h${heading.level}`;
+
+    const link = document.createElement("a");
+    link.className = "vizel-toc-link";
+    link.textContent = heading.text;
+    link.href = "#";
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      scrollToHeading(editor, heading.pos);
+    });
+
+    li.appendChild(link);
+    list.appendChild(li);
+  }
+
+  nav.appendChild(list);
+  dom.appendChild(nav);
+}
+
+/**
+ * Create the Vizel Table of Contents extension.
+ *
+ * @param options - TOC configuration options
+ * @returns Configured Tiptap Node extension
+ *
+ * @example
+ * ```ts
+ * const toc = createVizelTableOfContentsExtension({ maxDepth: 3 });
+ * ```
+ */
+export function createVizelTableOfContentsExtension(options: VizelTableOfContentsOptions = {}) {
+  const { maxDepth = 6, HTMLAttributes = {} } = options;
+
+  return Node.create({
+    name: "tableOfContents",
+
+    group: "block",
+
+    atom: true,
+
+    draggable: true,
+
+    parseHTML() {
+      return [{ tag: 'div[data-type="table-of-contents"]' }];
+    },
+
+    renderHTML({ HTMLAttributes: attrs }) {
+      return [
+        "div",
+        {
+          ...HTMLAttributes,
+          ...attrs,
+          "data-type": "table-of-contents",
+          class: `vizel-toc ${HTMLAttributes.class ?? ""}`.trim(),
+        },
+        ["p", "Table of Contents"],
+      ];
+    },
+
+    addNodeView() {
+      return ({ editor: nodeEditor }) => {
+        const dom = document.createElement("div");
+        dom.className = `vizel-toc ${HTMLAttributes.class ?? ""}`.trim();
+        dom.setAttribute("data-type", "table-of-contents");
+        dom.setAttribute("data-vizel-toc", "");
+        dom.contentEditable = "false";
+
+        const render = () => renderTOC(dom, nodeEditor, maxDepth);
+
+        render();
+
+        const handleUpdate = () => render();
+        nodeEditor.on("update", handleUpdate);
+
+        return {
+          dom,
+          update: () => {
+            render();
+            return true;
+          },
+          destroy: () => {
+            nodeEditor.off("update", handleUpdate);
+          },
+        };
+      };
+    },
+
+    addCommands() {
+      return {
+        insertTableOfContents:
+          () =>
+          ({ commands }) => {
+            return commands.insertContent({
+              type: this.name,
+            });
+          },
+      };
+    },
+  });
+}

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -42,7 +42,9 @@ export type VizelSlashCommandIconName =
   | "mathInline"
   | "mermaid"
   | "graphviz"
-  | "mention";
+  | "mention"
+  // Navigation
+  | "tableOfContents";
 
 /**
  * Icon names used in node type selector.
@@ -198,6 +200,8 @@ export const vizelDefaultIconIds: Record<VizelIconName, string> = {
   mermaid: "lucide:git-graph",
   graphviz: "lucide:workflow",
   mention: "lucide:at-sign",
+  // Navigation
+  tableOfContents: "lucide:list-tree",
   // Table controls
   arrowUp: "lucide:arrow-up",
   arrowDown: "lucide:arrow-down",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,8 @@ export {
   createVizelMentionExtension,
   // Table
   createVizelTableExtensions,
+  // Table of Contents
+  createVizelTableOfContentsExtension,
   // Task list
   createVizelTaskListExtensions,
   createVizelTextColorExtensions,
@@ -193,12 +195,14 @@ export {
   type VizelTableControlsUIOptions,
   VizelTableHeader,
   type VizelTableMenuItem,
+  type VizelTableOfContentsOptions,
   type VizelTableOptions,
   VizelTableWithControls,
   type VizelTaskItemOptions,
   type VizelTaskListExtensionsOptions,
   type VizelTaskListOptions,
   type VizelTextColorOptions,
+  type VizelTOCHeading,
   type VizelUploadImageFn,
   VizelWikiLink,
   type VizelWikiLinkOptions,

--- a/packages/core/src/styles/index.scss
+++ b/packages/core/src/styles/index.scss
@@ -40,6 +40,7 @@
 @use "embed";
 @use "save-indicator";
 @use "diagram";
+@use "table-of-contents";
 @use "wiki-link";
 @use "components/comment";
 @use "components/find-replace";

--- a/packages/core/src/styles/table-of-contents.scss
+++ b/packages/core/src/styles/table-of-contents.scss
@@ -1,0 +1,64 @@
+.vizel-toc {
+  border: 1px solid var(--vizel-border);
+  border-radius: var(--vizel-radius-md, 0.375rem);
+  padding: 1rem;
+  margin: 1rem 0;
+  background: var(--vizel-background-secondary);
+
+  &-empty {
+    color: var(--vizel-text-secondary);
+    font-style: italic;
+    margin: 0;
+  }
+
+  &-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &-item {
+    margin: 0;
+    padding: 0;
+
+    &--h1 {
+      padding-inline-start: 0;
+    }
+
+    &--h2 {
+      padding-inline-start: 1rem;
+    }
+
+    &--h3 {
+      padding-inline-start: 2rem;
+    }
+
+    &--h4 {
+      padding-inline-start: 3rem;
+    }
+
+    &--h5 {
+      padding-inline-start: 4rem;
+    }
+
+    &--h6 {
+      padding-inline-start: 5rem;
+    }
+  }
+
+  &-link {
+    display: block;
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--vizel-radius-sm, 0.25rem);
+    color: var(--vizel-text-primary);
+    text-decoration: none;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    transition: background-color 0.15s;
+
+    &:hover {
+      background: var(--vizel-background-tertiary);
+      color: var(--vizel-primary);
+    }
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,7 @@ import type { VizelMathematicsOptions } from "./extensions/mathematics.ts";
 import type { VizelMentionOptions } from "./extensions/mention.ts";
 import type { VizelSlashCommandItem } from "./extensions/slash-command.ts";
 import type { VizelTableOptions } from "./extensions/table.ts";
+import type { VizelTableOfContentsOptions } from "./extensions/table-of-contents.ts";
 import type { VizelTaskListExtensionsOptions } from "./extensions/task-list.ts";
 import type { VizelTextColorOptions } from "./extensions/text-color.ts";
 import type { VizelWikiLinkOptions } from "./extensions/wiki-link.ts";
@@ -87,6 +88,8 @@ export interface VizelFeatureOptions {
    * ```
    */
   mention?: VizelMentionOptions | boolean;
+  /** Table of Contents block that auto-collects headings */
+  tableOfContents?: VizelTableOfContentsOptions | boolean;
   /** Comment/annotation marks for collaborative review workflows */
   comment?: VizelCommentMarkOptions | boolean;
   /**


### PR DESCRIPTION
## Summary

- Add Table of Contents (TOC) block extension that auto-collects headings from the document
- Vanilla JS NodeView renders click-to-scroll navigation links with progressive indentation (H1-H6)
- Support `maxDepth` option (1-6) and custom HTML attributes
- Add TOC slash command in new "Navigation" group with fuzzy search keywords
- Add `tableOfContents` feature flag to `VizelFeatureOptions` (enabled by default)
- Wire up `lucide:list-tree` icon, extension registration, exports, and SCSS styles

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — all 4 packages pass
- [x] `pnpm build` — all packages build successfully
- [x] TOC exports present in `dist/index.d.ts`

Closes #227