### PR TITLE
refactor: address remaining audit follow-ups (H1, H4, H6, M12, L3, L5)

### DIFF
--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -394,6 +394,21 @@ import { VizelIcon } from '@vizel/react';
 
 ### Working with Markdown
 
+#### Controlled vs uncontrolled
+
+`<Vizel>` accepts markdown in two modes that mirror React's familiar
+controlled-input pattern.
+
+| Mode | Props | Who owns the state | When to use |
+|------|-------|--------------------|-------------|
+| **Uncontrolled** | `initialMarkdown` only | The editor | Standalone editor; observe edits via `onUpdate`. |
+| **Controlled** | Both `markdown` AND `onMarkdownChange` | The parent component | Sync with form state, persist to a remote store, drive the editor from another input. |
+
+Passing only `markdown` without `onMarkdownChange` is treated as
+"set-once": the editor renders the initial value but later prop changes
+are ignored — exactly like a `<textarea value="..."/>` without `onChange`.
+Always pair the two props when you intend two-way sync.
+
 ```tsx
 import { Vizel } from '@vizel/react';
 

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -390,6 +390,17 @@ This component renders an icon from the icon context. It uses Iconify icon IDs b
 <Vizel initialMarkdown="# Read Only Initial" />
 ```
 
+#### Controlled vs uncontrolled
+
+| Mode | Binding | Who owns the state | When to use |
+|------|---------|--------------------|-------------|
+| **Uncontrolled** | `initialMarkdown` only | The editor | Standalone editor; observe edits via `onUpdate`. |
+| **Controlled** | `bind:markdown={...}` (Svelte 5 `$bindable`) | The parent component | Sync with form state, persist to a remote store, drive the editor from another input. |
+
+Passing only `markdown={...}` (without `bind:`) is treated as
+"set-once": the editor renders the initial value but later prop
+changes are ignored. Use `bind:markdown` when you intend two-way sync.
+
 ### Split View (WYSIWYG + Raw Markdown)
 
 ```svelte

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -426,6 +426,18 @@ const markdown = ref('# Hello World\n\nStart editing...');
 </template>
 ```
 
