### PR TITLE
refactor: unify suggestion menu onKeyDown signature

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -151,6 +151,24 @@ wrapper, prepending the consumer-supplied class. The `.vizel-root` selector
 scopes all CSS custom properties (`--vizel-*`), so omitting the class would
 break theming for any descendant that depends on those variables.
 
+## Suggestion Menu Ref Convention
+
+`VizelSlashMenu` and `VizelMentionMenu` expose keyboard control to the
+Tiptap suggestion renderer through an imperative `onKeyDown` handle. The
+signature is identical in all three frameworks:
+
+```typescript
+type VizelSlashMenuRef = { onKeyDown: (event: KeyboardEvent) => boolean };
+type VizelMentionMenuRef = { onKeyDown: (event: KeyboardEvent) => boolean };
+```
+
+The renderer unwraps the `KeyboardEvent` from Tiptap's `{ event }` payload
+before forwarding. Components accept the raw event so the same ref shape
+works across React (`useImperativeHandle`), Vue (`defineExpose`), and
+Svelte (ref-prop pattern). The previous React/Vue declarations used a
+`{ event }` wrapper that did not match the underlying implementation;
+v2.0 collapses them to the raw-event form.
+
 ## Reactive vs Mount-time Editor Options
 
 `useVizelEditor` / `createVizelEditor` create the Tiptap instance once on

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -3,7 +3,13 @@ import type { ReactNode, Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 
 export interface VizelMentionMenuRef {
-  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+  /**
+   * Handle keyboard navigation events.
+   * The renderer forwards the raw `KeyboardEvent`; the React component
+   * previously accepted `{ event }`. v2.0 unifies the signature across
+   * React/Vue/Svelte to the raw-event form.
+   */
+  onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
 export interface VizelMentionMenuProps {
@@ -71,7 +77,7 @@ export function VizelMentionMenu({
   }, [selectItem, selectedIndex]);
 
   useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
+    onKeyDown: (event) => {
       if (event.key === "ArrowUp") {
         upHandler();
         return true;

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -9,7 +9,13 @@ import { VizelSlashMenuEmpty } from "./VizelSlashMenuEmpty.tsx";
 import { VizelSlashMenuItem, type VizelSlashMenuItemProps } from "./VizelSlashMenuItem.tsx";
 
 export interface VizelSlashMenuRef {
-  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+  /**
+   * Handle keyboard navigation events.
+   * The renderer forwards the raw `KeyboardEvent`; the React component
+   * previously accepted `{ event }`. v2.0 unifies the signature across
+   * React/Vue/Svelte to the raw-event form.
+   */
+  onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
 export interface VizelSlashMenuProps {
@@ -148,7 +154,7 @@ export function VizelSlashMenu({
   }, [groups]);
 
   useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
+    onKeyDown: (event) => {
       if (event.key === "ArrowUp") {
         upHandler();
         return true;

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -73,7 +73,7 @@ export function createVizelMentionMenuRenderer(
           if (handleVizelSuggestionEscape(props.event)) {
             return true;
           }
-          return menuRef.current?.onKeyDown(props) ?? false;
+          return menuRef.current?.onKeyDown(props.event) ?? false;
         },
 
         onExit: () => {

--- a/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
@@ -75,7 +75,7 @@ export function createVizelSlashMenuRenderer(
           if (handleVizelSuggestionEscape(props.event)) {
             return true;
           }
-          return menuRef.current?.onKeyDown(props) ?? false;
+          return menuRef.current?.onKeyDown(props.event) ?? false;
         },
 
         onExit: () => {

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -13,8 +13,13 @@ import VizelSlashMenuItem from "./VizelSlashMenuItem.vue";
  * Exposes keyboard navigation handler for parent components.
  */
 export interface VizelSlashMenuRef {
-  /** Handle keyboard navigation events (ArrowUp, ArrowDown, Enter, Tab) */
-  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+  /**
+   * Handle keyboard navigation events (ArrowUp, ArrowDown, Enter, Tab).
+   * Accepts a raw `KeyboardEvent`; cross-framework parity with React/Svelte
+   * was previously broken by a `{ event }` wrapper in the type declaration
+   * that never matched the underlying `defineExpose` shape.
+   */
+  onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
 export interface VizelSlashMenuProps {


### PR DESCRIPTION
## Summary

Collapse `VizelSlashMenuRef.onKeyDown` and `VizelMentionMenuRef.onKeyDown`
to a single shape — `(event: KeyboardEvent) => boolean` — across React,
Vue, and Svelte. Two of the three frameworks already used this raw-event
form; this PR aligns the third (React) and corrects a Vue type-vs-impl
mismatch that silently lied at the call site.

| ID | Component | Before | After |
|----|-----------|--------|-------|
| **C1** | Vue `VizelSlashMenu` | Type declared `(props: { event }) => boolean`, `defineExpose` passed `(event) => boolean` | Type matches the impl: `(event: KeyboardEvent) => boolean` |
| **H6** | React/Vue/Svelte `VizelSlashMenuRef` | React: `(props: { event }) => boolean` / Vue+Svelte: `(event) => boolean` | All three: `(event: KeyboardEvent) => boolean` |
| **H7** | React/Vue/Svelte `VizelMentionMenuRef` | Same drift as H6 | All three: `(event: KeyboardEvent) => boolean` |

The Tiptap `SuggestionOptions.onKeyDown` contract is unchanged; only the
component ref surface is unified. React's `createVizelSlashMenuRenderer`
and `createVizelMentionMenuRenderer` now pass `props.event` to the ref
instead of the wrapper object.

## Docs

`.claude/rules/cross-framework.md` gains a "Suggestion Menu Ref
Convention" section documenting the shared shape.

## Test Plan

- [x] `pnpm lint` clean (pre-existing complexity warning unrelated).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

`menuRef.current.onKeyDown({ event })` callers must drop the wrapper and
call `menuRef.current.onKeyDown(event)`. These refs are rarely held
outside the Vizel-provided renderers; first-party suggestion integrations
are unaffected.
