### PR TITLE
docs(guide): replace VizelPortal container prop with layer

### DIFF
--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -372,13 +372,21 @@ This component displays the save status.
 
 ### VizelPortal
 
-This component renders children in a portal.
+Render children outside the editor's DOM hierarchy, into the shared Vizel portal container at the document body level. Used internally for menus, dropdowns, and bubble menus so floating UI stacks correctly above the editor content.
 
 ```tsx
-<VizelPortal container={document.body}>
+<VizelPortal layer="dropdown">
   <div className="my-overlay">Content</div>
 </VizelPortal>
 ```
+
+Props:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `layer` | `VizelPortalLayer` | `"dropdown"` | Z-index layer (`"dropdown"`, `"popover"`, `"modal"`, `"toast"`). |
+| `className` | `string` | — | Class applied to the portal wrapper element. |
+| `disabled` | `boolean` | `false` | When `true`, renders children in place (no portal). Useful for SSR / debugging. |
 
 ### VizelIcon
 

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -352,13 +352,21 @@ This component displays the save status.
 
 ### VizelPortal
 
-This component renders children in a portal.
+Render children outside the editor's DOM hierarchy, into the shared Vizel portal container at the document body level. Used internally for menus, dropdowns, and bubble menus so floating UI stacks correctly above the editor content.
 
 ```svelte
-<VizelPortal container={document.body}>
+<VizelPortal layer="dropdown">
   <div class="my-overlay">Content</div>
 </VizelPortal>
 ```
+
+Props:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `layer` | `VizelPortalLayer` | `"dropdown"` | Z-index layer (`"dropdown"`, `"popover"`, `"modal"`, `"toast"`). |
+| `class` | `string` | — | Class applied to the portal wrapper element. |
+| `disabled` | `boolean` | `false` | When `true`, renders children in place (no portal). Useful for SSR / debugging. |
 
 ### VizelIcon
 

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -383,13 +383,21 @@ This component displays the save status.
 
 ### VizelPortal
 
-This component renders children in a portal.
+Render children outside the editor's DOM hierarchy, into the shared Vizel portal container at the document body level. Used internally for menus, dropdowns, and bubble menus so floating UI stacks correctly above the editor content.
 
 ```vue
-<VizelPortal :container="document.body">
+<VizelPortal layer="dropdown">
   <div class="my-overlay">Content</div>
 </VizelPortal>
 ```
+
+Props:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `layer` | `VizelPortalLayer` | `"dropdown"` | Z-index layer (`"dropdown"`, `"popover"`, `"modal"`, `"toast"`). |
+| `class` | `string` | — | Class applied to the portal wrapper element. |
+| `disabled` | `boolean` | `false` | When `true`, renders children in place (no portal). Useful for SSR / debugging. |
 
 ### VizelIcon
 


### PR DESCRIPTION
## Summary

The published `VizelPortal` component in every framework exposes
`layer` (z-index slot), `class` / `className`, and `disabled` — it
does NOT accept a `container` prop. The three framework guides
showed a fictional `<VizelPortal container={document.body}>`
example that would typecheck-fail and steered consumers toward the
wrong API.

This PR:
- Replaces the example with `layer="dropdown"` in all three guides
  (React, Vue, Svelte).
- Adds the full props table (`layer`, `class`/`className`,
  `disabled`) so the documented surface matches the implementation.

Refs: M11, L11 from the v2.x audit.

## Test Plan

- [x] Docs only — `pnpm lint` / `typecheck` / `build` unaffected.