### PR TITLE
refactor: rename slash/mention command to select, scope block menu events (PR δ)

### DIFF
--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -670,7 +670,7 @@ import { VizelSlashMenu } from '@vizel/react';
 
 <VizelSlashMenu
   items={items}
-  command={handleCommand}
+  onSelect={handleSelect}
   className="my-menu"
 />
 ```

--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -618,7 +618,7 @@ This component renders the slash command menu.
 ```svelte
 <VizelSlashMenu
   items={items}
-  command={handleCommand}
+  onselect={handleSelect}
   class="my-menu"
 />
 ```

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -678,7 +678,7 @@ This component renders the slash command menu.
 ```vue
 <VizelSlashMenu
   :items="items"
-  :command="handleCommand"
+  @select="handleSelect"
   class="my-menu"
 />
 ```

--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -15,9 +15,17 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
 
 export interface VizelBlockMenuProps {
+  /**
+   * Bind this menu to a specific editor. Falls back to the editor from
+   * `VizelProvider` context. When set (either way), the menu only reacts to
+   * drag-handle events from the bound editor, so multiple editors on the
+   * same page do not cross-trigger each other's menus.
+   */
+  editor?: Editor | null;
   /** Custom block menu actions (replaces defaults) */
   actions?: readonly VizelBlockMenuAction[];
   /** Custom node types for "Turn into" submenu */
@@ -38,11 +46,14 @@ interface BlockMenuState extends VizelBlockMenuOpenDetail {
  * Renders via fixed positioning near the drag handle.
  */
 export function VizelBlockMenu({
+  editor: editorProp,
   actions,
   nodeTypes,
   className,
   locale,
 }: VizelBlockMenuProps): ReactNode {
+  const context = useVizelContextSafe();
+  const boundEditor: Editor | null = editorProp ?? context?.editor ?? null;
   const effectiveActions =
     actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions);
   const effectiveNodeTypes =
@@ -66,6 +77,10 @@ export function VizelBlockMenu({
     const handler = (e: Event) => {
       if (!(e instanceof CustomEvent)) return;
       const detail = e.detail as VizelBlockMenuOpenDetail;
+      // When this menu is bound to an editor (via prop or VizelProvider
+      // context), ignore events from any other editor on the page. This
+      // prevents sibling editors from cross-triggering each other's menus.
+      if (boundEditor && detail.editor !== boundEditor) return;
       menuEditorRef.current = detail.editor;
       setMenuState({
         ...detail,
@@ -85,7 +100,7 @@ export function VizelBlockMenu({
 
     document.addEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
     return () => document.removeEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
-  }, []);
+  }, [boundEditor]);
 
   // Focus first menuitem when menu opens
   useEffect(() => {

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -12,7 +12,7 @@ export interface VizelMentionMenuProps {
   /** Mention items to display */
   items: VizelMentionItem[];
   /** Callback when an item is selected */
-  command: (item: VizelMentionItem) => void;
+  onSelect: (item: VizelMentionItem) => void;
   /** Custom class name for the menu container */
   className?: string;
 }
@@ -24,7 +24,7 @@ export interface VizelMentionMenuProps {
 export function VizelMentionMenu({
   ref,
   items,
-  command,
+  onSelect,
   className,
 }: VizelMentionMenuProps): ReactNode {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -52,10 +52,10 @@ export function VizelMentionMenu({
     (index: number) => {
       const item = items[index];
       if (item) {
-        command(item);
+        onSelect(item);
       }
     },
-    [items, command]
+    [items, onSelect]
   );
 
   const upHandler = useCallback(() => {

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -16,7 +16,7 @@ export interface VizelSlashMenuProps {
   /** Ref to access menu methods */
   ref?: Ref<VizelSlashMenuRef>;
   items: VizelSlashCommandItem[];
-  command: (item: VizelSlashCommandItem) => void;
+  onSelect: (item: VizelSlashCommandItem) => void;
   /** Custom class name for the menu container */
   className?: string;
   /** Whether to show items grouped by category (default: true when not searching) */
@@ -54,7 +54,7 @@ export interface VizelSlashMenuProps {
 export function VizelSlashMenu({
   ref,
   items,
-  command,
+  onSelect,
   className,
   showGroups = true,
   renderItem,
@@ -95,10 +95,10 @@ export function VizelSlashMenu({
     (index: number) => {
       const item = flatItems[index];
       if (item) {
-        command(item);
+        onSelect(item);
       }
     },
-    [flatItems, command]
+    [flatItems, onSelect]
   );
 
   const upHandler = useCallback(() => {

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -44,7 +44,7 @@ export function createVizelMentionMenuRenderer(
         root.render(
           createElement(VizelMentionMenu, {
             items,
-            command: commandFn,
+            onSelect: commandFn,
             ...(options.className !== undefined && { className: options.className }),
             ref: menuRef,
           })

--- a/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
@@ -46,7 +46,7 @@ export function createVizelSlashMenuRenderer(
         root.render(
           createElement(VizelSlashMenu, {
             items,
-            command: commandFn,
+            onSelect: commandFn,
             ...(options.className !== undefined && { className: options.className }),
             ref: menuRef,
           })

--- a/packages/svelte/src/components/VizelBlockMenu.svelte
+++ b/packages/svelte/src/components/VizelBlockMenu.svelte
@@ -1,7 +1,14 @@
 <script lang="ts" module>
-import type { VizelBlockMenuAction, VizelLocale, VizelNodeTypeOption } from "@vizel/core";
+import type { Editor, VizelBlockMenuAction, VizelLocale, VizelNodeTypeOption } from "@vizel/core";
 
 export interface VizelBlockMenuProps {
+  /**
+   * Bind this menu to a specific editor. Falls back to the editor from
+   * `VizelProvider` context. When set (either way), the menu only reacts to
+   * drag-handle events from the bound editor, so multiple editors on the
+   * same page do not cross-trigger each other's menus.
+   */
+  editor?: Editor | null;
   /** Custom block menu actions (replaces defaults) */
   actions?: readonly VizelBlockMenuAction[];
   /** Custom node types for "Turn into" submenu */
@@ -27,6 +34,7 @@ import {
   type VizelBlockMenuOpenDetail,
 } from "@vizel/core";
 import { tick } from "svelte";
+import { getVizelContextSafe } from "./VizelContext.js";
 import VizelIcon from "./VizelIcon.svelte";
 
 interface BlockMenuState extends VizelBlockMenuOpenDetail {
@@ -35,11 +43,15 @@ interface BlockMenuState extends VizelBlockMenuOpenDetail {
 }
 
 let {
+  editor: editorProp,
   actions,
   nodeTypes,
   class: className,
   locale,
 }: VizelBlockMenuProps = $props();
+
+const contextEditor = getVizelContextSafe();
+const boundEditor = $derived<Editor | null>(editorProp ?? contextEditor?.() ?? null);
 
 const effectiveActions = $derived(actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions));
 const effectiveNodeTypes = $derived(nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes));
@@ -126,6 +138,10 @@ $effect(() => {
   const handleOpen = (e: Event) => {
     if (!(e instanceof CustomEvent)) return;
     const detail = e.detail as VizelBlockMenuOpenDetail;
+    // When this menu is bound to an editor (via prop or VizelProvider
+    // context), ignore events from any other editor on the page. This
+    // prevents sibling editors from cross-triggering each other's menus.
+    if (boundEditor && detail.editor !== boundEditor) return;
     menuState = {
       ...detail,
       x: detail.handleRect.left,

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -8,7 +8,7 @@ export interface VizelMentionMenuRef {
 export interface VizelMentionMenuProps {
   items: VizelMentionItem[];
   class?: string;
-  oncommand?: (item: VizelMentionItem) => void;
+  onselect?: (item: VizelMentionItem) => void;
   /**
    * Mutable ref object the component populates with imperative handles
    * (notably `onKeyDown`). Pass an object; this component assigns to its
@@ -27,7 +27,7 @@ import { tick } from "svelte";
 let {
   items,
   class: className,
-  oncommand,
+  onselect,
   ref,
 }: VizelMentionMenuProps = $props();
 
@@ -59,7 +59,7 @@ function scrollToSelected() {
 function selectItem(index: number) {
   const item = items[index];
   if (item) {
-    oncommand?.(item);
+    onselect?.(item);
   }
 }
 

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -11,8 +11,8 @@ export interface VizelSlashMenuProps {
   items: VizelSlashCommandItem[];
   /** Custom class name */
   class?: string;
-  /** Command handler */
-  oncommand?: (item: VizelSlashCommandItem) => void;
+  /** Selection handler invoked when an item is chosen */
+  onselect?: (item: VizelSlashCommandItem) => void;
   /** Whether to show items grouped by category (default: true when not searching) */
   showGroups?: boolean;
   /** Custom group order */
@@ -42,7 +42,7 @@ import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.svelte";
 let {
   items,
   class: className,
-  oncommand,
+  onselect,
   showGroups = true,
   groupOrder,
   renderItem,
@@ -93,7 +93,7 @@ $effect(() => {
 function selectItem(index: number) {
   const item = flatItems[index];
   if (item) {
-    oncommand?.(item);
+    onselect?.(item);
   }
 }
 

--- a/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
+++ b/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
@@ -42,10 +42,10 @@ export function createVizelMentionMenuRenderer(
       let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
       const menuState = $state<{
         items: VizelMentionItem[];
-        oncommand: (item: VizelMentionItem) => void;
+        onselect: (item: VizelMentionItem) => void;
       }>({
         items: [],
-        oncommand: () => {
+        onselect: () => {
           // initial no-op; replaced by Tiptap's `props.command` in onStart.
         },
       });
@@ -54,7 +54,7 @@ export function createVizelMentionMenuRenderer(
       return {
         onStart: (props: SuggestionProps<VizelMentionItem>) => {
           menuState.items = props.items;
-          menuState.oncommand = props.command;
+          menuState.onselect = props.command;
 
           suggestionContainer = createVizelSuggestionContainer();
           component = mount(VizelMentionMenu, {
@@ -64,8 +64,8 @@ export function createVizelMentionMenuRenderer(
               get items() {
                 return menuState.items;
               },
-              get oncommand() {
-                return menuState.oncommand;
+              get onselect() {
+                return menuState.onselect;
               },
               ref: menuRef,
             },
@@ -75,7 +75,7 @@ export function createVizelMentionMenuRenderer(
 
         onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
           menuState.items = props.items;
-          menuState.oncommand = props.command;
+          menuState.onselect = props.command;
           suggestionContainer?.updatePosition(props.clientRect);
         },
 

--- a/packages/svelte/src/runes/createVizelSlashMenuRenderer.svelte.ts
+++ b/packages/svelte/src/runes/createVizelSlashMenuRenderer.svelte.ts
@@ -44,10 +44,10 @@ export function createVizelSlashMenuRenderer(
       // fields drives the component's reactivity instead of remounting.
       const menuState = $state<{
         items: VizelSlashCommandItem[];
-        oncommand: (item: VizelSlashCommandItem) => void;
+        onselect: (item: VizelSlashCommandItem) => void;
       }>({
         items: [],
-        oncommand: () => {
+        onselect: () => {
           // initial no-op; replaced by Tiptap's `props.command` in onStart.
         },
       });
@@ -59,7 +59,7 @@ export function createVizelSlashMenuRenderer(
       return {
         onStart: (props: SuggestionProps<VizelSlashCommandItem>) => {
           menuState.items = props.items;
-          menuState.oncommand = props.command;
+          menuState.onselect = props.command;
 
           suggestionContainer = createVizelSuggestionContainer();
           component = mount(VizelSlashMenu, {
@@ -69,8 +69,8 @@ export function createVizelSlashMenuRenderer(
               get items() {
                 return menuState.items;
               },
-              get oncommand() {
-                return menuState.oncommand;
+              get onselect() {
+                return menuState.onselect;
               },
               ref: menuRef,
             },
@@ -80,7 +80,7 @@ export function createVizelSlashMenuRenderer(
 
         onUpdate: (props: SuggestionProps<VizelSlashCommandItem>) => {
           menuState.items = props.items;
-          menuState.oncommand = props.command;
+          menuState.onselect = props.command;
           suggestionContainer?.updatePosition(props.clientRect);
         },
 

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -3,6 +3,7 @@ import {
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelNodeTypes,
+  type Editor,
   getVizelTurnIntoOptions,
   groupVizelBlockMenuActions,
   shouldFlipSubmenu,
@@ -15,9 +16,17 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
+import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelBlockMenuProps {
+  /**
+   * Bind this menu to a specific editor. Falls back to the editor from
+   * `VizelProvider` context. When set (either way), the menu only reacts to
+   * drag-handle events from the bound editor, so multiple editors on the
+   * same page do not cross-trigger each other's menus.
+   */
+  editor?: Editor | null;
   /** Custom block menu actions (replaces defaults) */
   actions?: readonly VizelBlockMenuAction[];
   /** Custom node types for "Turn into" submenu */
@@ -34,6 +43,9 @@ interface BlockMenuState extends VizelBlockMenuOpenDetail {
 }
 
 const props = defineProps<VizelBlockMenuProps>();
+
+const contextEditor = useVizelContextSafe();
+const boundEditor = computed<Editor | null>(() => props.editor ?? contextEditor?.value ?? null);
 
 const effectiveActions = computed(
   () =>
@@ -83,6 +95,10 @@ function handleTurnInto(nodeType: VizelNodeTypeOption) {
 function handleOpen(e: Event) {
   if (!(e instanceof CustomEvent)) return;
   const detail = e.detail as VizelBlockMenuOpenDetail;
+  // When this menu is bound to an editor (via prop or VizelProvider
+  // context), ignore events from any other editor on the page. This
+  // prevents sibling editors from cross-triggering each other's menus.
+  if (boundEditor.value && detail.editor !== boundEditor.value) return;
   menuState.value = {
     ...detail,
     x: detail.handleRect.left,

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -14,7 +14,7 @@ export interface VizelMentionMenuProps {
 const props = defineProps<VizelMentionMenuProps>();
 
 const emit = defineEmits<{
-  command: [item: VizelMentionItem];
+  select: [item: VizelMentionItem];
 }>();
 
 const selectedIndex = ref(0);
@@ -40,7 +40,7 @@ function scrollToSelected() {
 function selectItem(index: number) {
   const item = props.items[index];
   if (item) {
-    emit("command", item);
+    emit("select", item);
   }
 }
 

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<VizelSlashMenuProps>(), {
 });
 
 const emit = defineEmits<{
-  command: [item: VizelSlashCommandItem];
+  select: [item: VizelSlashCommandItem];
 }>();
 
 const slots = useSlots();
@@ -74,7 +74,7 @@ watch(selectedIndex, async (newIndex) => {
 function selectItem(index: number) {
   const item = flatItems.value[index];
   if (item) {
-    emit("command", item);
+    emit("select", item);
   }
 }
 

--- a/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
@@ -56,7 +56,7 @@ export function createVizelMentionMenuRenderer(
                   items: items.value,
                   ...(options.className !== undefined && { class: options.className }),
                   ref: componentRef,
-                  onCommand: (item: VizelMentionItem) => {
+                  onSelect: (item: VizelMentionItem) => {
                     commandFn.value?.(item);
                   },
                 });

--- a/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
@@ -58,7 +58,7 @@ export function createVizelSlashMenuRenderer(
                   items: items.value,
                   ...(options.className !== undefined && { class: options.className }),
                   ref: componentRef,
-                  onCommand: (item: VizelSlashCommandItem) => {
+                  onSelect: (item: VizelSlashCommandItem) => {
                     commandFn.value?.(item);
                   },
                 });


### PR DESCRIPTION
## Summary

PR δ of the post-audit improvement series. Two cross-framework parity fixes that live close to \`@vizel/core\`'s event surface.

### 1. Rename slash / mention menu \`command\` to \`select\`

The previous name collides with the HTML 2024 \`command\` attribute on \`<button>\` elements and reads ambiguously when bound via Vue's \`@command\` template directive. Renaming to \`select\` removes the collision and matches the conventional Listbox-style event name.

| Framework | Old shape | New shape |
|-----------|-----------|-----------|
| React | \`<VizelSlashMenu onCommand={fn} />\` | \`<VizelSlashMenu onSelect={fn} />\` |
| Vue | \`@command="fn"\` (with emit \`command\`) | \`@select="fn"\` (with emit \`select\`) |
| Svelte | \`oncommand={fn}\` | \`onselect={fn}\` |

The renderer helpers (\`createVizelSlashMenuRenderer\`, \`createVizelMentionMenuRenderer\`) update their internal wiring transparently. Tiptap's \`props.command\` callback is untouched.

### 2. Scope \`VizelBlockMenu\` events to the bound editor

\`VizelBlockMenu\` now accepts an optional \`editor\` prop and otherwise reads the editor from \`VizelProvider\` context. The CustomEvent handler filters by \`detail.editor === boundEditor\`, so multiple editors on the same page no longer cross-trigger each other's block menus.

Without a prop or context, the menu still listens for any event (matching the previous behavior); the explicit binding becomes important only when more than one Vizel instance lives on a page.

## Files touched

- \`packages/{react,vue,svelte}/src/components/VizelSlashMenu.*\`, \`VizelMentionMenu.*\`, \`VizelBlockMenu.*\`
- \`packages/{react,vue,svelte}/src/{hooks,composables,runes}/createVizel{Slash,Mention}MenuRenderer.*\`
- \`docs/api/{react,vue,svelte}.md\`

## Breaking Changes

### \`VizelSlashMenu\` / \`VizelMentionMenu\`: \`command\` → \`select\`

\`\`\`diff
- <VizelSlashMenu items={items} onCommand={fn} />
+ <VizelSlashMenu items={items} onSelect={fn} />
\`\`\`

\`\`\`diff
- <VizelSlashMenu :items="items" @command="fn" />
+ <VizelSlashMenu :items="items" @select="fn" />
\`\`\`

\`\`\`diff
- <VizelSlashMenu items={items} oncommand={fn} />
+ <VizelSlashMenu items={items} onselect={fn} />
\`\`\`

### \`VizelBlockMenu\`: scoped to bound editor when one is available

\`\`\`diff
+ <VizelBlockMenu editor={editor} />   // explicit binding
+ <VizelProvider editor={editor}>
+   <VizelBlockMenu />                 // resolves from context
+ </VizelProvider>
\`\`\`

Multi-editor pages must use one of the two forms to avoid cross-talk. Single-editor pages keep working without changes.

## Playwright CT review

- \`grep "@command\\|onCommand\\|oncommand" tests/ct\` → zero matches; no spec adjustments needed.
- The three \`BlockMenu.spec.*\` fixtures already mount \`<Vizel>\` (which composes \`VizelProvider\` + \`VizelBlockMenu\`), so the scoping behavior is exercised automatically.

## Test Plan

- [x] \`pnpm typecheck\` clean for all four packages.
- [x] \`pnpm lint\` reports zero errors (one pre-existing complexity warning unrelated).
- [x] \`pnpm build\` succeeds.
- [ ] CI \`pnpm test:ct\` green across React / Vue / Svelte × Chromium / Firefox / WebKit.