### PR TITLE
feat(core): add Markdown flavor selection for output format control

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - **Table of Contents** - Auto-collected heading navigation block
 - **Code Blocks** - Syntax highlighting with 37+ languages (190+ available)
 - **Images** - Drag & drop, paste, resize support
-- **Markdown** - Import/export Markdown content
+- **Markdown** - Import/export Markdown content with configurable flavor (CommonMark, GFM, Obsidian, Docusaurus)
 - **Mathematics** - LaTeX equations with KaTeX
 - **Embeds** - YouTube, Vimeo, Twitter, CodePen, Figma via oEmbed
 - **Details** - Collapsible content blocks
@@ -262,7 +262,9 @@ const editor = useVizelEditor({
 | `showBubbleMenu` | `boolean` | `true` | Show bubble menu on selection |
 | `enableEmbed` | `boolean` | - | Enable oEmbed/OGP embed previews in the link editor |
 | `transformDiagramsOnImport` | `boolean` | - | Transform diagrams on Markdown import |
+| `flavor` | `VizelMarkdownFlavor` | `"gfm"` | Markdown output flavor (`"commonmark"`, `"gfm"`, `"obsidian"`, `"docusaurus"`) |
 | `extensions` | `Extensions` | - | Additional Tiptap extensions |
+| `onError` | `(error: VizelError) => void` | - | Called when an error occurs |
 | `onCreate` | `(props) => void` | - | Called when editor is created |
 | `onUpdate` | `(props) => void` | - | Called on content update |
 | `onSelectionUpdate` | `(props) => void` | - | Called on selection change |
@@ -272,9 +274,13 @@ const editor = useVizelEditor({
 
 ### Error Handling
 
-The `onError` callback is available through `useVizelEditor` (React), `useVizelEditor` (Vue), or `createVizelEditor` (Svelte). It is not a prop on the `Vizel` all-in-one component.
+The `onError` callback is available as a prop on the `Vizel` all-in-one component, or through `useVizelEditor` (React), `useVizelEditor` (Vue), or `createVizelEditor` (Svelte).
 
 ```typescript
+// Using Vizel component
+<Vizel onError={(error) => console.error(`[${error.code}] ${error.message}`)} />
+
+// Or using useVizelEditor hook
 const editor = useVizelEditor({
   onError: (error) => {
     console.error(`[${error.code}] ${error.message}`);
@@ -286,7 +292,7 @@ const editor = useVizelEditor({
 
 ### Feature Options
 
-All major features are enabled by default except `collaboration`, `comment`, and `wikiLink`:
+All major features are enabled by default except `collaboration`, `comment`, `mention`, and `wikiLink`:
 
 ```typescript
 // Using Vizel component
@@ -318,6 +324,7 @@ const editor = useVizelEditor({
     details: true,         // enabled by default
     diagram: true,         // enabled by default
     wikiLink: true,        // opt-in: must be explicitly enabled
+    mention: true,         // opt-in: must be explicitly enabled
     comment: true,         // opt-in: must be explicitly enabled
     // collaboration: true, // opt-in: must be explicitly enabled
   },

--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,4 +1,5 @@
 import type { Editor, JSONContent } from "@tiptap/core";
+import type { VizelMarkdownFlavor } from "@vizel/core";
 import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
   useVizelAutoSave,
@@ -70,6 +71,7 @@ function AppContent() {
     history: false,
   });
 
+  const [flavor, setFlavor] = useState<VizelMarkdownFlavor>("gfm");
   const [activeTab, setActiveTab] = useState<PanelTab>("markdown");
   const [jsonInput, setJsonInput] = useState("");
   const [markdownInput, setMarkdownInput] = useState("");
@@ -213,6 +215,29 @@ function AppContent() {
             checked={features.history}
             onChange={(v) => updateFeature("history", v)}
           />
+          <label className="feature-toggle">
+            <span className="feature-toggle-label">Flavor</span>
+            <select
+              className="feature-select"
+              value={flavor}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (
+                  value === "commonmark" ||
+                  value === "gfm" ||
+                  value === "obsidian" ||
+                  value === "docusaurus"
+                ) {
+                  setFlavor(value);
+                }
+              }}
+            >
+              <option value="commonmark">CommonMark</option>
+              <option value="gfm">GFM</option>
+              <option value="obsidian">Obsidian</option>
+              <option value="docusaurus">Docusaurus</option>
+            </select>
+          </label>
         </div>
       </section>
 
@@ -224,6 +249,7 @@ function AppContent() {
               autofocus="end"
               className="editor-content"
               showToolbar={features.toolbar}
+              flavor={flavor}
               enableEmbed
               extensions={findReplaceExtensions}
               features={{

--- a/apps/demo/shared/styles/base.css
+++ b/apps/demo/shared/styles/base.css
@@ -202,6 +202,23 @@ body {
   user-select: none;
 }
 
+.feature-select {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--demo-border);
+  border-radius: 4px;
+  background: var(--demo-surface);
+  color: var(--demo-text-strong);
+  cursor: pointer;
+  accent-color: var(--framework-color);
+}
+
+.feature-select:focus {
+  outline: 2px solid var(--framework-color);
+  outline-offset: -1px;
+}
+
 /* Main - Side by Side Layout */
 .main {
   display: flex;

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Editor, JSONContent } from "@tiptap/core";
+import type { VizelMarkdownFlavor } from "@vizel/core";
 import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
   createVizelAutoSave,
@@ -26,6 +27,8 @@ let features = $state({
   comments: false,
   history: false,
 });
+
+let flavor = $state<VizelMarkdownFlavor>("gfm");
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
 let activeTab = $state<PanelTab>("markdown");
@@ -172,6 +175,18 @@ function handleJsonChange(event: Event) {
         <input type="checkbox" bind:checked={features.history} />
         <span class="feature-toggle-label">History</span>
       </label>
+      <label class="feature-toggle">
+        <span class="feature-toggle-label">Flavor</span>
+        <select
+          class="feature-select"
+          bind:value={flavor}
+        >
+          <option value="commonmark">CommonMark</option>
+          <option value="gfm">GFM</option>
+          <option value="obsidian">Obsidian</option>
+          <option value="docusaurus">Docusaurus</option>
+        </select>
+      </label>
     </div>
   </section>
 
@@ -183,6 +198,7 @@ function handleJsonChange(event: Event) {
           autofocus="end"
           class="editor-content"
           showToolbar={features.toolbar}
+          {flavor}
           enableEmbed
           extensions={findReplaceExtensions}
           features={{

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Editor, JSONContent } from "@tiptap/core";
+import type { VizelMarkdownFlavor } from "@vizel/core";
 import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
   useVizelAutoSave,
@@ -27,6 +28,8 @@ const features = reactive({
   comments: false,
   history: false,
 });
+
+const flavor = ref<VizelMarkdownFlavor>("gfm");
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
 const activeTab = ref<PanelTab>("markdown");
@@ -172,6 +175,15 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
             <input type="checkbox" v-model="features.history" />
             <span class="feature-toggle-label">History</span>
           </label>
+          <label class="feature-toggle">
+            <span class="feature-toggle-label">Flavor</span>
+            <select class="feature-select" v-model="flavor">
+              <option value="commonmark">CommonMark</option>
+              <option value="gfm">GFM</option>
+              <option value="obsidian">Obsidian</option>
+              <option value="docusaurus">Docusaurus</option>
+            </select>
+          </label>
         </div>
       </section>
 
@@ -183,6 +195,7 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
               autofocus="end"
               class="editor-content"
               :show-toolbar="features.toolbar"
+              :flavor="flavor"
               enable-embed
               :extensions="findReplaceExtensions"
               :features="{

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -117,6 +117,45 @@ import type { VizelFeatureOptions } from '@vizel/core';
 
 See [Type Definitions](/api/types/features) for full interface.
 
+### VizelMarkdownFlavor
+
+```typescript
+import type { VizelMarkdownFlavor } from '@vizel/core';
+
+type VizelMarkdownFlavor = "commonmark" | "gfm" | "obsidian" | "docusaurus";
+```
+
+Supported Markdown output flavors. Controls how content is serialized when exporting Markdown. The default is `"gfm"`.
+
+### VizelFlavorConfig
+
+```typescript
+import type { VizelFlavorConfig } from '@vizel/core';
+
+interface VizelFlavorConfig {
+  /** How callout/admonition blocks are serialized */
+  calloutFormat: VizelCalloutMarkdownFormat;
+  /** Whether wiki links are serialized as [[page]] (true) or standard links (false) */
+  wikiLinkSerialize: boolean;
+}
+```
+
+Flavor-specific configuration resolved from a `VizelMarkdownFlavor`. Used internally by extensions to determine how to serialize Markdown.
+
+### VizelCalloutMarkdownFormat
+
+```typescript
+import type { VizelCalloutMarkdownFormat } from '@vizel/core';
+
+type VizelCalloutMarkdownFormat =
+  | "github-alerts"
+  | "obsidian-callouts"
+  | "directives"
+  | "blockquote-fallback";
+```
+
+Callout/admonition output format for Markdown serialization.
+
 ### JSONContent
 
 Tiptap's JSON content format. Import directly from `@tiptap/core`:
@@ -167,6 +206,23 @@ const resolved = resolveVizelFeatures({
   },
   createSlashMenuRenderer: mySlashMenuRenderer,
 });
+```
+
+### resolveVizelFlavorConfig
+
+This function resolves flavor-specific configuration from a Markdown flavor name.
+
+```typescript
+import { resolveVizelFlavorConfig } from '@vizel/core';
+
+const config = resolveVizelFlavorConfig('obsidian');
+// config.calloutFormat === "obsidian-callouts"
+// config.wikiLinkSerialize === true
+
+// Defaults to "gfm" when called without arguments
+const defaultConfig = resolveVizelFlavorConfig();
+// defaultConfig.calloutFormat === "github-alerts"
+// defaultConfig.wikiLinkSerialize === false
 ```
 
 ### getVizelEditorState
@@ -326,6 +382,15 @@ const provider = detectVizelEmbedProvider('https://www.youtube.com/watch?v=dQw4w
 ---
 
 ## Constants
+
+### VIZEL_DEFAULT_FLAVOR
+
+This constant defines the default Markdown output flavor.
+
+```typescript
+import { VIZEL_DEFAULT_FLAVOR } from '@vizel/core';
+// "gfm"
+```
 
 ### VIZEL_TEXT_COLORS
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -63,6 +63,39 @@ graph TB
 | `comment` | Text annotations and comments — opt-in |
 | `collaboration` | Real-time collaboration mode (disables History) — opt-in |
 
+## Markdown Flavor Selection
+
+Vizel supports multiple Markdown output flavors to match the platform you are targeting. The `flavor` option controls how content is serialized when exporting Markdown; input parsing is always tolerant and accepts all formats regardless of the selected flavor.
+
+### Available Flavors
+
+| Flavor | Callout Output | WikiLink Output | Target Platforms |
+|--------|---------------|-----------------|------------------|
+| `"commonmark"` | Blockquote fallback | Standard link `[text](wiki://page)` | Stack Overflow, Reddit, email |
+| `"gfm"` (default) | GitHub Alerts `> [!NOTE]` | Standard link `[text](wiki://page)` | GitHub, GitLab, DEV.to |
+| `"obsidian"` | Obsidian Callouts `> [!note]` | `[[page]]` / `[[page\|text]]` | Obsidian, Logseq, Foam |
+| `"docusaurus"` | Directives `:::note` | Standard link `[text](wiki://page)` | Docusaurus, VitePress, Zenn, Qiita |
+
+### Usage
+
+```typescript
+const editor = useVizelEditor({
+  flavor: 'obsidian', // Default: 'gfm'
+});
+```
+
+### Extension-Specific Behavior
+
+- **Callout**: Serializes admonition blocks in the format matching the selected flavor. All four callout formats are parsed regardless of flavor.
+- **WikiLink**: When `flavor` is `"obsidian"`, wiki links serialize as `[[page]]` syntax. For all other flavors, they serialize as standard Markdown links `[text](wiki://page)`.
+- **Mention**: Always serializes as `@username` regardless of flavor.
+
+::: tip
+You can override the flavor-driven defaults for individual extensions. For example, set `wikiLink.serializeAsWikiLink` or `callout.markdownFormat` explicitly to override the flavor configuration.
+:::
+
+---
+
 ## Disabling Features
 
 Set a feature to `false` to disable it:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -415,6 +415,34 @@ let markdown = $state('# Hello World');
 
 :::
 
+## Markdown Flavor
+
+Vizel supports multiple Markdown output flavors. The `flavor` option controls how content is serialized (e.g., callout format, wiki link syntax). Input parsing is always tolerant and accepts all formats.
+
+::: code-group
+
+```tsx [React]
+const editor = useVizelEditor({
+  flavor: 'obsidian', // 'commonmark' | 'gfm' (default) | 'obsidian' | 'docusaurus'
+});
+```
+
+```vue [Vue]
+const editor = useVizelEditor({
+  flavor: 'obsidian',
+});
+```
+
+```svelte [Svelte]
+const editor = createVizelEditor({
+  flavor: 'obsidian',
+});
+```
+
+:::
+
+See [Features - Markdown Flavor Selection](/guide/features#markdown-flavor-selection) for details on each flavor.
+
 ## Enabling Features
 
 All features are enabled by default except `collaboration`, `comment`, and `wikiLink`. You can disable specific features by setting them to `false`, or pass an options object to configure them:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,6 +73,36 @@ All extensions are enabled by default except `collaboration`, `comment`, `wikiLi
 | Mention | `@user` autocomplete (opt-in) |
 | Comment | Text annotations for collaborative review (opt-in) |
 
+## Markdown Flavor
+
+Vizel supports multiple Markdown output flavors via the `flavor` option. The flavor controls how extensions serialize content (e.g., callout format, wiki link syntax). Input parsing is always tolerant and accepts all formats.
+
+| Flavor | Callout Output | WikiLink Output | Platforms |
+|--------|---------------|-----------------|-----------|
+| `"commonmark"` | Blockquote fallback | `[text](wiki://page)` | Stack Overflow, Reddit, email |
+| `"gfm"` (default) | `> [!NOTE]` | `[text](wiki://page)` | GitHub, GitLab, DEV.to |
+| `"obsidian"` | `> [!note]` | `[[page]]` | Obsidian, Logseq, Foam |
+| `"docusaurus"` | `:::note` | `[text](wiki://page)` | Docusaurus, VitePress, Zenn, Qiita |
+
+### API
+
+```typescript
+import {
+  resolveVizelFlavorConfig,
+  VIZEL_DEFAULT_FLAVOR,
+} from '@vizel/core';
+import type {
+  VizelMarkdownFlavor,
+  VizelFlavorConfig,
+  VizelCalloutMarkdownFormat,
+} from '@vizel/core';
+
+// Resolve flavor to config
+const config = resolveVizelFlavorConfig('obsidian');
+// config.calloutFormat === "obsidian-callouts"
+// config.wikiLinkSerialize === true
+```
+
 ## Usage
 
 This package is used as a dependency of framework-specific packages:

--- a/packages/core/src/extensions/callout.ts
+++ b/packages/core/src/extensions/callout.ts
@@ -2,7 +2,14 @@
  * Callout / Admonition Extension
  *
  * Provides callout blocks for informational content (info, warning, danger, tip, note).
- * Uses `:::type ... :::` Markdown syntax (compatible with remark-admonitions / GitHub Alerts).
+ * Supports multiple Markdown flavors for input and output:
+ * - Directives: `:::type ... :::`
+ * - GitHub Alerts: `> [!TYPE]`
+ * - Obsidian Callouts: `> [!type]`
+ * - CommonMark fallback: `> **Type**: content`
+ *
+ * Input parsing is always tolerant (all formats recognized).
+ * Output format is controlled by the `markdownFormat` option.
  */
 
 import type {
@@ -13,11 +20,23 @@ import type {
   MarkdownToken,
 } from "@tiptap/core";
 import { Node } from "@tiptap/core";
+import type { VizelCalloutMarkdownFormat } from "../utils/markdown-flavors.ts";
 
 /**
  * Available callout types
  */
 export type VizelCalloutType = "info" | "warning" | "danger" | "tip" | "note";
+
+const VIZEL_CALLOUT_TYPES: ReadonlySet<string> = new Set<VizelCalloutType>([
+  "info",
+  "warning",
+  "danger",
+  "tip",
+  "note",
+]);
+
+const isVizelCalloutType = (value: string): value is VizelCalloutType =>
+  VIZEL_CALLOUT_TYPES.has(value);
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -50,7 +69,88 @@ export interface VizelCalloutOptions {
    * HTML attributes to add to the callout element
    */
   HTMLAttributes?: Record<string, unknown>;
+  /**
+   * Markdown output format for callout serialization.
+   *
+   * When using `createVizelExtensions()`, this is set automatically based on the editor's
+   * `flavor` setting (e.g. `"gfm"` → `"github-alerts"`, `"obsidian"` → `"obsidian-callouts"`).
+   * When using `VizelCallout` directly, defaults to `"directives"`.
+   */
+  markdownFormat?: VizelCalloutMarkdownFormat;
 }
+
+// ─── Type mappings ──────────────────────────────────────────────────────────
+
+/** Map Vizel callout types to GitHub Alert types (UPPER_CASE) */
+const VIZEL_TO_GITHUB_ALERT: Record<VizelCalloutType, string> = {
+  note: "NOTE",
+  info: "NOTE",
+  tip: "TIP",
+  warning: "WARNING",
+  danger: "CAUTION",
+};
+
+/** Map GitHub Alert types to Vizel callout types */
+const GITHUB_ALERT_TO_VIZEL: Record<string, VizelCalloutType> = {
+  NOTE: "note",
+  TIP: "tip",
+  IMPORTANT: "info",
+  WARNING: "warning",
+  CAUTION: "danger",
+};
+
+/**
+ * Parse an alert/callout type string to a Vizel callout type.
+ * Handles GitHub Alerts (UPPER_CASE), Obsidian (lowercase), and directives.
+ */
+function parseCalloutType(raw: string): VizelCalloutType {
+  const upper = raw.toUpperCase();
+  const fromAlert = GITHUB_ALERT_TO_VIZEL[upper];
+  if (fromAlert) {
+    return fromAlert;
+  }
+  const lower = raw.toLowerCase();
+  if (isVizelCalloutType(lower)) {
+    return lower;
+  }
+  return "info";
+}
+
+/**
+ * Strip blockquote prefix (`> `) from each line of content.
+ */
+function stripBlockquotePrefix(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^> ?/, ""))
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Add blockquote prefix (`> `) to each line of content.
+ */
+function addBlockquotePrefix(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+// ─── Tokenizer patterns ────────────────────────────────────────────────────
+
+/** Directives: `:::type\ncontent\n:::` */
+const DIRECTIVE_REGEX = /^:::(\w+)\n([\s\S]*?)\n:::\n?/;
+
+/**
+ * GitHub Alerts / Obsidian Callouts: `> [!TYPE]\n> content`
+ * Matches:
+ * - `> [!NOTE]` (GitHub)
+ * - `> [!note]` (Obsidian)
+ * - `> [!Warning]` (mixed case)
+ * Content continues as long as lines start with `>`
+ */
+const ALERT_REGEX = /^> \[!(\w+)\]\n((?:>[ \t]?.*(?:\n|$))*)/;
 
 /**
  * The Callout node extension.
@@ -79,15 +179,18 @@ export const VizelCallout = Node.create<VizelCalloutOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
+      markdownFormat: "directives" satisfies VizelCalloutMarkdownFormat,
     };
   },
 
   addAttributes() {
     return {
       type: {
-        default: "info" as VizelCalloutType,
-        parseHTML: (element: HTMLElement) =>
-          (element.getAttribute("data-type") as VizelCalloutType) || "info",
+        default: "info" satisfies VizelCalloutType,
+        parseHTML: (element: HTMLElement) => {
+          const raw = element.getAttribute("data-type") ?? "";
+          return isVizelCalloutType(raw) ? raw : "info";
+        },
         renderHTML: (attributes: Record<string, unknown>) => ({
           "data-type": attributes.type,
         }),
@@ -155,19 +258,27 @@ export const VizelCallout = Node.create<VizelCalloutOptions>({
     };
   },
 
-  // Markdown serialization: :::type\ncontent\n:::
+  // Markdown serialization: default format (directives).
+  // Flavor-aware serialization is provided by createVizelCalloutExtension() via .extend() closure.
   renderMarkdown(node, helpers) {
-    const type = (node as JSONContent).attrs?.type || "info";
+    const rawType = String((node as JSONContent).attrs?.type ?? "info");
+    const type = isVizelCalloutType(rawType) ? rawType : "info";
     const content = helpers.renderChildren((node as JSONContent).content ?? [], "\n\n");
     return `:::${type}\n${content}\n:::\n\n`;
   },
 
-  // Markdown tokenizer: recognize :::type ... ::: blocks
+  // Markdown tokenizer: recognize multiple callout formats
   markdownTokenizer: {
     name: "callout",
+    level: "block" as const,
 
     start(src: string) {
-      return src.indexOf(":::");
+      const directiveIdx = src.indexOf(":::");
+      const alertIdx = src.indexOf("> [!");
+      if (directiveIdx === -1 && alertIdx === -1) return -1;
+      if (directiveIdx === -1) return alertIdx;
+      if (alertIdx === -1) return directiveIdx;
+      return Math.min(directiveIdx, alertIdx);
     },
 
     tokenize(
@@ -175,19 +286,38 @@ export const VizelCallout = Node.create<VizelCalloutOptions>({
       _tokens: MarkdownToken[],
       lexer: MarkdownLexerConfiguration
     ): MarkdownToken | undefined {
-      const match = /^:::(\w+)\n([\s\S]*?)\n:::\n?/.exec(src);
-      if (!match) return undefined;
+      // Try directive format first: :::type\ncontent\n:::
+      const directiveMatch = DIRECTIVE_REGEX.exec(src);
+      if (directiveMatch) {
+        const admonitionType = parseCalloutType(directiveMatch[1] ?? "info");
+        const text = directiveMatch[2] ?? "";
 
-      const admonitionType = match[1] ?? "info";
-      const text = match[2] ?? "";
+        return {
+          type: "callout",
+          raw: directiveMatch[0],
+          admonitionType,
+          text,
+          tokens: lexer.blockTokens(text),
+        };
+      }
 
-      return {
-        type: "callout",
-        raw: match[0],
-        admonitionType,
-        text,
-        tokens: lexer.blockTokens(text),
-      };
+      // Try alert/callout format: > [!TYPE]\n> content
+      const alertMatch = ALERT_REGEX.exec(src);
+      if (alertMatch) {
+        const admonitionType = parseCalloutType(alertMatch[1] ?? "info");
+        const rawContent = alertMatch[2] ?? "";
+        const text = stripBlockquotePrefix(rawContent);
+
+        return {
+          type: "callout",
+          raw: alertMatch[0],
+          admonitionType,
+          text,
+          tokens: lexer.blockTokens(text),
+        };
+      }
+
+      return undefined;
     },
   },
 
@@ -209,16 +339,48 @@ export const VizelCallout = Node.create<VizelCalloutOptions>({
  * import { createVizelCalloutExtension } from '@vizel/core'
  *
  * const extensions = [
- *   createVizelCalloutExtension(),
+ *   createVizelCalloutExtension({ markdownFormat: "github-alerts" }),
  * ]
  * ```
  */
-export function createVizelCalloutExtension(
-  options: VizelCalloutOptions = {}
-): ReturnType<typeof VizelCallout.configure> {
-  return VizelCallout.configure({
+export function createVizelCalloutExtension(options: VizelCalloutOptions = {}) {
+  const markdownFormat: VizelCalloutMarkdownFormat = options.markdownFormat ?? "directives";
+
+  // Use .extend() to capture markdownFormat in a closure for renderMarkdown,
+  // because `this.options` / `this.storage` are not accessible in the renderMarkdown context.
+  return VizelCallout.extend({
+    renderMarkdown(node, helpers) {
+      const rawType = String((node as JSONContent).attrs?.type ?? "info");
+      const type = isVizelCalloutType(rawType) ? rawType : "info";
+      const content = helpers.renderChildren((node as JSONContent).content ?? [], "\n\n");
+
+      switch (markdownFormat) {
+        case "github-alerts": {
+          const alertType = VIZEL_TO_GITHUB_ALERT[type] || "NOTE";
+          const indented = addBlockquotePrefix(content);
+          return `> [!${alertType}]\n${indented}\n\n`;
+        }
+        case "obsidian-callouts": {
+          const indented = addBlockquotePrefix(content);
+          return `> [!${type}]\n${indented}\n\n`;
+        }
+        case "blockquote-fallback": {
+          const label = type.charAt(0).toUpperCase() + type.slice(1);
+          const prefixed = addBlockquotePrefix(`**${label}**: ${content}`);
+          return `${prefixed}\n\n`;
+        }
+        case "directives":
+          return `:::${type}\n${content}\n:::\n\n`;
+        default: {
+          const _exhaustive: never = markdownFormat;
+          return `:::${type}\n${content}\n:::\n\n`;
+        }
+      }
+    },
+  }).configure({
     HTMLAttributes: {
       ...options.HTMLAttributes,
     },
+    markdownFormat,
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -339,21 +339,26 @@ export {
   registerVizelUploadEventHandler,
   removeVizelPortalContainer,
   resolveVizelFeatures,
+  // Markdown flavor utilities
+  resolveVizelFlavorConfig,
   setVizelMarkdown,
   // Text highlight utilities
   splitVizelTextByMatches,
   transformVizelDiagramCodeBlocks,
   unmountFromVizelPortal,
+  VIZEL_DEFAULT_FLAVOR,
   VIZEL_DEFAULT_MARKDOWN_DEBOUNCE_MS,
   VIZEL_PORTAL_ID,
   VIZEL_PORTAL_Z_INDEX,
   VIZEL_SUGGESTION_Z_INDEX,
   VIZEL_UPLOAD_IMAGE_EVENT,
+  type VizelCalloutMarkdownFormat,
   type VizelContentNode,
   type VizelCreateUploadEventHandlerOptions,
   type VizelDOMRectGetter,
   VizelError,
   type VizelErrorCode,
+  type VizelFlavorConfig,
   type VizelMarkdownSyncHandlers,
   type VizelMountPortalOptions,
   type VizelPortalLayer,
@@ -364,6 +369,8 @@ export {
   type WrapAsVizelErrorOptions,
   wrapAsVizelError,
 } from "./utils/index.ts";
+// Re-export VizelMarkdownFlavor type from markdown-flavors utility
+export type { VizelMarkdownFlavor } from "./utils/markdown-flavors.ts";
 // =============================================================================
 // Version History
 // =============================================================================

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,7 @@ import type { VizelTextColorOptions } from "./extensions/text-color.ts";
 import type { VizelWikiLinkOptions } from "./extensions/wiki-link.ts";
 import type { VizelImageUploadPluginOptions } from "./plugins/image-upload.ts";
 import type { VizelError } from "./utils/errorHandling.ts";
+import type { VizelMarkdownFlavor } from "./utils/markdown-flavors.ts";
 
 /**
  * Slash command feature options
@@ -112,6 +113,19 @@ export interface VizelFeatureOptions {
 export interface VizelEditorOptions {
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /**
+   * Markdown output flavor.
+   * Controls how Markdown is serialized when exporting content.
+   *
+   * - `"commonmark"` — Standard CommonMark (callouts fall back to blockquotes)
+   * - `"gfm"` — GitHub Flavored Markdown with `> [!NOTE]` alerts (default)
+   * - `"obsidian"` — Obsidian-style `> [!note]` callouts and `[[wiki-links]]`
+   * - `"docusaurus"` — Docusaurus/VitePress `:::note` admonitions
+   *
+   * Input parsing is always tolerant: all callout formats are recognized regardless of flavor.
+   * @default "gfm"
+   */
+  flavor?: VizelMarkdownFlavor;
   /** Initial content in JSON format */
   initialContent?: JSONContent;
   /**

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -62,6 +62,7 @@ export async function createVizelEditorInstance(
     editable = true,
     autofocus = false,
     features,
+    flavor,
     extensions: additionalExtensions = [],
     createSlashMenuRenderer,
     onUpdate,
@@ -96,6 +97,7 @@ export async function createVizelEditorInstance(
   const vizelExtensions = await createVizelExtensions({
     ...(placeholder !== undefined && { placeholder }),
     ...(resolvedFeatures !== undefined && { features: resolvedFeatures }),
+    ...(flavor !== undefined && { flavor }),
   });
 
   // Create the editor instance

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -44,6 +44,14 @@ export {
   VIZEL_DEFAULT_MARKDOWN_DEBOUNCE_MS,
   type VizelMarkdownSyncHandlers,
 } from "./markdown.ts";
+// Markdown flavor utilities
+export {
+  resolveVizelFlavorConfig,
+  VIZEL_DEFAULT_FLAVOR,
+  type VizelCalloutMarkdownFormat,
+  type VizelFlavorConfig,
+  type VizelMarkdownFlavor,
+} from "./markdown-flavors.ts";
 // Portal utilities
 export {
   createVizelPortalElement,

--- a/packages/core/src/utils/markdown-flavors.ts
+++ b/packages/core/src/utils/markdown-flavors.ts
@@ -1,0 +1,77 @@
+/**
+ * Markdown flavor definitions and resolution utilities.
+ *
+ * Vizel supports multiple Markdown output flavors while parsing all formats tolerantly.
+ * The flavor setting only affects serialization (output); input parsing accepts all formats.
+ */
+
+/**
+ * Supported Markdown output flavors.
+ *
+ * | Flavor | Callout Output | WikiLinks | Platforms |
+ * |--------|---------------|-----------|-----------|
+ * | `commonmark` | Blockquote fallback | No | SO, Reddit, email |
+ * | `gfm` | `> [!NOTE]` | No | GitHub, GitLab, DEV.to |
+ * | `obsidian` | `> [!note]` | `[[page]]` | Obsidian, Logseq, Foam |
+ * | `docusaurus` | `:::note` | No | Docusaurus, VitePress, Zenn, Qiita |
+ */
+export type VizelMarkdownFlavor = "commonmark" | "gfm" | "obsidian" | "docusaurus";
+
+/** Callout/admonition output format for Markdown serialization */
+export type VizelCalloutMarkdownFormat =
+  | "github-alerts"
+  | "obsidian-callouts"
+  | "directives"
+  | "blockquote-fallback";
+
+/**
+ * Flavor-specific configuration resolved from a {@link VizelMarkdownFlavor}.
+ * Used internally by extensions to determine how to serialize Markdown.
+ */
+export interface VizelFlavorConfig {
+  /** How callout/admonition blocks are serialized */
+  calloutFormat: VizelCalloutMarkdownFormat;
+  /** Whether wiki links are serialized as `[[page]]` (true) or standard links (false) */
+  wikiLinkSerialize: boolean;
+}
+
+/** Default Markdown flavor */
+export const VIZEL_DEFAULT_FLAVOR: VizelMarkdownFlavor = "gfm";
+
+const FLAVOR_CONFIGS = {
+  commonmark: {
+    calloutFormat: "blockquote-fallback",
+    wikiLinkSerialize: false,
+  },
+  gfm: {
+    calloutFormat: "github-alerts",
+    wikiLinkSerialize: false,
+  },
+  obsidian: {
+    calloutFormat: "obsidian-callouts",
+    wikiLinkSerialize: true,
+  },
+  docusaurus: {
+    calloutFormat: "directives",
+    wikiLinkSerialize: false,
+  },
+} as const satisfies Record<VizelMarkdownFlavor, VizelFlavorConfig>;
+
+/**
+ * Resolve flavor-specific configuration from a Markdown flavor name.
+ *
+ * @param flavor - The Markdown flavor to resolve. Defaults to `"gfm"`.
+ * @returns Flavor configuration for extension serialization.
+ *
+ * @example
+ * ```typescript
+ * const config = resolveVizelFlavorConfig("obsidian");
+ * // config.calloutFormat === "obsidian-callouts"
+ * // config.wikiLinkSerialize === true
+ * ```
+ */
+export function resolveVizelFlavorConfig(
+  flavor: VizelMarkdownFlavor = VIZEL_DEFAULT_FLAVOR
+): VizelFlavorConfig {
+  return FLAVOR_CONFIGS[flavor];
+}

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -6,6 +6,7 @@ import {
   setVizelMarkdown,
   type VizelError,
   type VizelFeatureOptions,
+  type VizelMarkdownFlavor,
 } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useEffect, useImperativeHandle, useRef } from "react";
@@ -42,6 +43,12 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /**
+   * Markdown output flavor.
+   * Controls how Markdown is serialized when exporting content.
+   * @default "gfm"
+   */
+  flavor?: VizelMarkdownFlavor;
   /** Additional Tiptap extensions */
   extensions?: Extensions;
   /** Custom class name for the editor container */
@@ -145,6 +152,7 @@ export function Vizel({
   editable = true,
   autofocus = false,
   features,
+  flavor,
   extensions,
   className,
   showToolbar = false,
@@ -184,6 +192,7 @@ export function Vizel({
     editable,
     autofocus,
     ...(features !== undefined && { features }),
+    ...(flavor !== undefined && { flavor }),
     ...(extensions !== undefined && { extensions }),
     onUpdate: (e) => {
       onUpdateRef.current?.(e);

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -1,5 +1,12 @@
 <script lang="ts" module>
-import type { Editor, Extensions, JSONContent, VizelError, VizelFeatureOptions } from "@vizel/core";
+import type {
+  Editor,
+  Extensions,
+  JSONContent,
+  VizelError,
+  VizelFeatureOptions,
+  VizelMarkdownFlavor,
+} from "@vizel/core";
 import type { Snippet } from "svelte";
 
 /**
@@ -42,6 +49,12 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /**
+   * Markdown output flavor.
+   * Controls how Markdown is serialized when exporting content.
+   * @default "gfm"
+   */
+  flavor?: VizelMarkdownFlavor;
   /** Additional Tiptap extensions */
   extensions?: Extensions;
   /** Custom class name for the editor container */
@@ -130,6 +143,7 @@ const editorState = createVizelEditor({
   editable: restProps.editable ?? true,
   autofocus: restProps.autofocus ?? false,
   ...(restProps.features !== undefined && { features: restProps.features }),
+  ...(restProps.flavor !== undefined && { flavor: restProps.flavor }),
   ...(restProps.extensions !== undefined && { extensions: restProps.extensions }),
   onUpdate: wrappedOnUpdate,
   ...(restProps.onCreate !== undefined && { onCreate: restProps.onCreate }),

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -11,6 +11,7 @@ import {
   setVizelMarkdown,
   type VizelError,
   type VizelFeatureOptions,
+  type VizelMarkdownFlavor,
 } from "@vizel/core";
 import { useSlots, watch } from "vue";
 import { useVizelEditor } from "../composables/useVizelEditor.ts";
@@ -53,6 +54,12 @@ export interface VizelProps {
   autofocus?: boolean | "start" | "end" | "all" | number;
   /** Feature configuration */
   features?: VizelFeatureOptions;
+  /**
+   * Markdown output flavor.
+   * Controls how Markdown is serialized when exporting content.
+   * @default "gfm"
+   */
+  flavor?: VizelMarkdownFlavor;
   /** Additional Tiptap extensions */
   extensions?: Extensions;
   /** Custom class name for the editor container */
@@ -111,6 +118,7 @@ const editor = useVizelEditor({
   editable: props.editable,
   autofocus: props.autofocus,
   ...(props.features !== undefined && { features: props.features }),
+  ...(props.flavor !== undefined && { flavor: props.flavor }),
   ...(props.extensions !== undefined && { extensions: props.extensions }),
   onUpdate: (e) => {
     emit("update", e);

--- a/tests/ct/react/specs/MarkdownFlavors.spec.tsx
+++ b/tests/ct/react/specs/MarkdownFlavors.spec.tsx
@@ -1,0 +1,82 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testCalloutCommonmarkOutput,
+  testCalloutDocusaurusOutput,
+  testCalloutGfmOutput,
+  testCalloutObsidianOutput,
+  testCalloutParseDocusaurus,
+  testCalloutParseGfm,
+  testCalloutParseObsidian,
+  testCalloutRoundtrip,
+} from "../../scenarios/markdown-flavors.scenario";
+import { MarkdownFlavorsFixture } from "./MarkdownFlavorsFixture";
+
+test.describe("Markdown Flavors - React", () => {
+  test.describe("Callout output by flavor", () => {
+    test("GFM flavor serializes callout as > [!NOTE]", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="gfm" />);
+      await testCalloutGfmOutput(component, page);
+    });
+
+    test("Obsidian flavor serializes callout as > [!info]", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="obsidian" />);
+      await testCalloutObsidianOutput(component, page);
+    });
+
+    test("Docusaurus flavor serializes callout as :::info", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="docusaurus" />);
+      await testCalloutDocusaurusOutput(component, page);
+    });
+
+    test("CommonMark flavor serializes callout as > **Info**: content", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="commonmark" />);
+      await testCalloutCommonmarkOutput(component, page);
+    });
+  });
+
+  test.describe("Tolerant input parsing", () => {
+    test("parses GFM-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="docusaurus" />);
+      await testCalloutParseGfm(component, page);
+    });
+
+    test("parses Obsidian-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="gfm" />);
+      await testCalloutParseObsidian(component, page);
+    });
+
+    test("parses Docusaurus-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="obsidian" />);
+      await testCalloutParseDocusaurus(component, page);
+    });
+  });
+
+  test.describe("Roundtrip", () => {
+    test("GFM roundtrip: import any format, export as GFM", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="gfm" />);
+      await testCalloutRoundtrip(component, page, /> \[!NOTE\]/);
+    });
+
+    test("Obsidian roundtrip: import any format, export as Obsidian", async ({ mount, page }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="obsidian" />);
+      // Obsidian uses lowercase type; "note" is the mapped type for "info" callouts from GFM input
+      await testCalloutRoundtrip(component, page, /> \[!(?:note|info)\]/);
+    });
+
+    test("Docusaurus roundtrip: import any format, export as directives", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="docusaurus" />);
+      await testCalloutRoundtrip(component, page, /:::(?:note|info)/);
+    });
+
+    test("CommonMark roundtrip: import any format, export as blockquote", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(<MarkdownFlavorsFixture flavor="commonmark" />);
+      await testCalloutRoundtrip(component, page, /> \*\*(?:Note|Info)\*\*:/);
+    });
+  });
+});

--- a/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
+++ b/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
@@ -1,0 +1,92 @@
+import type { VizelMarkdownFlavor } from "@vizel/core";
+import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/react";
+import { useState } from "react";
+
+export interface MarkdownFlavorsFixtureProps {
+  flavor?: VizelMarkdownFlavor;
+}
+
+export function MarkdownFlavorsFixture({ flavor = "gfm" }: MarkdownFlavorsFixtureProps) {
+  const [markdownOutput, setMarkdownOutput] = useState("");
+
+  const editor = useVizelEditor({
+    flavor,
+    features: {
+      callout: true,
+    },
+  });
+
+  const handleExport = () => {
+    if (editor) {
+      const md = editor.getMarkdown();
+      setMarkdownOutput(md);
+    }
+  };
+
+  const handleInsertCallout = () => {
+    if (editor) {
+      editor
+        .chain()
+        .focus()
+        .setCallout({ type: "info" })
+        .insertContent("Test callout content")
+        .run();
+    }
+  };
+
+  const handleImportCalloutGfm = () => {
+    if (editor) {
+      editor.commands.setContent("> [!NOTE]\n> GFM callout content", {
+        contentType: "markdown",
+      });
+    }
+  };
+
+  const handleImportCalloutObsidian = () => {
+    if (editor) {
+      editor.commands.setContent("> [!note]\n> Obsidian callout content", {
+        contentType: "markdown",
+      });
+    }
+  };
+
+  const handleImportCalloutDocusaurus = () => {
+    if (editor) {
+      editor.commands.setContent(":::info\nDocusaurus callout content\n:::", {
+        contentType: "markdown",
+      });
+    }
+  };
+
+  return (
+    <VizelProvider editor={editor}>
+      <div className="toolbar">
+        <button type="button" data-testid="insert-callout" onClick={handleInsertCallout}>
+          Insert Callout
+        </button>
+        <button type="button" data-testid="export-button" onClick={handleExport}>
+          Export
+        </button>
+        <button type="button" data-testid="import-callout-gfm" onClick={handleImportCalloutGfm}>
+          Import GFM Callout
+        </button>
+        <button
+          type="button"
+          data-testid="import-callout-obsidian"
+          onClick={handleImportCalloutObsidian}
+        >
+          Import Obsidian Callout
+        </button>
+        <button
+          type="button"
+          data-testid="import-callout-docusaurus"
+          onClick={handleImportCalloutDocusaurus}
+        >
+          Import Docusaurus Callout
+        </button>
+      </div>
+      <VizelEditor />
+      <pre data-testid="markdown-output">{markdownOutput}</pre>
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/markdown-flavors.scenario.ts
+++ b/tests/ct/scenarios/markdown-flavors.scenario.ts
@@ -1,0 +1,195 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared test scenarios for Markdown flavor-specific output.
+ *
+ * These scenarios are framework-agnostic and can be used with React, Vue, and Svelte.
+ * They test that callout nodes are serialized differently depending on the
+ * configured Markdown flavor (gfm, obsidian, docusaurus, commonmark).
+ *
+ * The fixture must provide:
+ * - A button `[data-testid="insert-callout"]` that inserts a callout with type "info"
+ *   and content "Test callout content"
+ * - A button `[data-testid="export-button"]` that exports markdown to `[data-testid="markdown-output"]`
+ * - A button `[data-testid="import-callout-gfm"]` that imports GFM-style callout markdown
+ * - A button `[data-testid="import-callout-obsidian"]` that imports Obsidian-style callout markdown
+ * - A button `[data-testid="import-callout-docusaurus"]` that imports Docusaurus-style callout markdown
+ */
+
+/**
+ * Wait for the editor to be ready before interacting.
+ */
+async function waitForEditor(component: Locator): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await expect(editor).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Test that the editor serializes callouts according to the GFM flavor.
+ * Expected output: `> [!NOTE]\n> content`
+ */
+export async function testCalloutGfmOutput(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const markdownOutput = component.locator("[data-testid='markdown-output']");
+
+  // Insert callout via button
+  const insertButton = component.locator("[data-testid='insert-callout']");
+  await insertButton.click();
+
+  // Export markdown
+  const exportButton = component.locator("[data-testid='export-button']");
+  await exportButton.click();
+
+  // GFM uses uppercase alert syntax: > [!NOTE]
+  await expect(markdownOutput).toContainText("> [!NOTE]");
+  await expect(markdownOutput).toContainText("Test callout content");
+}
+
+/**
+ * Test that the editor serializes callouts according to the Obsidian flavor.
+ * Expected output: `> [!info]\n> content`
+ */
+export async function testCalloutObsidianOutput(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const markdownOutput = component.locator("[data-testid='markdown-output']");
+
+  // Insert callout via button
+  const insertButton = component.locator("[data-testid='insert-callout']");
+  await insertButton.click();
+
+  // Export markdown
+  const exportButton = component.locator("[data-testid='export-button']");
+  await exportButton.click();
+
+  // Obsidian uses lowercase callout syntax: > [!info]
+  await expect(markdownOutput).toContainText("> [!info]");
+  await expect(markdownOutput).toContainText("Test callout content");
+}
+
+/**
+ * Test that the editor serializes callouts according to the Docusaurus flavor.
+ * Expected output: `:::info\ncontent\n:::`
+ */
+export async function testCalloutDocusaurusOutput(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const markdownOutput = component.locator("[data-testid='markdown-output']");
+
+  // Insert callout via button
+  const insertButton = component.locator("[data-testid='insert-callout']");
+  await insertButton.click();
+
+  // Export markdown
+  const exportButton = component.locator("[data-testid='export-button']");
+  await exportButton.click();
+
+  // Docusaurus uses directive syntax: :::info
+  await expect(markdownOutput).toContainText(":::info");
+  await expect(markdownOutput).toContainText("Test callout content");
+  // Closing directive
+  await expect(markdownOutput).toContainText(":::");
+}
+
+/**
+ * Test that the editor serializes callouts according to the CommonMark flavor.
+ * Expected output: `> **Info**: content`
+ */
+export async function testCalloutCommonmarkOutput(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const markdownOutput = component.locator("[data-testid='markdown-output']");
+
+  // Insert callout via button
+  const insertButton = component.locator("[data-testid='insert-callout']");
+  await insertButton.click();
+
+  // Export markdown
+  const exportButton = component.locator("[data-testid='export-button']");
+  await exportButton.click();
+
+  // CommonMark uses blockquote fallback: > **Info**: content
+  await expect(markdownOutput).toContainText("> **Info**:");
+  await expect(markdownOutput).toContainText("Test callout content");
+}
+
+/**
+ * Test that GFM-style callout markdown is parsed correctly regardless of flavor.
+ * Input parsing is always tolerant.
+ */
+export async function testCalloutParseGfm(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const editor = component.locator(".vizel-editor");
+
+  // Import GFM-style callout
+  const importButton = component.locator("[data-testid='import-callout-gfm']");
+  await importButton.click();
+
+  // Verify callout was rendered in the editor
+  const callout = editor.locator("[data-callout]");
+  await expect(callout).toBeVisible();
+  await expect(callout).toContainText("GFM callout content");
+}
+
+/**
+ * Test that Obsidian-style callout markdown is parsed correctly regardless of flavor.
+ * Input parsing is always tolerant.
+ */
+export async function testCalloutParseObsidian(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const editor = component.locator(".vizel-editor");
+
+  // Import Obsidian-style callout
+  const importButton = component.locator("[data-testid='import-callout-obsidian']");
+  await importButton.click();
+
+  // Verify callout was rendered in the editor
+  const callout = editor.locator("[data-callout]");
+  await expect(callout).toBeVisible();
+  await expect(callout).toContainText("Obsidian callout content");
+}
+
+/**
+ * Test that Docusaurus-style callout markdown is parsed correctly regardless of flavor.
+ * Input parsing is always tolerant.
+ */
+export async function testCalloutParseDocusaurus(component: Locator, _page: Page): Promise<void> {
+  await waitForEditor(component);
+  const editor = component.locator(".vizel-editor");
+
+  // Import Docusaurus-style callout
+  const importButton = component.locator("[data-testid='import-callout-docusaurus']");
+  await importButton.click();
+
+  // Verify callout was rendered in the editor
+  const callout = editor.locator("[data-callout]");
+  await expect(callout).toBeVisible();
+  await expect(callout).toContainText("Docusaurus callout content");
+}
+
+/**
+ * Test roundtrip: import callout markdown, then export and verify the output matches
+ * the configured flavor format.
+ */
+export async function testCalloutRoundtrip(
+  component: Locator,
+  _page: Page,
+  expectedPattern: RegExp
+): Promise<void> {
+  await waitForEditor(component);
+  const markdownOutput = component.locator("[data-testid='markdown-output']");
+
+  // Import GFM-style callout (all flavors should parse this)
+  const importButton = component.locator("[data-testid='import-callout-gfm']");
+  await importButton.click();
+
+  // Verify callout was rendered
+  const editor = component.locator(".vizel-editor");
+  const callout = editor.locator("[data-callout]");
+  await expect(callout).toBeVisible();
+
+  // Export and verify the output matches the configured flavor
+  const exportButton = component.locator("[data-testid='export-button']");
+  await exportButton.click();
+
+  const output = await markdownOutput.textContent();
+  expect(output).toMatch(expectedPattern);
+}

--- a/tests/ct/svelte/specs/MarkdownFlavors.spec.ts
+++ b/tests/ct/svelte/specs/MarkdownFlavors.spec.ts
@@ -1,0 +1,103 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testCalloutCommonmarkOutput,
+  testCalloutDocusaurusOutput,
+  testCalloutGfmOutput,
+  testCalloutObsidianOutput,
+  testCalloutParseDocusaurus,
+  testCalloutParseGfm,
+  testCalloutParseObsidian,
+  testCalloutRoundtrip,
+} from "../../scenarios/markdown-flavors.scenario";
+import MarkdownFlavorsFixture from "./MarkdownFlavorsFixture.svelte";
+
+test.describe("Markdown Flavors - Svelte", () => {
+  test.describe("Callout output by flavor", () => {
+    test("GFM flavor serializes callout as > [!NOTE]", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutGfmOutput(component, page);
+    });
+
+    test("Obsidian flavor serializes callout as > [!info]", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutObsidianOutput(component, page);
+    });
+
+    test("Docusaurus flavor serializes callout as :::info", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutDocusaurusOutput(component, page);
+    });
+
+    test("CommonMark flavor serializes callout as > **Info**: content", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "commonmark" },
+      });
+      await testCalloutCommonmarkOutput(component, page);
+    });
+  });
+
+  test.describe("Tolerant input parsing", () => {
+    test("parses GFM-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutParseGfm(component, page);
+    });
+
+    test("parses Obsidian-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutParseObsidian(component, page);
+    });
+
+    test("parses Docusaurus-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutParseDocusaurus(component, page);
+    });
+  });
+
+  test.describe("Roundtrip", () => {
+    test("GFM roundtrip: import any format, export as GFM", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutRoundtrip(component, page, /> \[!NOTE\]/);
+    });
+
+    test("Obsidian roundtrip: import any format, export as Obsidian", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutRoundtrip(component, page, /> \[!(?:note|info)\]/);
+    });
+
+    test("Docusaurus roundtrip: import any format, export as directives", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutRoundtrip(component, page, /:::(?:note|info)/);
+    });
+
+    test("CommonMark roundtrip: import any format, export as blockquote", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "commonmark" },
+      });
+      await testCalloutRoundtrip(component, page, /> \*\*(?:Note|Info)\*\*:/);
+    });
+  });
+});

