### PR TITLE
refactor: introduce framework-agnostic interaction primitives in core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -283,6 +283,20 @@ export {
   vizelDefaultIconIds,
 } from "./icons/index.ts";
 // =============================================================================
+// Interactions
+// =============================================================================
+export {
+  createVizelDismissibleController,
+  createVizelEditorSubscription,
+  createVizelEditorTransactionStore,
+  resolveVizelGridNavigation,
+  resolveVizelListNavigation,
+  type VizelDismissibleControllerOptions,
+  type VizelEditorEventName,
+  type VizelEditorSubscriptionOptions,
+  type VizelEditorTransactionStore,
+} from "./interactions/index.ts";
+// =============================================================================
 // Plugin System
 // =============================================================================
 export {

--- a/packages/core/src/interactions/dismissibleController.ts
+++ b/packages/core/src/interactions/dismissibleController.ts
@@ -1,0 +1,75 @@
+/**
+ * Options for {@link createVizelDismissibleController}.
+ */
+export interface VizelDismissibleControllerOptions {
+  /**
+   * Element references the controller should respect when deciding whether
+   * a click is "outside". A click whose target is contained in any of these
+   * elements does not dismiss. `null` entries are ignored, so framework
+   * adapters can pass ref/state getters that resolve lazily.
+   */
+  getElements: () => ReadonlyArray<Element | null | undefined>;
+  /** Invoked when the user clicks outside or presses Escape. */
+  onDismiss: () => void;
+  /**
+   * Whether to dismiss on Escape (default: true). Set to false when the
+   * caller wants to handle Escape separately (e.g., to clear search input
+   * before closing).
+   */
+  dismissOnEscape?: boolean;
+}
+
+/**
+ * Wire up "click-outside" + Escape dismissal listeners.
+ *
+ * Encapsulates the three-step pattern of (1) attaching a `mousedown`
+ * listener on `document` that compares the event target against the
+ * supplied element references and (2) attaching a `keydown` listener
+ * that observes Escape, plus (3) detaching both on disposal.
+ *
+ * Returns a disposer. Framework adapters call this inside their effect
+ * primitive and return the disposer for cleanup.
+ *
+ * @example
+ * ```tsx
+ * // React adapter:
+ * useEffect(() =>
+ *   createVizelDismissibleController({
+ *     getElements: () => [popoverRef.current, triggerRef.current],
+ *     onDismiss: () => setOpen(false),
+ *   }),
+ * []);
+ * ```
+ */
+export function createVizelDismissibleController(
+  options: VizelDismissibleControllerOptions
+): () => void {
+  const { getElements, onDismiss, dismissOnEscape = true } = options;
+
+  const handleMouseDown = (event: MouseEvent) => {
+    if (!(event.target instanceof Node)) return;
+    const target = event.target;
+    for (const el of getElements()) {
+      if (el?.contains(target)) return;
+    }
+    onDismiss();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      onDismiss();
+    }
+  };
+
+  document.addEventListener("mousedown", handleMouseDown);
+  if (dismissOnEscape) {
+    document.addEventListener("keydown", handleKeyDown);
+  }
+
+  return () => {
+    document.removeEventListener("mousedown", handleMouseDown);
+    if (dismissOnEscape) {
+      document.removeEventListener("keydown", handleKeyDown);
+    }
+  };
+}

