### PR TITLE
fix: post-merge consistency for callout exports, React demo styles, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,31 @@
 
 ## Features
 
-- **Text Formatting** - Bold, italic, underline, strikethrough, text color, highlight
+- **Text Formatting** - Bold, italic, underline, strikethrough, superscript, subscript, text color, highlight
+- **Typography** - Smart quotes, em dashes, and other typographic transformations
 - **Block Elements** - Headings (H1-H6), lists (bullet, numbered, task), blockquotes, horizontal rules
 - **Slash Commands** - Type `/` to insert blocks
 - **Floating Toolbar** - Inline formatting toolbar on text selection
 - **Fixed Toolbar** - Optional sticky toolbar with formatting buttons
 - **Tables** - Table editing with row/column controls
+- **Table of Contents** - Auto-collected heading navigation block
 - **Code Blocks** - Syntax highlighting with 37+ languages (190+ available)
 - **Images** - Drag & drop, paste, resize support
 - **Markdown** - Import/export Markdown content
 - **Mathematics** - LaTeX equations with KaTeX
 - **Embeds** - YouTube, Vimeo, Twitter, CodePen, Figma via oEmbed
 - **Details** - Collapsible content blocks
+- **Callout** - Info, warning, danger, tip, and note admonition blocks
 - **Auto-save** - localStorage, sessionStorage, or custom backend
 - **Dark Mode** - System-aware theme switching
 - **Character Count** - Real-time character and word count
-- **Wiki Links** - `[[page-name]]` syntax for internal linking
+- **Wiki Links** - `[[page-name]]` syntax for internal linking (opt-in)
+- **@Mention** - User mention autocomplete (opt-in)
 - **Find & Replace** - Search and replace with keyboard shortcuts
 - **Diagrams** - Mermaid and GraphViz diagram rendering
-- **Comments** - Text annotations for collaborative review
+- **Comments** - Text annotations for collaborative review (opt-in)
 - **Version History** - Document snapshots and restore
-- **Collaboration** - Real-time multi-user editing with Yjs
+- **Collaboration** - Real-time multi-user editing with Yjs (opt-in)
 - **Drag & Drop** - Block reordering with drag handle and Alt+Arrow keys
 - **Plugin System** - Extensible plugin architecture
 

--- a/apps/demo/react/src/entry.tsx
+++ b/apps/demo/react/src/entry.tsx
@@ -2,6 +2,7 @@ import "@vizel/core/styles.css";
 import "@vizel/core/mathematics.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