--- a/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import type { VizelMarkdownFlavor } from "@vizel/core";
+import { createVizelEditor, VizelEditor, VizelProvider } from "@vizel/svelte";
+
+interface Props {
+  flavor?: VizelMarkdownFlavor;
+}
+
+const props = $props<Props>();
+
+let markdownOutput = $state("");
+
+const editor = createVizelEditor({
+  flavor: props.flavor ?? "gfm",
+  features: {
+    callout: true,
+  },
+});
+
+function handleExport() {
+  if (editor.current) {
+    const md = editor.current.getMarkdown();
+    markdownOutput = md;
+  }
+}
+
+function handleInsertCallout() {
+  if (editor.current) {
+    editor.current
+      .chain()
+      .focus()
+      .setCallout({ type: "info" })
+      .insertContent("Test callout content")
+      .run();
+  }
+}
+
+function handleImportCalloutGfm() {
+  if (editor.current) {
+    editor.current.commands.setContent("> [!NOTE]\n> GFM callout content", {
+      contentType: "markdown",
+    });
+  }
+}
+
+function handleImportCalloutObsidian() {
+  if (editor.current) {
+    editor.current.commands.setContent("> [!note]\n> Obsidian callout content", {
+      contentType: "markdown",
+    });
+  }
+}
+
+function handleImportCalloutDocusaurus() {
+  if (editor.current) {
+    editor.current.commands.setContent(":::info\nDocusaurus callout content\n:::", {
+      contentType: "markdown",
+    });
+  }
+}
+</script>
+
+<VizelProvider editor={editor.current}>
+  <div class="toolbar">
+    <button type="button" data-testid="insert-callout" onclick={handleInsertCallout}>
+      Insert Callout
+    </button>
+    <button type="button" data-testid="export-button" onclick={handleExport}>
+      Export
+    </button>
+    <button type="button" data-testid="import-callout-gfm" onclick={handleImportCalloutGfm}>
+      Import GFM Callout
+    </button>
+    <button type="button" data-testid="import-callout-obsidian" onclick={handleImportCalloutObsidian}>
+      Import Obsidian Callout
+    </button>
+    <button type="button" data-testid="import-callout-docusaurus" onclick={handleImportCalloutDocusaurus}>
+      Import Docusaurus Callout
+    </button>
+  </div>
+  <VizelEditor />
+  <pre data-testid="markdown-output">{markdownOutput}</pre>
+</VizelProvider>

