### PR TITLE
fix(a11y): give VizelMentionMenu container proper listbox semantics

### DIFF
--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -89,13 +89,24 @@ export function VizelMentionMenu({
     );
   }
 
+  const activeOptionId = items[selectedIndex]
+    ? `vizel-mention-${items[selectedIndex].id}`
+    : undefined;
+
   return (
-    <div className={`vizel-mention-menu ${className ?? ""}`} data-vizel-mention-menu="">
+    <div
+      className={`vizel-mention-menu ${className ?? ""}`}
+      data-vizel-mention-menu=""
+      role="listbox"
+      aria-label="Mentions"
+      {...(activeOptionId && { "aria-activedescendant": activeOptionId })}
+    >
       {items.map((item, index) => {
         const isSelected = index === selectedIndex;
         return (
           <div
             key={item.id}
+            id={`vizel-mention-${item.id}`}
             ref={(el) => {
               itemRefs.current[index] = el;
             }}

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -87,12 +87,20 @@ if (ref) {
 }
 </script>
 
-<div class="vizel-mention-menu {className ?? ''}" data-vizel-mention-menu>
+<!-- svelte-ignore a11y_aria_activedescendant_has_tabindex -->
+<div
+  class="vizel-mention-menu {className ?? ''}"
+  data-vizel-mention-menu
+  role="listbox"
+  aria-label="Mentions"
+  aria-activedescendant={items[selectedIndex]?.id ? `vizel-mention-${items[selectedIndex]?.id}` : undefined}
+>
   {#if items.length === 0}
     <div class="vizel-mention-menu-empty">No results</div>
   {:else}
     {#each items as item, index (item.id)}
       <div
+        id="vizel-mention-{item.id}"
         bind:this={itemRefs[index]}
         class="vizel-mention-menu-item {index === selectedIndex ? 'is-selected' : ''}"
         role="option"

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { resolveVizelListNavigation, type VizelMentionItem } from "@vizel/core";
-import { nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 export interface VizelMentionMenuRef {
   onKeyDown: (event: KeyboardEvent) => boolean;
@@ -19,6 +19,11 @@ const emit = defineEmits<{
 
 const selectedIndex = ref(0);
 const itemRefs = ref<(HTMLElement | null)[]>([]);
+
+const activeOptionId = computed(() => {
+  const item = props.items[selectedIndex.value];
+  return item ? `vizel-mention-${item.id}` : undefined;
+});
 
 watch(
   () => props.items,
@@ -63,6 +68,9 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
   <div
     :class="['vizel-mention-menu', props.class]"
     data-vizel-mention-menu
+    role="listbox"
+    aria-label="Mentions"
+    :aria-activedescendant="activeOptionId"
   >
     <div v-if="items.length === 0" class="vizel-mention-menu-empty">
       No results
@@ -71,6 +79,7 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
       <div
         v-for="(item, index) in items"
         :key="item.id"
+        :id="`vizel-mention-${item.id}`"
         :ref="(el) => { itemRefs[index] = el as HTMLElement | null }"
         :class="['vizel-mention-menu-item', { 'is-selected': index === selectedIndex }]"
         role="option"


### PR DESCRIPTION
## Summary

`role="option"` items inside `VizelMentionMenu` were nested in a plain
`<div>` with no `role="listbox"`, so the WAI-ARIA combobox/listbox
pattern was broken. Screen readers could not announce the active
option or count the mention candidates.

Add to the container in all three frameworks:
- `role="listbox"`
- `aria-label="Mentions"`
- `aria-activedescendant` pointing at the keyboard-selected option's
  stable id (`vizel-mention-{itemId}`)

Each option gains an `id` matching the activedescendant target.

Refs: L12 from the v2.x audit.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None.