### PR TITLE
fix: hotfix React render loop and Vue/Svelte autofocus scroll

### DIFF
--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -7,6 +7,45 @@ import { resolveVizelFeatures, vizelDefaultEditorProps } from "./editorHelpers.t
 import { initializeVizelMarkdownContent } from "./markdown.ts";
 
 /**
+ * Re-apply the selection requested by the constructor's `autofocus` option
+ * after `setContent` has overridden it. Tiptap's `setContent` always lands
+ * the selection at the end of the new document and triggers `scrollIntoView`,
+ * which we have to undo for cases where the consumer asked for "start", "all",
+ * a numeric position, or no focus at all.
+ */
+function applyInitialSelection(editor: Editor, autofocus: VizelEditorOptions["autofocus"]): void {
+  const docSize = editor.state.doc.content.size;
+  if (autofocus === false || autofocus === undefined) {
+    // Consumer did not request focus. Put the selection at the very start and
+    // blur so the document does not scroll past the editor on mount.
+    editor.commands.setTextSelection(0);
+    editor.commands.blur();
+    return;
+  }
+  if (autofocus === "start") {
+    editor.commands.focus("start");
+    return;
+  }
+  if (autofocus === "end") {
+    editor.commands.focus("end");
+    return;
+  }
+  if (autofocus === "all") {
+    editor.commands.setTextSelection({ from: 0, to: docSize });
+    editor.commands.focus();
+    return;
+  }
+  if (typeof autofocus === "number") {
+    const clamped = Math.max(0, Math.min(autofocus, docSize));
+    editor.commands.focus(clamped);
+    return;
+  }
+  if (autofocus === true) {
+    editor.commands.focus("start");
+  }
+}
+
+/**
  * Options for creating a Vizel editor instance.
  * Extends VizelEditorOptions with additional framework-specific parameters.
  */
@@ -88,12 +127,17 @@ export async function createVizelEditorInstance(
   const imageOptions: VizelImageFeatureOptions =
     typeof features?.image === "object" ? features.image : {};
 
-  // Wrap onCreate to handle initialMarkdown
+  // Wrap onCreate to handle initialMarkdown. Tiptap's `setContent` resets the
+  // selection to the end of the new document and triggers a scroll-into-view,
+  // which silently overrides the constructor's `autofocus` option. Re-apply
+  // the selection (and the autofocus default of "no scroll") after the markdown
+  // has been loaded so the editor starts where the consumer asked.
   const wrappedOnCreate = initialMarkdown
     ? (props: { editor: Editor }) => {
         initializeVizelMarkdownContent(props.editor, initialMarkdown, {
           transformDiagrams: transformDiagramsOnImport,
         });
+        applyInitialSelection(props.editor, autofocus);
         onCreate?.(props);
       }
     : onCreate;

--- a/packages/react/src/hooks/useVizelState.ts
+++ b/packages/react/src/hooks/useVizelState.ts
@@ -1,11 +1,10 @@
 import type { Editor } from "@vizel/core";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
-const NO_TICK = 0;
-const NO_OP_SUBSCRIBE = () => () => {
-  /* no-op unsubscribe when editor is null */
+const noSubscribe = () => () => {
+  /* no-op when editor is null */
 };
-const NO_OP_SNAPSHOT = () => NO_TICK;
+const noSnapshot = () => 0;
 
 /**
  * Hook that forces a re-render whenever the editor's state changes.
@@ -32,6 +31,12 @@ const NO_OP_SNAPSHOT = () => NO_TICK;
  * ```
  */
 export function useVizelState(editor: Editor | null | undefined): number {
+  // A stable tick counter incremented by the subscribe callback. Reading
+  // anything off `editor.view` here would either return a fresh object every
+  // call (state.tr) or throw before mount, breaking useSyncExternalStore's
+  // referential-stability contract and triggering an infinite render loop.
+  const tickRef = useRef(0);
+
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (!editor) {
@@ -39,25 +44,23 @@ export function useVizelState(editor: Editor | null | undefined): number {
           /* no-op unsubscribe */
         };
       }
-      editor.on("transaction", onStoreChange);
+      const handler = () => {
+        tickRef.current = (tickRef.current + 1) | 0;
+        onStoreChange();
+      };
+      editor.on("transaction", handler);
       return () => {
-        editor.off("transaction", onStoreChange);
+        editor.off("transaction", handler);
       };
     },
     [editor]
   );
 
-  // The snapshot returns the editor's transaction count when available so
-  // identical-content re-renders return identical numbers (preventing
-  // useSyncExternalStore from looping).
-  const getSnapshot = useCallback(
-    () => (editor ? (editor.view?.state.tr.time ?? NO_TICK) : NO_TICK),
-    [editor]
-  );
+  const getSnapshot = useCallback(() => tickRef.current, []);
 
   return useSyncExternalStore(
-    editor ? subscribe : NO_OP_SUBSCRIBE,
-    editor ? getSnapshot : NO_OP_SNAPSHOT,
-    editor ? getSnapshot : NO_OP_SNAPSHOT
+    editor ? subscribe : noSubscribe,
+    editor ? getSnapshot : noSnapshot,
+    editor ? getSnapshot : noSnapshot
   );
 }