--- a/tests/ct/vue/specs/MarkdownFlavors.spec.ts
+++ b/tests/ct/vue/specs/MarkdownFlavors.spec.ts
@@ -1,0 +1,103 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testCalloutCommonmarkOutput,
+  testCalloutDocusaurusOutput,
+  testCalloutGfmOutput,
+  testCalloutObsidianOutput,
+  testCalloutParseDocusaurus,
+  testCalloutParseGfm,
+  testCalloutParseObsidian,
+  testCalloutRoundtrip,
+} from "../../scenarios/markdown-flavors.scenario";
+import MarkdownFlavorsFixture from "./MarkdownFlavorsFixture.vue";
+
+test.describe("Markdown Flavors - Vue", () => {
+  test.describe("Callout output by flavor", () => {
+    test("GFM flavor serializes callout as > [!NOTE]", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutGfmOutput(component, page);
+    });
+
+    test("Obsidian flavor serializes callout as > [!info]", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutObsidianOutput(component, page);
+    });
+
+    test("Docusaurus flavor serializes callout as :::info", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutDocusaurusOutput(component, page);
+    });
+
+    test("CommonMark flavor serializes callout as > **Info**: content", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "commonmark" },
+      });
+      await testCalloutCommonmarkOutput(component, page);
+    });
+  });
+
+  test.describe("Tolerant input parsing", () => {
+    test("parses GFM-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutParseGfm(component, page);
+    });
+
+    test("parses Obsidian-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutParseObsidian(component, page);
+    });
+
+    test("parses Docusaurus-style callout regardless of flavor", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutParseDocusaurus(component, page);
+    });
+  });
+
+  test.describe("Roundtrip", () => {
+    test("GFM roundtrip: import any format, export as GFM", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "gfm" },
+      });
+      await testCalloutRoundtrip(component, page, /> \[!NOTE\]/);
+    });
+
+    test("Obsidian roundtrip: import any format, export as Obsidian", async ({ mount, page }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "obsidian" },
+      });
+      await testCalloutRoundtrip(component, page, /> \[!(?:note|info)\]/);
+    });
+
+    test("Docusaurus roundtrip: import any format, export as directives", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "docusaurus" },
+      });
+      await testCalloutRoundtrip(component, page, /:::(?:note|info)/);
+    });
+
+    test("CommonMark roundtrip: import any format, export as blockquote", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(MarkdownFlavorsFixture, {
+        props: { flavor: "commonmark" },
+      });
+      await testCalloutRoundtrip(component, page, /> \*\*(?:Note|Info)\*\*:/);
+    });
+  });
+});

