### PR TITLE
refactor: align consumer API with each framework's idiom (PR γ)

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -116,7 +116,25 @@ interface VizelEditorOptions {
 |-------|-----|--------|
 | `Editor \| null` | `ShallowRef<Editor \| null>` | `{ get current(): Editor \| null }` |
 
-All hooks, composables, and runes accept editor accessors via the getter pattern: `() => editor`.
+### Editor Accessor Convention
+
+Each framework accepts the editor in the shape that is idiomatic for its
+reactivity model.
+
+| Framework | Hook / composable / rune signature |
+|-----------|-----------------------------------|
+| React | `useVizelX(editor: Editor \| null \| undefined, options?)` — pass the editor value directly. React reads the variable each render, no getter indirection needed. |
+| Vue | `useVizelX(() => editor.value, options?)` — pass a getter that reads `.value` so the composable can track the `ShallowRef` across changes. |
+| Svelte | `createVizelX(() => editor.current, options?)` — pass a getter that reads `.current` so the rune can react inside `$effect`. |
+
+The cross-framework concept (`hook(editor, options)`) is identical; only the
+binding form differs to honor each framework's reactivity model.
+
+### Context Consumer Return Shape
+
+| React | Vue | Svelte |
+|-------|-----|--------|
+| `{ editor: Editor \| null }` | `ComputedRef<Editor \| null>` (both `useVizelContext()` and `useVizelContextSafe()`; the safe variant returns `null` outside a provider) | `{ get current(): Editor \| null }` |
 
 ## Context API Equivalence
 

--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -83,23 +83,23 @@ function AppContent() {
   const [editor, setEditor] = useState<Editor | null>(null);
 
   // Track editor state for character/word count (only when stats enabled)
-  const editorState = useVizelEditorState(() => (features.stats ? editor : null));
+  const editorState = useVizelEditorState(features.stats ? editor : null);
 
   // Auto-save functionality (only when autoSave enabled)
-  const { status, lastSaved } = useVizelAutoSave(() => (features.autoSave ? editor : null), {
+  const { status, lastSaved } = useVizelAutoSave(features.autoSave ? editor : null, {
     debounceMs: 2000,
     storage: "localStorage",
     key: "vizel-demo-react",
   });
 
   // Version History (only when history panel enabled)
-  const versionHistory = useVizelVersionHistory(() => (features.history ? editor : null), {
+  const versionHistory = useVizelVersionHistory(features.history ? editor : null, {
     key: "vizel-demo-react-versions",
     maxVersions: 20,
   });
 
   // Comments (only when comments panel enabled)
-  const commentManager = useVizelComment(() => (features.comments ? editor : null), {
+  const commentManager = useVizelComment(features.comments ? editor : null, {
     key: "vizel-demo-react-comments",
   });
 

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -90,7 +90,7 @@ This hook forces a re-render on editor state changes.
 ```tsx
 import { useVizelState } from '@vizel/react';
 
-const updateCount = useVizelState(() => editor);
+const updateCount = useVizelState(editor);
 ```
 
 **Returns:** `number` (update count)
@@ -102,7 +102,7 @@ This hook returns a `VizelEditorState` object that reactively tracks editor stat
 ```tsx
 import { useVizelEditorState } from '@vizel/react';
 
-const state = useVizelEditorState(() => editor);
+const state = useVizelEditorState(editor);
 // state.isBold, state.isItalic, state.headingLevel, etc.
 ```
 
@@ -116,7 +116,7 @@ This hook auto-saves editor content with debouncing.
 import { useVizelAutoSave } from '@vizel/react';
 
 const result = useVizelAutoSave(
-  () => editor,
+  editor,
   options?: VizelAutoSaveOptions
 );
 ```
@@ -140,7 +140,7 @@ This hook provides two-way Markdown synchronization with debouncing.
 import { useVizelMarkdown } from '@vizel/react';
 
 const result = useVizelMarkdown(
-  () => editor,
+  editor,
   options?: VizelMarkdownSyncOptions
 );
 ```
@@ -205,7 +205,7 @@ const {
   disconnect,
   updateUser,
 } = useVizelCollaboration(
-  () => wsProvider,
+  wsProvider,
   { user: { name: 'Alice', color: '#ff0000' } }
 );
 ```
@@ -214,7 +214,7 @@ const {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `getProvider` | `() => VizelYjsProvider \| null \| undefined` | Getter function for the Yjs provider |
+| `provider` | `VizelYjsProvider \| null \| undefined` | The Yjs provider instance |
 | `options` | `VizelCollaborationOptions` | Collaboration options including user info |
 
 **Returns:** `UseVizelCollaborationResult`
@@ -249,14 +249,14 @@ const {
   setActiveComment,
   loadComments,
   getCommentById,
-} = useVizelComment(() => editor, { key: 'my-comments' });
+} = useVizelComment(editor, { key: 'my-comments' });
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `editor` | `Editor \| null \| undefined` | The editor instance |
 | `options` | `VizelCommentOptions` | Comment configuration options |
 
 **Returns:** `UseVizelCommentResult`
@@ -292,14 +292,14 @@ const {
   loadVersions,
   deleteVersion,
   clearVersions,
-} = useVizelVersionHistory(() => editor, { maxVersions: 20 });
+} = useVizelVersionHistory(editor, { maxVersions: 20 });
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `getEditor` | `() => Editor \| null \| undefined` | Getter function for the editor |
+| `editor` | `Editor \| null \| undefined` | The editor instance |
 | `options` | `VizelVersionHistoryOptions` | Version history configuration |
 
 **Returns:** `UseVizelVersionHistoryResult`

--- a/docs/guide/auto-save.md
+++ b/docs/guide/auto-save.md
@@ -12,7 +12,7 @@ import { useVizelEditor, useVizelAutoSave, VizelEditor, VizelSaveIndicator } fro
 function Editor() {
   const editor = useVizelEditor();
   
-  const { status, lastSaved } = useVizelAutoSave(() => editor, {
+  const { status, lastSaved } = useVizelAutoSave(editor, {
     debounceMs: 2000,
     storage: 'localStorage',
     key: 'my-editor-content',
@@ -89,7 +89,7 @@ const { status, lastSaved } = useVizelAutoSave(() => editor.value, {
 This backend persists content in the browser's localStorage:
 
 ```typescript
-const { status } = useVizelAutoSave(() => editor, {
+const { status } = useVizelAutoSave(editor, {
   storage: 'localStorage',
   key: 'my-editor-content',
 });
@@ -100,7 +100,7 @@ const { status } = useVizelAutoSave(() => editor, {
 This backend persists content only for the current session:
 
 ```typescript
-const { status } = useVizelAutoSave(() => editor, {
+const { status } = useVizelAutoSave(editor, {
   storage: 'sessionStorage',
   key: 'my-editor-content',
 });
@@ -111,7 +111,7 @@ const { status } = useVizelAutoSave(() => editor, {
 You can implement your own storage backend for server-side persistence. Both `save` and `load` are required:
 
 ```typescript
-const { status } = useVizelAutoSave(() => editor, {
+const { status } = useVizelAutoSave(editor, {
   storage: {
     save: async (content) => {
       await fetch('/api/save', {
@@ -159,7 +159,7 @@ const { status } = useVizelAutoSave(() => editor, {
 ## Manual Save/Restore
 
 ```typescript
-const { save, restore } = useVizelAutoSave(() => editor, { storage: 'localStorage' });
+const { save, restore } = useVizelAutoSave(editor, { storage: 'localStorage' });
 
 // Trigger manual save
 await save();
@@ -237,10 +237,10 @@ The `debounceMs` option controls how long to wait after the last change before s
 
 ```typescript
 // Save 500ms after last change (more responsive)
-useVizelAutoSave(() => editor, { debounceMs: 500 });
+useVizelAutoSave(editor, { debounceMs: 500 });
 
 // Save 5 seconds after last change (less frequent)
-useVizelAutoSave(() => editor, { debounceMs: 5000 });
+useVizelAutoSave(editor, { debounceMs: 5000 });
 ```
 
 ## Error Handling
@@ -248,7 +248,7 @@ useVizelAutoSave(() => editor, { debounceMs: 5000 });
 You can handle save errors with the `onError` callback:
 
 ```typescript
-const { status, error } = useVizelAutoSave(() => editor, {
+const { status, error } = useVizelAutoSave(editor, {
   storage: {
     save: async (content) => {
       const response = await fetch('/api/save', {
@@ -281,7 +281,7 @@ import { useVizelEditor, useVizelAutoSave, VizelEditor } from '@vizel/react';
 function Editor() {
   const editor = useVizelEditor();
   
-  const { restore } = useVizelAutoSave(() => editor, {
+  const { restore } = useVizelAutoSave(editor, {
     storage: 'localStorage',
     key: 'my-editor-content',
     onRestore: (content) => {
@@ -356,7 +356,7 @@ watch(editor, async (ed) => {
 You can temporarily disable auto-save:
 
 ```typescript
-const { status } = useVizelAutoSave(() => editor, {
+const { status } = useVizelAutoSave(editor, {
   enabled: false, // Disable auto-save
 });
 ```
@@ -366,7 +366,7 @@ Or conditionally based on state:
 ```typescript
 const [autoSaveEnabled, setAutoSaveEnabled] = useState(true);
 
-const { status } = useVizelAutoSave(() => editor, {
+const { status } = useVizelAutoSave(editor, {
   enabled: autoSaveEnabled,
 });
 ```

--- a/docs/guide/collaboration.md
+++ b/docs/guide/collaboration.md
@@ -76,7 +76,7 @@ function CollaborativeEditor() {
 
   // Track collaboration state
   const { isConnected, isSynced, peerCount } = useVizelCollaboration(
-    () => provider,
+    provider,
     { user }
   );
 

--- a/docs/guide/comments.md
+++ b/docs/guide/comments.md
@@ -24,7 +24,7 @@ function Editor() {
     features: { comment: true },
   });
   const { comments, addComment, resolveComment, removeComment, setActiveComment } =
-    useVizelComment(() => editor, {
+    useVizelComment(editor, {
       key: "my-doc-comments",
     });
 
@@ -175,7 +175,7 @@ interface VizelCommentOptions {
 Provide both `save` and `load` (both are required):
 
 ```typescript
-useVizelComment(() => editor, {
+useVizelComment(editor, {
   storage: {
     save: async (comments) => {
       await fetch("/api/comments", {

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -207,7 +207,7 @@ console.log(state);
 import { useVizelState } from '@vizel/react';
 
 function EditorStatus({ editor }) {
-  const updateCount = useVizelState(() => editor);
+  const updateCount = useVizelState(editor);
   
   // Component re-renders on editor changes
   return (

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -375,7 +375,7 @@ import { useVizelEditor, useVizelMarkdown, VizelEditor } from '@vizel/react';
 
 function Editor() {
   const editor = useVizelEditor();
-  const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor);
+  const { markdown, setMarkdown, isPending } = useVizelMarkdown(editor);
   
   // markdown updates automatically when editor content changes
   // setMarkdown() updates editor content from markdown

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -130,7 +130,7 @@ const editor = useVizelEditor({
   },
 });
 
-useVizelAutoSave(() => editor, {
+useVizelAutoSave(editor, {
   debounceMs: 2000,
   storage: 'localStorage',
   key: 'my-content',
@@ -259,7 +259,7 @@ function Editor() {
   const editor = useVizelEditor({});
 
   // Reactive state without manual onUpdate tracking
-  const { characterCount, wordCount } = useVizelEditorState(() => editor);
+  const { characterCount, wordCount } = useVizelEditorState(editor);
 
   return (
     <div>

--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -151,7 +151,7 @@ import { useVizelState } from '@vizel/react';
 
 function EditorStats({ editor }) {
   // Re-renders when editor state changes
-  useVizelState(() => editor);
+  useVizelState(editor);
 
   if (!editor) return null;
 
@@ -175,7 +175,7 @@ import { useVizelEditor, useVizelEditorState, VizelEditor } from '@vizel/react';
 function Editor() {
   const editor = useVizelEditor();
   const { characterCount, wordCount, canUndo, canRedo, isFocused, isEmpty } =
-    useVizelEditorState(() => editor);
+    useVizelEditorState(editor);
 
   return (
     <div>
@@ -212,7 +212,7 @@ import { useVizelAutoSave, VizelEditor, VizelSaveIndicator } from '@vizel/react'
 function Editor() {
   const editor = useVizelEditor();
 
-  const { status, lastSaved, save, restore } = useVizelAutoSave(() => editor, {
+  const { status, lastSaved, save, restore } = useVizelAutoSave(editor, {
     debounceMs: 2000,
     storage: 'localStorage',
     key: 'my-editor-content',
@@ -238,7 +238,7 @@ import { useVizelEditor, useVizelMarkdown, VizelEditor } from '@vizel/react';
 
 function MarkdownEditor() {
   const editor = useVizelEditor();
-  const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor, {
+  const { markdown, setMarkdown, isPending } = useVizelMarkdown(editor, {
     debounceMs: 300, // default: 300ms
   });
 
@@ -415,7 +415,7 @@ function TwoWayMarkdownSync() {
   const editor = useVizelEditor({
     initialMarkdown: '# Hello',
   });
-  const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor);
+  const { markdown, setMarkdown, isPending } = useVizelMarkdown(editor);
 
   return (
     <div className="split-view">

--- a/docs/guide/version-history.md
+++ b/docs/guide/version-history.md
@@ -22,7 +22,7 @@ import { useVizelEditor, useVizelVersionHistory, VizelProvider, VizelEditor } fr
 function Editor() {
   const editor = useVizelEditor({});
   const { snapshots, saveVersion, restoreVersion, deleteVersion } =
-    useVizelVersionHistory(() => editor, {
+    useVizelVersionHistory(editor, {
       maxVersions: 20,
       key: "my-doc-versions",
     });
@@ -135,7 +135,7 @@ interface VizelVersionHistoryOptions {
 Limits the number of stored snapshots. When the limit is reached, Vizel removes the oldest snapshot.
 
 ```typescript
-useVizelVersionHistory(() => editor, {
+useVizelVersionHistory(editor, {
   maxVersions: 10, // Keep only the last 10 versions
 });
 ```
@@ -146,12 +146,12 @@ You can choose between built-in `localStorage`, `sessionStorage`, or a custom ba
 
 ```typescript
 // localStorage (default)
-useVizelVersionHistory(() => editor, {
+useVizelVersionHistory(editor, {
   storage: "localStorage",
 });
 
 // Custom backend (e.g., API)
-useVizelVersionHistory(() => editor, {
+useVizelVersionHistory(editor, {
   storage: {
     save: async (snapshots) => {
       await fetch("/api/versions", {

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -35,7 +35,7 @@ export function VizelBubbleMenuDefault({
   locale,
 }: VizelBubbleMenuDefaultProps) {
   // Subscribe to editor state changes to update active states
-  useVizelState(() => editor);
+  useVizelState(editor);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
 
   if (showLinkEditor) {

--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -39,7 +39,7 @@ export function VizelNodeSelector({
   const effectiveNodeTypes =
     nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes);
   // Subscribe to editor state changes
-  useVizelState(() => editor);
+  useVizelState(editor);
 
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(0);

--- a/packages/react/src/components/VizelToolbarDefault.tsx
+++ b/packages/react/src/components/VizelToolbarDefault.tsx
@@ -43,7 +43,7 @@ export function VizelToolbarDefault({
   locale,
 }: VizelToolbarDefaultProps) {
   // Subscribe to editor state changes to update active/enabled states
-  useVizelState(() => editor);
+  useVizelState(editor);
 
   const effectiveActions: readonly VizelToolbarActionItem[] =
     actions ?? (locale ? createVizelToolbarActions(locale) : vizelDefaultToolbarActions);

--- a/packages/react/src/hooks/useVizelAutoSave.ts
+++ b/packages/react/src/hooks/useVizelAutoSave.ts
@@ -30,7 +30,7 @@ export interface UseVizelAutoSaveResult {
 /**
  * Hook for auto-saving editor content with debouncing.
  *
- * @param getEditor - Function that returns the editor instance
+ * @param editor - The editor instance (or `null` while it is still initializing)
  * @param options - Auto-save configuration options
  * @returns Auto-save state and controls
  *
@@ -38,7 +38,7 @@ export interface UseVizelAutoSaveResult {
  * ```tsx
  * function Editor() {
  *   const editor = useVizelEditor({ ... });
- *   const { status, lastSaved, save } = useVizelAutoSave(() => editor, {
+ *   const { status, lastSaved, save } = useVizelAutoSave(editor, {
  *     debounceMs: 2000,
  *     storage: 'localStorage',
  *     key: 'my-document',
@@ -46,15 +46,15 @@ export interface UseVizelAutoSaveResult {
  *
  *   return (
  *     <div>
- *       <EditorContent editor={editor} />
- *       <SaveIndicator status={status} lastSaved={lastSaved} />
+ *       <VizelEditor editor={editor} />
+ *       <VizelSaveIndicator status={status} lastSaved={lastSaved} />
  *     </div>
  *   );
  * }
  * ```
  */
 export function useVizelAutoSave(
-  getEditor: () => Editor | null | undefined,
+  editor: Editor | null | undefined,
   options: VizelAutoSaveOptions = {}
 ): UseVizelAutoSaveResult {
   // Store full options in ref to access callbacks without recreating handlers
@@ -75,9 +75,10 @@ export function useVizelAutoSave(
     error: null,
   });
 
-  // Keep a ref to the getEditor function for the handlers
-  const getEditorRef = useRef(getEditor);
-  getEditorRef.current = getEditor;
+  // Keep a ref to the editor for the handlers so they always read the latest
+  // value without forcing a memo rebuild on every render.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
 
   const handleStateChange = useCallback((partial: Partial<VizelAutoSaveState>) => {
     setState((prev) => ({ ...prev, ...partial }));
@@ -88,7 +89,7 @@ export function useVizelAutoSave(
   const handlers = useMemo(
     () =>
       createVizelAutoSaveHandlers(
-        () => getEditorRef.current(),
+        () => editorRef.current,
         {
           enabled,
           debounceMs,
@@ -104,10 +105,6 @@ export function useVizelAutoSave(
     [enabled, debounceMs, storage, key, handleStateChange]
   );
 
-  // Track editor value (stable reference) instead of getEditor (unstable function).
-  // Depending on getEditor causes the effect to tear down on every parent re-render,
-  // which cancels in-flight debounced saves and drops unsaved edits.
-  const editor = getEditor();
   useEffect(() => {
     if (!(editor && enabled)) return;
 

--- a/packages/react/src/hooks/useVizelCollaboration.ts
+++ b/packages/react/src/hooks/useVizelCollaboration.ts
@@ -35,7 +35,7 @@ export interface UseVizelCollaborationResult {
  * sync state, and peer count. It does NOT create the Yjs document or provider —
  * users must create those themselves and pass them in.
  *
- * @param getProvider - Function that returns the Yjs provider instance
+ * @param provider - The Yjs provider instance (or `null` while it is still initializing)
  * @param options - Collaboration options including user info and callbacks
  * @returns Collaboration state and controls
  *
@@ -54,7 +54,7 @@ export interface UseVizelCollaborationResult {
  *   );
  *
  *   const { isConnected, peerCount } = useVizelCollaboration(
- *     () => provider,
+ *     provider,
  *     { user: { name: "Alice", color: "#ff0000" } }
  *   );
  *
@@ -79,7 +79,7 @@ export interface UseVizelCollaborationResult {
  * ```
  */
 export function useVizelCollaboration(
-  getProvider: () => VizelYjsProvider | null | undefined,
+  provider: VizelYjsProvider | null | undefined,
   options: VizelCollaborationOptions = { user: { name: "Anonymous", color: "#6366f1" } }
 ): UseVizelCollaborationResult {
   const optionsRef = useRef(options);
@@ -94,8 +94,10 @@ export function useVizelCollaboration(
     error: null,
   });
 
-  const getProviderRef = useRef(getProvider);
-  getProviderRef.current = getProvider;
+  // Keep a ref to the provider for the handlers so they always read the latest
+  // value without forcing a memo rebuild on every render.
+  const providerRef = useRef(provider);
+  providerRef.current = provider;
 
   const handleStateChange = useCallback((partial: Partial<VizelCollaborationState>) => {
     setState((prev) => ({ ...prev, ...partial }));
@@ -104,7 +106,7 @@ export function useVizelCollaboration(
   const handlers = useMemo(
     () =>
       createVizelCollaborationHandlers(
-        () => getProviderRef.current(),
+        () => providerRef.current,
         {
           enabled,
           user: options.user,
@@ -120,12 +122,11 @@ export function useVizelCollaboration(
   );
 
   useEffect(() => {
-    const provider = getProvider();
     if (!(provider && enabled)) {
       return;
     }
     return handlers.subscribe();
-  }, [getProvider, enabled, handlers]);
+  }, [provider, enabled, handlers]);
 
   const connect = useCallback(() => handlers.connect(), [handlers]);
   const disconnect = useCallback(() => handlers.disconnect(), [handlers]);

--- a/packages/react/src/hooks/useVizelComment.ts
+++ b/packages/react/src/hooks/useVizelComment.ts
@@ -46,7 +46,7 @@ export interface UseVizelCommentResult {
 /**
  * Hook for managing document comments and annotations.
  *
- * @param getEditor - Function that returns the editor instance
+ * @param editor - The editor instance (or `null` while it is still initializing)
  * @param options - Comment configuration options
  * @returns Comment state and controls
  *
@@ -57,7 +57,7 @@ export interface UseVizelCommentResult {
  *     features: { comment: true },
  *   });
  *   const { comments, addComment, resolveComment, setActiveComment } =
- *     useVizelComment(() => editor, { key: "my-comments" });
+ *     useVizelComment(editor, { key: "my-comments" });
  *
  *   const handleAddComment = () => {
  *     const text = prompt("Enter comment:");
@@ -82,7 +82,7 @@ export interface UseVizelCommentResult {
  * ```
  */
 export function useVizelComment(
-  getEditor: () => Editor | null | undefined,
+  editor: Editor | null | undefined,
   options: VizelCommentOptions = {}
 ): UseVizelCommentResult {
   const optionsRef = useRef(options);
@@ -99,8 +99,10 @@ export function useVizelComment(
     error: null,
   });
 
-  const getEditorRef = useRef(getEditor);
-  getEditorRef.current = getEditor;
+  // Keep a ref to the editor for the handlers so they always read the latest
+  // value without forcing a memo rebuild on every render.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
 
   const handleStateChange = useCallback((partial: Partial<VizelCommentState>) => {
     setState((prev) => ({ ...prev, ...partial }));
@@ -109,7 +111,7 @@ export function useVizelComment(
   const handlers = useMemo(
     () =>
       createVizelCommentHandlers(
-        () => getEditorRef.current(),
+        () => editorRef.current,
         {
           enabled,
           storage,
@@ -125,8 +127,6 @@ export function useVizelComment(
     [enabled, storage, key, handleStateChange]
   );
 
-  // Track editor value (stable reference) instead of getEditor (unstable function)
-  const editor = getEditor();
   useEffect(() => {
     if (editor && enabled) {
       handlers.loadComments();

--- a/packages/react/src/hooks/useVizelEditorState.ts
+++ b/packages/react/src/hooks/useVizelEditorState.ts
@@ -7,13 +7,13 @@ import { useVizelState } from "./useVizelState.ts";
  * This is a convenience hook that combines `useVizelState` (for reactivity)
  * and `getVizelEditorState` (for state extraction).
  *
- * @param getEditor - A function that returns the editor instance to observe
+ * @param editor - The editor instance to observe (or `null` while it is still initializing)
  * @returns The current editor state including focus, empty status, undo/redo, and character/word counts
  *
  * @example
  * ```tsx
  * function StatusBar({ editor }: { editor: Editor | null }) {
- *   const { characterCount, wordCount, canUndo, canRedo } = useVizelEditorState(() => editor);
+ *   const { characterCount, wordCount, canUndo, canRedo } = useVizelEditorState(editor);
  *
  *   return (
  *     <div className="status-bar">
@@ -26,12 +26,12 @@ import { useVizelState } from "./useVizelState.ts";
  * }
  * ```
  */
-export function useVizelEditorState(getEditor: () => Editor | null | undefined): VizelEditorState {
+export function useVizelEditorState(editor: Editor | null | undefined): VizelEditorState {
   // Subscribe to editor state changes for reactivity
-  const updateCount = useVizelState(getEditor);
-  const editor = getEditor() ?? null;
+  const updateCount = useVizelState(editor);
+  const editorOrNull = editor ?? null;
 
   // Memoize the state extraction to avoid unnecessary recalculations
   // biome-ignore lint/correctness/useExhaustiveDependencies: updateCount triggers recalculation on state changes
-  return useMemo(() => getVizelEditorState(editor), [editor, updateCount]);
+  return useMemo(() => getVizelEditorState(editorOrNull), [editorOrNull, updateCount]);
 }

--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -38,7 +38,7 @@ export interface UseVizelMarkdownResult {
 /**
  * React hook for bidirectional Markdown synchronization with the editor.
  *
- * @param getEditor - Function to get the editor instance
+ * @param editor - The editor instance (or `null` while it is still initializing)
  * @param options - Sync options
  * @returns Markdown state and control functions
  *
@@ -48,7 +48,7 @@ export interface UseVizelMarkdownResult {
  *
  * function App() {
  *   const editor = useVizelEditor();
- *   const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor, {
+ *   const { markdown, setMarkdown, isPending } = useVizelMarkdown(editor, {
  *     debounceMs: 300,
  *   });
  *
@@ -68,14 +68,14 @@ export interface UseVizelMarkdownResult {
  * @example
  * ```tsx
  * // With initial markdown value
- * const { markdown, setMarkdown } = useVizelMarkdown(() => editor, {
+ * const { markdown, setMarkdown } = useVizelMarkdown(editor, {
  *   initialValue: "# Hello World",
  *   transformDiagrams: true,
  * });
  * ```
  */
 export function useVizelMarkdown(
-  getEditor: () => Editor | null | undefined,
+  editor: Editor | null | undefined,
   options: UseVizelMarkdownOptions = {}
 ): UseVizelMarkdownResult {
   const { initialValue, ...syncOptions } = options;
@@ -89,12 +89,16 @@ export function useVizelMarkdown(
     handlersRef.current = createVizelMarkdownSyncHandlers(syncOptions);
   }
 
+  // Keep a ref to the editor so memoized callbacks can read the latest value
+  // without depending on the editor identity.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+
   // Track if initial value has been set
   const initialSetRef = useRef(false);
 
   // Set initial markdown when editor is ready
   useEffect(() => {
-    const editor = getEditor();
     if (!editor || initialSetRef.current) return;
 
     if (initialValue === undefined) {
@@ -107,11 +111,10 @@ export function useVizelMarkdown(
     }
 
     initialSetRef.current = true;
-  }, [getEditor, initialValue]);
+  }, [editor, initialValue]);
 
   // Subscribe to editor updates
   useEffect(() => {
-    const editor = getEditor();
     if (!editor) return;
 
     const handlers = handlersRef.current;
@@ -145,7 +148,7 @@ export function useVizelMarkdown(
       editor.off("update", handleUpdate);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [getEditor]);
+  }, [editor]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -154,24 +157,21 @@ export function useVizelMarkdown(
     };
   }, []);
 
-  const setMarkdown = useCallback(
-    (newMarkdown: string) => {
-      const editor = getEditor();
-      if (!editor) return;
-      handlersRef.current?.setMarkdown(editor, newMarkdown);
-      setMarkdownState(newMarkdown);
-      setIsPending(false);
-    },
-    [getEditor]
-  );
+  const setMarkdown = useCallback((newMarkdown: string) => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+    handlersRef.current?.setMarkdown(currentEditor, newMarkdown);
+    setMarkdownState(newMarkdown);
+    setIsPending(false);
+  }, []);
 
   const flush = useCallback(() => {
-    const editor = getEditor();
-    if (!editor) return;
-    handlersRef.current?.flush(editor);
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+    handlersRef.current?.flush(currentEditor);
     setMarkdownState(handlersRef.current?.getMarkdown() ?? "");
     setIsPending(false);
-  }, [getEditor]);
+  }, []);
 
   return {
     markdown,

--- a/packages/react/src/hooks/useVizelState.ts
+++ b/packages/react/src/hooks/useVizelState.ts
@@ -6,13 +6,13 @@ import { useEffect, useReducer } from "react";
  * This is useful for components that need to reflect the current editor state
  * (e.g., formatting buttons that show active state).
  *
- * @param getEditor - A function that returns the editor instance
+ * @param editor - The editor instance (or `null` while it is still initializing)
  * @returns A number that changes on each editor state update (can be ignored)
  *
  * @example
  * ```tsx
  * function FormattingButtons({ editor }: { editor: Editor }) {
- *   useVizelState(() => editor);
+ *   useVizelState(editor);
  *   // Now editor.isActive() will be re-evaluated on each state change
  *   return (
  *     <button className={editor.isActive("bold") ? "active" : ""}>
@@ -22,9 +22,8 @@ import { useEffect, useReducer } from "react";
  * }
  * ```
  */
-export function useVizelState(getEditor: () => Editor | null | undefined): number {
+export function useVizelState(editor: Editor | null | undefined): number {
   const [updateCount, forceUpdate] = useReducer((x: number) => x + 1, 0);
-  const editor = getEditor() ?? null;
 
   useEffect(() => {
     if (!editor) return;

--- a/packages/react/src/hooks/useVizelVersionHistory.ts
+++ b/packages/react/src/hooks/useVizelVersionHistory.ts
@@ -33,7 +33,7 @@ export interface UseVizelVersionHistoryResult {
 /**
  * Hook for managing document version history.
  *
- * @param getEditor - Function that returns the editor instance
+ * @param editor - The editor instance (or `null` while it is still initializing)
  * @param options - Version history configuration options
  * @returns Version history state and controls
  *
@@ -42,7 +42,7 @@ export interface UseVizelVersionHistoryResult {
  * function Editor() {
  *   const editor = useVizelEditor({ ... });
  *   const { snapshots, saveVersion, restoreVersion } = useVizelVersionHistory(
- *     () => editor,
+ *     editor,
  *     { maxVersions: 20, key: 'my-doc-versions' }
  *   );
  *
@@ -64,7 +64,7 @@ export interface UseVizelVersionHistoryResult {
  * ```
  */
 export function useVizelVersionHistory(
-  getEditor: () => Editor | null | undefined,
+  editor: Editor | null | undefined,
   options: VizelVersionHistoryOptions = {}
 ): UseVizelVersionHistoryResult {
   const optionsRef = useRef(options);
@@ -81,8 +81,10 @@ export function useVizelVersionHistory(
     error: null,
   });
 
-  const getEditorRef = useRef(getEditor);
-  getEditorRef.current = getEditor;
+  // Keep a ref to the editor for the handlers so they always read the latest
+  // value without forcing a memo rebuild on every render.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
 
   const handleStateChange = useCallback((partial: Partial<VizelVersionHistoryState>) => {
     setState((prev) => ({ ...prev, ...partial }));
@@ -91,7 +93,7 @@ export function useVizelVersionHistory(
   const handlers = useMemo(
     () =>
       createVizelVersionHistoryHandlers(
-        () => getEditorRef.current(),
+        () => editorRef.current,
         {
           enabled,
           maxVersions,
@@ -105,9 +107,6 @@ export function useVizelVersionHistory(
       ),
     [enabled, maxVersions, storage, key, handleStateChange]
   );
-
-  // Track editor value (stable reference) instead of getEditor (unstable function)
-  const editor = getEditor();
 
   // Load versions when editor becomes available
   useEffect(() => {

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -1,37 +1,42 @@
 <script lang="ts" module>
 import type { Editor } from "@vizel/core";
 
+export interface VizelExposed {
+  /** The container DOM element */
+  container: HTMLDivElement | null;
+}
+
 export interface VizelEditorProps {
   /** Override the editor from context */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;
-}
-
-export interface VizelExposed {
-  /** The container DOM element */
-  container: HTMLDivElement | null;
+  /**
+   * Mutable ref object the component keeps in sync with the editor container.
+   * Pass an object; this component assigns `container` so callers can read
+   * `ref.container` directly — symmetric with React's `useImperativeHandle`
+   * and Vue's `defineExpose`.
+   */
+  ref?: VizelExposed;
 }
 </script>
 
 <script lang="ts">
 import { getVizelContextSafe } from "./VizelContext.js";
 
-let { editor: editorProp, class: className }: VizelEditorProps = $props();
+let { editor: editorProp, class: className, ref }: VizelEditorProps = $props();
 
 const contextEditor = getVizelContextSafe();
 const editor = $derived(editorProp ?? contextEditor?.());
 
 let element: HTMLDivElement | null = $state(null);
 
-// Expose container element to parent component
-export function getExposed(): VizelExposed {
-  return {
-    get container() {
-      return element;
-    },
-  };
-}
+// Keep ref.container in sync with the bound element.
+$effect(() => {
+  if (ref) {
+    ref.container = element;
+  }
+});
 
 $effect(() => {
   if (!editor || !element) {

--- a/packages/svelte/src/components/VizelIconContext.ts
+++ b/packages/svelte/src/components/VizelIconContext.ts
@@ -1,30 +1,7 @@
-import type { CustomIconMap, VizelIconContextValue } from "@vizel/core";
-import { getContext, setContext } from "svelte";
+import type { VizelIconContextValue } from "@vizel/core";
+import { getContext } from "svelte";
 
 export const VIZEL_ICON_CONTEXT_KEY = Symbol("vizel-icon-context");
-
-/**
- * Set custom icon mappings for child components.
- * Call this in a parent component to customize icons for all descendants.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { setVizelIcons } from "@vizel/svelte";
- *
- *   // Use Phosphor icons
- *   setVizelIcons({
- *     heading1: "ph:text-h-one",
- *     heading2: "ph:text-h-two",
- *     bold: "ph:text-b-bold",
- *     italic: "ph:text-italic",
- *   });
- * </script>
- * ```
- */
-export function setVizelIcons(customIcons?: CustomIconMap): void {
-  setContext(VIZEL_ICON_CONTEXT_KEY, { customIcons } satisfies VizelIconContextValue);
-}
 
 /**
  * Get custom icon mappings from parent context.

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -69,7 +69,7 @@ export {
 // Vizel Icon component
 // ============================================================================
 export { default as VizelIcon, type VizelIconProps } from "./VizelIcon.svelte";
-export { getVizelIconContext, setVizelIcons } from "./VizelIconContext.js";
+export { getVizelIconContext } from "./VizelIconContext.js";
 export {
   default as VizelIconProvider,
   type VizelIconProviderProps,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -17,7 +17,6 @@ export {
   getVizelContext,
   getVizelContextSafe,
   getVizelIconContext,
-  setVizelIcons,
   // Vizel all-in-one
   Vizel,
   // BlockMenu

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -156,18 +156,12 @@ watch(markdown, (newMarkdown) => {
   isUpdatingFromMarkdown = false;
 });
 
-// Expose editor instance for advanced use cases
-// Both `editor` property and `getEditor()` method are provided for compatibility
-defineExpose<VizelRef & { getEditor: () => Editor | null }>({
+// Expose editor instance for advanced use cases.
+defineExpose<VizelRef>({
   /** The underlying Tiptap editor instance */
   get editor() {
     return editor.value;
   },
-  /**
-   * Get the underlying Tiptap editor instance
-   * @deprecated Use the `editor` property instead
-   */
-  getEditor: () => editor.value,
 });
 </script>
 

--- a/packages/vue/src/components/VizelBubbleMenu.vue
+++ b/packages/vue/src/components/VizelBubbleMenu.vue
@@ -31,8 +31,8 @@ const props = withDefaults(defineProps<VizelBubbleMenuProps>(), {
 
 const slots = useSlots();
 const menuRef = ref<HTMLElement | null>(null);
-const getContextEditor = useVizelContextSafe();
-const editor = computed(() => props.editor ?? getContextEditor?.());
+const contextEditor = useVizelContextSafe();
+const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
 
 // Handle Escape key to hide bubble menu by collapsing selection
 function handleKeyDown(event: KeyboardEvent) {

--- a/packages/vue/src/components/VizelContext.ts
+++ b/packages/vue/src/components/VizelContext.ts
@@ -33,12 +33,19 @@ export function useVizelContext(): ComputedRef<Editor | null> {
 }
 
 /**
- * Composable to access the editor getter from context.
- * Returns null if used outside of VizelProvider (does not throw).
+ * Composable to access the editor instance from VizelProvider context.
+ * Returns `null` if used outside a VizelProvider (does NOT throw).
  *
- * @returns A getter function that returns the editor, or null if outside VizelProvider
+ * Both `useVizelContext` and `useVizelContextSafe` return a
+ * `ComputedRef<Editor | null>` so destructuring / template usage is
+ * symmetric; the only difference is whether the absence of a provider
+ * is treated as fatal.
+ *
+ * @returns A computed ref of the editor, or `null` when no provider is present.
  */
-export function useVizelContextSafe(): (() => Editor | null) | null {
+export function useVizelContextSafe(): ComputedRef<Editor | null> | null {
   // Provide null as default to suppress Vue warning when used outside VizelProvider
-  return inject(VIZEL_CONTEXT_KEY, null);
+  const getEditor = inject(VIZEL_CONTEXT_KEY, null);
+  if (!getEditor) return null;
+  return computed(() => getEditor());
 }

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -18,8 +18,8 @@ export interface VizelExposed {
 const props = defineProps<VizelEditorProps>();
 
 const containerRef = ref<HTMLDivElement | null>(null);
-const getContextEditor = useVizelContextSafe();
-const resolvedEditor = computed(() => props.editor ?? getContextEditor?.());
+const contextEditor = useVizelContextSafe();
+const resolvedEditor = computed(() => props.editor ?? contextEditor?.value ?? null);
 
 // Expose container ref to parent component
 defineExpose<VizelExposed>({

--- a/packages/vue/src/components/VizelToolbar.vue
+++ b/packages/vue/src/components/VizelToolbar.vue
@@ -19,8 +19,8 @@ const props = withDefaults(defineProps<VizelToolbarProps>(), {
   showDefaultToolbar: true,
 });
 
-const getContextEditor = useVizelContextSafe();
-const editor = computed(() => props.editor ?? getContextEditor?.() ?? null);
+const contextEditor = useVizelContextSafe();
+const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
 </script>
 
 <template>

--- a/tests/ct/react/specs/UseEditorStateFixture.tsx
+++ b/tests/ct/react/specs/UseEditorStateFixture.tsx
@@ -11,7 +11,7 @@ export function UseEditorStateFixture({ nullEditor = false }: UseEditorStateFixt
   });
 
   const actualEditor = nullEditor ? null : editor;
-  const updateCount = useVizelState(() => actualEditor);
+  const updateCount = useVizelState(actualEditor);
 
   const isBoldActive = actualEditor?.isActive("bold") ?? false;
   const isItalicActive = actualEditor?.isActive("italic") ?? false;

--- a/tests/ct/react/specs/UserFlowFixture.tsx
+++ b/tests/ct/react/specs/UserFlowFixture.tsx
@@ -6,7 +6,7 @@ import {
   VizelEditor,
   VizelProvider,
 } from "@vizel/react";
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
 
 export interface UserFlowFixtureProps {
   mode?: "markdown" | "auto-save" | "default";
@@ -92,15 +92,7 @@ function MarkdownMode() {
 function AutoSaveMode({ storageKey }: { storageKey: string }) {
   const editor = useVizelEditor({});
 
-  // Use a ref + useCallback to keep the getter stable across re-renders,
-  // preventing useEffect cleanup from cancelling the debounced save.
-  // Depend on `editor` so the hook re-subscribes when editor initializes.
-  const editorRef = useRef(editor);
-  editorRef.current = editor;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: editor triggers re-subscription in auto-save hook
-  const getEditor = useCallback(() => editorRef.current, [editor]);
-
-  const { status } = useVizelAutoSave(getEditor, {
+  const { status } = useVizelAutoSave(editor, {
     debounceMs: 50,
     storage: "localStorage",
     key: storageKey,

--- a/tests/ct/react/specs/VizelRefStateFixture.tsx
+++ b/tests/ct/react/specs/VizelRefStateFixture.tsx
@@ -22,7 +22,7 @@ export function VizelRefStateFixture({
   const [editor, setEditor] = useState<Editor | null>(null);
 
   // Track editor state for character/word count
-  useVizelState(() => editor);
+  useVizelState(editor);
   const editorState = getVizelEditorState(editor);
 
   return (


### PR DESCRIPTION
## Summary

PR γ of the post-audit improvement series. Five breaking changes that let each framework speak its native dialect while keeping the conceptual API identical across React, Vue, and Svelte.

| Framework | Change | Why |
|-----------|--------|-----|
| React | Hooks accept the editor (or provider) directly instead of a \`() => Editor\` getter | The getter pattern was a Vue/Svelte affordance for their reactivity models; React reads the variable each render, so the indirection was pure boilerplate. |
| Vue | \`useVizelContextSafe()\` returns \`ComputedRef<Editor \| null> \| null\` to match \`useVizelContext()\` | Removes the surprising asymmetry that forced consumers to call \`ctx()\` from one half of the API and \`ctx.value\` from the other. |
| Vue | \`<Vizel>\` drops the deprecated \`getEditor()\` alias on its exposed ref | Brings the \`VizelRef\` shape into parity with React and Svelte: \`vizelRef.editor\` only. |
| Svelte | \`<VizelEditor>\` replaces \`getExposed()\` with a \`ref?: VizelExposed\` prop | Mirrors React's \`useImperativeHandle\` and Vue's \`defineExpose\` shape; reuses the ref-prop pattern introduced for the slash and mention menus in PR α. |
| Svelte | Remove the \`setVizelIcons\` public function | \`<VizelIconProvider>\` is the supported way to provide icons; the bare setter duplicated its job and had no React or Vue counterpart. |

Internal callsites and docs are updated to match. The new \`Editor Accessor Convention\` subsection in \`.claude/rules/cross-framework.md\` records the per-framework signature so future sessions don't re-converge on the old uniform getter.

### Files touched (33)

- \`packages/react/src/hooks/*.ts\` (7 hook files)
- \`packages/react/src/components/Vizel{BubbleMenu,NodeSelector,Toolbar}Default.tsx\` (3 internal callers)
- \`packages/vue/src/components/Vizel.vue\`, \`VizelContext.ts\`, \`VizelEditor.vue\`, \`VizelBubbleMenu.vue\`, \`VizelToolbar.vue\`
- \`packages/svelte/src/components/VizelEditor.svelte\`, \`VizelIconContext.ts\`, \`components/index.ts\`, \`index.ts\`
- \`apps/demo/react/src/App.tsx\`
- \`docs/guide/{auto-save,comments,version-history,collaboration,configuration,getting-started,performance,react}.md\`
- \`docs/api/react.md\`
- \`.claude/rules/cross-framework.md\`

## Breaking Changes

### React hooks accept the editor directly

\`\`\`diff
- useVizelAutoSave(() => editor, opts)
+ useVizelAutoSave(editor, opts)
\`\`\`

Applies to \`useVizelAutoSave\`, \`useVizelComment\`, \`useVizelEditorState\`, \`useVizelMarkdown\`, \`useVizelState\`, \`useVizelVersionHistory\`. \`useVizelCollaboration\` accepts \`provider\` directly.

### Vue \`useVizelContextSafe()\` return shape

\`\`\`diff
- const getEditor = useVizelContextSafe();
- const current = getEditor?.();
+ const ctx = useVizelContextSafe();
+ const current = ctx?.value ?? null;
\`\`\`

### Vue \`<Vizel>\` ref drops \`getEditor()\`

\`\`\`diff
- const editor = vizelRef.value?.getEditor();
+ const editor = vizelRef.value?.editor;
\`\`\`

### Svelte \`<VizelEditor>\` exposes \`container\` via a \`ref\` prop

\`\`\`diff
- <VizelEditor bind:this={ref} {editor} />
- const el = ref?.getExposed().container;
+ const exposed: VizelExposed = { container: null };
+ <VizelEditor {editor} ref={exposed} />
+ const el = exposed.container;
\`\`\`

### Svelte \`setVizelIcons\` is removed

\`\`\`diff
- setVizelIcons({ bold: "ph:text-b-bold" });
+ <VizelIconProvider icons={{ bold: "ph:text-b-bold" }}>
+   <App />
+ </VizelIconProvider>
\`\`\`

## Playwright CT review

Surveyed \`tests/ct/\` for usages of \`useVizelContextSafe\`, \`VizelExposed\`, \`getExposed\`, and \`setVizelIcons\`: zero matches in source (only build-artefact files under \`.cache/\`). The existing React fixtures that called hooks via \`() => editor\` have been migrated to the bare-editor form (\`UserFlowFixture.tsx\`, \`UseEditorStateFixture.tsx\`, \`VizelRefStateFixture.tsx\`). CI will re-exercise the full Playwright CT matrix.

## Test Plan

- [x] \`pnpm typecheck\` clean across all four packages.
- [x] \`pnpm lint\` reports zero errors (one pre-existing complexity warning unrelated to this PR).
- [x] \`pnpm build\` succeeds.
- [ ] CI \`pnpm test:ct\` green for React / Vue / Svelte × Chromium / Firefox / WebKit.