### PR TITLE
fix: phase 1 cross-framework parity bug fixes

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -144,6 +144,27 @@ binding form differs to honor each framework's reactivity model.
 | Consumer (required) | `useVizelContext()` | `useVizelContext()` | `getVizelContext()` |
 | Consumer (optional) | `useVizelContextSafe()` | `useVizelContextSafe()` | `getVizelContextSafe()` |
 
+### Provider Root Class
+
+`VizelProvider` in every framework renders a `<div class="vizel-root" data-vizel-root>`
+wrapper, prepending the consumer-supplied class. The `.vizel-root` selector
+scopes all CSS custom properties (`--vizel-*`), so omitting the class would
+break theming for any descendant that depends on those variables.
+
+## Reactive vs Mount-time Editor Options
+
+`useVizelEditor` / `createVizelEditor` create the Tiptap instance once on
+mount. Most options (`initialContent`, `initialMarkdown`, `placeholder`,
+`features`, `extensions`, `flavor`, `locale`, `autofocus`) are captured at
+that point and cannot be changed via prop updates.
+
+The single exception is `editable`, which all three frameworks mirror through
+`editor.setEditable()` whenever the prop changes after mount. Toggle this to
+switch the editor between read-write and read-only modes.
+
+To change other options at runtime, use the corresponding Tiptap command
+(`editor.commands.setContent(...)`, `editor.commands.focus(...)`, etc.).
+
 ## Adding a New Feature
 
 Follow this sequence to add a feature with consistent cross-framework support:

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,4 +1,8 @@
 export { vizelEnLocale } from "./en.ts";
 export type { SlashItemText, VizelLocale, VizelLocalePartial } from "./types.ts";
 
-export { createVizelLocale, formatRelativeTimeWithLocale } from "./utils.ts";
+export {
+  createVizelLocale,
+  formatRelativeTimeWithLocale,
+  resolveVizelFindReplaceLabels,
+} from "./utils.ts";