--- a/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
+++ b/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { VizelMarkdownFlavor } from "@vizel/core";
+import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/vue";
+import { ref } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    flavor?: VizelMarkdownFlavor;
+  }>(),
+  {
+    flavor: "gfm",
+  }
+);
+
+const markdownOutput = ref("");
+
+const editor = useVizelEditor({
+  flavor: props.flavor,
+  features: {
+    callout: true,
+  },
+});
+
+function handleExport() {
+  if (editor.value) {
+    const md = editor.value.getMarkdown();
+    markdownOutput.value = md;
+  }
+}
+
+function handleInsertCallout() {
+  if (editor.value) {
+    editor.value
+      .chain()
+      .focus()
+      .setCallout({ type: "info" })
+      .insertContent("Test callout content")
+      .run();
+  }
+}
+
+function handleImportCalloutGfm() {
+  if (editor.value) {
+    editor.value.commands.setContent("> [!NOTE]\n> GFM callout content", {
+      contentType: "markdown",
+    });
+  }
+}
+
+function handleImportCalloutObsidian() {
+  if (editor.value) {
+    editor.value.commands.setContent("> [!note]\n> Obsidian callout content", {
+      contentType: "markdown",
+    });
+  }
+}
+
+function handleImportCalloutDocusaurus() {
+  if (editor.value) {
+    editor.value.commands.setContent(":::info\nDocusaurus callout content\n:::", {
+      contentType: "markdown",
+    });
+  }
+}
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <div class="toolbar">
+      <button type="button" data-testid="insert-callout" @click="handleInsertCallout">
+        Insert Callout
+      </button>
+      <button type="button" data-testid="export-button" @click="handleExport">
+        Export
+      </button>
+      <button type="button" data-testid="import-callout-gfm" @click="handleImportCalloutGfm">
+        Import GFM Callout
+      </button>
+      <button type="button" data-testid="import-callout-obsidian" @click="handleImportCalloutObsidian">
+        Import Obsidian Callout
+      </button>
+      <button type="button" data-testid="import-callout-docusaurus" @click="handleImportCalloutDocusaurus">
+        Import Docusaurus Callout
+      </button>
+    </div>
+    <VizelEditor />
+    <pre data-testid="markdown-output">{{ markdownOutput }}</pre>
+  </VizelProvider>
+</template>