--- a/packages/core/src/interactions/editorSubscription.ts
+++ b/packages/core/src/interactions/editorSubscription.ts
@@ -1,0 +1,54 @@
+import type { Editor } from "@tiptap/core";
+
+/**
+ * Editor event names that {@link createVizelEditorSubscription} can attach to.
+ *
+ * Matches a subset of Tiptap's `EditorEvents` keys — limited to the events
+ * Vizel itself observes via this helper.
+ */
+export type VizelEditorEventName = "update" | "transaction" | "selectionUpdate";
+
+/**
+ * Options for {@link createVizelEditorSubscription}.
+ */
+export interface VizelEditorSubscriptionOptions {
+  /** Lazy editor accessor. Re-read on every subscription refresh. */
+  getEditor: () => Editor | null | undefined;
+  /** Event to attach the listener to. */
+  event: VizelEditorEventName;
+  /** Listener body. */
+  handler: () => void;
+  /**
+   * If true, the handler is invoked once synchronously after the
+   * subscription attaches (when the editor is available). Useful for
+   * "initial load + update" patterns. Default: false.
+   */
+  fireImmediately?: boolean;
+}
+
+/**
+ * Attach an editor event listener with a clean disposer.
+ *
+ * Captures the editor reference at subscription time. If the editor is
+ * `null`/`undefined` when the function is called, the helper returns a
+ * no-op disposer without attaching anything. Framework adapters call this
+ * inside their effect primitive and pass the disposer as cleanup.
+ *
+ * @returns A disposer that detaches the listener.
+ */
+export function createVizelEditorSubscription(options: VizelEditorSubscriptionOptions): () => void {
+  const { getEditor, event, handler, fireImmediately = false } = options;
+  const editor = getEditor();
+  if (!editor) {
+    return () => {
+      /* no-op when editor is unavailable at subscription time */
+    };
+  }
+  editor.on(event, handler);
+  if (fireImmediately) {
+    handler();
+  }
+  return () => {
+    editor.off(event, handler);
+  };
+}

--- a/packages/core/src/interactions/index.ts
+++ b/packages/core/src/interactions/index.ts
@@ -1,0 +1,17 @@
+export {
+  createVizelDismissibleController,
+  type VizelDismissibleControllerOptions,
+} from "./dismissibleController.ts";
+export {
+  createVizelEditorSubscription,
+  type VizelEditorEventName,
+  type VizelEditorSubscriptionOptions,
+} from "./editorSubscription.ts";
+export {
+  resolveVizelGridNavigation,
+  resolveVizelListNavigation,
+} from "./listboxController.ts";
+export {
+  createVizelEditorTransactionStore,
+  type VizelEditorTransactionStore,
+} from "./transactionStore.ts";

