### PR TITLE
docs: surface docs/deps commands and record svelte/pnpm gotchas

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -76,6 +76,25 @@ Heading.configure({
 - `@tiptap/starter-kit` (use individual extensions instead).
 - Runtime-only dependencies that consumers must install separately.
 
+### Adding a Dependency With Post-Install Scripts
+
+pnpm 10+ refuses to run post-install / install scripts unless the
+package is explicitly approved. When a new dependency triggers an
+`ERR_PNPM_IGNORED_BUILDS` warning at install time, add it to the
+`allowBuilds` block of `pnpm-workspace.yaml` (at the repo root). Skipping
+this leaves the build scripts silently ignored — native binaries and
+git-hook installers will not run, and CI commands that exit on the
+warning will fail.
+
+```yaml
+# pnpm-workspace.yaml
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true
+  lefthook: true
+  leveldown: true
+```
+
 ## Build Configuration
 
 The core package uses Vite. Externalize all `@tiptap/*` packages and emit ES modules.

--- a/.claude/rules/packages/svelte.md
+++ b/.claude/rules/packages/svelte.md
@@ -37,6 +37,25 @@ component = mount(SlashMenu, {
 });
 ```
 
+## Imports
+
+Use the `.js` extension when importing one source file from another within
+this package, even though the file on disk is `.ts` or `.svelte.ts`.
+`svelte-package` copies the import string verbatim into the compiled
+output, so any `.ts` suffix leaks into `dist/` and breaks consumers that
+build against the published files (notably the demo apps and Rolldown).
+
+```ts
+// CORRECT: matches what dist/ will resolve.
+import { VIZEL_THEME_CONTEXT_KEY } from "./VizelThemeContext.js";
+
+// WRONG: leaks ".ts" into dist and breaks downstream builds.
+import { VIZEL_THEME_CONTEXT_KEY } from "./VizelThemeContext.ts";
+```
+
+This applies to `.svelte` cross-file imports as well — use `.svelte.js`
+for runes living in `*.svelte.ts` files.
+
 ## Component Structure
 
 ```svelte

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Vizel is a block-based visual Markdown editor. The project ships Tiptap-based co
 | `packages/svelte/` | Svelte 5 components and runes |
 | `apps/demo/` | Demo applications, one per framework |
 | `tests/ct/` | Playwright Component Tests with shared scenarios |
+| `docs/` | VitePress documentation site published to GitHub Pages |
 
 ## Development Commands
 
@@ -39,6 +40,11 @@ Use Node.js LTS and pnpm. Invoke scripts with `pnpm <script>` and external binar
 | `pnpm test:ct` | Run all Playwright Component Tests in parallel |
 | `pnpm test:ct:seq` | Run all Playwright Component Tests sequentially |
 | `pnpm test:ct:react` / `test:ct:vue` / `test:ct:svelte` | Run tests for one framework |
+| `pnpm docs:dev` | Run the VitePress documentation site locally |
+| `pnpm docs:build` | Build the VitePress site and copy demo bundles into `docs/.vitepress/dist/demo/` |
+| `pnpm docs:preview` | Preview the built VitePress site |
+| `pnpm deps:check` | List outdated dependencies (read-only) |
+| `pnpm deps:update` | Bump dependencies via `taze major -r -w` and run `pnpm install` |
 
 ## Project Rules
 


### PR DESCRIPTION
## Summary

Two related additions for future Claude Code sessions to discover the docs / deps workflows from the project index, and to avoid two gotchas that bit us during recent PR work.

### CLAUDE.md (commit \`e5ffb21\`)

- **Project Layout**: add a row for \`docs/\` (the VitePress site published to GitHub Pages).
- **Development Commands**: add \`pnpm docs:dev\` / \`docs:build\` / \`docs:preview\` and \`pnpm deps:check\` / \`deps:update\`. Both workflows surfaced repeatedly in PR #403 (deps refresh) and #404 (docs deploy).

File stays at 88 lines — within the 200-line guideline noted in the maintainer header.

### Project rules (commit \`7031658\`)

- \`.claude/rules/packages/svelte.md\`: new **Imports** section explaining that cross-file imports inside \`@vizel/svelte\` must use the \`.js\` extension. \`svelte-package\` preserves the source extension verbatim, so a \`.ts\` suffix leaks into \`dist/\` and breaks Rolldown / demo builds. This was the deploy blocker fixed in PR #404 (\`2c145e4\`).
- \`.claude/rules/packages/core.md\`: extend the **Dependencies** section with **Adding a Dependency With Post-Install Scripts**. pnpm 10+ refuses install hooks unless the package is in \`pnpm-workspace.yaml\`'s \`allowBuilds\` list; missing entries cause silent failures and broken CI. Captures the workflow PR #399 set up for \`@parcel/watcher\`, \`esbuild\`, \`lefthook\`, \`leveldown\`.

Both gotchas already happened once each; this turns them into one-time mistakes.

## Test Plan

- [x] \`pnpm lint\` clean.
- [x] CLAUDE.md renders correctly (table syntax verified visually).
- [x] Rule frontmatter \`paths\` still match the existing patterns; no changes to load behaviour.