### PR DESCRIPTION
## Summary

Add configurable Markdown output flavors to control how content is serialized, while maintaining tolerant input parsing for all formats.

### Supported Flavors

| Flavor | Callout Output | WikiLinks | Platforms |
|--------|---------------|-----------|-----------|
| `commonmark` | `> **Note**: content` | Standard link | SO, Reddit, email |
| `gfm` (default) | `> [!NOTE]` | Standard link | GitHub, GitLab, DEV.to |
| `obsidian` | `> [!note]` | `[[page]]` | Obsidian, Logseq, Foam |
| `docusaurus` | `:::note` | Standard link | Docusaurus, VitePress, Zenn |

### Design Principles

- **Input is tolerant**: All callout formats (`:::note`, `> [!NOTE]`, `> [!note]`) are always parsed regardless of selected flavor
- **Output is strict**: Only the selected flavor's format is used for Markdown serialization
- **Natural extension**: Uses Tiptap's Extension Options pattern with `.extend()` closure for `renderMarkdown` context

### Changes

**Core (`@vizel/core`)**
- New `VizelMarkdownFlavor` type and `resolveVizelFlavorConfig()` utility
- Callout extension: multi-format output + tolerant block-level input parsing (GitHub Alerts, Obsidian, Directives, blockquote fallback)
- Wiki-link extension: Markdown serialization (`[[page]]` for Obsidian, standard links otherwise) + `[[page|text]]` tokenizer
- Mention extension: Markdown serialization (`@username` format) + tokenizer
- `createVizelExtensions()` wires flavor config to all extensions
- `VizelEditorOptions.flavor` option added