--- a/packages/core/src/i18n/utils.ts
+++ b/packages/core/src/i18n/utils.ts
@@ -2,6 +2,40 @@ import { vizelEnLocale } from "./en.ts";
 import type { VizelLocale, VizelLocalePartial } from "./types.ts";
 
 /**
+ * Resolve FindReplace locale labels with English defaults.
+ *
+ * Returns a complete labels object even when the caller supplies a partial
+ * locale or no locale at all. Framework components consume this helper to
+ * avoid hand-writing `?? "Find..."` fallbacks inline.
+ */
+export function resolveVizelFindReplaceLabels(
+  partial: VizelLocale["findReplace"] | undefined
+): VizelLocale["findReplace"] {
+  return {
+    label: partial?.label ?? vizelEnLocale.findReplace.label,
+    findPlaceholder: partial?.findPlaceholder ?? vizelEnLocale.findReplace.findPlaceholder,
+    replacePlaceholder: partial?.replacePlaceholder ?? vizelEnLocale.findReplace.replacePlaceholder,
+    noResults: partial?.noResults ?? vizelEnLocale.findReplace.noResults,
+    findTextAriaLabel: partial?.findTextAriaLabel ?? vizelEnLocale.findReplace.findTextAriaLabel,
+    replaceTextAriaLabel:
+      partial?.replaceTextAriaLabel ?? vizelEnLocale.findReplace.replaceTextAriaLabel,
+    findPreviousAriaLabel:
+      partial?.findPreviousAriaLabel ?? vizelEnLocale.findReplace.findPreviousAriaLabel,
+    findPreviousTitle: partial?.findPreviousTitle ?? vizelEnLocale.findReplace.findPreviousTitle,
+    findNextAriaLabel: partial?.findNextAriaLabel ?? vizelEnLocale.findReplace.findNextAriaLabel,
+    findNextTitle: partial?.findNextTitle ?? vizelEnLocale.findReplace.findNextTitle,
+    replaceAriaLabel: partial?.replaceAriaLabel ?? vizelEnLocale.findReplace.replaceAriaLabel,
+    replaceTitle: partial?.replaceTitle ?? vizelEnLocale.findReplace.replaceTitle,
+    replaceAllAriaLabel:
+      partial?.replaceAllAriaLabel ?? vizelEnLocale.findReplace.replaceAllAriaLabel,
+    replaceAllTitle: partial?.replaceAllTitle ?? vizelEnLocale.findReplace.replaceAllTitle,
+    caseSensitive: partial?.caseSensitive ?? vizelEnLocale.findReplace.caseSensitive,
+    closeAriaLabel: partial?.closeAriaLabel ?? vizelEnLocale.findReplace.closeAriaLabel,
+    closeTitle: partial?.closeTitle ?? vizelEnLocale.findReplace.closeTitle,
+  };
+}
+
+/**
  * Create a complete locale by deep-merging partial translations with the default English locale.
  * Supports overriding individual strings at any nesting depth.
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,6 +243,7 @@ export {
 export {
   createVizelLocale,
   formatRelativeTimeWithLocale,
+  resolveVizelFindReplaceLabels,
   type SlashItemText,
   type VizelLocale,
   type VizelLocalePartial,

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -1,6 +1,7 @@
 import {
   type Editor,
   getVizelFindReplaceState,
+  resolveVizelFindReplaceLabels,
   type VizelFindReplaceState,
   type VizelLocale,
 } from "@vizel/core";
@@ -24,34 +25,11 @@ export interface VizelFindReplaceProps {
   onClose?: () => void;
 }
 
-/** Resolve FindReplace locale labels with English defaults. */
-function resolveFindReplaceLabels(t: VizelLocale["findReplace"] | undefined) {
-  return {
-    label: t?.label ?? "Find and Replace",
-    findPlaceholder: t?.findPlaceholder ?? "Find...",
-    findTextAriaLabel: t?.findTextAriaLabel ?? "Find text",
-    noResults: t?.noResults ?? "No results",
-    findPreviousAriaLabel: t?.findPreviousAriaLabel ?? "Find previous",
-    findPreviousTitle: t?.findPreviousTitle ?? "Find previous (Shift+Enter)",
-    findNextAriaLabel: t?.findNextAriaLabel ?? "Find next",
-    findNextTitle: t?.findNextTitle ?? "Find next (Enter)",
-    closeAriaLabel: t?.closeAriaLabel ?? "Close",
-    closeTitle: t?.closeTitle ?? "Close (Escape)",
-    replacePlaceholder: t?.replacePlaceholder ?? "Replace with...",
-    replaceTextAriaLabel: t?.replaceTextAriaLabel ?? "Replace text",
-    replaceAriaLabel: t?.replaceAriaLabel ?? "Replace",
-    replaceTitle: t?.replaceTitle ?? "Replace current match",
-    replaceAllAriaLabel: t?.replaceAllAriaLabel ?? "Replace all",
-    replaceAllTitle: t?.replaceAllTitle ?? "Replace all matches",
-    caseSensitive: t?.caseSensitive ?? "Case sensitive",
-  };
-}
-
 /**
  * Find & Replace panel component for React
  */
 export function VizelFindReplace({ editor, className, locale, onClose }: VizelFindReplaceProps) {
-  const labels = resolveFindReplaceLabels(locale?.findReplace);
+  const labels = resolveVizelFindReplaceLabels(locale?.findReplace);
   const [findText, setFindText] = useState("");
   const [replaceText, setReplaceText] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);

