### PR TITLE
fix: preserve icon renderer init in framework package sideEffects

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,9 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -30,7 +30,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,9 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Hotfix for v1.3.0. Framework packages declared `"sideEffects": false`, which let Rolldown eliminate the top-level `initVizelIconRenderer()` call in each entry during consumer production builds. Without that call the renderer stays unset and every `renderVizelIcon()` consumer (drag handle, code block line-number toggle / copy button, table controls, etc.) produces empty innerHTML — icons disappear on GitHub Pages and in any user's production build.

## Reproduction

- https://seijikohara.github.io/vizel/demo/react/ (v1.3.0 deploy) — drag handle, code block toolbar, and similar icons render as empty `<div>` / empty buttons.
- Local `pnpm dev:*` works because Vite dev mode does not drop top-level calls.
- `cd apps/demo/react && pnpm exec vite build` reproduces the drop locally.

## Fix

Set `"sideEffects": ["./dist/index.js"]` on `@vizel/react`, `@vizel/vue`, and `@vizel/svelte`. The entry file is the only location that calls `initVizelIconRenderer()`; everything else in the package remains tree-shakeable.

## Verification

After the fix, `pnpm exec vite build` on the React demo produces a bundle whose `.vizel-drag-handle-grip` and code-block copy button both contain the expected lucide SVG. Verified in Chrome DevTools against `vite preview`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Local `vite build` of React demo + `vite preview` — icons present
- [x] CI: Playwright CT across react / vue / svelte

## Release

Ship as `v1.3.1` after merge. v1.3.0 is broken for any consumer on a production build.