### PR TITLE
docs: correct feature descriptions and reflect per-item list drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 - **Text Formatting** - Bold, italic, underline, strikethrough, superscript, subscript, text color, highlight
 - **Typography** - Smart quotes, em dashes, and other typographic transformations
-- **Block Elements** - Headings (H1-H6), lists (bullet, numbered, task), blockquotes, horizontal rules
+- **Block Elements** - Headings (H1-H3 by default, configurable up to H6), lists (bullet, numbered, task), blockquotes, horizontal rules
 - **Slash Commands** - Type `/` to insert blocks
 - **Floating Toolbar** - Inline formatting toolbar on text selection
 - **Fixed Toolbar** - Optional sticky toolbar with formatting buttons
@@ -54,7 +54,7 @@
 - **Comments** - Text annotations for collaborative review (opt-in)
 - **Version History** - Document snapshots and restore
 - **Collaboration** - Real-time multi-user editing with Yjs (opt-in)
-- **Drag & Drop** - Block reordering with drag handle and Alt+Arrow keys
+- **Drag & Drop** - Per-item drag handle for every block, including individual bullet, ordered, and task list items at any nesting depth; `Alt+↑` / `Alt+↓` also reorder blocks and list items
 - **Block Menu** - Context menu on drag handle click (delete, duplicate, turn into)
 - **Plugin System** - Extensible plugin architecture
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -64,7 +64,7 @@ const extensions = await createVizelExtensions({
 | `Strike` | Strikethrough mark |
 | `Underline` | Underline mark |
 | `Code` | Inline code mark |
-| `Heading` | H1-H6 headings |
+| `Heading` | Headings (default levels: `[1, 2, 3]`, configurable up to 6) |
 | `BulletList` | Bullet list |
 | `OrderedList` | Numbered list |
 | `ListItem` | List item |

--- a/docs/api/types/features.md
+++ b/docs/api/types/features.md
@@ -38,7 +38,11 @@ interface VizelFeatureOptions {
   /** Mathematics (LaTeX) support with KaTeX rendering */
   mathematics?: VizelMathematicsOptions | boolean;
 
-  /** Drag handle for block reordering */
+  /**
+   * Per-item drag handle for reordering blocks and list items
+   * (bullet, ordered, task) at any nesting depth, with Alt+Up/Down
+   * keyboard shortcuts.
+   */
   dragHandle?: VizelDragHandleOptions | boolean;
 
   /** URL embedding with oEmbed/OGP support */

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -44,7 +44,7 @@ graph TB
 | `tableOfContents` | Auto-collected heading navigation block |
 | `image` | Image upload and resize |
 | `codeBlock` | Code blocks with syntax highlighting |
-| `dragHandle` | Drag handle for block reordering |
+| `dragHandle` | Per-item drag handle for reordering blocks and list items |
 | `characterCount` | Character and word counting |
 | `textColor` | Text color and highlight |
 | `taskList` | Checkbox task lists |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -36,14 +36,14 @@ graph LR
 ### Text Editing
 
 - **Text Formatting** - Bold, italic, underline, strikethrough, text color, highlight
-- **Block Elements** - Headings (H1-H6), lists (bullet, numbered, task), blockquotes
+- **Block Elements** - Headings (H1-H3 by default, configurable up to H6), lists (bullet, numbered, task), blockquotes
 - **Code Blocks** - Syntax highlighting via [lowlight](https://github.com/wooorm/lowlight)
 
 ### Block-Based Editing
 
 - **Slash Commands** - Type `/` to insert blocks
 - **Bubble Menu** - Formatting menu on text selection
-- **Drag Handle** - Reorder blocks with drag and drop
+- **Drag Handle** - Per-item drag handle for every block, including individual list items at any nesting depth
 
 ### Media
 
@@ -100,8 +100,10 @@ graph TB
 
 ## Feature Comparison
 
-| Feature | Default | Optional |
-|---------|:-------:|:--------:|
+Most features are enabled by default. Opt-in features must be explicitly enabled in the `features` option.
+
+| Feature | Default | Opt-in |
+|---------|:-------:|:------:|
 | Text Formatting | :white_check_mark: | - |
 | Headings | :white_check_mark: | - |
 | Lists (Bullet, Numbered) | :white_check_mark: | - |
@@ -115,11 +117,18 @@ graph TB
 | Drag Handle | :white_check_mark: | - |
 | Character Count | :white_check_mark: | - |
 | Text Color / Highlight | :white_check_mark: | - |
-| Markdown Import/Export | - | :white_check_mark: |
-| Mathematics (LaTeX) | - | :white_check_mark: |
-| Embeds (oEmbed) | - | :white_check_mark: |
-| Collapsible Details | - | :white_check_mark: |
-| Diagrams (Mermaid) | - | :white_check_mark: |
+| Markdown Import/Export | :white_check_mark: | - |
+| Mathematics (LaTeX) | :white_check_mark: | - |
+| Embeds (oEmbed) | :white_check_mark: | - |
+| Collapsible Details | :white_check_mark: | - |
+| Callouts | :white_check_mark: | - |
+| Diagrams (Mermaid, GraphViz) | :white_check_mark: | - |
+| Superscript / Subscript | :white_check_mark: | - |
+| Typography | :white_check_mark: | - |
+| Wiki Links | - | :white_check_mark: |
+| @Mention | - | :white_check_mark: |
+| Comments | - | :white_check_mark: |
+| Collaboration (Yjs) | - | :white_check_mark: |
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,7 +160,7 @@ Select text to display the bubble menu:
 
 ### Drag & Drop
 
-Drag blocks by their handle to reorder content.
+Drag any block by its handle to reorder content. Every block has its own handle — including individual list items (bullet, ordered, task) at any nesting depth.
 
 ## Features
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -54,7 +54,7 @@ All extensions are enabled by default except `collaboration`, `comment`, `wikiLi
 
 | Extension | Description |
 |-----------|-------------|
-| Base | Headings (H1-H6), bold, italic, underline, strikethrough, lists, blockquotes |
+| Base | Headings (H1-H3 by default, configurable up to H6), bold, italic, underline, strikethrough, lists, blockquotes |
 | Superscript | Superscript text formatting |
 | Subscript | Subscript text formatting |
 | Typography | Smart quotes, em dashes, and typographic transformations |
@@ -67,8 +67,8 @@ All extensions are enabled by default except `collaboration`, `comment`, `wikiLi
 | CharacterCount | Real-time character and word count |
 | TextColor | Text color and highlight |
 | TaskList | Checkbox task lists |
-| DragHandle | Block drag handle and Alt+Arrow keyboard shortcuts |
-| Markdown | Import/export with GitHub Flavored Markdown |
+| DragHandle | Per-item drag handle for every block (including individual list items at any nesting depth) plus `Alt+↑` / `Alt+↓` keyboard shortcuts |
+| Markdown | Import and export with configurable flavor (CommonMark, GFM, Obsidian, Docusaurus) |
 | Mathematics | LaTeX equations with KaTeX |
 | Embed | oEmbed/OGP URL embedding |
 | Details | Collapsible content blocks |

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,7 +67,11 @@ export interface VizelFeatureOptions {
   codeBlock?: VizelCodeBlockOptions | boolean;
   /** Mathematics (LaTeX) support with KaTeX rendering */
   mathematics?: VizelMathematicsOptions | boolean;
-  /** Drag handle for block reordering (includes Alt+Up/Down keyboard shortcuts) */
+  /**
+   * Per-item drag handle for reordering blocks and list items
+   * (bullet, ordered, task) at any nesting depth, with Alt+Up/Down
+   * keyboard shortcuts.
+   */
   dragHandle?: VizelDragHandleOptions | boolean;
   /** URL embedding with oEmbed/OGP support */
   embed?: VizelEmbedOptions | boolean;


### PR DESCRIPTION
## Summary

Fix factual inaccuracies surfaced during a full documentation audit of README files, the VitePress site, and the core JSDoc that annotates `VizelFeatureOptions`.

### Corrections

- **Heading levels**: the base extension defaults to `[1, 2, 3]`, not all six. Replace "H1-H6" with "H1-H3 by default, configurable up to H6" in README.md, docs/guide/index.md, docs/api/core.md, and packages/core/README.md.
- **Feature comparison table** (docs/guide/index.md): Markdown, Mathematics, Embeds, Collapsible Details, and Diagrams were marked optional but are enabled by default. Rebuild the table with accurate defaults, rename the "Optional" column to "Opt-in", and add the actually-opt-in features (Wiki Links, @Mention, Comments, Collaboration).
- **Drag-handle descriptions** across README.md, docs/index.md, docs/guide/index.md, docs/guide/features.md, and packages/core/README.md still described top-level block reordering only. Update them to describe the v1.4.0 behavior: every block — including individual bullet, ordered, and task list items at any nesting depth — has its own handle.
- **JSDoc in source and reference docs**: update the `VizelFeatureOptions.dragHandle` comment in `packages/core/src/types.ts` and its rendered copy in `docs/api/types/features.md` so source and reference stay aligned.
- **Markdown flavor description** (packages/core/README.md): the extension table called Markdown "GitHub Flavored Markdown" but the same file lists four flavors. Rewrite to "CommonMark, GFM, Obsidian, Docusaurus".

### Scope

Documentation and a single JSDoc comment only. No runtime code changes. Typecheck, lint, and build all pass locally.

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm --filter @vizel/core build`
- [x] Cross-check each corrected statement against the implementation (heading level default, feature defaults in `resolveVizelFeatures`, drag-handle behavior in `packages/core/src/extensions/drag-handle.ts`, flavor support in `utils/markdown-flavors.ts`).
- [x] CI green (pending)