### PR TITLE
fix: rethrow editor init errors only when onError is not supplied (PR β)

### DIFF
--- a/docs/api/types/editor.md
+++ b/docs/api/types/editor.md
@@ -47,7 +47,12 @@ interface VizelEditorOptions {
   /** Called when editor loses focus */
   onBlur?: (props: { editor: Editor }) => void;
 
-  /** Called when an error occurs (error is re-thrown after callback) */
+  /**
+   * Called when an error occurs. When this callback is set, the editor
+   * hook treats the failure as handled and does not also rethrow. Omit it
+   * to let global handlers (Sentry, `unhandledrejection`) observe the
+   * failure via a rejected promise.
+   */
   onError?: (error: VizelError) => void;
 }
 ```

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -29,7 +29,7 @@ The main configuration object passed to `useVizelEditor` (React/Vue) or `createV
 | `onSelectionUpdate` | `({ editor }) => void` | Fires when selection changes |
 | `onFocus` | `({ editor }) => void` | Fires when the editor receives focus |
 | `onBlur` | `({ editor }) => void` | Fires when the editor loses focus |
-| `onError` | `(error: VizelError) => void` | Fires when an error occurs during editor operations. The error is re-thrown after this callback |
+| `onError` | `(error: VizelError) => void` | Fires when an error occurs. Supplying this callback takes over the failure path; the editor hook does not also rethrow. Omit the callback to let global handlers (Sentry, `unhandledrejection`) observe failures. |
 
 ### Example
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,16 +197,23 @@ export interface VizelEditorOptions {
    * Callback when an error occurs during editor operations.
    * Provides structured error information for logging or user feedback.
    *
-   * Note: After this callback is invoked, the error is re-thrown to preserve
-   * existing error handling behavior. This callback is primarily for logging,
-   * analytics, or showing user notifications.
+   * Behavior:
+   * - When this callback is supplied, the consumer is treated as having
+   *   handled the failure. The hook/composable/rune does NOT also rethrow.
+   * - When this callback is omitted, the error is rethrown so global
+   *   handlers (Sentry, `window.onunhandledrejection`, test runners) can
+   *   observe initialization failures.
+   *
+   * Supply this callback only when you want to fully take over the error
+   * surface (e.g. translate to UI state, swallow during tests). Leave it
+   * unset to keep the default rethrow contract.
    *
    * @example
    * ```typescript
    * const editor = useVizelEditor({
    *   onError: (error) => {
    *     console.error(`[${error.code}] ${error.message}`);
-   *     // Optionally show user notification
+   *     setEditorError(error);
    *   },
    * });
    * ```

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -81,7 +81,16 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
           context: "Editor initialization failed",
           code: "EDITOR_INIT_FAILED",
         });
-        opts.editorOptions.onError?.(vizelError);
+        const handler = opts.editorOptions.onError;
+        if (handler) {
+          // When a handler is supplied, the consumer has opted in to handling
+          // the failure. Do not also rethrow; that turned the same error into
+          // a console-noisy unhandled rejection right after the handler ran.
+          handler(vizelError);
+          return;
+        }
+        // Otherwise rethrow so global handlers (Sentry, unhandledrejection
+        // listeners) can observe the initialization failure.
         throw vizelError;
       }
     })();

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -87,11 +87,16 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
           context: "Editor initialization failed",
           code: "EDITOR_INIT_FAILED",
         });
-        // Notify the `onError` observer before rethrowing. `onError` is
-        // observation-only; the error is always rethrown so global handlers
-        // (Sentry, test runners' `unhandledrejection` listeners) can see
-        // initialization failures.
-        editorOptions.onError?.(vizelError);
+        const handler = editorOptions.onError;
+        if (handler) {
+          // When a handler is supplied, the consumer has opted in to handling
+          // the failure. Do not also rethrow; that turned the same error into
+          // a console-noisy unhandled rejection right after the handler ran.
+          handler(vizelError);
+          return;
+        }
+        // Otherwise rethrow so global handlers (Sentry, unhandledrejection
+        // listeners) can observe the initialization failure.
         throw vizelError;
       }
     })();

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -82,11 +82,16 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
           context: "Editor initialization failed",
           code: "EDITOR_INIT_FAILED",
         });
-        // Notify the `onError` observer before rethrowing. `onError` is
-        // observation-only; the error is always rethrown so global handlers
-        // (Sentry, test runners' `unhandledrejection` listeners) can see
-        // initialization failures.
-        editorOptions.onError?.(vizelError);
+        const handler = editorOptions.onError;
+        if (handler) {
+          // When a handler is supplied, the consumer has opted in to handling
+          // the failure. Do not also rethrow; that turned the same error into
+          // a console-noisy unhandled rejection right after the handler ran.
+          handler(vizelError);
+          return;
+        }
+        // Otherwise rethrow so global handlers (Sentry, unhandledrejection
+        // listeners) can observe the initialization failure.
         throw vizelError;
       }
     })();


### PR DESCRIPTION
## Summary

PR β of the post-audit improvement series. Unify the editor initialization error contract across React, Vue, and Svelte so the \`onError\` callback is meaningful: supplying it actually owns the failure path instead of being a console-noisy logger that runs right before the same error becomes an unhandled rejection.

### Behavior change

- When the consumer passes \`onError\`, the hook/composable/rune now treats the failure as handled and DOES NOT also rethrow. The handler runs once, then nothing else happens.
- When the consumer omits \`onError\`, the error is still rethrown so global handlers (Sentry, \`window.onunhandledrejection\`, Playwright's test-runner unhandled-rejection watch) can observe the failure.

### Files touched

| Type | File |
|------|------|
| Code | \`packages/react/src/hooks/useVizelEditor.ts\` |
| Code | \`packages/vue/src/composables/useVizelEditor.ts\` |
| Code | \`packages/svelte/src/runes/createVizelEditor.svelte.ts\` |
| Type / JSDoc | \`packages/core/src/types.ts\` |
| Guide | \`docs/guide/configuration.md\` |
| API reference | \`docs/api/types/editor.md\` |

## Breaking Changes

Consumers that previously relied on the error being rethrown despite supplying an \`onError\` callback (combined inline handling AND global capture) must now choose one path. To keep both behaviors, manually rethrow from inside \`onError\`:

\`\`\`ts
onError: (error) => {
  showInlineNotification(error);
  throw error; // forward to global handlers
}
\`\`\`

## Playwright CT review

\`grep onError tests/ct\` finds no test that exercises the callback, so no spec updates are needed. CI on this PR will confirm the existing editor flows still pass with the new contract.

## Test Plan

- [x] \`pnpm typecheck\` clean for all four packages.
- [x] \`pnpm lint\` reports zero issues.
- [x] \`pnpm build\` succeeds.
- [ ] CI \`pnpm test:ct\` green across React / Vue / Svelte × Chromium / Firefox / WebKit.