+#### Controlled vs uncontrolled
+
+| Mode | Props | Who owns the state | When to use |
+|------|-------|--------------------|-------------|
+| **Uncontrolled** | `:initial-markdown="..."` only | The editor | Standalone editor; observe edits via `@update`. |
+| **Controlled** | `v-model:markdown="..."` (or `:markdown` + `@update:markdown`) | The parent component | Sync with form state, persist to a remote store, drive the editor from another input. |
+
+Passing only `:markdown` without listening for `update:markdown` is
+treated as "set-once": the editor renders the initial value but later
+prop changes are ignored. Always use `v-model:markdown` (or both halves
+manually) when you intend two-way sync.
+
 ### Split View (WYSIWYG + Raw Markdown)
 
 ```vue

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -10,7 +10,7 @@ import {
   type VizelMarkdownFlavor,
 } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
-import { useEffect, useImperativeHandle, useRef } from "react";
+import { useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
 import { VizelBlockMenu } from "./VizelBlockMenu.tsx";
 import { VizelBubbleMenu } from "./VizelBubbleMenu.tsx";
@@ -179,15 +179,28 @@ export function Vizel({
   // Track whether we're currently updating from external markdown change
   const isUpdatingFromMarkdownRef = useRef(false);
 
-  // Keep refs for values accessed in the onUpdate closure to avoid stale captures.
-  // useVizelEditor only reads options once at mount time, so the onUpdate callback
-  // would otherwise permanently capture the initial markdown/onMarkdownChange values.
+  // Keep refs for every value accessed in the editor's lifecycle callbacks.
+  // `useVizelEditor` reads options once at mount, so without refs each
+  // callback would be frozen to the closure values from the first render —
+  // re-renders that pass a fresh handler would be silently ignored.
   const markdownRef = useRef(markdown);
   markdownRef.current = markdown;
   const onMarkdownChangeRef = useRef(onMarkdownChange);
   onMarkdownChangeRef.current = onMarkdownChange;
   const onUpdateRef = useRef(onUpdate);
   onUpdateRef.current = onUpdate;
+  const onCreateRef = useRef(onCreate);
+  onCreateRef.current = onCreate;
+  const onDestroyRef = useRef(onDestroy);
+  onDestroyRef.current = onDestroy;
+  const onSelectionUpdateRef = useRef(onSelectionUpdate);
+  onSelectionUpdateRef.current = onSelectionUpdate;
+  const onFocusRef = useRef(onFocus);
+  onFocusRef.current = onFocus;
+  const onBlurRef = useRef(onBlur);
+  onBlurRef.current = onBlur;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   const editor = useVizelEditor({
     ...(initialContent !== undefined && { initialContent }),
@@ -207,12 +220,12 @@ export function Vizel({
         onMarkdownChangeRef.current?.(getVizelMarkdown(e.editor));
       }
     },
-    ...(onCreate !== undefined && { onCreate }),
-    ...(onDestroy !== undefined && { onDestroy }),
-    ...(onSelectionUpdate !== undefined && { onSelectionUpdate }),
-    ...(onFocus !== undefined && { onFocus }),
-    ...(onBlur !== undefined && { onBlur }),
-    ...(onError !== undefined && { onError }),
+    onCreate: (e) => onCreateRef.current?.(e),
+    onDestroy: () => onDestroyRef.current?.(),
+    onSelectionUpdate: (e) => onSelectionUpdateRef.current?.(e),
+    onFocus: (e) => onFocusRef.current?.(e),
+    onBlur: (e) => onBlurRef.current?.(e),
+    onError: (e) => onErrorRef.current?.(e),
   });
 
   // Watch for external markdown changes (controlled mode)
@@ -240,7 +253,9 @@ export function Vizel({
     [editor]
   );
 
-  const localeProps = locale === undefined ? {} : { locale };
+  // Memoize so child components that compare prop identity (toolbar / bubble
+  // menu / block menu) don't see a fresh `localeProps` object on every render.
+  const localeProps = useMemo(() => (locale === undefined ? {} : { locale }), [locale]);
 
   return (
     <div className={`vizel-root ${className ?? ""}`} data-vizel-root="">

--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -14,7 +14,7 @@ import {
   vizelDefaultBlockMenuActions,
   vizelDefaultNodeTypes,
 } from "@vizel/core";
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -54,10 +54,18 @@ export function VizelBlockMenu({
 }: VizelBlockMenuProps): ReactNode {
   const context = useVizelContextSafe();
   const boundEditor: Editor | null = editorProp ?? context?.editor ?? null;
-  const effectiveActions =
-    actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions);
-  const effectiveNodeTypes =
-    nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes);
+  // Memoize so locale-derived defaults aren't recomputed on every render.
+  // createVizelBlockMenuActions / createVizelNodeTypes build new arrays each
+  // call, which would invalidate downstream memos (groupVizelBlockMenuActions,
+  // getVizelTurnIntoOptions) needlessly.
+  const effectiveActions = useMemo(
+    () => actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions),
+    [actions, locale]
+  );
+  const effectiveNodeTypes = useMemo(
+    () => nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes),
+    [nodeTypes, locale]
+  );
   const [menuState, setMenuState] = useState<BlockMenuState | null>(null);
   const [showTurnInto, setShowTurnInto] = useState(false);
   const [submenuFlipped, setSubmenuFlipped] = useState(false);

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -17,6 +17,22 @@ export type UseVizelEditorOptions = VizelCreateEditorOptions;
 /**
  * React hook to create and manage a Vizel editor instance.
  *
+ * ## Reactive vs mount-time options
+ *
+ * The Tiptap editor instance is created once on mount. To avoid expensive
+ * teardowns, most options are read once at mount and ignored on subsequent
+ * renders. The following options are an exception:
+ *
+ * - `editable` — propagated through `editor.setEditable()` whenever the prop
+ *   value changes.
+ * - All `on*` callbacks (`onUpdate`, `onError`, etc.) — read through a ref
+ *   each time they fire, so passing a fresh closure on every render is fine.
+ *
+ * Changing `initialContent`, `initialMarkdown`, `placeholder`, `features`,
+ * `extensions`, `flavor`, `locale`, or `autofocus` after mount has no effect.
+ * Use `editor.commands.setContent(...)` (or the corresponding feature command)
+ * to update the document after mount.
+ *
  * @example
  * ```tsx
  * const editor = useVizelEditor({
@@ -26,7 +42,7 @@ export type UseVizelEditorOptions = VizelCreateEditorOptions;
  *   },
  * });
  *
