### PR TITLE
feat(core): add list item keyboard navigation with Tab indent and Alt+Arrow reorder (#236)

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -568,7 +568,7 @@ const editor = useVizelEditor({
 
 ## Task Lists
 
-This feature adds checkbox task lists.
+This feature adds checkbox task lists with nested indentation support.
 
 ### Options
 
@@ -576,6 +576,17 @@ This feature adds checkbox task lists.
 |----------|------|-------------|
 | `taskList` | `TaskListOptions` | Task list container options |
 | `taskItem` | `TaskItemOptions` | Task item options |
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Tab` | Indent (nest) the current task item |
+| `Shift+Tab` | Outdent (un-nest) the current task item |
+| `Alt+↑` | Move the current task item up |
+| `Alt+↓` | Move the current task item down |
+
+These shortcuts also work for bullet lists and ordered lists.
 
 ### Example
 
@@ -595,13 +606,24 @@ const editor = useVizelEditor({
 
 ## Drag Handle
 
-This feature provides a handle for drag-and-drop block reordering.
+This feature provides a handle for drag-and-drop block reordering. It also adds keyboard shortcuts for moving blocks and list items.
 
 ### Options
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Show drag handle |
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Alt+↑` | Move the current block or list item up |
+| `Alt+↓` | Move the current block or list item down |
+| `Tab` | Indent (nest) a list item |
+| `Shift+Tab` | Outdent (un-nest) a list item |
+
+The drag handle is automatically positioned next to the hovered block. For list items, it adjusts its size to be less intrusive.
 
 ### Example
 

--- a/packages/core/src/extensions/drag-handle.ts
+++ b/packages/core/src/extensions/drag-handle.ts
@@ -7,6 +7,12 @@ import { VIZEL_BLOCK_MENU_EVENT, type VizelBlockMenuOpenDetail } from "./block-m
 
 export { DragHandle as VizelDragHandle };
 
+/** Node types that represent individual list items */
+const LIST_ITEM_NODE_TYPES = new Set(["listItem", "taskItem"]);
+
+/** Node types that represent list containers */
+const LIST_CONTAINER_NODE_TYPES = new Set(["bulletList", "orderedList", "taskList"]);
+
 export interface VizelDragHandleOptions {
   /**
    * Whether to show the drag handle
@@ -106,8 +112,13 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
       if (dragHandleElement) {
         if (node) {
           dragHandleElement.classList.add("is-visible");
+
+          // Add list-specific class for styling adjustments
+          const isListContainer = LIST_CONTAINER_NODE_TYPES.has(node.type.name);
+          const isListItem = LIST_ITEM_NODE_TYPES.has(node.type.name);
+          dragHandleElement.classList.toggle("is-list-target", isListContainer || isListItem);
         } else {
-          dragHandleElement.classList.remove("is-visible");
+          dragHandleElement.classList.remove("is-visible", "is-list-target");
         }
       }
     },

--- a/packages/core/src/extensions/task-list.ts
+++ b/packages/core/src/extensions/task-list.ts
@@ -1,4 +1,4 @@
-import type { Extensions } from "@tiptap/core";
+import { Extension, type Extensions } from "@tiptap/core";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 
@@ -42,6 +42,24 @@ export interface VizelTaskListExtensionsOptions {
 }
 
 /**
+ * Keyboard shortcuts for task item indentation.
+ * Tab sinks a task item (makes it a child of the previous sibling),
+ * Shift+Tab lifts it out of the current nesting level.
+ *
+ * This complements ListKeymap which only handles regular listItem nodes.
+ */
+const VizelTaskItemKeymap = Extension.create({
+  name: "vizelTaskItemKeymap",
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => this.editor.commands.sinkListItem("taskItem"),
+      "Shift-Tab": () => this.editor.commands.liftListItem("taskItem"),
+    };
+  },
+});
+
+/**
  * Creates task list extensions for checkbox/todo functionality.
  *
  * @example
@@ -76,6 +94,7 @@ export function createVizelTaskListExtensions(
         onReadOnlyChecked: taskItem.onReadOnlyChecked,
       }),
     }),
+    VizelTaskItemKeymap,
   ];
 }
 

--- a/packages/core/src/styles/drag-handle.scss
+++ b/packages/core/src/styles/drag-handle.scss
@@ -65,6 +65,16 @@
     pointer-events: auto;
   }
 
+  // Adjust handle size for list items to be less intrusive
+  &.is-list-target {
+    height: 1.25rem;
+
+    .vizel-drag-handle-grip svg {
+      width: 12px;
+      height: 12px;
+    }
+  }
+
   &-grip {
     display: flex;
     align-items: center;

--- a/tests/ct/react/specs/ListDnd.spec.tsx
+++ b/tests/ct/react/specs/ListDnd.spec.tsx
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testBulletListAltArrowReorder,
+  testBulletListShiftTabOutdent,
+  testBulletListTabIndent,
+  testOrderedListAltArrowReorder,
+  testTaskListShiftTabOutdent,
+  testTaskListTabIndent,
+} from "../../scenarios/list-dnd.scenario";
+import { EditorFixture } from "./EditorFixture";
+
+test.describe("ListDnd - React", () => {
+  test.describe("Bullet List Indentation", () => {
+    test("Tab indents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testBulletListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testBulletListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Task List Indentation", () => {
+    test("Tab indents a task list item", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testTaskListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a task list item", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testTaskListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Keyboard Reordering", () => {
+    test("Alt+Arrow reorders bullet list items", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testBulletListAltArrowReorder(component, page);
+    });
+
+    test("Alt+Arrow reorders ordered list items", async ({ mount, page }) => {
+      const component = await mount(<EditorFixture />);
+      await testOrderedListAltArrowReorder(component, page);
+    });
+  });
+});

--- a/tests/ct/scenarios/list-dnd.scenario.ts
+++ b/tests/ct/scenarios/list-dnd.scenario.ts
@@ -1,0 +1,154 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared test scenarios for list item keyboard navigation and reordering.
+ * These scenarios are framework-agnostic and can be used with React, Vue, and Svelte.
+ */
+
+/** Verify Tab indents a bullet list item (sinks it) */
+export async function testBulletListTabIndent(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create a bullet list with two items
+  await page.keyboard.type("- First item");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Second item");
+
+  // Cursor is in the second item, press Tab to indent
+  await page.keyboard.press("Tab");
+
+  // The second item should now be nested inside the first item
+  // This creates a nested list: <ul><li>First item<ul><li>Second item</li></ul></li></ul>
+  const nestedList = editor.locator("ul ul");
+  await expect(nestedList).toBeVisible();
+  await expect(nestedList.locator("li")).toContainText("Second item");
+}
+
+/** Verify Shift+Tab outdents a bullet list item (lifts it) */
+export async function testBulletListShiftTabOutdent(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create a bullet list with two items
+  await page.keyboard.type("- First item");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Second item");
+
+  // Indent the second item first
+  await page.keyboard.press("Tab");
+
+  // Verify it's nested
+  const nestedList = editor.locator("ul ul");
+  await expect(nestedList).toBeVisible();
+
+  // Now outdent it
+  await page.keyboard.press("Shift+Tab");
+
+  // The second item should be back at the top level
+  const topLevelItems = editor.locator(":scope > ul > li");
+  await expect(topLevelItems).toHaveCount(2);
+  await expect(topLevelItems.nth(1)).toContainText("Second item");
+}
+
+/** Verify Tab indents a task list item (sinks it) */
+export async function testTaskListTabIndent(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create a task list with two items using slash command
+  await page.keyboard.type("/task");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Task one");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Task two");
+
+  // Cursor is in the second task, press Tab to indent
+  await page.keyboard.press("Tab");
+
+  // The second task should now be nested inside the first
+  const nestedTaskList = editor.locator("ul[data-type='taskList'] ul[data-type='taskList']");
+  await expect(nestedTaskList).toBeVisible();
+  await expect(nestedTaskList.locator("li")).toContainText("Task two");
+}
+
+/** Verify Shift+Tab outdents a task list item (lifts it) */
+export async function testTaskListShiftTabOutdent(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create a task list with two items using slash command
+  await page.keyboard.type("/task");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Task one");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Task two");
+
+  // Indent the second task
+  await page.keyboard.press("Tab");
+
+  // Verify it's nested
+  const nestedTaskList = editor.locator("ul[data-type='taskList'] ul[data-type='taskList']");
+  await expect(nestedTaskList).toBeVisible();
+
+  // Now outdent it
+  await page.keyboard.press("Shift+Tab");
+
+  // The second task should be back at the top level
+  const topLevelTasks = editor.locator(":scope > ul[data-type='taskList'] > li");
+  await expect(topLevelTasks).toHaveCount(2);
+  await expect(topLevelTasks.nth(1)).toContainText("Task two");
+}
+
+/** Verify Alt+Up/Down reorders bullet list items */
+export async function testBulletListAltArrowReorder(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create a bullet list with three items
+  await page.keyboard.type("- Apple");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Banana");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Cherry");
+
+  // Cursor is in "Cherry" (third item), move it up
+  await page.keyboard.press("Alt+ArrowUp");
+
+  // Now order should be: Apple, Cherry, Banana
+  const listItems = editor.locator("ul li");
+  await expect(listItems.nth(0)).toContainText("Apple");
+  await expect(listItems.nth(1)).toContainText("Cherry");
+  await expect(listItems.nth(2)).toContainText("Banana");
+
+  // Move Cherry up again to first position
+  await page.keyboard.press("Alt+ArrowUp");
+
+  // Now order should be: Cherry, Apple, Banana
+  await expect(listItems.nth(0)).toContainText("Cherry");
+  await expect(listItems.nth(1)).toContainText("Apple");
+  await expect(listItems.nth(2)).toContainText("Banana");
+}
+
+/** Verify ordered list items can be reordered with Alt+Up/Down */
+export async function testOrderedListAltArrowReorder(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Create an ordered list with two items
+  await page.keyboard.type("1. First");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Second");
+
+  // Cursor is in "Second", move it up
+  await page.keyboard.press("Alt+ArrowUp");
+
+  // Now "Second" should be first
+  const listItems = editor.locator("ol li");
+  await expect(listItems.first()).toContainText("Second");
+  await expect(listItems.nth(1)).toContainText("First");
+}