--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -145,6 +145,13 @@ export function useVizelMarkdown(
     editor.on("update", handleUpdate);
 
     return () => {
+      // Flush any pending debounced export before detaching so editor swaps
+      // (or unmount) do not drop unsynced markdown. Matches the Svelte rune.
+      if (handlers.isPending()) {
+        handlers.flush(editor);
+        setMarkdownState(handlers.getMarkdown());
+        setIsPending(false);
+      }
       editor.off("update", handleUpdate);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };

--- a/packages/svelte/src/components/VizelBubbleMenu.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenu.svelte
@@ -26,6 +26,7 @@ export interface VizelBubbleMenuProps {
 
 <script lang="ts">
 import { BubbleMenuPlugin } from "@vizel/core";
+import { untrack } from "svelte";
 import VizelBubbleMenuDefault from "./VizelBubbleMenuDefault.svelte";
 import { getVizelContextSafe } from "./VizelContext.js";
 
@@ -60,13 +61,19 @@ $effect(() => {
   const currentEditor = editor;
   const currentPluginKey = pluginKey;
 
+  // Capture `shouldShow` without tracking so value updates flow through the
+  // wrapper closure (read lazily, outside any reactive context) without
+  // re-registering the plugin. Matches the React `shouldShowRef` pattern.
+  const initialShouldShow = untrack(() => shouldShow);
+
   const plugin = BubbleMenuPlugin({
     pluginKey: currentPluginKey,
     editor: currentEditor,
     element: menuElement,
     updateDelay,
-    ...(shouldShow && {
-      shouldShow: ({ editor: e, from, to }) => shouldShow({ editor: e as Editor, from, to }),
+    ...(initialShouldShow && {
+      shouldShow: ({ editor: e, from, to }) =>
+        shouldShow?.({ editor: e as Editor, from, to }) ?? false,
     }),
     options: {
       placement: "top",

--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -16,11 +16,13 @@ export interface VizelFindReplaceProps {
 <script lang="ts">
 import {
   getVizelFindReplaceState,
+  resolveVizelFindReplaceLabels,
   type VizelFindReplaceState,
 } from "@vizel/core";
 import { tick } from "svelte";
 
 let { editor, class: className, locale, onClose }: VizelFindReplaceProps = $props();
+const labels = $derived(resolveVizelFindReplaceLabels(locale?.findReplace));
 
 // Empty state for initial value
 const emptyState: VizelFindReplaceState = {
@@ -137,28 +139,28 @@ function handleKeyDown(e: KeyboardEvent) {
   <div
     class={`vizel-find-replace-panel ${className || ""}`}
     role="dialog"
-    aria-label={locale?.findReplace.label ?? "Find and Replace"}
+    aria-label={labels.label}
   >
     <div class="vizel-find-replace-row">
       <input
         bind:this={findInputRef}
         type="text"
         class="vizel-find-replace-input"
-        placeholder={locale?.findReplace.findPlaceholder ?? "Find..."}
+        placeholder={labels.findPlaceholder}
         value={findText}
         oninput={handleFindInputChange}
         onkeydown={handleKeyDown}
-        aria-label={locale?.findReplace.findTextAriaLabel ?? "Find text"}
+        aria-label={labels.findTextAriaLabel}
       />
       <span class="vizel-find-replace-count" aria-live="polite">
-        {matchCount > 0 ? `${currentMatch}/${matchCount}` : (locale?.findReplace.noResults ?? "No results")}
+        {matchCount > 0 ? `${currentMatch}/${matchCount}` : labels.noResults}
       </span>
       <button
         type="button"
         class="vizel-find-replace-button"
         disabled={matchCount === 0}
-        aria-label={locale?.findReplace.findPreviousAriaLabel ?? "Find previous"}
-        title={locale?.findReplace.findPreviousTitle ?? "Find previous (Shift+Enter)"}
+        aria-label={labels.findPreviousAriaLabel}
+        title={labels.findPreviousTitle}
         onclick={handleFindPrevious}
       >
         ↑
@@ -167,8 +169,8 @@ function handleKeyDown(e: KeyboardEvent) {
         type="button"
         class="vizel-find-replace-button"
         disabled={matchCount === 0}
-        aria-label={locale?.findReplace.findNextAriaLabel ?? "Find next"}
-        title={locale?.findReplace.findNextTitle ?? "Find next (Enter)"}
+        aria-label={labels.findNextAriaLabel}
+        title={labels.findNextTitle}
         onclick={handleFindNext}
       >
         ↓
@@ -176,8 +178,8 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button"
-        aria-label={locale?.findReplace.closeAriaLabel ?? "Close"}
-        title={locale?.findReplace.closeTitle ?? "Close (Escape)"}
+        aria-label={labels.closeAriaLabel}
+        title={labels.closeTitle}
         onclick={handleClose}
       >
         ✕
@@ -189,30 +191,30 @@ function handleKeyDown(e: KeyboardEvent) {
         <input
           type="text"
           class="vizel-find-replace-input"
-          placeholder={locale?.findReplace.replacePlaceholder ?? "Replace with..."}
+          placeholder={labels.replacePlaceholder}
           bind:value={replaceText}
           onkeydown={handleKeyDown}
-          aria-label={locale?.findReplace.replaceTextAriaLabel ?? "Replace text"}
+          aria-label={labels.replaceTextAriaLabel}
         />
         <button
           type="button"
           class="vizel-find-replace-button"
           disabled={matchCount === 0}
-          aria-label={locale?.findReplace.replaceAriaLabel ?? "Replace"}
-          title={locale?.findReplace.replaceTitle ?? "Replace current match"}
+          aria-label={labels.replaceAriaLabel}
+          title={labels.replaceTitle}
           onclick={handleReplace}
         >
-          {locale?.findReplace.replaceAriaLabel ?? "Replace"}
+          {labels.replaceAriaLabel}
         </button>
         <button
           type="button"
           class="vizel-find-replace-button vizel-find-replace-button--primary"
           disabled={matchCount === 0}
-          aria-label={locale?.findReplace.replaceAllAriaLabel ?? "Replace all"}
-          title={locale?.findReplace.replaceAllTitle ?? "Replace all matches"}
+          aria-label={labels.replaceAllAriaLabel}
+          title={labels.replaceAllTitle}
           onclick={handleReplaceAll}
         >
-          {locale?.findReplace.replaceAllAriaLabel ?? "All"}
+          {labels.replaceAllAriaLabel}
         </button>
       </div>
     {/if}
@@ -224,7 +226,7 @@ function handleKeyDown(e: KeyboardEvent) {
           checked={caseSensitive}
           onchange={handleCaseSensitiveChange}
         />
-        {locale?.findReplace.caseSensitive ?? "Case sensitive"}
+        {labels.caseSensitive}
       </label>
     </div>
   </div>

--- a/packages/svelte/src/components/VizelPortal.svelte
+++ b/packages/svelte/src/components/VizelPortal.svelte
@@ -27,44 +27,54 @@ export interface VizelPortalProps {
     disabled = false,
   }: VizelPortalProps = $props();
 
-  // Create portal action that moves content to the portal container
-  function portal(node: HTMLElement) {
+  let host = $state<HTMLDivElement | null>(null);
+  let wrapper = $state<HTMLDivElement | null>(null);
+
+  // Mount/unmount the portal wrapper.
+  // The previous shape used a `use:portal` action whose closure captured
+  // `layer`/`className` at action creation, so prop changes never propagated.
+  // Splitting the lifecycle from the attribute updates restores cross-FW
+  // parity with React/Vue, where reactive updates to layer/className flow
+  // through without remounting the portal contents.
+  $effect(() => {
+    if (disabled || !host) return;
+
+    const node = host;
     const container = getVizelPortalContainer();
+    const w = document.createElement("div");
+    w.style.position = "absolute";
+    w.style.top = "0";
+    w.style.left = "0";
 
-    // Create wrapper element
-    const wrapper = document.createElement("div");
-    wrapper.setAttribute("data-vizel-portal-layer", layer);
-    if (className) {
-      wrapper.className = className;
-    }
-    wrapper.style.position = "absolute";
-    wrapper.style.top = "0";
-    wrapper.style.left = "0";
-    wrapper.style.zIndex = String(VIZEL_PORTAL_Z_INDEX[layer]);
-
-    // Move node's children to wrapper
     while (node.firstChild) {
-      wrapper.appendChild(node.firstChild);
+      w.appendChild(node.firstChild);
     }
+    container.appendChild(w);
+    wrapper = w;
 
-    container.appendChild(wrapper);
-
-    return {
-      destroy() {
-        // Move content back to original location for cleanup
-        while (wrapper.firstChild) {
-          node.appendChild(wrapper.firstChild);
-        }
-        wrapper.remove();
-      },
+    return () => {
+      while (w.firstChild) {
+        node.appendChild(w.firstChild);
+      }
+      w.remove();
+      wrapper = null;
     };
-  }
+  });
+
+  // Reactive attribute updates. Reads `layer` and `className` so any change
+  // re-runs without re-mounting the wrapper.
+  $effect(() => {
+    if (!wrapper) return;
+    wrapper.setAttribute("data-vizel-portal-layer", layer);
+    wrapper.style.zIndex = String(VIZEL_PORTAL_Z_INDEX[layer]);
+    wrapper.className = className ?? "";
+  });
 </script>
 
 {#if disabled}
   {@render children()}
 {:else}
-  <div use:portal>
+  <div bind:this={host}>
     {@render children()}
   </div>
 {/if}

--- a/packages/svelte/src/components/VizelProvider.svelte
+++ b/packages/svelte/src/components/VizelProvider.svelte
@@ -19,8 +19,12 @@ import { VIZEL_CONTEXT_KEY } from "./VizelContext.js";
 let { editor, class: className, children }: VizelProviderProps = $props();
 
 setContext(VIZEL_CONTEXT_KEY, () => editor);
+
+// Always emit the `vizel-root` class so consumers get the CSS variable scope
+// for free (.vizel-root { --vizel-* }). Matches the React provider behavior.
+const rootClass = $derived(className ? `vizel-root ${className}` : "vizel-root");
 </script>
 
-<div class={className} data-vizel-root>
+<div class={rootClass} data-vizel-root>
   {@render children()}
 </div>

--- a/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
+++ b/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
@@ -92,15 +92,21 @@ export function createVizelCollaboration(
 
   $effect(() => {
     const provider = getProvider();
-    handlers = createVizelCollaborationHandlers(getProvider, options, handleStateChange);
-
-    let unsubscribe: (() => void) | undefined;
-    if (provider && enabled) {
-      unsubscribe = handlers.subscribe();
+    // Only instantiate handlers once the provider is available. The previous
+    // shape recreated handlers on every effect re-run (including the null →
+    // null transition that fires before the provider is constructed), which
+    // wasted allocation and made the `connect/disconnect/updateUser` methods
+    // briefly point at a different `handlers` instance every cycle.
+    if (!(provider && enabled)) {
+      handlers = null;
+      return;
     }
 
+    handlers = createVizelCollaborationHandlers(getProvider, options, handleStateChange);
+    const unsubscribe = handlers.subscribe();
+
     return () => {
-      unsubscribe?.();
+      unsubscribe();
       handlers = null;
     };
   });

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -17,6 +17,20 @@ export type CreateVizelEditorOptions = VizelCreateEditorOptions;
  * Svelte 5 rune to create and manage a Vizel editor instance.
  * Returns a reactive editor state that works with EditorContent component.
  *
+ * ## Reactive vs mount-time options
+ *
+ * The Tiptap editor instance is created once on mount. To avoid expensive
+ * teardowns, most options are read once at mount and ignored on subsequent
+ * renders. The following option is an exception:
+ *
+ * - `editable` — propagated through `editor.setEditable()` whenever the prop
+ *   value changes.
+ *
+ * Changing `initialContent`, `initialMarkdown`, `placeholder`, `features`,
+ * `extensions`, `flavor`, `locale`, or `autofocus` after mount has no effect.
+ * Use `editor.current.commands.setContent(...)` (or the corresponding feature
+ * command) to update the document after mount.
+ *
  * @example
  * ```svelte
  * <script lang="ts">
@@ -106,6 +120,16 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
       cleanupHandler?.();
       instance?.destroy();
     };
+  });
+
+  // Mirror the `editable` option into the underlying editor. The constructor
+  // option is captured at mount; without this effect consumers cannot toggle
+  // read-only mode after the editor exists. Matches the React hook behavior.
+  $effect(() => {
+    const desired = editorOptions.editable ?? true;
+    if (editor && editor.isEditable !== desired) {
+      editor.setEditable(desired);
+    }
   });
 
   return {

--- a/packages/vue/src/components/VizelFindReplace.vue
+++ b/packages/vue/src/components/VizelFindReplace.vue
@@ -2,6 +2,7 @@
 import {
   type Editor,
   getVizelFindReplaceState,
+  resolveVizelFindReplaceLabels,
   type VizelFindReplaceState,
   type VizelLocale,
 } from "@vizel/core";
@@ -34,6 +35,7 @@ const currentMatch = computed(() =>
 );
 const isReplaceMode = computed(() => state.value?.mode === "replace");
 const isOpen = computed(() => state.value?.isOpen ?? false);
+const labels = computed(() => resolveVizelFindReplaceLabels(props.locale?.findReplace));
 
 function updateState() {
   if (props.editor) {
@@ -134,28 +136,28 @@ function handleKeyDown(e: KeyboardEvent) {
     v-if="isOpen"
     :class="['vizel-find-replace-panel', props.class]"
     role="dialog"
-    :aria-label="props.locale?.findReplace.label ?? 'Find and Replace'"
+    :aria-label="labels.label"
   >
     <div class="vizel-find-replace-row">
       <input
         ref="findInputRef"
         type="text"
         class="vizel-find-replace-input"
-        :placeholder="props.locale?.findReplace.findPlaceholder ?? 'Find...'"
+        :placeholder="labels.findPlaceholder"
         :value="findText"
         @input="handleFindInputChange"
         @keydown="handleKeyDown"
-        :aria-label="props.locale?.findReplace.findTextAriaLabel ?? 'Find text'"
+        :aria-label="labels.findTextAriaLabel"
       />
       <span class="vizel-find-replace-count" aria-live="polite">
-        {{ matchCount > 0 ? `${currentMatch}/${matchCount}` : (props.locale?.findReplace.noResults ?? 'No results') }}
+        {{ matchCount > 0 ? `${currentMatch}/${matchCount}` : labels.noResults }}
       </span>
       <button
         type="button"
         class="vizel-find-replace-button"
         :disabled="matchCount === 0"
-        :aria-label="props.locale?.findReplace.findPreviousAriaLabel ?? 'Find previous'"
-        :title="props.locale?.findReplace.findPreviousTitle ?? 'Find previous (Shift+Enter)'"
+        :aria-label="labels.findPreviousAriaLabel"
+        :title="labels.findPreviousTitle"
         @click="handleFindPrevious"
       >
         ↑
@@ -164,8 +166,8 @@ function handleKeyDown(e: KeyboardEvent) {
         type="button"
         class="vizel-find-replace-button"
         :disabled="matchCount === 0"
-        :aria-label="props.locale?.findReplace.findNextAriaLabel ?? 'Find next'"
-        :title="props.locale?.findReplace.findNextTitle ?? 'Find next (Enter)'"
+        :aria-label="labels.findNextAriaLabel"
+        :title="labels.findNextTitle"
         @click="handleFindNext"
       >
         ↓
@@ -173,8 +175,8 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button"
-        :aria-label="props.locale?.findReplace.closeAriaLabel ?? 'Close'"
-        :title="props.locale?.findReplace.closeTitle ?? 'Close (Escape)'"
+        :aria-label="labels.closeAriaLabel"
+        :title="labels.closeTitle"
         @click="handleClose"
       >
         ✕
@@ -185,30 +187,30 @@ function handleKeyDown(e: KeyboardEvent) {
       <input
         type="text"
         class="vizel-find-replace-input"
-        :placeholder="props.locale?.findReplace.replacePlaceholder ?? 'Replace with...'"
+        :placeholder="labels.replacePlaceholder"
         v-model="replaceText"
         @keydown="handleKeyDown"
-        :aria-label="props.locale?.findReplace.replaceTextAriaLabel ?? 'Replace text'"
+        :aria-label="labels.replaceTextAriaLabel"
       />
       <button
         type="button"
         class="vizel-find-replace-button"
         :disabled="matchCount === 0"
-        :aria-label="props.locale?.findReplace.replaceAriaLabel ?? 'Replace'"
-        :title="props.locale?.findReplace.replaceTitle ?? 'Replace current match'"
+        :aria-label="labels.replaceAriaLabel"
+        :title="labels.replaceTitle"
         @click="handleReplace"
       >
-        {{ props.locale?.findReplace.replaceAriaLabel ?? 'Replace' }}
+        {{ labels.replaceAriaLabel }}
       </button>
       <button
         type="button"
         class="vizel-find-replace-button vizel-find-replace-button--primary"
         :disabled="matchCount === 0"
-        :aria-label="props.locale?.findReplace.replaceAllAriaLabel ?? 'Replace all'"
-        :title="props.locale?.findReplace.replaceAllTitle ?? 'Replace all matches'"
+        :aria-label="labels.replaceAllAriaLabel"
+        :title="labels.replaceAllTitle"
         @click="handleReplaceAll"
       >
-        {{ props.locale?.findReplace.replaceAllAriaLabel ?? 'All' }}
+        {{ labels.replaceAllAriaLabel }}
       </button>
     </div>
 
@@ -219,7 +221,7 @@ function handleKeyDown(e: KeyboardEvent) {
           :checked="caseSensitive"
           @change="handleCaseSensitiveChange"
         />
-        {{ props.locale?.findReplace.caseSensitive ?? 'Case sensitive' }}
+        {{ labels.caseSensitive }}
       </label>
     </div>
   </div>

--- a/packages/vue/src/components/VizelProvider.vue
+++ b/packages/vue/src/components/VizelProvider.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Editor } from "@vizel/core";
-import { provide } from "vue";
+import { computed, provide } from "vue";
 import { VIZEL_CONTEXT_KEY } from "./VizelContext.ts";
 
 export interface VizelProviderProps {
@@ -13,10 +13,14 @@ export interface VizelProviderProps {
 const props = defineProps<VizelProviderProps>();
 
 provide(VIZEL_CONTEXT_KEY, () => props.editor);
+
+// Always emit the `vizel-root` class so consumers get the CSS variable scope
+// for free (.vizel-root { --vizel-* }). Matches the React provider behavior.
+const rootClass = computed(() => (props.class ? `vizel-root ${props.class}` : "vizel-root"));
 </script>
 
 <template>
-  <div :class="$props.class" data-vizel-root>
+  <div :class="rootClass" data-vizel-root>
     <slot />
   </div>
 </template>

--- a/packages/vue/src/composables/useVizelComment.ts
+++ b/packages/vue/src/composables/useVizelComment.ts
@@ -7,7 +7,7 @@ import {
   type VizelCommentReply,
   type VizelCommentState,
 } from "@vizel/core";
-import { type ComputedRef, computed, onMounted, shallowReactive, watch } from "vue";
+import { type ComputedRef, computed, shallowReactive, watch } from "vue";
 
 /**
  * Comment composable result
@@ -83,7 +83,12 @@ export function useVizelComment(
     Object.assign(state, partial);
   };
 
-  let handlers = createVizelCommentHandlers(
+  // Comment handlers use `getEditor` lazily, so editor swaps are handled
+  // automatically without re-instantiating them. Options are captured at
+  // composable call time (consistent with how `useVizelEditor` treats its
+  // options as mount-time); a previous `watch` on options never fired because
+  // the destructured locals aren't reactive, and has been removed.
+  const handlers = createVizelCommentHandlers(
     getEditor,
     {
       enabled,
@@ -98,38 +103,20 @@ export function useVizelComment(
     handleStateChange
   );
 
+  // Single load path: `immediate: true` covers the initial mount AND every
+  // subsequent editor swap. The previous shape split this into `onMounted`
+  // plus a non-immediate `watch`, which left the initial fire dependent on
+  // the editor being non-null inside `onMounted` (a race with async editor
+  // creation in `useVizelEditor`).
   watch(
-    () => ({ enabled, storage, key }),
-    () => {
-      handlers = createVizelCommentHandlers(
-        getEditor,
-        {
-          enabled,
-          storage,
-          key,
-          onAdd: (comment) => options.onAdd?.(comment),
-          onRemove: (id) => options.onRemove?.(id),
-          onResolve: (comment) => options.onResolve?.(comment),
-          onReopen: (comment) => options.onReopen?.(comment),
-          onError: (error) => options.onError?.(error),
-        },
-        handleStateChange
-      );
-    }
+    getEditor,
+    (editor) => {
+      if (editor && enabled) {
+        void handlers.loadComments();
+      }
+    },
+    { immediate: true }
   );
-
-  onMounted(() => {
-    const editor = getEditor();
-    if (editor && enabled) {
-      void handlers.loadComments();
-    }
-  });
-
-  watch(getEditor, (editor) => {
-    if (editor && enabled) {
-      void handlers.loadComments();
-    }
-  });
 
   return {
     comments: computed(() => state.comments),

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -6,7 +6,7 @@ import {
   wrapAsVizelError,
 } from "@vizel/core";
 import type { ShallowRef } from "vue";
-import { onBeforeUnmount, onMounted, shallowRef } from "vue";
+import { onBeforeUnmount, onMounted, shallowRef, watch } from "vue";
 import { createVizelSlashMenuRenderer } from "./createVizelSlashMenuRenderer.ts";
 
 /**
@@ -17,6 +17,20 @@ export type UseVizelEditorOptions = VizelCreateEditorOptions;
 
 /**
  * Vue composable to create and manage a Vizel editor instance.
+ *
+ * ## Reactive vs mount-time options
+ *
+ * The Tiptap editor instance is created once on mount. To avoid expensive
+ * teardowns, most options are read once at mount and ignored on subsequent
+ * renders. The following option is an exception:
+ *
+ * - `editable` — propagated through `editor.setEditable()` whenever the prop
+ *   value changes.
+ *
+ * Changing `initialContent`, `initialMarkdown`, `placeholder`, `features`,
+ * `extensions`, `flavor`, `locale`, or `autofocus` after mount has no effect.
+ * Use `editor.value.commands.setContent(...)` (or the corresponding feature
+ * command) to update the document after mount.
  *
  * @example
  * ```vue
@@ -96,6 +110,20 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
       }
     })();
   });
+
+  // Mirror the `editable` option into the underlying editor. The constructor
+  // option is captured at mount; without this watcher consumers cannot toggle
+  // read-only mode after the editor exists. Matches the React hook behavior.
+  watch(
+    [editor, () => editorOptions.editable],
+    ([editorValue, editable]) => {
+      const desired = editable ?? true;
+      if (editorValue && editorValue.isEditable !== desired) {
+        editorValue.setEditable(desired);
+      }
+    },
+    { immediate: true }
+  );
 
   onBeforeUnmount(() => {
     cleanupHandler?.();

--- a/packages/vue/src/composables/useVizelMarkdown.ts
+++ b/packages/vue/src/composables/useVizelMarkdown.ts
@@ -144,6 +144,13 @@ export function useVizelMarkdown(
 
       // Cleanup when watch re-runs or component unmounts
       onCleanup(() => {
+        // Flush any pending debounced export before detaching so editor swaps
+        // (or unmount) do not drop unsynced markdown. Matches the Svelte rune.
+        if (h.isPending()) {
+          h.flush(editor);
+          markdown.value = h.getMarkdown();
+          pendingState.value = false;
+        }
         editor.off("update", handleUpdate);
         if (rafId !== null) cancelAnimationFrame(rafId);
       });


### PR DESCRIPTION
## Summary

Address pure parity bugs identified in the v2.x audit. No architectural
changes — each fix is independent and applies to the framework(s) that
drift from the established pattern.

| ID | Area | Fix |
|----|------|-----|
| **B8a** | Vue/Svelte `useVizelEditor` / `createVizelEditor` | Mirror the `editable` prop through `editor.setEditable()` when it changes after mount. Matches the React hook. |
| **B12a** | React/Vue `useVizelMarkdown` | Flush any pending debounced export before detaching from an editor. Editor swaps and unmount no longer drop unsynced markdown. Matches the Svelte rune. |
| **B16a** | Svelte `VizelBubbleMenu` | Read `shouldShow` with `untrack(...)` so value updates flow through the wrapper closure without re-registering the plugin. Matches the React ref-latest pattern. |
| **B20** | All three `VizelFindReplace` components | `resolveVizelFindReplaceLabels` is hoisted from `VizelFindReplace.tsx` to `@vizel/core/i18n`. Vue/Svelte stop hand-writing `?? "Find..."` fallbacks inline. |
| **H3** | Vue/Svelte `VizelProvider` | Always emit the `vizel-root` class so consumer CSS variable scope (`.vizel-root { --vizel-* }`) applies consistently with React. |
| **C2** (prior) | Svelte `VizelPortal` | Migrate from a `use:portal` action (whose closure captured `layer`/`className` at creation) to a `$effect`-based mount pair so prop changes propagate to the wrapper element. |
| **H8/H9** | Vue `useVizelComment` | Drop the dead options watcher (locals are not reactive) and replace the `onMounted` + non-immediate `watch` split with a single `watch(getEditor, ..., { immediate: true })`. |
| **H13** | Svelte `createVizelCollaboration` | No longer recreate handlers on the `null → null` provider transition. Scope the allocation to the enabled/connected lifetime. |

## Docs

`.claude/rules/cross-framework.md` gains two sections:
- Provider Root Class convention.
- Reactive vs Mount-time Editor Options (documents `editable` as the sole runtime-mirrored option).

## Test Plan

- [x] `pnpm lint` clean (pre-existing complexity warning unrelated).
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None. All changes are bug fixes preserving public API.