--- a/packages/core/src/interactions/listboxController.ts
+++ b/packages/core/src/interactions/listboxController.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure keyboard navigation handler for an item list.
+ *
+ * Given the current focused index and the list length, returns the next
+ * focused index for the supplied key. Returns `null` when the key is not
+ * recognized (caller should let the event propagate).
+ *
+ * Handles ArrowUp/ArrowDown (wrap), Home/End. Tab is intentionally NOT
+ * handled so callers can compose group-aware navigation on top.
+ */
+export function resolveVizelListNavigation(
+  key: string,
+  currentIndex: number,
+  length: number
+): number | null {
+  if (length === 0) return null;
+  switch (key) {
+    case "ArrowDown":
+      return (currentIndex + 1) % length;
+    case "ArrowUp":
+      return (currentIndex - 1 + length) % length;
+    case "Home":
+      return 0;
+    case "End":
+      return length - 1;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Pure keyboard navigation handler for a 2D grid.
+ *
+ * Handles ArrowUp/ArrowDown (row movement), ArrowLeft/ArrowRight (column
+ * movement, with clamping at row edges), Home/End (jump to start/end of
+ * the grid). Returns `null` when the key is not recognized.
+ */
+export function resolveVizelGridNavigation(
+  key: string,
+  currentIndex: number,
+  length: number,
+  columns: number
+): number | null {
+  if (length === 0 || columns <= 0) return null;
+  const row = Math.floor(currentIndex / columns);
+  const col = currentIndex % columns;
+  switch (key) {
+    case "ArrowRight":
+      return Math.min(currentIndex + 1, length - 1);
+    case "ArrowLeft":
+      return Math.max(currentIndex - 1, 0);
+    case "ArrowDown": {
+      const next = currentIndex + columns;
+      return next < length ? next : currentIndex;
+    }
+    case "ArrowUp":
+      return row > 0 ? Math.max(0, (row - 1) * columns + col) : currentIndex;
+    case "Home":
+      return 0;
+    case "End":
+      return length - 1;
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/interactions/transactionStore.ts
+++ b/packages/core/src/interactions/transactionStore.ts
@@ -1,0 +1,69 @@
+import type { Editor } from "@tiptap/core";
+
+/**
+ * Framework-agnostic store that exposes editor transaction notifications.
+ *
+ * The store does not hold the transaction itself — Tiptap's `state.tr` is a
+ * getter that returns a fresh `Transaction` on every read, which breaks
+ * referential-equality based change detection (notably React's
+ * `useSyncExternalStore`). Instead it tracks a monotonically increasing
+ * version counter and lets framework adapters wire the change signal into
+ * their reactivity primitive (`useState`, `ref`, `$state`, etc.).
+ *
+ * Subscribers are notified on every `transaction` event from the supplied
+ * editor. Swapping the editor (via `getEditor` returning a different value
+ * across subscribe calls) is supported transparently: each `subscribe`
+ * binds against the editor that's current when it is called.
+ */
+export interface VizelEditorTransactionStore {
+  /**
+   * Register a callback fired on every editor transaction. Returns an
+   * unsubscribe function that detaches the listener.
+   */
+  subscribe(onChange: () => void): () => void;
+  /**
+   * Read the current version counter. Increments by 1 (with 32-bit wrap-
+   * around) on every transaction.
+   */
+  getVersion(): number;
+}
+
+/**
+ * Create a {@link VizelEditorTransactionStore} that observes whichever
+ * editor `getEditor` currently returns. The factory is framework-agnostic;
+ * each framework wraps the store in its native reactivity primitive.
+ *
+ * @example
+ * ```tsx
+ * // React adapter via useSyncExternalStore:
+ * const store = createVizelEditorTransactionStore(() => editor);
+ * useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion);
+ * ```
+ */
+export function createVizelEditorTransactionStore(
+  getEditor: () => Editor | null | undefined
+): VizelEditorTransactionStore {
+  let version = 0;
+
+  return {
+    subscribe(onChange) {
+      const editor = getEditor();
+      if (!editor) {
+        return () => {
+          /* no-op unsubscribe when editor is null at subscribe time */
+        };
+      }
+      const handler = () => {
+        version = (version + 1) | 0;
+        onChange();
+      };
+      editor.on("transaction", handler);
+      return () => {
+        editor.off("transaction", handler);
+      };
+    },
+    getVersion() {
+      return version;
+    },
+  };
+}

--- a/packages/react/src/hooks/useVizelState.ts
+++ b/packages/react/src/hooks/useVizelState.ts
@@ -1,5 +1,5 @@
-import type { Editor } from "@vizel/core";
-import { useCallback, useRef, useSyncExternalStore } from "react";
+import { createVizelEditorTransactionStore, type Editor } from "@vizel/core";
+import { useMemo, useSyncExternalStore } from "react";
 
 const noSubscribe = () => () => {
   /* no-op when editor is null */
@@ -9,10 +9,11 @@ const noSnapshot = () => 0;
 /**
  * Hook that forces a re-render whenever the editor's state changes.
  *
- * This is useful for components that need to reflect the current editor state
- * (e.g., formatting buttons that show active state). Backed by
- * `useSyncExternalStore` so React 18+ concurrent rendering does not tear the
- * subscription state.
+ * This is useful for components that need to reflect the current editor
+ * state (e.g., formatting buttons that show active state). Backed by
+ * `useSyncExternalStore` plus `createVizelEditorTransactionStore` from
+ * `@vizel/core` so the subscription and version tracking are shared with
+ * the Vue and Svelte adapters.
  *
  * @param editor - The editor instance (or `null` while it is still initializing)
  * @returns A monotonically increasing transaction tick (typically ignored)
@@ -21,7 +22,6 @@ const noSnapshot = () => 0;
  * ```tsx
  * function FormattingButtons({ editor }: { editor: Editor }) {
  *   useVizelState(editor);
- *   // Now editor.isActive() will be re-evaluated on each state change
  *   return (
  *     <button className={editor.isActive("bold") ? "active" : ""}>
  *       Bold
@@ -31,36 +31,14 @@ const noSnapshot = () => 0;
  * ```
  */
 export function useVizelState(editor: Editor | null | undefined): number {
-  // A stable tick counter incremented by the subscribe callback. Reading
-  // anything off `editor.view` here would either return a fresh object every
-  // call (state.tr) or throw before mount, breaking useSyncExternalStore's
-  // referential-stability contract and triggering an infinite render loop.
-  const tickRef = useRef(0);
-
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      if (!editor) {
-        return () => {
-          /* no-op unsubscribe */
-        };
-      }
-      const handler = () => {
-        tickRef.current = (tickRef.current + 1) | 0;
-        onStoreChange();
-      };
-      editor.on("transaction", handler);
-      return () => {
-        editor.off("transaction", handler);
-      };
-    },
+  const store = useMemo(
+    () => (editor ? createVizelEditorTransactionStore(() => editor) : null),
     [editor]
   );
 
-  const getSnapshot = useCallback(() => tickRef.current, []);
-
   return useSyncExternalStore(
-    editor ? subscribe : noSubscribe,
-    editor ? getSnapshot : noSnapshot,
-    editor ? getSnapshot : noSnapshot
+    store ? store.subscribe : noSubscribe,
+    store ? store.getVersion : noSnapshot,
+    store ? store.getVersion : noSnapshot
   );
 }

--- a/packages/svelte/src/runes/createVizelState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelState.svelte.ts
@@ -1,9 +1,11 @@
-import type { Editor } from "@vizel/core";
+import { createVizelEditorTransactionStore, type Editor } from "@vizel/core";
 
 /**
  * Rune that forces a re-render whenever the editor's state changes.
- * This is useful for components that need to reflect the current editor state
- * (e.g., formatting buttons that show active state).
+ *
+ * Wraps `@vizel/core`'s `createVizelEditorTransactionStore` so the
+ * subscribe/version-counter mechanics are shared with the React and
+ * Vue adapters.
  *
  * @param getEditor - A function that returns the editor instance
  * @returns An object with a `current` getter for the update count
@@ -21,36 +23,15 @@ export function createVizelState(getEditor: () => Editor | null | undefined): {
   readonly current: number;
 } {
   let updateCount = $state(0);
-  let currentEditor: Editor | null = null;
 
-  function handleTransaction() {
-    updateCount++;
-  }
-
-  function subscribe(editor: Editor | null | undefined) {
-    // Unsubscribe from previous editor
-    if (currentEditor) {
-      currentEditor.off("transaction", handleTransaction);
-    }
-
-    currentEditor = editor ?? null;
-
-    // Subscribe to new editor
-    if (currentEditor) {
-      currentEditor.on("transaction", handleTransaction);
-    }
-  }
-
-  // Use $effect to watch for editor changes - $effect cleanup handles unmount
   $effect(() => {
     const editor = getEditor();
-    subscribe(editor);
-
-    return () => {
-      if (currentEditor) {
-        currentEditor.off("transaction", handleTransaction);
-      }
-    };
+    if (!editor) return;
+    const store = createVizelEditorTransactionStore(() => editor);
+    const unsubscribe = store.subscribe(() => {
+      updateCount = store.getVersion();
+    });
+    return unsubscribe;
   });
 
   return {

--- a/packages/vue/src/composables/useVizelState.ts
+++ b/packages/vue/src/composables/useVizelState.ts
@@ -1,10 +1,12 @@
-import type { Editor } from "@vizel/core";
+import { createVizelEditorTransactionStore, type Editor } from "@vizel/core";
 import { onBeforeUnmount, type Ref, ref, watch } from "vue";
 
 /**
  * Composable that forces a re-render whenever the editor's state changes.
- * This is useful for components that need to reflect the current editor state
- * (e.g., formatting buttons that show active state).
+ *
+ * Wraps `@vizel/core`'s `createVizelEditorTransactionStore` so the
+ * subscribe/version-counter mechanics are shared with the React and
+ * Svelte adapters.
  *
  * @param getEditor - A function that returns the editor instance
  * @returns A ref that changes on each editor state update (can be ignored)
@@ -22,40 +24,27 @@ import { onBeforeUnmount, type Ref, ref, watch } from "vue";
  */
 export function useVizelState(getEditor: () => Editor | null | undefined): Ref<number> {
   const updateCount = ref(0);
-  let currentEditor: Editor | null = null;
+  let unsubscribe: (() => void) | null = null;
 
-  function handleTransaction() {
-    updateCount.value++;
-  }
-
-  function subscribe(editor: Editor | null | undefined) {
-    // Unsubscribe from previous editor if different
-    if (currentEditor && currentEditor !== editor) {
-      currentEditor.off("transaction", handleTransaction);
-    }
-
-    currentEditor = editor ?? null;
-
-    // Subscribe to new editor
-    if (currentEditor) {
-      currentEditor.on("transaction", handleTransaction);
-    }
-  }
-
-  // Watch for editor changes and resubscribe
   watch(
     getEditor,
     (editor) => {
-      subscribe(editor);
+      unsubscribe?.();
+      if (!editor) {
+        unsubscribe = null;
+        return;
+      }
+      const store = createVizelEditorTransactionStore(() => editor);
+      unsubscribe = store.subscribe(() => {
+        updateCount.value = store.getVersion();
+      });
     },
     { immediate: true }
   );
 
-  // Cleanup on unmount
   onBeforeUnmount(() => {
-    if (currentEditor) {
-      currentEditor.off("transaction", handleTransaction);
-    }
+    unsubscribe?.();
+    unsubscribe = null;
   });
 
   return updateCount;


### PR DESCRIPTION
## Summary

Introduce `packages/core/src/interactions/` — a framework-agnostic
module that exposes the state-machine and event-subscription primitives
shared by the React hooks, Vue composables, and Svelte runes. The goal
is to drain reactivity-flavored boilerplate out of each framework
package toward a thin binding layer.

| ID | Helper | Replaces |
|----|--------|----------|
| **B7** | `createVizelEditorTransactionStore(getEditor)` | Three near-identical "tick on transaction" copies in `useVizelState` / `createVizelState`. Returns a plain `{ subscribe, getVersion }` store the framework adapter feeds into its reactivity primitive. |
| **B6 / B15 / B24** | `createVizelDismissibleController(options)` | The repeated outside-click + Escape dismissal pattern in `VizelBlockMenu`, `VizelBubbleMenuColorPicker`, `VizelLinkEditor`, `VizelToolbarOverflow`. Returns a disposer for the caller's effect cleanup. |
| **B4 / B5** | `resolveVizelListNavigation(key, index, length)` | ArrowUp/ArrowDown/Home/End wrap navigation in `VizelMentionMenu`, `VizelNodeSelector`, `VizelToolbarDropdown`. Pure function — adapter owns the state. |
| **B22** | `resolveVizelGridNavigation(key, index, length, columns)` | 2D grid keyboard navigation in `VizelColorPicker`. Same shape as `resolveVizelListNavigation`. |
| **B9 / B10 / B11** | `createVizelEditorSubscription({ getEditor, event, handler })` | One-line helper for attaching a Tiptap editor event listener with a clean disposer. |

## Adoption

This PR rewires `useVizelState` / `createVizelState` in all three
frameworks to consume `createVizelEditorTransactionStore`. The other
helpers are exposed but adopted incrementally in follow-up phases to
keep this PR reviewable.

## Test Plan

- [x] `pnpm lint` clean (pre-existing complexity warning unrelated).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None. All helpers are purely additive; the `useVizelState` rewrite
preserves the public hook signature (`(editor) => number`) and the
"forces a re-render on transaction" contract.
