### PR TITLE
refactor: extract pure helpers from framework packages to core

### DIFF
--- a/packages/core/src/auto-save.ts
+++ b/packages/core/src/auto-save.ts
@@ -258,3 +258,111 @@ export function formatVizelRelativeTime(date: Date, locale?: VizelLocale): strin
   }
   return `${diffDay}d ago`;
 }
+
+/**
+ * Options for {@link createVizelRelativeTimeTicker}.
+ */
+export interface VizelRelativeTimeTickerOptions {
+  /** Returns the reference date. `null`/`undefined` is rendered as an empty string. */
+  getDate: () => Date | null | undefined;
+  /** Returns the active locale (optional, called per tick). */
+  getLocale?: () => VizelLocale | undefined;
+  /** Tick interval in milliseconds (default: 10000). */
+  intervalMs?: number;
+  /** Called with the formatted string on every tick (and once synchronously). */
+  onTick: (text: string) => void;
+}
+
+/**
+ * Start a relative-time interval ticker.
+ *
+ * Calls `onTick` once synchronously with the current relative-time string,
+ * then on every `intervalMs` boundary until the returned dispose function
+ * fires. Framework components wrap this in their effect primitive instead
+ * of reimplementing the `setInterval`/`clearInterval` pair.
+ */
+export function createVizelRelativeTimeTicker(options: VizelRelativeTimeTickerOptions): () => void {
+  const { getDate, getLocale, intervalMs = 10000, onTick } = options;
+
+  const emit = () => {
+    const date = getDate();
+    onTick(date ? formatVizelRelativeTime(date, getLocale?.()) : "");
+  };
+
+  emit();
+  const id = setInterval(emit, intervalMs);
+  return () => clearInterval(id);
+}
+
+/**
+ * Resolved view-model for {@link VizelSaveIndicator}.
+ *
+ * Captures the status → display mapping so each framework only has to
+ * render the icon and text once, instead of hand-writing a `switch`
+ * inside both `<script>` and template.
+ */
+export interface VizelSaveIndicatorView {
+  /** Name of the {@link VizelIcon} to render. */
+  iconName: "check" | "loader" | "circle" | "warning";
+  /** Whether the icon should be wrapped in the `vizel-save-indicator-spinner` element. */
+  isSpinner: boolean;
+  /** Localized status text. */
+  text: string;
+  /** Whether to render the relative timestamp span. */
+  shouldShowTimestamp: boolean;
+}
+
+/**
+ * Resolve the icon, text, and timestamp visibility for a {@link VizelSaveStatus}.
+ *
+ * Pure function consumed by framework `VizelSaveIndicator` components.
+ *
+ * @param status - Current save status.
+ * @param locale - Optional locale providing translated status strings.
+ * @param lastSaved - Last successful save timestamp (for visibility check).
+ * @param relativeTime - Pre-computed relative-time string (empty when none).
+ * @param showTimestamp - Whether the consumer requested timestamp display.
+ */
+export function resolveVizelSaveIndicatorView(
+  status: VizelSaveStatus,
+  locale: VizelLocale | undefined,
+  lastSaved: Date | null | undefined,
+  relativeTime: string,
+  showTimestamp: boolean
+): VizelSaveIndicatorView {
+  const t = locale?.saveIndicator;
+  switch (status) {
+    case "saved":
+      return {
+        iconName: "check",
+        isSpinner: false,
+        text: t?.saved ?? "Saved",
+        shouldShowTimestamp: Boolean(showTimestamp && lastSaved && relativeTime),
+      };
+    case "saving":
+      return {
+        iconName: "loader",
+        isSpinner: true,
+        text: t?.saving ?? "Saving...",
+        shouldShowTimestamp: false,
+      };
+    case "unsaved":
+      return {
+        iconName: "circle",
+        isSpinner: false,
+        text: t?.unsaved ?? "Unsaved",
+        shouldShowTimestamp: false,
+      };
+    case "error":
+      return {
+        iconName: "warning",
+        isSpinner: false,
+        text: t?.error ?? "Error saving",
+        shouldShowTimestamp: false,
+      };
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+}

--- a/packages/core/src/extensions/embed.ts
+++ b/packages/core/src/extensions/embed.ts
@@ -946,3 +946,111 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
 export function createVizelEmbedExtension(options: VizelEmbedOptions = {}) {
   return VizelEmbed.configure(options);
 }
+
+// =============================================================================
+// Embed View Helpers
+// =============================================================================
+
+/**
+ * Re-parent any `<script>` tags inside an oEmbed container so the browser
+ * actually executes them (innerHTML-inserted scripts are inert).
+ *
+ * Optionally invokes provider-specific bootstrap (Twitter widgets) when
+ * the provider is `"twitter"`. Framework `VizelEmbedView` components call
+ * this helper after their effect runs.
+ */
+export function loadVizelEmbedScripts(container: HTMLElement, provider?: string): void {
+  const scripts = container.querySelectorAll("script");
+  for (const oldScript of scripts) {
+    const newScript = document.createElement("script");
+    for (const attr of Array.from(oldScript.attributes)) {
+      newScript.setAttribute(attr.name, attr.value);
+    }
+    if (oldScript.textContent) {
+      newScript.textContent = oldScript.textContent;
+    }
+    oldScript.parentNode?.replaceChild(newScript, oldScript);
+  }
+
+  if (provider === "twitter" && typeof window !== "undefined" && "twttr" in window) {
+    const twttr = (window as { twttr?: { widgets?: { load?: (el?: HTMLElement) => void } } }).twttr;
+    twttr?.widgets?.load?.(container);
+  }
+}
+
+/**
+ * Discriminated view-model for {@link VizelEmbedView}.
+ *
+ * Each variant maps to one of the four render branches (oEmbed,
+ * OGP, title-link, plain-link) plus the loading state. Framework
+ * components consume the resolved variant and only have to render
+ * each branch's tree once.
+ */
+export type VizelEmbedViewModel =
+  | { kind: "loading"; provider: string | undefined }
+  | {
+      kind: "oembed";
+      provider: string | undefined;
+      html: string;
+      isVideo: boolean;
+    }
+  | {
+      kind: "ogp";
+      provider: string | undefined;
+      url: string;
+      title: string | undefined;
+      description: string | undefined;
+      image: string | undefined;
+      favicon: string | undefined;
+      siteName: string | undefined;
+      hostname: string;
+    }
+  | { kind: "title"; provider: string | undefined; url: string; title: string }
+  | { kind: "link"; provider: string | undefined; url: string };
+
+const VIDEO_PROVIDERS: readonly string[] = ["youtube", "vimeo", "loom", "tiktok"];
+
+/**
+ * Resolve an {@link VizelEmbedData} into the variant-shaped view-model.
+ *
+ * Encodes the same fallback chain previously hand-coded in each framework's
+ * `VizelEmbedView`: loading → oEmbed → OGP → title-link → plain-link.
+ */
+export function resolveVizelEmbedView(data: VizelEmbedData): VizelEmbedViewModel {
+  if (data.loading) {
+    return { kind: "loading", provider: data.provider };
+  }
+  if (data.type === "oembed" && data.html) {
+    return {
+      kind: "oembed",
+      provider: data.provider,
+      html: data.html,
+      isVideo: VIDEO_PROVIDERS.includes(data.provider ?? ""),
+    };
+  }
+  if (data.type === "ogp") {
+    return {
+      kind: "ogp",
+      provider: data.provider,
+      url: data.url,
+      title: data.title,
+      description: data.description,
+      image: data.image,
+      favicon: data.favicon,
+      siteName: data.siteName,
+      hostname: safeHostname(data.url),
+    };
+  }
+  if (data.type === "title" && data.title) {
+    return { kind: "title", provider: data.provider, url: data.url, title: data.title };
+  }
+  return { kind: "link", provider: data.provider, url: data.url };
+}
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -74,11 +74,14 @@ export {
   createVizelDefaultFetchEmbedData,
   createVizelEmbedExtension,
   detectVizelEmbedProvider,
+  loadVizelEmbedScripts,
+  resolveVizelEmbedView,
   VizelEmbed,
   type VizelEmbedData,
   type VizelEmbedOptions,
   type VizelEmbedProvider,
   type VizelEmbedType,
+  type VizelEmbedViewModel,
   type VizelFetchEmbedDataFn,
   vizelDefaultEmbedProviders,
   vizelEmbedPastePluginKey,
@@ -220,6 +223,7 @@ export {
 // Text color
 export {
   addVizelRecentColor,
+  applyVizelColorToEditor,
   createVizelTextColorExtensions,
   getVizelRecentColors,
   VIZEL_HIGHLIGHT_COLORS,

--- a/packages/core/src/extensions/text-color.ts
+++ b/packages/core/src/extensions/text-color.ts
@@ -1,4 +1,4 @@
-import type { Extensions } from "@tiptap/core";
+import type { Editor, Extensions } from "@tiptap/core";
 import { Color } from "@tiptap/extension-color";
 import { Highlight } from "@tiptap/extension-highlight";
 import { TextStyle } from "@tiptap/extension-text-style";
@@ -120,6 +120,46 @@ export function addVizelRecentColor(type: "textColor" | "highlight", color: stri
   } catch {
     // Ignore localStorage errors
   }
+}
+
+/**
+ * Apply a color to the current selection.
+ *
+ * Routes through the appropriate Tiptap command and special-cases the
+ * "remove" sentinels (`"inherit"` for text color, `"transparent"` for
+ * highlight). Concrete colors are also recorded via `addVizelRecentColor`.
+ *
+ * Framework components consume this helper instead of hand-coding the
+ * `editor.chain().focus().setColor(...)` / `toggleHighlight(...)` plumbing
+ * three times. The behavior is intentionally identical to the previous
+ * per-framework copies.
+ *
+ * @example
+ * ```ts
+ * applyVizelColorToEditor(editor, "textColor", "#FF0000");
+ * applyVizelColorToEditor(editor, "highlight", "transparent"); // unsets
+ * ```
+ */
+export function applyVizelColorToEditor(
+  editor: Editor,
+  type: "textColor" | "highlight",
+  color: string
+): void {
+  if (type === "textColor") {
+    if (color === "inherit") {
+      editor.chain().focus().unsetColor().run();
+      return;
+    }
+    editor.chain().focus().setColor(color).run();
+    addVizelRecentColor(type, color);
+    return;
+  }
+  if (color === "transparent") {
+    editor.chain().focus().unsetHighlight().run();
+    return;
+  }
+  editor.chain().focus().toggleHighlight({ color }).run();
+  addVizelRecentColor(type, color);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,11 +19,15 @@ export type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 // =============================================================================
 export {
   createVizelAutoSaveHandlers,
+  createVizelRelativeTimeTicker,
   formatVizelRelativeTime,
   getVizelStorageBackend,
+  resolveVizelSaveIndicatorView,
   VIZEL_DEFAULT_AUTO_SAVE_OPTIONS,
   type VizelAutoSaveOptions,
   type VizelAutoSaveState,
+  type VizelRelativeTimeTickerOptions,
+  type VizelSaveIndicatorView,
   type VizelSaveStatus,
   type VizelStorageBackend,
 } from "./auto-save.ts";
@@ -60,6 +64,7 @@ export {
 export {
   // Text color
   addVizelRecentColor,
+  applyVizelColorToEditor,
   // Block menu (locale-aware)
   createVizelBlockMenuActions,
   // Callout / Admonition
@@ -133,6 +138,8 @@ export {
   groupVizelSlashCommands,
   handleVizelImageDrop,
   handleVizelImagePaste,
+  loadVizelEmbedScripts,
+  resolveVizelEmbedView,
   searchVizelSlashCommands,
   VIZEL_BLOCK_MENU_EVENT,
   VIZEL_DEFAULT_FILE_MIME_TYPES,
@@ -169,6 +176,7 @@ export {
   type VizelEmbedOptions,
   type VizelEmbedProvider,
   type VizelEmbedType,
+  type VizelEmbedViewModel,
   type VizelExtensionsOptions,
   type VizelFetchEmbedDataFn,
   type VizelFileHandlerError,

--- a/packages/react/src/components/VizelBubbleMenuColorPicker.tsx
+++ b/packages/react/src/components/VizelBubbleMenuColorPicker.tsx
@@ -1,5 +1,5 @@
 import {
-  addVizelRecentColor,
+  applyVizelColorToEditor,
   type Editor,
   getVizelRecentColors,
   VIZEL_HIGHLIGHT_COLORS,
@@ -64,22 +64,11 @@ export function VizelBubbleMenuColorPicker({
     }
   }, [isOpen, showRecentColors, type]);
 
-  // Apply color to editor
+  // Apply color to editor (centralized in @vizel/core to keep behavior parity
+  // across React/Vue/Svelte).
   const handleColorChange = useCallback(
     (color: string) => {
-      if (type === "textColor") {
-        if (color === "inherit") {
-          editor.chain().focus().unsetColor().run();
-        } else {
-          editor.chain().focus().setColor(color).run();
-          addVizelRecentColor(type, color);
-        }
-      } else if (color === "transparent") {
-        editor.chain().focus().unsetHighlight().run();
-      } else {
-        editor.chain().focus().toggleHighlight({ color }).run();
-        addVizelRecentColor(type, color);
-      }
+      applyVizelColorToEditor(editor, type, color);
       setIsOpen(false);
     },
     [editor, type]

--- a/packages/react/src/components/VizelEmbedView.tsx
+++ b/packages/react/src/components/VizelEmbedView.tsx
@@ -1,6 +1,12 @@
-import type { VizelEmbedData, VizelEmbedType } from "@vizel/core";
+import {
+  loadVizelEmbedScripts,
+  resolveVizelEmbedView,
+  type VizelEmbedData,
+  type VizelEmbedType,
+  type VizelEmbedViewModel,
+} from "@vizel/core";
 import type React from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
 export interface VizelEmbedViewProps {
@@ -12,167 +18,125 @@ export interface VizelEmbedViewProps {
   selected?: boolean;
 }
 
-/** Build base class name for embed container */
-const buildBaseClass = (
+function buildBaseClass(
   loading: boolean | undefined,
   selected: boolean | undefined,
   className: string | undefined
-): string =>
-  `vizel-embed ${loading ? "is-loading" : ""} ${selected ? "ProseMirror-selectednode" : ""} ${className ?? ""}`;
-
-/** Render loading state */
-const renderLoading = (baseClass: string, provider: string | undefined): React.JSX.Element => (
-  <div className={baseClass} data-embed-type="loading" data-embed-provider={provider}>
-    <div className="vizel-embed-loading">
-      <div className="vizel-embed-loading-spinner" />
-      <span>Loading embed...</span>
-    </div>
-  </div>
-);
-
-/** Render oEmbed (rich embed) */
-const renderOEmbed = (
-  baseClass: string,
-  data: VizelEmbedData,
-  containerRef: React.RefObject<HTMLDivElement | null>
-): React.JSX.Element => {
-  const isVideo = ["youtube", "vimeo", "loom", "tiktok"].includes(data.provider ?? "");
-
-  return (
-    <div
-      ref={containerRef}
-      className={baseClass}
-      data-embed-type="oembed"
-      data-embed-provider={data.provider}
-    >
-      <div
-        className={isVideo ? "vizel-embed-video" : "vizel-embed-oembed"}
-        // biome-ignore lint/security/noDangerouslySetInnerHtml lint/style/useNamingConvention: oEmbed requires rendering provider HTML; __html is React API
-        dangerouslySetInnerHTML={{ __html: data.html ?? "" }}
-      />
-    </div>
-  );
-};
-
-/** Render OGP card */
-const renderOGPCard = (baseClass: string, data: VizelEmbedData): React.JSX.Element => {
-  const hasImage = Boolean(data.image);
-  const cardLayout = hasImage ? "vizel-embed-card-horizontal" : "";
-
-  return (
-    <div className={baseClass} data-embed-type="ogp" data-embed-provider={data.provider}>
-      <a
-        href={data.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={`vizel-embed-card ${cardLayout}`}
-      >
-        {hasImage && (
-          <img src={data.image} alt="" className="vizel-embed-card-image" loading="lazy" />
-        )}
-        <div className="vizel-embed-card-content">
-          {(data.siteName || data.favicon) && (
-            <div className="vizel-embed-card-site">
-              {data.favicon && (
-                <img src={data.favicon} alt="" className="vizel-embed-card-favicon" />
-              )}
-              {data.siteName && <span>{data.siteName}</span>}
-            </div>
-          )}
-          {data.title && <div className="vizel-embed-card-title">{data.title}</div>}
-          {data.description && (
-            <div className="vizel-embed-card-description">{data.description}</div>
-          )}
-          <div className="vizel-embed-card-url">{new URL(data.url).hostname}</div>
-        </div>
-      </a>
-    </div>
-  );
-};
-
-/** Render title link */
-const renderTitleLink = (
-  baseClass: string,
-  data: VizelEmbedData,
-  LinkIcon: React.JSX.Element
-): React.JSX.Element => (
-  <div className={baseClass} data-embed-type="title" data-embed-provider={data.provider}>
-    <a href={data.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
-      <span className="vizel-embed-link-icon">{LinkIcon}</span>
-      <span className="vizel-embed-link-text">{data.title}</span>
-    </a>
-  </div>
-);
-
-/** Render plain link (fallback) */
-const renderPlainLink = (
-  baseClass: string,
-  data: VizelEmbedData,
-  LinkIcon: React.JSX.Element
-): React.JSX.Element => (
-  <div className={baseClass} data-embed-type="link" data-embed-provider={data.provider}>
-    <a href={data.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
-      <span className="vizel-embed-link-icon">{LinkIcon}</span>
-      <span className="vizel-embed-link-text">{data.url}</span>
-    </a>
-  </div>
-);
+): string {
+  return `vizel-embed ${loading ? "is-loading" : ""} ${selected ? "ProseMirror-selectednode" : ""} ${className ?? ""}`;
+}
 
 /**
  * Renders an embed based on its type.
- * Supports oEmbed (rich), OGP (card), title (link with text), and plain link.
+ *
+ * The display variant (loading / oEmbed / OGP card / title link / plain link)
+ * is resolved by `@vizel/core`'s `resolveVizelEmbedView`. This component
+ * just maps the variant to React JSX and delegates script reparenting to
+ * `loadVizelEmbedScripts`.
  */
 export function VizelEmbedView({ data, className, selected }: VizelEmbedViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Handle oEmbed scripts (Twitter, Instagram, etc.)
-  useEffect(() => {
-    if (data.type === "oembed" && data.html && containerRef.current) {
-      // Find and execute any scripts in the HTML
-      const scripts = containerRef.current.querySelectorAll("script");
-      for (const script of scripts) {
-        const newScript = document.createElement("script");
-        if (script.src) {
-          newScript.src = script.src;
-        } else {
-          newScript.textContent = script.textContent;
-        }
-        script.parentNode?.replaceChild(newScript, script);
-      }
-
-      // Load Twitter widgets if present
-      if (data.provider === "twitter" && "twttr" in window) {
-        (window as { twttr?: { widgets?: { load?: () => void } } }).twttr?.widgets?.load?.();
-      }
-    }
-  }, [data.type, data.html, data.provider]);
-
+  const view = useMemo(() => resolveVizelEmbedView(data), [data]);
   const baseClass = buildBaseClass(data.loading, selected, className);
 
-  // Loading state
-  if (data.loading) {
-    return renderLoading(baseClass, data.provider);
+  useEffect(() => {
+    if (view.kind === "oembed" && containerRef.current) {
+      loadVizelEmbedScripts(containerRef.current, view.provider);
+    }
+  }, [view]);
+
+  return renderEmbed(view, baseClass, containerRef);
+}
+
+function renderEmbed(
+  view: VizelEmbedViewModel,
+  baseClass: string,
+  containerRef: React.RefObject<HTMLDivElement | null>
+): React.JSX.Element {
+  switch (view.kind) {
+    case "loading":
+      return (
+        <div className={baseClass} data-embed-type="loading" data-embed-provider={view.provider}>
+          <div className="vizel-embed-loading">
+            <div className="vizel-embed-loading-spinner" />
+            <span>Loading embed...</span>
+          </div>
+        </div>
+      );
+    case "oembed":
+      return (
+        <div
+          ref={containerRef}
+          className={baseClass}
+          data-embed-type="oembed"
+          data-embed-provider={view.provider}
+        >
+          <div
+            className={view.isVideo ? "vizel-embed-video" : "vizel-embed-oembed"}
+            // biome-ignore lint/security/noDangerouslySetInnerHtml lint/style/useNamingConvention: oEmbed provider HTML is sanitized in core/extensions/embed.ts via DOMPurify before reaching this view; __html is the React API
+            dangerouslySetInnerHTML={{ __html: view.html }}
+          />
+        </div>
+      );
+    case "ogp": {
+      const cardLayout = view.image ? "vizel-embed-card-horizontal" : "";
+      return (
+        <div className={baseClass} data-embed-type="ogp" data-embed-provider={view.provider}>
+          <a
+            href={view.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`vizel-embed-card ${cardLayout}`}
+          >
+            {view.image && (
+              <img src={view.image} alt="" className="vizel-embed-card-image" loading="lazy" />
+            )}
+            <div className="vizel-embed-card-content">
+              {(view.siteName || view.favicon) && (
+                <div className="vizel-embed-card-site">
+                  {view.favicon && (
+                    <img src={view.favicon} alt="" className="vizel-embed-card-favicon" />
+                  )}
+                  {view.siteName && <span>{view.siteName}</span>}
+                </div>
+              )}
+              {view.title && <div className="vizel-embed-card-title">{view.title}</div>}
+              {view.description && (
+                <div className="vizel-embed-card-description">{view.description}</div>
+              )}
+              <div className="vizel-embed-card-url">{view.hostname}</div>
+            </div>
+          </a>
+        </div>
+      );
+    }
+    case "title":
+      return (
+        <div className={baseClass} data-embed-type="title" data-embed-provider={view.provider}>
+          <a href={view.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
+            <span className="vizel-embed-link-icon">
+              <VizelIcon name="link" />
+            </span>
+            <span className="vizel-embed-link-text">{view.title}</span>
+          </a>
+        </div>
+      );
+    case "link":
+      return (
+        <div className={baseClass} data-embed-type="link" data-embed-provider={view.provider}>
+          <a href={view.url} target="_blank" rel="noopener noreferrer" className="vizel-embed-link">
+            <span className="vizel-embed-link-icon">
+              <VizelIcon name="link" />
+            </span>
+            <span className="vizel-embed-link-text">{view.url}</span>
+          </a>
+        </div>
+      );
+    default: {
+      const exhaustive: never = view;
+      return exhaustive;
+    }
   }
-
-  // oEmbed (rich embed)
-  if (data.type === "oembed" && data.html) {
-    return renderOEmbed(baseClass, data, containerRef);
-  }
-
-  // OGP card
-  if (data.type === "ogp") {
-    return renderOGPCard(baseClass, data);
-  }
-
-  const linkIcon = <VizelIcon name="link" />;
-
-  // Title link
-  if (data.type === "title" && data.title) {
-    return renderTitleLink(baseClass, data, linkIcon);
-  }
-
-  // Plain link (fallback)
-  return renderPlainLink(baseClass, data, linkIcon);
 }
 
 /**

--- a/packages/react/src/components/VizelSaveIndicator.tsx
+++ b/packages/react/src/components/VizelSaveIndicator.tsx
@@ -1,5 +1,10 @@
-import { formatVizelRelativeTime, type VizelLocale, type VizelSaveStatus } from "@vizel/core";
-import { useEffect, useState } from "react";
+import {
+  createVizelRelativeTimeTicker,
+  resolveVizelSaveIndicatorView,
+  type VizelLocale,
+  type VizelSaveStatus,
+} from "@vizel/core";
+import { useEffect, useRef, useState } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
 export interface VizelSaveIndicatorProps {
@@ -18,13 +23,14 @@ export interface VizelSaveIndicatorProps {
 /**
  * Visual indicator for the current save state of the editor.
  *
+ * The status → display mapping (icon, text, timestamp visibility) lives in
+ * `@vizel/core`'s `resolveVizelSaveIndicatorView`. The relative-time interval
+ * comes from `createVizelRelativeTimeTicker`. The component is just the
+ * React-flavored binding.
+ *
  * @example
  * ```tsx
- * <VizelSaveIndicator
- *   status={status}
- *   lastSaved={lastSaved}
- *   showTimestamp
- * />
+ * <VizelSaveIndicator status={status} lastSaved={lastSaved} showTimestamp />
  * ```
  */
 export function VizelSaveIndicator({
@@ -36,59 +42,30 @@ export function VizelSaveIndicator({
 }: VizelSaveIndicatorProps) {
   const [relativeTime, setRelativeTime] = useState<string>("");
 
-  // Update relative time every 10 seconds
-  useEffect(() => {
-    if (!lastSaved) {
-      setRelativeTime("");
-      return;
-    }
+  // Keep the latest `lastSaved`/`locale` accessible from the ticker callback
+  // without rebuilding the interval on every render.
+  const lastSavedRef = useRef(lastSaved);
+  lastSavedRef.current = lastSaved;
+  const localeRef = useRef(locale);
+  localeRef.current = locale;
 
-    const updateTime = () => {
-      setRelativeTime(formatVizelRelativeTime(lastSaved, locale));
-    };
+  useEffect(
+    () =>
+      createVizelRelativeTimeTicker({
+        getDate: () => lastSavedRef.current,
+        getLocale: () => localeRef.current,
+        onTick: setRelativeTime,
+      }),
+    []
+  );
 
-    updateTime();
-    const interval = setInterval(updateTime, 10000);
-
-    return () => clearInterval(interval);
-  }, [lastSaved, locale]);
-
-  const getStatusIcon = () => {
-    switch (status) {
-      case "saved":
-        return <VizelIcon name="check" />;
-      case "saving":
-        return (
-          <span className="vizel-save-indicator-spinner" aria-hidden="true">
-            <VizelIcon name="loader" />
-          </span>
-        );
-      case "unsaved":
-        return <VizelIcon name="circle" />;
-      case "error":
-        return <VizelIcon name="warning" />;
-      default:
-        return null;
-    }
-  };
-
-  const getStatusText = () => {
-    const t = locale?.saveIndicator;
-    switch (status) {
-      case "saved":
-        return t?.saved ?? "Saved";
-      case "saving":
-        return t?.saving ?? "Saving...";
-      case "unsaved":
-        return t?.unsaved ?? "Unsaved";
-      case "error":
-        return t?.error ?? "Error saving";
-      default:
-        return "";
-    }
-  };
-
-  const shouldShowTimestamp = showTimestamp && lastSaved && relativeTime && status === "saved";
+  const view = resolveVizelSaveIndicatorView(
+    status,
+    locale,
+    lastSaved,
+    relativeTime,
+    showTimestamp
+  );
 
   return (
     <div
@@ -99,10 +76,16 @@ export function VizelSaveIndicator({
       data-vizel-save-indicator
     >
       <span className="vizel-save-indicator-icon" aria-hidden="true">
-        {getStatusIcon()}
+        {view.isSpinner ? (
+          <span className="vizel-save-indicator-spinner" aria-hidden="true">
+            <VizelIcon name={view.iconName} />
+          </span>
+        ) : (
+          <VizelIcon name={view.iconName} />
+        )}
       </span>
-      <span className="vizel-save-indicator-text">{getStatusText()}</span>
-      {shouldShowTimestamp && (
+      <span className="vizel-save-indicator-text">{view.text}</span>
+      {view.shouldShowTimestamp && (
         <span className="vizel-save-indicator-timestamp">{relativeTime}</span>
       )}
     </div>

--- a/packages/svelte/src/components/VizelBubbleMenuColorPicker.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuColorPicker.svelte
@@ -21,7 +21,7 @@ export interface VizelBubbleMenuColorPickerProps {
 
 <script lang="ts">
 import {
-  addVizelRecentColor,
+  applyVizelColorToEditor,
   getVizelRecentColors,
   VIZEL_HIGHLIGHT_COLORS,
   VIZEL_TEXT_COLORS,
@@ -64,19 +64,7 @@ $effect(() => {
 });
 
 function handleColorChange(color: string) {
-  if (type === "textColor") {
-    if (color === "inherit") {
-      editor.chain().focus().unsetColor().run();
-    } else {
-      editor.chain().focus().setColor(color).run();
-      addVizelRecentColor(type, color);
-    }
-  } else if (color === "transparent") {
-    editor.chain().focus().unsetHighlight().run();
-  } else {
-    editor.chain().focus().toggleHighlight({ color }).run();
-    addVizelRecentColor(type, color);
-  }
+  applyVizelColorToEditor(editor, type, color);
   isOpen = false;
 }
 

--- a/packages/svelte/src/components/VizelEmbedView.svelte
+++ b/packages/svelte/src/components/VizelEmbedView.svelte
@@ -12,151 +12,90 @@ export interface VizelEmbedViewProps {
 </script>
 
 <script lang="ts">
+import { loadVizelEmbedScripts, resolveVizelEmbedView } from "@vizel/core";
 import VizelIcon from "./VizelIcon.svelte";
 
 let { data, class: className, selected = false }: VizelEmbedViewProps = $props();
 
 let containerRef: HTMLDivElement | null = $state(null);
 
+const view = $derived(resolveVizelEmbedView(data));
+
 const baseClass = $derived(
   `vizel-embed ${data.loading ? "is-loading" : ""} ${selected ? "ProseMirror-selectednode" : ""} ${className ?? ""}`
 );
 
-const isVideo = $derived(
-  ["youtube", "vimeo", "loom", "tiktok"].includes(data.provider ?? "")
-);
-
-const hasImage = $derived(Boolean(data.image));
-
-const hostname = $derived.by(() => {
-  try {
-    return new URL(data.url).hostname;
-  } catch {
-    return data.url;
-  }
-});
-
-// Handle oEmbed scripts
-function loadScripts() {
-  if (data.type === "oembed" && data.html && containerRef) {
-    const scripts = containerRef.querySelectorAll("script");
-    for (const script of scripts) {
-      const newScript = document.createElement("script");
-      if (script.src) {
-        newScript.src = script.src;
-      } else {
-        newScript.textContent = script.textContent;
-      }
-      script.parentNode?.replaceChild(newScript, script);
-    }
-
-    // Load Twitter widgets if present
-    if (data.provider === "twitter" && "twttr" in window) {
-      (window as { twttr?: { widgets?: { load?: () => void } } }).twttr?.widgets?.load?.();
-    }
-  }
-}
-
-// Load scripts on mount and when data changes
+// Re-parent any <script> tags so the browser executes them (innerHTML-inserted
+// scripts are inert). Runs again on every data change via $effect tracking.
 $effect(() => {
-  loadScripts();
+  if (view.kind === "oembed" && containerRef) {
+    loadVizelEmbedScripts(containerRef, view.provider);
+  }
 });
 </script>
 
-{#if data.loading}
-  <!-- Loading state -->
-  <div
-    class={baseClass}
-    data-embed-type="loading"
-    data-embed-provider={data.provider}
-  >
+{#if view.kind === "loading"}
+  <div class={baseClass} data-embed-type="loading" data-embed-provider={view.provider}>
     <div class="vizel-embed-loading">
       <div class="vizel-embed-loading-spinner"></div>
       <span>Loading embed...</span>
     </div>
   </div>
-{:else if data.type === "oembed" && data.html}
-  <!-- oEmbed (rich embed) -->
+{:else if view.kind === "oembed"}
   <div
     bind:this={containerRef}
     class={baseClass}
     data-embed-type="oembed"
-    data-embed-provider={data.provider}
+    data-embed-provider={view.provider}
   >
-    <div
-      class={isVideo ? "vizel-embed-video" : "vizel-embed-oembed"}
-    >
-      {@html data.html}
+    <div class={view.isVideo ? "vizel-embed-video" : "vizel-embed-oembed"}>
+      {@html view.html}
     </div>
   </div>
-{:else if data.type === "ogp"}
-  <!-- OGP card -->
-  <div
-    class={baseClass}
-    data-embed-type="ogp"
-    data-embed-provider={data.provider}
-  >
+{:else if view.kind === "ogp"}
+  <div class={baseClass} data-embed-type="ogp" data-embed-provider={view.provider}>
     <a
-      href={data.url}
+      href={view.url}
       target="_blank"
       rel="noopener noreferrer"
-      class="vizel-embed-card {hasImage ? 'vizel-embed-card-horizontal' : ''}"
+      class="vizel-embed-card {view.image ? 'vizel-embed-card-horizontal' : ''}"
     >
-      {#if hasImage}
-        <img
-          src={data.image}
-          alt=""
-          class="vizel-embed-card-image"
-          loading="lazy"
-        />
+      {#if view.image}
+        <img src={view.image} alt="" class="vizel-embed-card-image" loading="lazy" />
       {/if}
       <div class="vizel-embed-card-content">
-        {#if data.siteName || data.favicon}
+        {#if view.siteName || view.favicon}
           <div class="vizel-embed-card-site">
-            {#if data.favicon}
-              <img
-                src={data.favicon}
-                alt=""
-                class="vizel-embed-card-favicon"
-              />
+            {#if view.favicon}
+              <img src={view.favicon} alt="" class="vizel-embed-card-favicon" />
             {/if}
-            {#if data.siteName}
-              <span>{data.siteName}</span>
+            {#if view.siteName}
+              <span>{view.siteName}</span>
             {/if}
           </div>
         {/if}
-        {#if data.title}
-          <div class="vizel-embed-card-title">{data.title}</div>
+        {#if view.title}
+          <div class="vizel-embed-card-title">{view.title}</div>
         {/if}
-        {#if data.description}
-          <div class="vizel-embed-card-description">{data.description}</div>
+        {#if view.description}
+          <div class="vizel-embed-card-description">{view.description}</div>
         {/if}
-        <div class="vizel-embed-card-url">{hostname}</div>
+        <div class="vizel-embed-card-url">{view.hostname}</div>
       </div>
     </a>
   </div>
-{:else if data.type === "title" && data.title}
-  <!-- Title link -->
-  <div
-    class={baseClass}
-    data-embed-type="title"
-    data-embed-provider={data.provider}
-  >
-    <a href={data.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
+{:else if view.kind === "title"}
+  <div class={baseClass} data-embed-type="title" data-embed-provider={view.provider}>
+    <a href={view.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
       <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
-      <span class="vizel-embed-link-text">{data.title}</span>
+      <span class="vizel-embed-link-text">{view.title}</span>
     </a>
   </div>
 {:else}
-  <!-- Plain link (fallback) -->
-  <div
-    class={baseClass}
-    data-embed-type="link"
-    data-embed-provider={data.provider}
-  >
-    <a href={data.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
+  <div class={baseClass} data-embed-type="link" data-embed-provider={view.provider}>
+    <a href={view.url} target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
       <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
-      <span class="vizel-embed-link-text">{data.url}</span>
+      <span class="vizel-embed-link-text">{view.url}</span>
     </a>
   </div>
 {/if}

--- a/packages/svelte/src/components/VizelSaveIndicator.svelte
+++ b/packages/svelte/src/components/VizelSaveIndicator.svelte
@@ -16,7 +16,7 @@ export interface VizelSaveIndicatorProps {
 </script>
 
 <script lang="ts">
-import { formatVizelRelativeTime } from "@vizel/core";
+import { createVizelRelativeTimeTicker, resolveVizelSaveIndicatorView } from "@vizel/core";
 import VizelIcon from "./VizelIcon.svelte";
 
 let {
@@ -29,47 +29,19 @@ let {
 
 let relativeTime = $state("");
 
-function updateTime() {
-  if (lastSaved) {
-    relativeTime = formatVizelRelativeTime(lastSaved, locale);
-  } else {
-    relativeTime = "";
-  }
-}
+$effect(() =>
+  createVizelRelativeTimeTicker({
+    getDate: () => lastSaved,
+    getLocale: () => locale,
+    onTick: (text) => {
+      relativeTime = text;
+    },
+  })
+);
 
-$effect(() => {
-  updateTime();
-  const intervalId = setInterval(updateTime, 10000);
-
-  return () => {
-    clearInterval(intervalId);
-  };
-});
-
-// Watch lastSaved changes
-$effect(() => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  lastSaved;
-  updateTime();
-});
-
-const statusText = $derived.by(() => {
-  const t = locale?.saveIndicator;
-  switch (status) {
-    case "saved":
-      return t?.saved ?? "Saved";
-    case "saving":
-      return t?.saving ?? "Saving...";
-    case "unsaved":
-      return t?.unsaved ?? "Unsaved";
-    case "error":
-      return t?.error ?? "Error saving";
-    default:
-      return "";
-  }
-});
-
-const shouldShowTimestamp = $derived(showTimestamp && lastSaved && relativeTime && status === "saved");
+const view = $derived(
+  resolveVizelSaveIndicatorView(status, locale, lastSaved, relativeTime, showTimestamp)
+);
 </script>
 
 <div
@@ -80,20 +52,16 @@ const shouldShowTimestamp = $derived(showTimestamp && lastSaved && relativeTime 
   data-vizel-save-indicator
 >
   <span class="vizel-save-indicator-icon" aria-hidden="true">
-    {#if status === "saved"}
-      <VizelIcon name="check" />
-    {:else if status === "saving"}
+    {#if view.isSpinner}
       <span class="vizel-save-indicator-spinner" aria-hidden="true">
-        <VizelIcon name="loader" />
+        <VizelIcon name={view.iconName} />
       </span>
-    {:else if status === "unsaved"}
-      <VizelIcon name="circle" />
-    {:else if status === "error"}
-      <VizelIcon name="warning" />
+    {:else}
+      <VizelIcon name={view.iconName} />
     {/if}
   </span>
-  <span class="vizel-save-indicator-text">{statusText}</span>
-  {#if shouldShowTimestamp}
+  <span class="vizel-save-indicator-text">{view.text}</span>
+  {#if view.shouldShowTimestamp}
     <span class="vizel-save-indicator-timestamp">{relativeTime}</span>
   {/if}
 </div>

--- a/packages/vue/src/components/VizelBubbleMenuColorPicker.vue
+++ b/packages/vue/src/components/VizelBubbleMenuColorPicker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  addVizelRecentColor,
+  applyVizelColorToEditor,
   type Editor,
   getVizelRecentColors,
   VIZEL_HIGHLIGHT_COLORS,
@@ -61,19 +61,7 @@ watch(isOpen, (open) => {
 });
 
 function handleColorChange(color: string) {
-  if (props.type === "textColor") {
-    if (color === "inherit") {
-      props.editor.chain().focus().unsetColor().run();
-    } else {
-      props.editor.chain().focus().setColor(color).run();
-      addVizelRecentColor(props.type, color);
-    }
-  } else if (color === "transparent") {
-    props.editor.chain().focus().unsetHighlight().run();
-  } else {
-    props.editor.chain().focus().toggleHighlight({ color }).run();
-    addVizelRecentColor(props.type, color);
-  }
+  applyVizelColorToEditor(props.editor, props.type, color);
   isOpen.value = false;
 }
 

--- a/packages/vue/src/components/VizelEmbedView.vue
+++ b/packages/vue/src/components/VizelEmbedView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { VizelEmbedData } from "@vizel/core";
+import { loadVizelEmbedScripts, resolveVizelEmbedView, type VizelEmbedData } from "@vizel/core";
 import { computed, onMounted, ref, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -16,6 +16,8 @@ const props = defineProps<VizelEmbedViewProps>();
 
 const containerRef = ref<HTMLDivElement | null>(null);
 
+const view = computed(() => resolveVizelEmbedView(props.data));
+
 const baseClass = computed(() => {
   const classes = ["vizel-embed"];
   if (props.data.loading) classes.push("is-loading");
@@ -24,133 +26,88 @@ const baseClass = computed(() => {
   return classes.join(" ");
 });
 
-const isVideo = computed(() => {
-  return ["youtube", "vimeo", "loom", "tiktok"].includes(props.data.provider ?? "");
-});
-
-const hasImage = computed(() => Boolean(props.data.image));
-
-const hostname = computed(() => {
-  try {
-    return new URL(props.data.url).hostname;
-  } catch {
-    return props.data.url;
-  }
-});
-
-// Handle oEmbed scripts (Twitter, Instagram, etc.)
 function loadScripts() {
-  if (props.data.type === "oembed" && props.data.html && containerRef.value) {
-    const scripts = containerRef.value.querySelectorAll("script");
-    for (const script of scripts) {
-      const newScript = document.createElement("script");
-      if (script.src) {
-        newScript.src = script.src;
-      } else {
-        newScript.textContent = script.textContent;
-      }
-      script.parentNode?.replaceChild(newScript, script);
-    }
-
-    // Load Twitter widgets if present
-    if (props.data.provider === "twitter" && "twttr" in window) {
-      (window as { twttr?: { widgets?: { load?: () => void } } }).twttr?.widgets?.load?.();
-    }
+  if (view.value.kind === "oembed" && containerRef.value) {
+    loadVizelEmbedScripts(containerRef.value, view.value.provider);
   }
 }
 
 onMounted(loadScripts);
-watch(() => [props.data.type, props.data.html], loadScripts);
+watch(view, loadScripts);
 </script>
 
 <template>
-  <!-- Loading state -->
-  <div
-    v-if="data.loading"
-    :class="baseClass"
-    data-embed-type="loading"
-    :data-embed-provider="data.provider"
-  >
-    <div class="vizel-embed-loading">
-      <div class="vizel-embed-loading-spinner" />
-      <span>Loading embed...</span>
-    </div>
-  </div>
-
-  <!-- oEmbed (rich embed) -->
-  <div
-    v-else-if="data.type === 'oembed' && data.html"
-    ref="containerRef"
-    :class="baseClass"
-    data-embed-type="oembed"
-    :data-embed-provider="data.provider"
-  >
-    <div
-      :class="isVideo ? 'vizel-embed-video' : 'vizel-embed-oembed'"
-      v-html="data.html"
-    />
-  </div>
-
-  <!-- OGP card -->
-  <div
-    v-else-if="data.type === 'ogp'"
-    :class="baseClass"
-    data-embed-type="ogp"
-    :data-embed-provider="data.provider"
-  >
-    <a
-      :href="data.url"
-      target="_blank"
-      rel="noopener noreferrer"
-      :class="['vizel-embed-card', hasImage ? 'vizel-embed-card-horizontal' : '']"
-    >
-      <img
-        v-if="hasImage"
-        :src="data.image"
-        alt=""
-        class="vizel-embed-card-image"
-        loading="lazy"
-      />
-      <div class="vizel-embed-card-content">
-        <div v-if="data.siteName || data.favicon" class="vizel-embed-card-site">
-          <img
-            v-if="data.favicon"
-            :src="data.favicon"
-            alt=""
-            class="vizel-embed-card-favicon"
-          />
-          <span v-if="data.siteName">{{ data.siteName }}</span>
-        </div>
-        <div v-if="data.title" class="vizel-embed-card-title">{{ data.title }}</div>
-        <div v-if="data.description" class="vizel-embed-card-description">{{ data.description }}</div>
-        <div class="vizel-embed-card-url">{{ hostname }}</div>
+  <template v-if="view.kind === 'loading'">
+    <div :class="baseClass" data-embed-type="loading" :data-embed-provider="view.provider">
+      <div class="vizel-embed-loading">
+        <div class="vizel-embed-loading-spinner" />
+        <span>Loading embed...</span>
       </div>
-    </a>
-  </div>
+    </div>
+  </template>
 
-  <!-- Title link -->
-  <div
-    v-else-if="data.type === 'title' && data.title"
-    :class="baseClass"
-    data-embed-type="title"
-    :data-embed-provider="data.provider"
-  >
-    <a :href="data.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
-      <span class="vizel-embed-link-text">{{ data.title }}</span>
-    </a>
-  </div>
+  <template v-else-if="view.kind === 'oembed'">
+    <div
+      ref="containerRef"
+      :class="baseClass"
+      data-embed-type="oembed"
+      :data-embed-provider="view.provider"
+    >
+      <div
+        :class="view.isVideo ? 'vizel-embed-video' : 'vizel-embed-oembed'"
+        v-html="view.html"
+      />
+    </div>
+  </template>
 
-  <!-- Plain link (fallback) -->
-  <div
-    v-else
-    :class="baseClass"
-    data-embed-type="link"
-    :data-embed-provider="data.provider"
-  >
-    <a :href="data.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
-      <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
-      <span class="vizel-embed-link-text">{{ data.url }}</span>
-    </a>
-  </div>
+  <template v-else-if="view.kind === 'ogp'">
+    <div :class="baseClass" data-embed-type="ogp" :data-embed-provider="view.provider">
+      <a
+        :href="view.url"
+        target="_blank"
+        rel="noopener noreferrer"
+        :class="['vizel-embed-card', view.image ? 'vizel-embed-card-horizontal' : '']"
+      >
+        <img
+          v-if="view.image"
+          :src="view.image"
+          alt=""
+          class="vizel-embed-card-image"
+          loading="lazy"
+        />
+        <div class="vizel-embed-card-content">
+          <div v-if="view.siteName || view.favicon" class="vizel-embed-card-site">
+            <img
+              v-if="view.favicon"
+              :src="view.favicon"
+              alt=""
+              class="vizel-embed-card-favicon"
+            />
+            <span v-if="view.siteName">{{ view.siteName }}</span>
+          </div>
+          <div v-if="view.title" class="vizel-embed-card-title">{{ view.title }}</div>
+          <div v-if="view.description" class="vizel-embed-card-description">{{ view.description }}</div>
+          <div class="vizel-embed-card-url">{{ view.hostname }}</div>
+        </div>
+      </a>
+    </div>
+  </template>
+
+  <template v-else-if="view.kind === 'title'">
+    <div :class="baseClass" data-embed-type="title" :data-embed-provider="view.provider">
+      <a :href="view.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
+        <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
+        <span class="vizel-embed-link-text">{{ view.title }}</span>
+      </a>
+    </div>
+  </template>
+
+  <template v-else>
+    <div :class="baseClass" data-embed-type="link" :data-embed-provider="view.provider">
+      <a :href="view.url" target="_blank" rel="noopener noreferrer" class="vizel-embed-link">
+        <span class="vizel-embed-link-icon"><VizelIcon name="link" /></span>
+        <span class="vizel-embed-link-text">{{ view.url }}</span>
+      </a>
+    </div>
+  </template>
 </template>

--- a/packages/vue/src/components/VizelSaveIndicator.vue
+++ b/packages/vue/src/components/VizelSaveIndicator.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { formatVizelRelativeTime, type VizelLocale, type VizelSaveStatus } from "@vizel/core";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import {
+  createVizelRelativeTimeTicker,
+  resolveVizelSaveIndicatorView,
+  type VizelLocale,
+  type VizelSaveStatus,
+} from "@vizel/core";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelSaveIndicatorProps {
@@ -21,53 +26,32 @@ const props = withDefaults(defineProps<VizelSaveIndicatorProps>(), {
 });
 
 const relativeTime = ref("");
-let intervalId: ReturnType<typeof setInterval> | null = null;
-
-function updateTime() {
-  if (props.lastSaved) {
-    relativeTime.value = formatVizelRelativeTime(props.lastSaved, props.locale);
-  } else {
-    relativeTime.value = "";
-  }
-}
+let stopTicker: (() => void) | null = null;
 
 onMounted(() => {
-  updateTime();
-  intervalId = setInterval(updateTime, 10000);
+  stopTicker = createVizelRelativeTimeTicker({
+    getDate: () => props.lastSaved,
+    getLocale: () => props.locale,
+    onTick: (text) => {
+      relativeTime.value = text;
+    },
+  });
 });
-
-watch(
-  () => props.lastSaved,
-  () => {
-    updateTime();
-  }
-);
 
 onBeforeUnmount(() => {
-  if (intervalId) {
-    clearInterval(intervalId);
-  }
+  stopTicker?.();
+  stopTicker = null;
 });
 
-const statusText = computed(() => {
-  const t = props.locale?.saveIndicator;
-  switch (props.status) {
-    case "saved":
-      return t?.saved ?? "Saved";
-    case "saving":
-      return t?.saving ?? "Saving...";
-    case "unsaved":
-      return t?.unsaved ?? "Unsaved";
-    case "error":
-      return t?.error ?? "Error saving";
-    default:
-      return "";
-  }
-});
-
-const shouldShowTimestamp = computed(() => {
-  return props.showTimestamp && props.lastSaved && relativeTime.value && props.status === "saved";
-});
+const view = computed(() =>
+  resolveVizelSaveIndicatorView(
+    props.status,
+    props.locale,
+    props.lastSaved ?? null,
+    relativeTime.value,
+    props.showTimestamp
+  )
+);
 </script>
 
 <template>
@@ -79,22 +63,12 @@ const shouldShowTimestamp = computed(() => {
     data-vizel-save-indicator
   >
     <span class="vizel-save-indicator-icon" aria-hidden="true">
-      <template v-if="props.status === 'saved'">
-        <VizelIcon name="check" />
-      </template>
-      <template v-else-if="props.status === 'saving'">
-        <span class="vizel-save-indicator-spinner" aria-hidden="true">
-          <VizelIcon name="loader" />
-        </span>
-      </template>
-      <template v-else-if="props.status === 'unsaved'">
-        <VizelIcon name="circle" />
-      </template>
-      <template v-else-if="props.status === 'error'">
-        <VizelIcon name="warning" />
-      </template>
+      <span v-if="view.isSpinner" class="vizel-save-indicator-spinner" aria-hidden="true">
+        <VizelIcon :name="view.iconName" />
+      </span>
+      <VizelIcon v-else :name="view.iconName" />
     </span>
-    <span class="vizel-save-indicator-text">{{ statusText }}</span>
-    <span v-if="shouldShowTimestamp" class="vizel-save-indicator-timestamp">{{ relativeTime }}</span>
+    <span class="vizel-save-indicator-text">{{ view.text }}</span>
+    <span v-if="view.shouldShowTimestamp" class="vizel-save-indicator-timestamp">{{ relativeTime }}</span>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Lift three families of duplicated logic out of the per-framework
`VizelSaveIndicator`, `VizelBubbleMenuColorPicker`, and `VizelEmbedView`
components into `@vizel/core` so the framework packages stop carrying
identical copies of pure functions.

| ID | Helper | What moved |
|----|--------|-----------|
| **B13** | `createVizelRelativeTimeTicker` | 10-second `setInterval` + initial-emit + cleanup pair previously hand-coded in three SaveIndicators. |
| **B14** | `resolveVizelSaveIndicatorView` | Pure status → `{ iconName, isSpinner, text, shouldShowTimestamp }` resolver. Replaces a `switch` duplicated in both script and template across three frameworks. |
| **B25** | `applyVizelColorToEditor` | Color-apply logic (textColor vs highlight, `"inherit"`/`"transparent"` remove sentinels) — three identical copies collapse to one call. |
| **B26** | `loadVizelEmbedScripts` | Re-parents inert `<script>` tags from oEmbed HTML and triggers `twttr.widgets.load(container)` for Twitter embeds. |
| **C8** | `resolveVizelEmbedView` + `VizelEmbedViewModel` | Discriminated union resolver covering loading / oEmbed / OGP / title-link / plain-link branches. Hostname parsing (with try/catch fallback) also moves into core. |

Each helper is purely additive: no public-API changes, no behavior
changes. The framework components consume them and shed boilerplate.

`applyVizelColorToEditor` lives in `extensions/text-color.ts` next to
`addVizelRecentColor` to avoid an `extensions → utils` cycle.
`loadVizelEmbedScripts` / `resolveVizelEmbedView` live in
`extensions/embed.ts` alongside the `VizelEmbedData` type they consume.

## Test Plan

- [x] `pnpm lint` clean (pre-existing complexity warning unrelated).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None.