+import "./styles.css";
 
 const container = document.getElementById("root");
 if (!container) {

--- a/docs/api/types/features.md
+++ b/docs/api/types/features.md
@@ -47,11 +47,29 @@ interface VizelFeatureOptions {
   /** Collapsible content blocks (accordion) */
   details?: VizelDetailsOptions | boolean;
 
+  /** Callout/admonition blocks (info, warning, danger, tip, note) */
+  callout?: VizelCalloutOptions | boolean;
+
   /** Diagram support (Mermaid, GraphViz) */
   diagram?: VizelDiagramOptions | boolean;
 
   /** Wiki links ([[page-name]], [[page|display text]]) */
   wikiLink?: VizelWikiLinkOptions | boolean;
+
+  /** @mention autocomplete (disabled by default) */
+  mention?: VizelMentionOptions | boolean;
+
+  /** Table of Contents block that auto-collects headings */
+  tableOfContents?: VizelTableOfContentsOptions | boolean;
+
+  /** Superscript text formatting */
+  superscript?: boolean;
+
+  /** Subscript text formatting */
+  subscript?: boolean;
+
+  /** Typography transformations (smart quotes, em dashes) */
+  typography?: boolean;
 
   /** Comment/annotation marks for collaborative review */
   comment?: VizelCommentMarkOptions | boolean;

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -11,6 +11,7 @@ graph TB
     subgraph default["All Features (Enabled by Default)"]
         SlashCommand["Slash Commands"]
         Table["Tables"]
+        ToC["Table of Contents"]
         Image["Images"]
         CodeBlock["Code Blocks"]
         DragHandle["Drag Handle"]
@@ -22,10 +23,15 @@ graph TB
         Math["Mathematics"]
         Embed["Embeds"]
         Details["Details"]
+        Callout["Callout"]
         Diagram["Diagrams"]
+        Superscript["Superscript"]
+        Subscript["Subscript"]
+        Typography["Typography"]
     end
     subgraph opt["Opt-in Features"]
         WikiLink["Wiki Links"]
+        Mention["@Mention"]
         Comment["Comments"]
         Collaboration["Collaboration"]
     end
@@ -35,6 +41,7 @@ graph TB
 |---------|-------------|
 | `slashCommand` | Slash command menu (type `/` to open) |
 | `table` | Table editing support |
+| `tableOfContents` | Auto-collected heading navigation block |
 | `image` | Image upload and resize |
 | `codeBlock` | Code blocks with syntax highlighting |
 | `dragHandle` | Drag handle for block reordering |
@@ -46,10 +53,15 @@ graph TB
 | `mathematics` | LaTeX math equations |
 | `embed` | URL embeds (YouTube, etc.) |
 | `details` | Collapsible content blocks |
+| `callout` | Info, warning, danger, tip, and note admonition blocks |
 | `diagram` | Mermaid/GraphViz diagrams |
-| `wikiLink` | Wiki-style internal links (`[[page-name]]`) |
-| `comment` | Text annotations and comments |
-| `collaboration` | Real-time collaboration mode (disables History) |
+| `superscript` | Superscript text formatting |
+| `subscript` | Subscript text formatting |
+| `typography` | Smart quotes, em dashes, and other typographic transformations |
+| `wikiLink` | Wiki-style internal links (`[[page-name]]`) — opt-in |
+| `mention` | `@user` autocomplete — opt-in |
+| `comment` | Text annotations and comments — opt-in |
+| `collaboration` | Real-time collaboration mode (disables History) — opt-in |
 
 ## Disabling Features
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,13 +45,17 @@ This package provides:
 
 ## Extensions
 
-All extensions are enabled by default except `collaboration`, `comment`, and `wikiLink`:
+All extensions are enabled by default except `collaboration`, `comment`, `wikiLink`, and `mention`:
 
 | Extension | Description |
 |-----------|-------------|
-| Base | Headings, bold, italic, underline, strikethrough, lists, blockquotes |
+| Base | Headings (H1-H6), bold, italic, underline, strikethrough, lists, blockquotes |
+| Superscript | Superscript text formatting |
+| Subscript | Subscript text formatting |
+| Typography | Smart quotes, em dashes, and typographic transformations |
 | SlashCommand | Type `/` to open command menu |
 | Table | Table editing with row/column controls |
+| TableOfContents | Auto-collected heading navigation block |
 | Link | Autolink and paste URL detection |
 | Image | Upload, paste, drag-and-drop, resize |
 | CodeBlock | Syntax highlighting with lowlight (37+ languages) |
@@ -63,9 +67,11 @@ All extensions are enabled by default except `collaboration`, `comment`, and `wi
 | Mathematics | LaTeX equations with KaTeX |
 | Embed | oEmbed/OGP URL embedding |
 | Details | Collapsible content blocks |
+| Callout | Info, warning, danger, tip, and note admonition blocks |
 | Diagram | Mermaid and GraphViz diagrams |
-| WikiLink | `[[page-name]]` internal linking |
-| Comment | Text annotations for collaborative review |
+| WikiLink | `[[page-name]]` internal linking (opt-in) |
+| Mention | `@user` autocomplete (opt-in) |
+| Comment | Text annotations for collaborative review (opt-in) |
 
 ## Usage
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,8 @@ export {
 export {
   // Text color
   addVizelRecentColor,
+  // Callout / Admonition
+  createVizelCalloutExtension,
   // Character count
   createVizelCharacterCountExtension,
   // Code block with syntax highlighting
@@ -129,6 +131,9 @@ export {
   VIZEL_TABLE_MENU_ITEMS,
   VIZEL_TEXT_COLORS,
   VizelBlockMoveKeymap,
+  VizelCallout,
+  type VizelCalloutOptions,
+  type VizelCalloutType,
   type VizelCharacterCountOptions,
   type VizelCharacterCountStorage,
   type VizelCodeBlockLanguage,


### PR DESCRIPTION
## Summary

Post-merge consistency fixes after squash-merging all 29 PRs (#265-#300):

- Add missing callout extension re-exports (`createVizelCalloutExtension`, `VizelCallout`, `VizelCalloutOptions`, `VizelCalloutType`) in `@vizel/core` index.ts
- Add missing `./styles.css` import in React demo `entry.tsx` (Vue/Svelte already had it)
- Document 6 new features (callout, mention, tableOfContents, superscript, subscript, typography) across:
  - Root README.md Features list
  - packages/core/README.md Extensions table
  - docs/guide/features.md feature overview and Mermaid diagram
  - docs/api/types/features.md VizelFeatureOptions interface
- Add `mention` to opt-in features group in Mermaid diagram

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (warnings only from .d.ts files)
- [x] `pnpm build` succeeds