### PR TITLE
feat(core): add Superscript, Subscript, and Typography extensions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,6 +139,9 @@
     "@iconify-json/lucide": "^1.2.89",
     "@iconify/utils": "^3.1.0",
     "@tiptap/extension-mention": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
+    "@tiptap/extension-typography": "^3.19.0",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -17,7 +17,10 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Strike from "@tiptap/extension-strike";
+import Subscript from "@tiptap/extension-subscript";
+import Superscript from "@tiptap/extension-superscript";
 import Text from "@tiptap/extension-text";
+import Typography from "@tiptap/extension-typography";
 import Underline from "@tiptap/extension-underline";
 import type { VizelFeatureOptions } from "../types.ts";
 import { createVizelCalloutExtension } from "./callout.ts";
@@ -415,6 +418,17 @@ export async function createVizelExtensions(
   addWikiLinkExtension(extensions, features);
   addMentionExtension(extensions, features);
   addCommentExtension(extensions, features);
+
+  // Add typography marks
+  if (features.superscript !== false) {
+    extensions.push(Superscript);
+  }
+  if (features.subscript !== false) {
+    extensions.push(Subscript);
+  }
+  if (features.typography !== false) {
+    extensions.push(Typography);
+  }
 
   // Add code block extension (async - lowlight is loaded dynamically)
   await addCodeBlockExtension(extensions, features);

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -101,7 +101,9 @@ export type VizelBubbleMenuIconName =
   | "code"
   | "link"
   | "textColor"
-  | "highlighter";
+  | "highlighter"
+  | "superscript"
+  | "subscript";
 
 /**
  * Icon names used in Toolbar.
@@ -235,6 +237,8 @@ export const vizelDefaultIconIds: Record<VizelIconName, string> = {
   link: "lucide:link",
   textColor: "lucide:baseline",
   highlighter: "lucide:highlighter",
+  superscript: "lucide:superscript",
+  subscript: "lucide:subscript",
   // Internal (NodeView rendering)
   grip: "lucide:grip-vertical",
   plusSmall: "lucide:plus",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,6 +92,12 @@ export interface VizelFeatureOptions {
   tableOfContents?: VizelTableOfContentsOptions | boolean;
   /** Comment/annotation marks for collaborative review workflows */
   comment?: VizelCommentMarkOptions | boolean;
+  /** Superscript mark (e.g., x²) */
+  superscript?: boolean;
+  /** Subscript mark (e.g., H₂O) */
+  subscript?: boolean;
+  /** Typography auto-conversion (smart quotes, em-dashes, ellipsis, etc.) */
+  typography?: boolean;
   /**
    * Real-time collaboration mode.
    * When enabled, the History extension is excluded (Yjs provides its own undo manager).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,18 +52,20 @@
     "react-dom": "^19"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@tiptap/extension-bold": "^3.19.0",
     "@tiptap/extension-code": "^3.19.0",
     "@tiptap/extension-color": "^3.19.0",
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.3",
+    "@vizel/core": "workspace:^",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
   }

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -89,6 +89,26 @@ export function VizelBubbleMenuDefault({
       >
         <VizelIcon name="code" />
       </VizelBubbleMenuButton>
+      {editor.extensionManager.extensions.some((ext) => ext.name === "superscript") && (
+        <VizelBubbleMenuButton
+          action="superscript"
+          onClick={() => editor.chain().focus().toggleSuperscript().run()}
+          isActive={editor.isActive("superscript")}
+          title="Superscript (Cmd+.)"
+        >
+          <VizelIcon name="superscript" />
+        </VizelBubbleMenuButton>
+      )}
+      {editor.extensionManager.extensions.some((ext) => ext.name === "subscript") && (
+        <VizelBubbleMenuButton
+          action="subscript"
+          onClick={() => editor.chain().focus().toggleSubscript().run()}
+          isActive={editor.isActive("subscript")}
+          title="Subscript (Cmd+,)"
+        >
+          <VizelIcon name="subscript" />
+        </VizelBubbleMenuButton>
+      )}
       <VizelBubbleMenuDivider />
       <VizelBubbleMenuButton
         action="link"

--- a/packages/react/src/tiptap-extensions.ts
+++ b/packages/react/src/tiptap-extensions.ts
@@ -15,3 +15,5 @@ import "@tiptap/extension-italic";
 import "@tiptap/extension-strike";
 import "@tiptap/extension-text-style";
 import "@tiptap/extension-underline";
+import "@tiptap/extension-superscript";
+import "@tiptap/extension-subscript";

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -53,7 +53,6 @@
     "svelte": "^5"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tiptap/extension-bold": "^3.19.0",
@@ -62,8 +61,11 @@
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
+    "@vizel/core": "workspace:^",
     "svelte-check": "^4.3.6"
   }
 }

--- a/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
@@ -52,6 +52,17 @@ const isLinkActive = $derived.by(() => {
   void editorState.current;
   return editor.isActive("link");
 });
+const isSuperscriptActive = $derived.by(() => {
+  void editorState.current;
+  return editor.isActive("superscript");
+});
+const isSubscriptActive = $derived.by(() => {
+  void editorState.current;
+  return editor.isActive("subscript");
+});
+
+const hasSuperscript = $derived(editor.extensionManager.extensions.some((ext) => ext.name === "superscript"));
+const hasSubscript = $derived(editor.extensionManager.extensions.some((ext) => ext.name === "subscript"));
 </script>
 
 {#if showLinkEditor}
@@ -100,6 +111,26 @@ const isLinkActive = $derived.by(() => {
     >
       <VizelIcon name="code" />
     </VizelBubbleMenuButton>
+    {#if hasSuperscript}
+      <VizelBubbleMenuButton
+        action="superscript"
+        isActive={isSuperscriptActive}
+        title="Superscript (Cmd+.)"
+        onclick={() => editor.chain().focus().toggleSuperscript().run()}
+      >
+        <VizelIcon name="superscript" />
+      </VizelBubbleMenuButton>
+    {/if}
+    {#if hasSubscript}
+      <VizelBubbleMenuButton
+        action="subscript"
+        isActive={isSubscriptActive}
+        title="Subscript (Cmd+,)"
+        onclick={() => editor.chain().focus().toggleSubscript().run()}
+      >
+        <VizelIcon name="subscript" />
+      </VizelBubbleMenuButton>
+    {/if}
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuButton
       action="link"

--- a/packages/svelte/src/tiptap-extensions.ts
+++ b/packages/svelte/src/tiptap-extensions.ts
@@ -18,5 +18,7 @@
 /// <reference types="@tiptap/extension-strike" />
 /// <reference types="@tiptap/extension-text-style" />
 /// <reference types="@tiptap/extension-underline" />
+/// <reference types="@tiptap/extension-superscript" />
+/// <reference types="@tiptap/extension-subscript" />
 
 export {};

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,16 +51,18 @@
     "vue": "^3.4"
   },
   "devDependencies": {
-    "@vizel/core": "workspace:^",
     "@tiptap/extension-bold": "^3.19.0",
     "@tiptap/extension-code": "^3.19.0",
     "@tiptap/extension-color": "^3.19.0",
     "@tiptap/extension-highlight": "^3.19.0",
     "@tiptap/extension-italic": "^3.19.0",
     "@tiptap/extension-strike": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-text-style": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@vitejs/plugin-vue": "^6.0.4",
+    "@vizel/core": "workspace:^",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",
     "vue-tsc": "^3.2.4"

--- a/packages/vue/src/components/VizelBubbleMenuDefault.vue
+++ b/packages/vue/src/components/VizelBubbleMenuDefault.vue
@@ -48,6 +48,21 @@ const isLinkActive = computed(() => {
   void editorStateVersion.value;
   return props.editor.isActive("link");
 });
+const isSuperscriptActive = computed(() => {
+  void editorStateVersion.value;
+  return props.editor.isActive("superscript");
+});
+const isSubscriptActive = computed(() => {
+  void editorStateVersion.value;
+  return props.editor.isActive("subscript");
+});
+
+const hasSuperscript = computed(() =>
+  props.editor.extensionManager.extensions.some((ext) => ext.name === "superscript")
+);
+const hasSubscript = computed(() =>
+  props.editor.extensionManager.extensions.some((ext) => ext.name === "subscript")
+);
 
 const showLinkEditor = ref(false);
 </script>
@@ -101,6 +116,24 @@ const showLinkEditor = ref(false);
       @click="props.editor.chain().focus().toggleCode().run()"
     >
       <VizelIcon name="code" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      v-if="hasSuperscript"
+      action="superscript"
+      :is-active="isSuperscriptActive"
+      title="Superscript (Cmd+.)"
+      @click="props.editor.chain().focus().toggleSuperscript().run()"
+    >
+      <VizelIcon name="superscript" />
+    </VizelBubbleMenuButton>
+    <VizelBubbleMenuButton
+      v-if="hasSubscript"
+      action="subscript"
+      :is-active="isSubscriptActive"
+      title="Subscript (Cmd+,)"
+      @click="props.editor.chain().focus().toggleSubscript().run()"
+    >
+      <VizelIcon name="subscript" />
     </VizelBubbleMenuButton>
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuButton

--- a/packages/vue/src/tiptap-extensions.ts
+++ b/packages/vue/src/tiptap-extensions.ts
@@ -15,3 +15,5 @@ import "@tiptap/extension-italic";
 import "@tiptap/extension-strike";
 import "@tiptap/extension-text-style";
 import "@tiptap/extension-underline";
+import "@tiptap/extension-superscript";
+import "@tiptap/extension-subscript";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ importers:
         version: 3.19.0
       '@tiptap/suggestion':
         specifier: ^3.18.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+        version: 3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0
@@ -465,7 +465,16 @@ importers:
         version: 3.1.0
       '@tiptap/extension-mention':
         specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-typography':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
@@ -503,6 +512,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -532,17 +547,17 @@ importers:
     dependencies:
       '@iconify/svelte':
         specifier: ^5.2.1
-        version: 5.2.1(svelte@5.49.0)
+        version: 5.2.1(svelte@5.50.0)
       svelte:
         specifier: ^5
-        version: 5.49.0
+        version: 5.50.0
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(svelte@5.49.0)(typescript@5.9.3)
+        version: 2.5.7(svelte@5.50.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
+        version: 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
       '@tiptap/extension-bold':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -561,6 +576,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -572,7 +593,7 @@ importers:
         version: link:../core
       svelte-check:
         specifier: ^4.3.6
-        version: 4.3.6(picomatch@4.0.3)(svelte@5.49.0)(typescript@5.9.3)
+        version: 4.3.6(picomatch@4.0.3)(svelte@5.50.0)(typescript@5.9.3)
 
   packages/vue:
     dependencies:
@@ -601,6 +622,12 @@ importers:
       '@tiptap/extension-strike':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/extension-text-style':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
@@ -2169,6 +2196,18 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.19.0
 
+  '@tiptap/extension-subscript@3.19.0':
+    resolution: {integrity: sha512-RchUOSIDprlnuzmA/znZIBKMONIlCAXHuR6XkoNX2jFJ/9OHk/si+jEeY8jJfpPDpVqZ3KrwS/zJrqhU/pT+hQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-superscript@3.19.0':
+    resolution: {integrity: sha512-PjLUGjM23/7hqFP5HS1DbdywRm63GhjJ5SD6KqNgyZQwcwDZeJTAW2b/LYTHAP+k07OxOLPdj/k4ntQKtgKNow==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
   '@tiptap/extension-table@3.18.0':
     resolution: {integrity: sha512-04BQYiSKxhy33Pd7UFZchW8UYH0FOts8LCwel11n507w2lNd/wbYMTI2A5AfOEOXvr6Xwx/jOWX4MWuhMqiZwQ==}
     peerDependencies:
@@ -2221,6 +2260,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.19.0
 
+  '@tiptap/extension-typography@3.19.0':
+    resolution: {integrity: sha512-2Rwwz1ErNhqUcXPzPX2u4frdyrK4Yj6ZMvCLPxLt5lQXj9Eq9YEoD9isw8abR105ko3BCidvfElQYSFu6dWPSw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
   '@tiptap/extension-underline@3.18.0':
     resolution: {integrity: sha512-009IeXURNJ/sm1pBqbj+2YQgjQaBtNlJR3dbl6xu49C+qExqCmI7klhKQuwsVVGLR7ahsYlp7d9RlftnhCXIcQ==}
     peerDependencies:
@@ -2251,6 +2295,12 @@ packages:
 
   '@tiptap/pm@3.19.0':
     resolution: {integrity: sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==}
+
+  '@tiptap/suggestion@3.18.0':
+    resolution: {integrity: sha512-AxJfM34e6wFPKVsfyXSvHN1wBBiXIm65hUmY+newop+DMeOjsvkO7M6j7tzUR2Nnrh1AQEsVr6iR0UzO91PBSA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
 
   '@tiptap/suggestion@3.19.0':
     resolution: {integrity: sha512-tUZwMRFqTVPIo566ZmHNRteyZxJy2EE4FA+S3IeIUOOvY6AW0h1imhbpBO7sXV8CeEQvpa+2DWwLvy7L3vmstA==}
@@ -3881,10 +3931,6 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.49.0:
-    resolution: {integrity: sha512-Fn2mCc3XX0gnnbBYzWOTrZHi5WnF9KvqmB1+KGlUWoJkdioPmFYtg2ALBr6xl2dcnFTz3Vi7/mHpbKSVg/imVg==}
-    engines: {node: '>=18'}
-
   svelte@5.50.0:
     resolution: {integrity: sha512-FR9kTLmX5i0oyeQ5j/+w8DuagIkQ7MWMuPpPVioW2zx9Dw77q+1ufLzF1IqNtcTXPRnIIio4PlasliVn43OnbQ==}
     engines: {node: '>=18'}
@@ -4830,10 +4876,10 @@ snapshots:
       '@iconify/types': 2.0.0
       react: 19.2.3
 
-  '@iconify/svelte@5.2.1(svelte@5.49.0)':
+  '@iconify/svelte@5.2.1(svelte@5.50.0)':
     dependencies:
       '@iconify/types': 2.0.0
-      svelte: 5.49.0
+      svelte: 5.50.0
 
   '@iconify/types@2.0.0': {}
 
@@ -5251,14 +5297,14 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/package@2.5.7(svelte@5.49.0)(typescript@5.9.3)':
+  '@sveltejs/package@2.5.7(svelte@5.50.0)(typescript@5.9.3)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.3
-      svelte: 5.49.0
-      svelte2tsx: 0.7.46(svelte@5.49.0)(typescript@5.9.3)
+      svelte: 5.50.0
+      svelte2tsx: 0.7.46(svelte@5.50.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -5270,13 +5316,6 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
-      obug: 2.1.1
-      svelte: 5.49.0
-      vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
     dependencies:
@@ -5297,16 +5336,6 @@ snapshots:
       vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3)))(svelte@5.49.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.49.0
-      vite: 7.3.1(@types/node@25.2.2)(sass@1.97.3)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@25.2.2)(sass@1.97.3))':
     dependencies:
@@ -5577,11 +5606,11 @@ snapshots:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
 
-  '@tiptap/extension-mention@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+  '@tiptap/extension-mention@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
-      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/suggestion': 3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
 
   '@tiptap/extension-node-range@3.16.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
@@ -5619,6 +5648,16 @@ snapshots:
   '@tiptap/extension-strike@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-subscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-superscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
 
   '@tiptap/extension-table@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
@@ -5659,6 +5698,10 @@ snapshots:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
 
   '@tiptap/extension-text@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-typography@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
 
@@ -5707,6 +5750,11 @@ snapshots:
       prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.5
+
+  '@tiptap/suggestion@3.18.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
 
   '@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
@@ -7520,42 +7568,24 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.49.0)(typescript@5.9.3):
+  svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.50.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.49.0
+      svelte: 5.50.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte2tsx@0.7.46(svelte@5.49.0)(typescript@5.9.3):
+  svelte2tsx@0.7.46(svelte@5.50.0)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.49.0
+      svelte: 5.50.0
       typescript: 5.9.3
-
-  svelte@5.49.0:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@types/estree': 1.0.8
-      acorn: 8.15.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      clsx: 2.1.1
-      devalue: 5.6.2
-      esm-env: 1.2.2
-      esrap: 2.2.2
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
 
   svelte@5.50.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add **Superscript** mark extension (`@tiptap/extension-superscript`) — Cmd+. shortcut
- Add **Subscript** mark extension (`@tiptap/extension-subscript`) — Cmd+, shortcut
- Add **Typography** auto-conversion extension (`@tiptap/extension-typography`) — smart quotes, em-dashes, ellipsis, fractions, symbols
- All three are enabled by default via `VizelFeatureOptions` (set to `false` to disable)
- Add bubble menu buttons for superscript/subscript in all 3 frameworks (React, Vue, Svelte)
- Buttons conditionally rendered based on extension presence
- Add `superscript` and `subscript` icon mappings (lucide:superscript, lucide:subscript)

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — all 4 packages pass

Closes #223