--- a/tests/ct/svelte/specs/ListDnd.spec.ts
+++ b/tests/ct/svelte/specs/ListDnd.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testBulletListAltArrowReorder,
+  testBulletListShiftTabOutdent,
+  testBulletListTabIndent,
+  testOrderedListAltArrowReorder,
+  testTaskListShiftTabOutdent,
+  testTaskListTabIndent,
+} from "../../scenarios/list-dnd.scenario";
+import EditorFixture from "./EditorFixture.svelte";
+
+test.describe("ListDnd - Svelte", () => {
+  test.describe("Bullet List Indentation", () => {
+    test("Tab indents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Task List Indentation", () => {
+    test("Tab indents a task list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testTaskListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a task list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testTaskListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Keyboard Reordering", () => {
+    test("Alt+Arrow reorders bullet list items", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListAltArrowReorder(component, page);
+    });
+
+    test("Alt+Arrow reorders ordered list items", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testOrderedListAltArrowReorder(component, page);
+    });
+  });
+});

--- a/tests/ct/vue/specs/ListDnd.spec.ts
+++ b/tests/ct/vue/specs/ListDnd.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testBulletListAltArrowReorder,
+  testBulletListShiftTabOutdent,
+  testBulletListTabIndent,
+  testOrderedListAltArrowReorder,
+  testTaskListShiftTabOutdent,
+  testTaskListTabIndent,
+} from "../../scenarios/list-dnd.scenario";
+import EditorFixture from "./EditorFixture.vue";
+
+test.describe("ListDnd - Vue", () => {
+  test.describe("Bullet List Indentation", () => {
+    test("Tab indents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a bullet list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Task List Indentation", () => {
+    test("Tab indents a task list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testTaskListTabIndent(component, page);
+    });
+
+    test("Shift+Tab outdents a task list item", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testTaskListShiftTabOutdent(component, page);
+    });
+  });
+
+  test.describe("Keyboard Reordering", () => {
+    test("Alt+Arrow reorders bullet list items", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testBulletListAltArrowReorder(component, page);
+    });
+
+    test("Alt+Arrow reorders ordered list items", async ({ mount, page }) => {
+      const component = await mount(EditorFixture);
+      await testOrderedListAltArrowReorder(component, page);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add Tab/Shift+Tab keyboard shortcuts for task list item indentation (complementing ListKeymap which only handles regular list items)
- Add `is-list-target` CSS class on drag handle when targeting list container or list item nodes, with adjusted sizing
- Add comprehensive Playwright component tests for list keyboard navigation (Tab indent, Shift+Tab outdent, Alt+Arrow reorder) across all 3 frameworks
- Update documentation for Task Lists and Drag Handle sections with keyboard shortcut tables

Closes #236

## Test plan

- [x] `pnpm typecheck` — all packages pass (1 known svelte-check warning)
- [x] `pnpm lint` — 42 pre-existing warnings only (all from .d.ts files)
- [x] `pnpm build` — all packages build successfully
- [x] `pnpm test:ct` — React 18/18, Vue 18/18, Svelte 18/18 new ListDnd tests pass
- [x] Full test suite: no regressions (7 pre-existing Svelte/Firefox/BlockMenu flaky failures only)