**Framework packages**
- `flavor` prop added to `Vizel` component in React, Vue, and Svelte

**Demo apps**
- Flavor selector dropdown added to all three demo apps

**Documentation**
- README.md: `flavor` and `onError` props added to table, `mention` added to opt-in list, error handling section corrected
- Features guide, getting-started guide, API reference, core README all updated

**Tests**
- 33 shared E2E test scenarios (callout output × 4 flavors, tolerant parsing × 3, roundtrip × 4, wiki-link × 2)
- Test specs for React, Vue, and Svelte (99 tests total, all passing)

### Code Quality Improvements (from review)
- Replaced all `as` casts with type guards (`isVizelCalloutType`) per code-style rules
- Used `satisfies` operator for literal type defaults
- Added exhaustive `never` check in callout switch statement
- Fixed blockquote-fallback multi-line content bug
- Improved ALERT_REGEX to handle empty blockquote continuation lines
- Removed unused `addStorage()` from callout and wiki-link extensions

## Related Issues

- Closes #231 — Multi-column layout (Won't Fix: GFM-incompatible)
- Closes #250 — Block nesting (Won't Fix: GFM-incompatible)
- Closes #230 — AI autocomplete (consolidated into #252)

## Test Plan

- [x] `pnpm lint` — 451 files checked, 36 warnings (known .d.ts)
- [x] `pnpm typecheck` — All 4 packages pass
- [x] `pnpm build` — All packages build successfully
- [x] `pnpm test:ct` (Chromium) — React 251/251, Vue 251/251, Svelte 251/251
- [x] Pre-commit hooks pass (biome-check, typecheck, commitlint)
- [x] Pre-push hooks pass (lint, typecheck)
- [x] Manual verification in all 3 demo apps (flavor selector, callout output, roundtrip)