### PR TITLE
refactor(mention): consume resolveVizelListNavigation in mention menu

### DIFF
--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -1,4 +1,4 @@
-import type { VizelMentionItem } from "@vizel/core";
+import { resolveVizelListNavigation, type VizelMentionItem } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 
@@ -64,33 +64,20 @@ export function VizelMentionMenu({
     [items, onSelect]
   );
 
-  const upHandler = useCallback(() => {
-    setSelectedIndex((index) => (index + items.length - 1) % items.length);
-  }, [items.length]);
-
-  const downHandler = useCallback(() => {
-    setSelectedIndex((index) => (index + 1) % items.length);
-  }, [items.length]);
-
   const enterHandler = useCallback(() => {
     selectItem(selectedIndex);
   }, [selectItem, selectedIndex]);
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
-      if (event.key === "ArrowUp") {
-        upHandler();
-        return true;
-      }
-      if (event.key === "ArrowDown") {
-        downHandler();
-        return true;
-      }
       if (event.key === "Enter") {
         enterHandler();
         return true;
       }
-      return false;
+      const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
+      if (next === null) return false;
+      setSelectedIndex(next);
+      return true;
     },
   }));
 

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -22,6 +22,7 @@ export interface VizelMentionMenuProps {
 </script>
 
 <script lang="ts">
+import { resolveVizelListNavigation } from "@vizel/core";
 import { tick } from "svelte";
 
 let {
@@ -64,21 +65,15 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "ArrowUp") {
-    selectedIndex = (selectedIndex + items.length - 1) % items.length;
-    scrollToSelected();
-    return true;
-  }
-  if (event.key === "ArrowDown") {
-    selectedIndex = (selectedIndex + 1) % items.length;
-    scrollToSelected();
-    return true;
-  }
   if (event.key === "Enter") {
     selectItem(selectedIndex);
     return true;
   }
-  return false;
+  const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
+  if (next === null) return false;
+  selectedIndex = next;
+  scrollToSelected();
+  return true;
 }
 
 // Expose the keyboard handler through the optional ref prop so suggestion

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { VizelMentionItem } from "@vizel/core";
+import { resolveVizelListNavigation, type VizelMentionItem } from "@vizel/core";
 import { nextTick, ref, watch } from "vue";
 
 export interface VizelMentionMenuRef {
@@ -45,21 +45,15 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "ArrowUp") {
-    selectedIndex.value = (selectedIndex.value + props.items.length - 1) % props.items.length;
-    scrollToSelected();
-    return true;
-  }
-  if (event.key === "ArrowDown") {
-    selectedIndex.value = (selectedIndex.value + 1) % props.items.length;
-    scrollToSelected();
-    return true;
-  }
   if (event.key === "Enter") {
     selectItem(selectedIndex.value);
     return true;
   }
-  return false;
+  const next = resolveVizelListNavigation(event.key, selectedIndex.value, props.items.length);
+  if (next === null) return false;
+  selectedIndex.value = next;
+  scrollToSelected();
+  return true;
 }
 
 defineExpose<VizelMentionMenuRef>({ onKeyDown });


### PR DESCRIPTION
## Summary

Adopt `resolveVizelListNavigation` (introduced in the previous Phase 4
PR) inside the three `VizelMentionMenu` components so they share a
single source of truth for keyboard navigation behavior (ArrowUp /
ArrowDown / Home / End / wrap semantics).

Each component now delegates the navigation decision to the resolver
and only owns:
- The Enter-to-select action.
- The scroll-into-view side effect after the index moves.

Behavior is unchanged: identical keys are handled, identical wrapping
behavior is preserved.

## Why MentionMenu only?

`SlashMenu` retains its current implementation because its
Tab-to-next-group handler still requires component-local group
awareness. Lifting that into a richer controller is planned alongside
the eventual UI skeletonization (which will treat the menu structure
itself as a core-provided spec).

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None. The mention menu ref shape and keyboard contract are unchanged.