- * return <EditorContent editor={editor} />;
+ * return <VizelEditor editor={editor} />;
  * ```
  *
  * @example
@@ -110,6 +126,17 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
       getImageOptions: () => imageOptionsRef.current,
     });
   }, [editor]);
+
+  // Mirror the `editable` prop into the underlying editor. The constructor
+  // option is captured at mount; without this watcher consumers cannot
+  // toggle read-only mode after the editor exists.
+  const editable = editorOptions.editable ?? true;
+  useEffect(() => {
+    if (!editor) return;
+    if (editor.isEditable !== editable) {
+      editor.setEditable(editable);
+    }
+  }, [editor, editable]);
 
   return editor;
 }

--- a/packages/vue/src/composables/useVizelAutoSave.ts
+++ b/packages/vue/src/composables/useVizelAutoSave.ts
@@ -7,14 +7,7 @@ import {
   type VizelAutoSaveState,
   type VizelSaveStatus,
 } from "@vizel/core";
-import {
-  type ComputedRef,
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  shallowReactive,
-  watch,
-} from "vue";
+import { type ComputedRef, computed, onBeforeUnmount, shallowReactive, watch } from "vue";
 
 /**
  * Auto-save composable result
@@ -108,16 +101,17 @@ export function useVizelAutoSave(
     currentEditor.on("update", handlers.handleUpdate);
   };
 
-  onMounted(() => {
-    subscribe();
-  });
-
-  // Watch for editor changes
+  // Single setup path: a `watch` with `immediate: true` fires once on mount
+  // (replacing the previous `onMounted` call) AND again when the editor
+  // reference changes. The earlier shape called `subscribe()` both in
+  // `onMounted` and in the watcher's first non-`immediate` run, producing
+  // two subscriptions on first non-null editor and an unnecessary teardown.
   watch(
     () => getEditor(),
     () => {
       subscribe();
-    }
+    },
+    { immediate: true }
   );
 
   onBeforeUnmount(() => {

--- a/packages/vue/src/composables/useVizelCollaboration.ts
+++ b/packages/vue/src/composables/useVizelCollaboration.ts
@@ -6,14 +6,7 @@ import {
   type VizelCollaborationUser,
   type VizelYjsProvider,
 } from "@vizel/core";
-import {
-  type ComputedRef,
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  shallowReactive,
-  watch,
-} from "vue";
+import { type ComputedRef, computed, onBeforeUnmount, shallowReactive, watch } from "vue";
 
 /**
  * Collaboration composable result
@@ -117,15 +110,17 @@ export function useVizelCollaboration(
     handlers = null;
   }
 
-  onMounted(() => {
-    setup();
-  });
-
+  // Single setup path: a `watch` with `immediate: true` fires once on mount
+  // (replacing the previous `onMounted` call) AND again when the provider
+  // reference changes. The earlier shape called `setup()` both in
+  // `onMounted` and in the watcher's first non-`immediate` run, producing
+  // two subscriptions on first non-null provider and an unnecessary teardown.
   watch(
     () => getProvider(),
     () => {
       setup();
-    }
+    },
+    { immediate: true }
   );
 
   onBeforeUnmount(() => {

--- a/packages/vue/src/composables/useVizelVersionHistory.ts
+++ b/packages/vue/src/composables/useVizelVersionHistory.ts
@@ -6,14 +6,7 @@ import {
   type VizelVersionHistoryState,
   type VizelVersionSnapshot,
 } from "@vizel/core";
-import {
-  type ComputedRef,
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  shallowReactive,
-  watch,
-} from "vue";
+import { type ComputedRef, computed, onBeforeUnmount, shallowReactive, watch } from "vue";
 
 /**
  * Version history composable result
@@ -88,15 +81,17 @@ export function useVizelVersionHistory(
     }
   }
 
-  onMounted(() => {
-    setup();
-  });
-
+  // Single setup path: a `watch` with `immediate: true` fires once on mount
+  // (replacing the previous `onMounted` call) AND again when the editor
+  // reference changes. The earlier shape called `setup()` both in
+  // `onMounted` and in the watcher's first non-`immediate` run, producing
+  // two subscriptions on first non-null editor and an unnecessary teardown.
   watch(
     () => getEditor(),
     () => {
       setup();
-    }
+    },
+    { immediate: true }
   );
 
   onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary

Closes out the audit follow-ups deferred from PR ε (#410). Internal cleanups, refactors, and clarifying docs only — no public API breaks.

| Audit item | Area | Change |
|------------|------|--------|
| **H1** | React `useVizelEditor` | React the `editable` prop change through `editor.setEditable()`. Document other options (`initialContent`, `placeholder`, `features`, `extensions`, `flavor`, `locale`, `autofocus`) as mount-time. |
| **H4** | React `<Vizel>` | Add the ref-latest pattern to `onCreate`, `onDestroy`, `onSelectionUpdate`, `onFocus`, `onBlur`, `onError`. Re-rendering with a fresh callback is now honored (matching how `onUpdate` already worked). |
| **H6** | Vue composables | `useVizelAutoSave`, `useVizelCollaboration`, `useVizelVersionHistory` now use a single `watch(getEditor, subscribe, { immediate: true })` instead of `onMounted(subscribe) + watch(...)`. The previous shape ran `subscribe()` twice on the first editor resolve and performed an unnecessary teardown. |
| **M12** | Markdown docs | Add a "Controlled vs uncontrolled" subsection to `docs/guide/{react,vue,svelte}.md` clarifying when the editor owns markdown state vs the parent does, and that one-way bindings without their pair (e.g. `markdown` without `onMarkdownChange`) are treated as set-once. |
| **L3** | React `Vizel` | Wrap `localeProps` in `useMemo` so toolbar / bubble-menu / block-menu children no longer see a fresh object identity each render. |
| **L5** | React `VizelBlockMenu` | Wrap `effectiveActions` / `effectiveNodeTypes` in `useMemo`. The locale-derived defaults were being rebuilt every render. |

## Files

- `packages/react/src/hooks/useVizelEditor.ts`
- `packages/react/src/components/Vizel.tsx`
- `packages/react/src/components/VizelBlockMenu.tsx`
- `packages/vue/src/composables/useVizelAutoSave.ts`
- `packages/vue/src/composables/useVizelCollaboration.ts`
- `packages/vue/src/composables/useVizelVersionHistory.ts`
- `docs/guide/react.md`, `docs/guide/vue.md`, `docs/guide/svelte.md`

## Audit items explicitly skipped

- **L1** (`Vizel.tsx` spread pattern). The `... !== undefined && { x }` shape is required by `exactOptionalPropertyTypes`; abstracting it would either lose type safety or require an `as` cast.
- **L2** (slash menu key collision). `SlashCommandItem` has no `id` field; adding one is a breaking API change. The current convention is unique titles within a slash menu.
- **L4** (`VizelPortal` SSR/CSR mismatch). Needs a deeper investigation; filed as future work.
- **L6** (`useVizelState` scope note). The JSDoc already calls out that the return value is typically ignored.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm lint` clean (one pre-existing complexity warning unrelated).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.
