### PR TITLE
refactor: extract mountVizelEditorView to core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -394,6 +394,7 @@ export {
   isVizelValidHexColor,
   type MenuPosition,
   mountToVizelPortal,
+  mountVizelEditorView,
   normalizeVizelHexColor,
   parseVizelMarkdown,
   registerVizelUploadEventHandler,

--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -7,6 +7,36 @@ import type { VizelSlashCommandItem } from "../extensions/slash-command.ts";
 import type { VizelEditorState, VizelFeatureOptions, VizelImageFeatureOptions } from "../types.ts";
 
 /**
+ * Mount a Tiptap editor's `view.dom` into a container element and return a
+ * disposer that removes it.
+ *
+ * Each framework's `VizelEditor` component previously hand-wrote the same
+ * three-step pattern:
+ *
+ * 1. `container.appendChild(editor.view.dom)`
+ * 2. `editor.view.setProps({ editable: () => editor.isEditable })`
+ * 3. Cleanup that removes the DOM only if it is still parented to `container`
+ *    (so swapping the editor or container does not yank a node that has
+ *    already been re-parented elsewhere).
+ *
+ * Lifting this into core keeps the three adapters as thin lifecycle wrappers
+ * and ensures behavior parity across React, Vue, and Svelte.
+ *
+ * @returns A disposer that detaches the editor view from the container.
+ */
+export function mountVizelEditorView(editor: Editor, container: HTMLElement): () => void {
+  container.appendChild(editor.view.dom);
+  editor.view.setProps({
+    editable: () => editor.isEditable,
+  });
+  return () => {
+    if (editor.view.dom.parentNode === container) {
+      container.removeChild(editor.view.dom);
+    }
+  };
+}
+
+/**
  * JSON content type for Tiptap documents
  */
 export interface VizelContentNode {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -12,6 +12,7 @@ export {
   convertVizelCodeBlocksToDiagrams,
   createVizelUploadEventHandler,
   getVizelEditorState,
+  mountVizelEditorView,
   registerVizelUploadEventHandler,
   resolveVizelFeatures,
   transformVizelDiagramCodeBlocks,

--- a/packages/react/src/components/VizelEditor.tsx
+++ b/packages/react/src/components/VizelEditor.tsx
@@ -1,4 +1,4 @@
-import type { Editor } from "@vizel/core";
+import { type Editor, mountVizelEditorView } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useEffect, useImperativeHandle, useRef } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
@@ -54,24 +54,8 @@ export function VizelEditor({ ref, editor: editorProp, className }: VizelEditorP
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!(editor && container)) {
-      return;
-    }
-
-    // Mount the editor's DOM view to the container element
-    container.appendChild(editor.view.dom);
-
-    // Update editable state
-    editor.view.setProps({
-      editable: () => editor?.isEditable ?? false,
-    });
-
-    // Cleanup: remove DOM element when editor changes or unmounts
-    return () => {
-      if (editor.view.dom.parentNode === container) {
-        container.removeChild(editor.view.dom);
-      }
-    };
+    if (!(editor && container)) return;
+    return mountVizelEditorView(editor, container);
   }, [editor]);
 
   if (!editor) {

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -22,6 +22,7 @@ export interface VizelEditorProps {
 </script>
 
 <script lang="ts">
+import { mountVizelEditorView } from "@vizel/core";
 import { getVizelContextSafe } from "./VizelContext.js";
 
 let { editor: editorProp, class: className, ref }: VizelEditorProps = $props();
@@ -39,27 +40,8 @@ $effect(() => {
 });
 
 $effect(() => {
-  if (!editor || !element) {
-    return;
-  }
-
-  const currentEditor = editor;
-  const currentElement = element;
-
-  // Mount the editor's DOM view to the container element
-  currentElement.appendChild(currentEditor.view.dom);
-
-  // Update editable state
-  currentEditor.view.setProps({
-    editable: () => currentEditor?.isEditable ?? false,
-  });
-
-  // Cleanup: remove DOM element when editor changes or unmounts
-  return () => {
-    if (currentEditor.view.dom.parentNode === currentElement) {
-      currentElement.removeChild(currentEditor.view.dom);
-    }
-  };
+  if (!editor || !element) return;
+  return mountVizelEditorView(editor, element);
 });
 </script>
 

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Editor } from "@vizel/core";
-import { computed, ref, watch } from "vue";
+import { type Editor, mountVizelEditorView } from "@vizel/core";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
 export interface VizelEditorProps {
@@ -28,31 +28,24 @@ defineExpose<VizelExposed>({
   },
 });
 
+let dispose: (() => void) | null = null;
+
 watch(
   () => [resolvedEditor.value, containerRef.value] as const,
-  (
-    [editorValue, container],
-    oldValue?: readonly [Editor | null | undefined, HTMLDivElement | null]
-  ) => {
-    // Cleanup: remove DOM from previous container if editor or container changed
-    const prevEditor = oldValue?.[0];
-    const prevContainer = oldValue?.[1];
-    if (prevEditor && prevContainer && prevEditor.view.dom.parentNode === prevContainer) {
-      prevContainer.removeChild(prevEditor.view.dom);
-    }
-
+  ([editorValue, container]) => {
+    dispose?.();
+    dispose = null;
     if (editorValue && container) {
-      // Mount the editor's DOM view to the container element
-      container.appendChild(editorValue.view.dom);
-
-      // Update editable state
-      editorValue.view.setProps({
-        editable: () => editorValue?.isEditable ?? false,
-      });
+      dispose = mountVizelEditorView(editorValue, container);
     }
   },
   { immediate: true }
 );
+
+onBeforeUnmount(() => {
+  dispose?.();
+  dispose = null;
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Lift the three-step "mount editor view into container" pattern from
each framework's `VizelEditor` component into `mountVizelEditorView` in
`@vizel/core`.

The three adapters used to hand-write:

1. `container.appendChild(editor.view.dom)`
2. `editor.view.setProps({ editable: () => editor.isEditable })`
3. A cleanup that re-parents the node only when it is still inside the
   original container (so swapping the editor or container does not
   yank a DOM node that has already moved elsewhere)

`mountVizelEditorView(editor, container)` now owns all three steps and
returns the disposer the React `useEffect` / Vue `watch` / Svelte
`$effect` simply hands back to their cleanup hook. Behavior is
unchanged; the framework components shrink to one-line bindings.

Refs: B17 from the v2.x architecture audit.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None.