### PR DESCRIPTION
## Summary

Two related hotfixes for the production demos deployed to GitHub Pages. Bundled because they both block https://seijikohara.github.io/vizel/demo/ from functioning, and both are regressions traceable to recent PRs.

### Fix 1 — React demo: `useVizelState` infinite render loop (regression from PR ε #410)

The production React demo throws **React error #185** (Maximum update depth exceeded) before the first paint, with a secondary Tiptap stack trace about `editor.view['dom']` not being available.

**Root cause:** The PR ε migration of `useVizelState` to `useSyncExternalStore` derived the snapshot from `editor.view?.state.tr.time`. ProseMirror's `state.tr` is a getter that materializes a new Transaction on every access, so `getSnapshot` returned a different number each call — violating `useSyncExternalStore`'s referential-stability contract and looping the React render cycle. The loop incidentally kept reading `editor.view` between transactions, which throws before the editor DOM view is mounted ("Cannot access view['dom']").

**Fix:** Restore the original tick-counter pattern but keep `useSyncExternalStore` for React 18+ concurrent safety.

```ts
const tickRef = useRef(0);
const subscribe = (onChange) => {
  if (!editor) return () => {};
  const handler = () => {
    tickRef.current = (tickRef.current + 1) | 0;
    onChange();
  };
  editor.on("transaction", handler);
  return () => editor.off("transaction", handler);
};
const getSnapshot = () => tickRef.current;
```

The counter is incremented inside the subscribe handler before notifying React, so the snapshot is stable between transactions.

**File:** `packages/react/src/hooks/useVizelState.ts`

### Fix 2 — Vue & Svelte demos: scroll past the editor on mount (regression from PR #404 being silently undone by core)

After PR #404 changed the demos to `autofocus="start"`, mounting still scrolled the page to the bottom of the editor whenever `initialMarkdown` was provided.

**Root cause:** Tiptap's `setContent` resets the selection to the end of the new document and triggers `scrollIntoView`. `initializeVizelMarkdownContent` (called from `wrappedOnCreate` in `editorFactory.ts`) ran AFTER the editor was constructed with `autofocus: "start"`, so the autofocus position was clobbered by the markdown load. The demos appeared to "ignore" the fix from PR #404.

**Fix:** In `editorFactory.ts`, re-apply the requested `autofocus` value after `initializeVizelMarkdownContent`:

| `autofocus` value | Behavior after fix |
|-------------------|--------------------|
| `"start"` / `true` | `focus("start")` |
| `"end"` | `focus("end")` |
| `"all"` | select the whole document |
| number | focus the clamped position |
| `false` / `undefined` | place selection at 0 and blur (no scroll) |

**File:** `packages/core/src/utils/editorFactory.ts`

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm lint` clean (one pre-existing complexity warning unrelated).
- [x] `pnpm docs:build` succeeds; demo bundles re-emit without runtime errors.
- [ ] CI `pnpm test:ct` green.
- [ ] After merge, the Pages deploy succeeds and:
  - The production React demo loads without React error #185.
  - The Vue and Svelte demos no longer scroll past the editor on mount.
