### PR TITLE
fix(svelte,demo,docs): unblock pages deploy + add homepage demo nav

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -67,8 +67,8 @@ function AppContent() {
     autoSave: true,
     stats: true,
     syncPanel: true,
-    comments: false,
-    history: false,
+    comments: true,
+    history: true,
   });
 
   const [flavor, setFlavor] = useState<VizelMarkdownFlavor>("gfm");
@@ -257,7 +257,7 @@ function AppContent() {
           <div className="editor-container">
             <Vizel
               initialMarkdown={getFlavorContent(flavor)}
-              autofocus="end"
+              autofocus="start"
               className="editor-content"
               showToolbar={features.toolbar}
               flavor={flavor}

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -24,8 +24,8 @@ let features = $state({
   autoSave: true,
   stats: true,
   syncPanel: true,
-  comments: false,
-  history: false,
+  comments: true,
+  history: true,
 });
 
 let flavor = $state<VizelMarkdownFlavor>("gfm");
@@ -205,7 +205,7 @@ function handleJsonChange(event: Event) {
       <div class="editor-container">
         <Vizel
           initialMarkdown={getFlavorContent(flavor)}
-          autofocus="end"
+          autofocus="start"
           class="editor-content"
           showToolbar={features.toolbar}
           {flavor}

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -25,8 +25,8 @@ const features = reactive({
   autoSave: true,
   stats: true,
   syncPanel: true,
-  comments: false,
-  history: false,
+  comments: true,
+  history: true,
 });
 
 const flavor = ref<VizelMarkdownFlavor>("gfm");
@@ -199,7 +199,7 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
           <div class="editor-container">
             <Vizel
               :initial-markdown="getFlavorContent(flavor)"
-              autofocus="end"
+              autofocus="start"
               class="editor-content"
               :show-toolbar="features.toolbar"
               :flavor="flavor"

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -778,7 +778,7 @@ import {
 | `VizelCommentReply` | Reply with id, text, author, createdAt |
 | `VizelCommentState` | State object containing comments, activeCommentId, isLoading, error |
 | `VizelCommentOptions` | Configuration for enabled, storage, key, and event callbacks |
-| `VizelCommentStorage` | `'localStorage'` or custom `{ save, load }` backend |
+| `VizelCommentStorage` | `'localStorage'`, `'sessionStorage'`, or a custom `{ save, load }` backend (both methods required) |
 
 ---
 
@@ -862,7 +862,7 @@ import { VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS } from '@vizel/core';
 | `VizelVersionSnapshot` | Snapshot with id, content (JSONContent), timestamp, description, author |
 | `VizelVersionHistoryState` | State object containing snapshots, isLoading, error |
 | `VizelVersionHistoryOptions` | Configuration for enabled, maxVersions, storage, key, and callbacks |
-| `VizelVersionStorage` | `'localStorage'` or custom `{ save, load }` backend |
+| `VizelVersionStorage` | `'localStorage'`, `'sessionStorage'`, or a custom `{ save, load }` backend (both methods required) |
 
 #### Default Options
 

--- a/docs/guide/auto-save.md
+++ b/docs/guide/auto-save.md
@@ -108,7 +108,7 @@ const { status } = useVizelAutoSave(() => editor, {
 
 ### Custom Backend
 
-You can implement your own storage backend for server-side persistence:
+You can implement your own storage backend for server-side persistence. Both `save` and `load` are required:
 
 ```typescript
 const { status } = useVizelAutoSave(() => editor, {

--- a/docs/guide/comments.md
+++ b/docs/guide/comments.md
@@ -172,6 +172,8 @@ interface VizelCommentOptions {
 
 ### Custom Storage Backend
 
+Provide both `save` and `load` (both are required):
+
 ```typescript
 useVizelComment(() => editor, {
   storage: {

--- a/docs/guide/version-history.md
+++ b/docs/guide/version-history.md
@@ -142,7 +142,7 @@ useVizelVersionHistory(() => editor, {
 
 ### `storage`
 
-You can choose between built-in localStorage or a custom backend.
+You can choose between built-in `localStorage`, `sessionStorage`, or a custom backend (both `save` and `load` are required for custom backends).
 
 ```typescript
 // localStorage (default)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,14 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
-      text: View on GitHub
-      link: https://github.com/seijikohara/vizel
+      text: Live Demo
+      link: /demo/
     - theme: alt
       text: API Reference
       link: /api/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/seijikohara/vizel
 
 features:
   - title: Block-based Editing
@@ -138,6 +141,78 @@ import '@vizel/core/styles.css';
 ```
 
 :::
+
+## Try the Demo
+
+Each framework ships a live demo that exercises the full feature set:
+
+<div class="home-demo-links">
+  <a href="./demo/react/" target="_blank" rel="noopener" class="home-demo-link">
+    <img src="./public/react.svg" alt="" aria-hidden="true" class="home-demo-icon" />
+    <span class="home-demo-name">React 19</span>
+    <span class="home-demo-hint">@vizel/react</span>
+  </a>
+  <a href="./demo/vue/" target="_blank" rel="noopener" class="home-demo-link">
+    <img src="./public/vue.svg" alt="" aria-hidden="true" class="home-demo-icon" />
+    <span class="home-demo-name">Vue 3</span>
+    <span class="home-demo-hint">@vizel/vue</span>
+  </a>
+  <a href="./demo/svelte/" target="_blank" rel="noopener" class="home-demo-link">
+    <img src="./public/svelte.svg" alt="" aria-hidden="true" class="home-demo-icon" />
+    <span class="home-demo-name">Svelte 5</span>
+    <span class="home-demo-hint">@vizel/svelte</span>
+  </a>
+</div>
+
+<style>
+.home-demo-links {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.home-demo-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  text-decoration: none;
+  transition: border-color 0.2s, background-color 0.2s, transform 0.2s;
+}
+
+.home-demo-link:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-soft);
+  transform: translateY(-2px);
+}
+
+.home-demo-icon {
+  width: 56px;
+  height: 56px;
+}
+
+.home-demo-name {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--vp-c-text-1);
+}
+
+.home-demo-hint {
+  font-size: 0.85rem;
+  font-family: var(--vp-font-family-mono);
+  color: var(--vp-c-text-2);
+}
+
+@media (max-width: 640px) {
+  .home-demo-links {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
 
 ## Feature Highlights
 

--- a/packages/svelte/src/components/VizelThemeProvider.svelte
+++ b/packages/svelte/src/components/VizelThemeProvider.svelte
@@ -23,7 +23,7 @@ export interface VizelThemeProviderProps extends VizelThemeProviderOptions {
     type VizelThemeState,
   } from "@vizel/core";
   import { setContext } from "svelte";
-  import { VIZEL_THEME_CONTEXT_KEY } from "./VizelThemeContext.ts";
+  import { VIZEL_THEME_CONTEXT_KEY } from "./VizelThemeContext.js";
 
   let {
     children,

--- a/packages/svelte/src/runes/getVizelTheme.svelte.ts
+++ b/packages/svelte/src/runes/getVizelTheme.svelte.ts
@@ -1,6 +1,6 @@
 import type { VizelThemeState } from "@vizel/core";
 import { getContext } from "svelte";
-import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.ts";
+import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
 
 /**
  * Get theme state and controls from context


### PR DESCRIPTION
## Summary

Three independent fixes bundled because they all surfaced while preparing the same docs deploy:

### 1. Unblock the GitHub Pages deploy (Critical)

The \`Deploy VitePress site to Pages\` workflow has been failing on every push to \`main\` since PR #399. Rolldown could not resolve:

\`\`\`
[UNRESOLVED_IMPORT] Error: Could not resolve '../components/VizelThemeContext.ts'
  in packages/svelte/dist/runes/getVizelTheme.svelte.js
[UNRESOLVED_IMPORT] Error: Could not resolve './VizelThemeContext.ts'
  in packages/svelte/dist/components/VizelThemeProvider.js
\`\`\`

\`svelte-package\` preserves the source import extension verbatim, so the \`.ts\` suffix used by the two new imports leaked into the published \`dist/\` files. Renaming both imports to \`.js\` matches every other cross-file import inside \`@vizel/svelte\` (\`VizelIconContext.js\`, \`VizelContext.js\`, etc.) and lets Rolldown resolve the file at demo build time.

### 2. Demo UX fixes

- Switch \`autofocus\` from \`"end"\` to \`"start"\` in all three demos. The pre-filled sample document is long enough that focusing at the end caused the browser to scroll past the toolbar and feature toggles on load.
- Initialise the \`comments\` and \`history\` feature toggles to \`true\` so the panel and its tabs are visible by default. Other toggles (\`toolbar\`, \`theme\`, \`autoSave\`, \`stats\`, \`syncPanel\`) were already \`true\`; this restores parity.

Applied symmetrically in \`apps/demo/{react,vue,svelte}\`.

### 3. Homepage and docs polish

- Hero gets a fourth \"Live Demo\" action button.
- New \"Try the Demo\" section on the homepage with three framework cards (React 19 / Vue 3 / Svelte 5) linking to the hosted demos.
- Reconcile the storage backend description: \`auto-save.md\`, \`version-history.md\`, \`comments.md\`, \`api/core.md\` now mention \`sessionStorage\` as an option and state that custom backends require both \`save\` and \`load\` (which has been true since PR #399's \`VizelCustomStorageBackend.load\` requirement).

## Test Plan

- [x] \`pnpm typecheck\` clean across all four packages.
- [x] \`pnpm lint\` reports zero issues.
- [x] \`pnpm docs:build\` succeeds end-to-end (was failing on main).
- [x] \`vitepress preview docs\` serves the homepage; demo cards link to the three hosted demos and load correctly.
- [x] Visiting each demo no longer scrolls past the editor; Comments and History tabs render in the side panel by default.
- [ ] CI \`pnpm test:ct\` passes for all framework / browser pairs.
- [ ] After merge, the \"Deploy VitePress site to Pages\" workflow goes green.