### PR TITLE
refactor: lift bubble-menu action list into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -328,12 +328,17 @@ export {
 // Toolbar
 // =============================================================================
 export {
+  createVizelBubbleMenuActions,
   createVizelToolbarActions,
+  filterVizelBubbleMenuActions,
+  groupVizelBubbleMenuActions,
   groupVizelToolbarActions,
   isVizelToolbarDropdownAction,
+  type VizelBubbleMenuAction,
   type VizelToolbarAction,
   type VizelToolbarActionItem,
   type VizelToolbarDropdownAction,
+  vizelDefaultBubbleMenuActions,
   vizelDefaultToolbarActions,
 } from "./toolbar/index.ts";
 // =============================================================================

--- a/packages/core/src/toolbar/actions.ts
+++ b/packages/core/src/toolbar/actions.ts
@@ -264,3 +264,179 @@ export function groupVizelToolbarActions(
 ): VizelToolbarActionItem[][] {
   return groupByConsecutiveField(actions, "group");
 }
+
+// =============================================================================
+// Bubble menu actions
+// =============================================================================
+
+/**
+ * A single bubble-menu action definition.
+ *
+ * Similar to {@link VizelToolbarAction} but specialised for the inline
+ * bubble menu surface: bound to a Tiptap mark name, with a tooltip
+ * shortcut and an optional extension-name precondition (so actions
+ * tied to extensions a consumer hasn't enabled don't show up).
+ */
+export interface VizelBubbleMenuAction {
+  /** Unique action identifier (stable across locale changes). */
+  id: string;
+  /** Localized label (used for `title` / `aria-label`). */
+  label: string;
+  /** Icon name from the Vizel icon system. */
+  icon: VizelIconName;
+  /** Group identifier for visual separation (dividers between groups). */
+  group: string;
+  /** Returns true when the action is currently applied to the selection. */
+  isActive: (editor: Editor) => boolean;
+  /** Executes the toggle command. */
+  run: (editor: Editor) => void;
+  /** Keyboard shortcut label for the tooltip (e.g. `"Mod+B"`). */
+  shortcut: string;
+  /**
+   * If set, the action is only emitted when an extension with this name
+   * is registered on the editor. Lets `superscript` / `subscript` opt
+   * out cleanly when the consumer didn't enable those features.
+   */
+  requiresExtension?: string;
+}
+
+const VIZEL_BUBBLE_MENU_DEFAULT_ACTIONS = [
+  {
+    id: "bold",
+    label: "Bold",
+    icon: "bold",
+    group: "marks",
+    isActive: (editor) => editor.isActive("bold"),
+    run: (editor) => editor.chain().focus().toggleBold().run(),
+    shortcut: "Mod+B",
+  },
+  {
+    id: "italic",
+    label: "Italic",
+    icon: "italic",
+    group: "marks",
+    isActive: (editor) => editor.isActive("italic"),
+    run: (editor) => editor.chain().focus().toggleItalic().run(),
+    shortcut: "Mod+I",
+  },
+  {
+    id: "strike",
+    label: "Strikethrough",
+    icon: "strikethrough",
+    group: "marks",
+    isActive: (editor) => editor.isActive("strike"),
+    run: (editor) => editor.chain().focus().toggleStrike().run(),
+    shortcut: "Mod+Shift+S",
+  },
+  {
+    id: "underline",
+    label: "Underline",
+    icon: "underline",
+    group: "marks",
+    isActive: (editor) => editor.isActive("underline"),
+    run: (editor) => editor.chain().focus().toggleUnderline().run(),
+    shortcut: "Mod+U",
+  },
+  {
+    id: "code",
+    label: "Code",
+    icon: "code",
+    group: "marks",
+    isActive: (editor) => editor.isActive("code"),
+    run: (editor) => editor.chain().focus().toggleCode().run(),
+    shortcut: "Mod+E",
+  },
+  {
+    id: "superscript",
+    label: "Superscript",
+    icon: "superscript",
+    group: "marks",
+    isActive: (editor) => editor.isActive("superscript"),
+    run: (editor) => editor.chain().focus().toggleSuperscript().run(),
+    shortcut: "Cmd+.",
+    requiresExtension: "superscript",
+  },
+  {
+    id: "subscript",
+    label: "Subscript",
+    icon: "subscript",
+    group: "marks",
+    isActive: (editor) => editor.isActive("subscript"),
+    run: (editor) => editor.chain().focus().toggleSubscript().run(),
+    shortcut: "Cmd+,",
+    requiresExtension: "subscript",
+  },
+  {
+    id: "link",
+    label: "Link",
+    icon: "link",
+    group: "link",
+    isActive: (editor) => editor.isActive("link"),
+    // The `run` for "link" intentionally doesn't toggle the mark — clicking
+    // the bubble-menu link button opens the link editor. Frameworks override
+    // this in their component to drive their own modal state. Provided here
+    // so consumers iterating the list have a stable id and label.
+    run: () => {
+      /* overridden by VizelBubbleMenuDefault to open the link editor */
+    },
+    shortcut: "Mod+K",
+  },
+] as const satisfies readonly VizelBubbleMenuAction[];
+
+/** Default bubble-menu actions, locale-resolved. */
+export const vizelDefaultBubbleMenuActions: readonly VizelBubbleMenuAction[] =
+  VIZEL_BUBBLE_MENU_DEFAULT_ACTIONS;
+
+/**
+ * Create bubble-menu actions with locale-specific labels.
+ *
+ * Mirrors {@link createVizelToolbarActions}. Consumers that want to add or
+ * filter actions can `.filter` / `.concat` on the returned array; the
+ * built-in set is exposed as `vizelDefaultBubbleMenuActions` for the
+ * pure-default case.
+ *
+ * `locale` is optional — when `undefined`, the actions keep their built-in
+ * English labels (suitable for components that allow consumers to omit a
+ * locale entirely).
+ */
+export function createVizelBubbleMenuActions(locale?: VizelLocale): VizelBubbleMenuAction[] {
+  if (!locale) return vizelDefaultBubbleMenuActions.map((action) => ({ ...action }));
+  const labels: Record<string, string> = {
+    bold: locale.bubbleMenu.bold,
+    italic: locale.bubbleMenu.italic,
+    strike: locale.bubbleMenu.strikethrough,
+    underline: locale.bubbleMenu.underline,
+    code: locale.bubbleMenu.code,
+    superscript: locale.bubbleMenu.superscript,
+    subscript: locale.bubbleMenu.subscript,
+    link: locale.bubbleMenu.link,
+  };
+  return vizelDefaultBubbleMenuActions.map((action) => ({
+    ...action,
+    label: labels[action.id] ?? action.label,
+  }));
+}
+
+/**
+ * Filter bubble-menu actions down to the ones whose `requiresExtension`
+ * precondition is satisfied by the supplied editor. Returns the original
+ * list when no actions declare a precondition.
+ */
+export function filterVizelBubbleMenuActions(
+  actions: readonly VizelBubbleMenuAction[],
+  editor: Editor
+): VizelBubbleMenuAction[] {
+  return actions.filter((action) => {
+    if (!action.requiresExtension) return true;
+    return editor.extensionManager.extensions.some((ext) => ext.name === action.requiresExtension);
+  });
+}
+
+/**
+ * Group bubble-menu actions by their group identifier for visual separation.
+ */
+export function groupVizelBubbleMenuActions(
+  actions: readonly VizelBubbleMenuAction[]
+): VizelBubbleMenuAction[][] {
+  return groupByConsecutiveField(actions, "group");
+}

--- a/packages/core/src/toolbar/index.ts
+++ b/packages/core/src/toolbar/index.ts
@@ -1,9 +1,14 @@
 export {
+  createVizelBubbleMenuActions,
   createVizelToolbarActions,
+  filterVizelBubbleMenuActions,
+  groupVizelBubbleMenuActions,
   groupVizelToolbarActions,
   isVizelToolbarDropdownAction,
+  type VizelBubbleMenuAction,
   type VizelToolbarAction,
   type VizelToolbarActionItem,
   type VizelToolbarDropdownAction,
+  vizelDefaultBubbleMenuActions,
   vizelDefaultToolbarActions,
 } from "./actions.ts";

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -1,5 +1,13 @@
-import { type Editor, formatVizelTooltip, type VizelLocale } from "@vizel/core";
-import { useState } from "react";
+import {
+  createVizelBubbleMenuActions,
+  type Editor,
+  filterVizelBubbleMenuActions,
+  formatVizelTooltip,
+  groupVizelBubbleMenuActions,
+  type VizelBubbleMenuAction,
+  type VizelLocale,
+} from "@vizel/core";
+import { useMemo, useState } from "react";
 import { useVizelState } from "../hooks/useVizelState.ts";
 import { VizelBubbleMenuButton } from "./VizelBubbleMenuButton.tsx";
 import { VizelBubbleMenuColorPicker } from "./VizelBubbleMenuColorPicker.tsx";
@@ -19,14 +27,11 @@ export interface VizelBubbleMenuDefaultProps {
 
 /**
  * The default menu content for VizelBubbleMenu.
- * Provides formatting buttons for bold, italic, strikethrough, code, and link.
  *
- * @example
- * ```tsx
- * <VizelBubbleMenu>
- *   <VizelBubbleMenuDefault editor={editor} />
- * </VizelBubbleMenu>
- * ```
+ * Renders an iterated list of mark-toggle buttons driven by
+ * `createVizelBubbleMenuActions` from `@vizel/core`. The `link` action
+ * is plucked out and rendered specially because its activation opens the
+ * link editor instead of running a Tiptap command.
  */
 export function VizelBubbleMenuDefault({
   editor,
@@ -34,9 +39,19 @@ export function VizelBubbleMenuDefault({
   enableEmbed,
   locale,
 }: VizelBubbleMenuDefaultProps) {
-  // Subscribe to editor state changes to update active states
+  // Subscribe to editor state changes so isActive() reflects the latest state.
   useVizelState(editor);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
+
+  const { markGroups, linkAction } = useMemo(() => {
+    const all = filterVizelBubbleMenuActions(createVizelBubbleMenuActions(locale), editor);
+    const link = all.find((a) => a.id === "link");
+    const marks = all.filter((a) => a.id !== "link");
+    return {
+      markGroups: groupVizelBubbleMenuActions(marks),
+      linkAction: link,
+    };
+  }, [locale, editor]);
 
   if (showLinkEditor) {
     return (
@@ -49,82 +64,42 @@ export function VizelBubbleMenuDefault({
     );
   }
 
+  const renderAction = (action: VizelBubbleMenuAction) => (
+    <VizelBubbleMenuButton
+      key={action.id}
+      action={action.id}
+      onClick={() => action.run(editor)}
+      isActive={action.isActive(editor)}
+      title={formatVizelTooltip(action.label, action.shortcut)}
+    >
+      <VizelIcon name={action.icon} />
+    </VizelBubbleMenuButton>
+  );
+
   return (
     <div className={`vizel-bubble-menu-toolbar ${className ?? ""}`}>
       <VizelNodeSelector editor={editor} />
       <VizelBubbleMenuDivider />
-      <VizelBubbleMenuButton
-        action="bold"
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        isActive={editor.isActive("bold")}
-        title={formatVizelTooltip(locale?.bubbleMenu?.bold ?? "Bold", "Mod+B")}
-      >
-        <VizelIcon name="bold" />
-      </VizelBubbleMenuButton>
-      <VizelBubbleMenuButton
-        action="italic"
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        isActive={editor.isActive("italic")}
-        title={formatVizelTooltip(locale?.bubbleMenu?.italic ?? "Italic", "Mod+I")}
-      >
-        <VizelIcon name="italic" />
-      </VizelBubbleMenuButton>
-      <VizelBubbleMenuButton
-        action="strike"
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        isActive={editor.isActive("strike")}
-        title={formatVizelTooltip(
-          locale?.bubbleMenu?.strikethrough ?? "Strikethrough",
-          "Mod+Shift+S"
-        )}
-      >
-        <VizelIcon name="strikethrough" />
-      </VizelBubbleMenuButton>
-      <VizelBubbleMenuButton
-        action="underline"
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
-        isActive={editor.isActive("underline")}
-        title={formatVizelTooltip(locale?.bubbleMenu?.underline ?? "Underline", "Mod+U")}
-      >
-        <VizelIcon name="underline" />
-      </VizelBubbleMenuButton>
-      <VizelBubbleMenuButton
-        action="code"
-        onClick={() => editor.chain().focus().toggleCode().run()}
-        isActive={editor.isActive("code")}
-        title={formatVizelTooltip(locale?.bubbleMenu?.code ?? "Code", "Mod+E")}
-      >
-        <VizelIcon name="code" />
-      </VizelBubbleMenuButton>
-      {editor.extensionManager.extensions.some((ext) => ext.name === "superscript") && (
-        <VizelBubbleMenuButton
-          action="superscript"
-          onClick={() => editor.chain().focus().toggleSuperscript().run()}
-          isActive={editor.isActive("superscript")}
-          title={formatVizelTooltip(locale?.bubbleMenu?.superscript ?? "Superscript", "Cmd+.")}
-        >
-          <VizelIcon name="superscript" />
-        </VizelBubbleMenuButton>
+      {markGroups.map((group, groupIndex) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: groups are derived from the stable action list whose ordering is fixed at locale resolution time
+        <div key={`group-${groupIndex}`} style={{ display: "contents" }}>
+          {groupIndex > 0 && <VizelBubbleMenuDivider />}
+          {group.map(renderAction)}
+        </div>
+      ))}
+      {linkAction && (
+        <>
+          <VizelBubbleMenuDivider />
+          <VizelBubbleMenuButton
+            action={linkAction.id}
+            onClick={() => setShowLinkEditor(true)}
+            isActive={linkAction.isActive(editor)}
+            title={formatVizelTooltip(linkAction.label, linkAction.shortcut)}
+          >
+            <VizelIcon name={linkAction.icon} />
+          </VizelBubbleMenuButton>
+        </>
       )}
-      {editor.extensionManager.extensions.some((ext) => ext.name === "subscript") && (
-        <VizelBubbleMenuButton
-          action="subscript"
-          onClick={() => editor.chain().focus().toggleSubscript().run()}
-          isActive={editor.isActive("subscript")}
-          title={formatVizelTooltip(locale?.bubbleMenu?.subscript ?? "Subscript", "Cmd+,")}
-        >
-          <VizelIcon name="subscript" />
-        </VizelBubbleMenuButton>
-      )}
-      <VizelBubbleMenuDivider />
-      <VizelBubbleMenuButton
-        action="link"
-        onClick={() => setShowLinkEditor(true)}
-        isActive={editor.isActive("link")}
-        title={formatVizelTooltip(locale?.bubbleMenu?.link ?? "Link", "Mod+K")}
-      >
-        <VizelIcon name="link" />
-      </VizelBubbleMenuButton>
       <VizelBubbleMenuDivider />
       <VizelBubbleMenuColorPicker
         editor={editor}

--- a/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
@@ -14,7 +14,12 @@ export interface VizelBubbleMenuDefaultProps {
 </script>
 
 <script lang="ts">
-import { formatVizelTooltip } from "@vizel/core";
+import {
+  createVizelBubbleMenuActions,
+  filterVizelBubbleMenuActions,
+  formatVizelTooltip,
+  groupVizelBubbleMenuActions,
+} from "@vizel/core";
 import { createVizelState } from "../runes/createVizelState.svelte.js";
 import VizelBubbleMenuButton from "./VizelBubbleMenuButton.svelte";
 import VizelBubbleMenuColorPicker from "./VizelBubbleMenuColorPicker.svelte";
@@ -26,45 +31,27 @@ import VizelNodeSelector from "./VizelNodeSelector.svelte";
 let { editor, class: className, enableEmbed, locale }: VizelBubbleMenuDefaultProps = $props();
 let showLinkEditor = $state(false);
 
-// Subscribe to editor state changes to update active states
+// Subscribe to editor state changes so derived isActive flags refresh.
 const editorState = createVizelState(() => editor);
 
-// Create derived values that depend on editorState.current to trigger re-renders
-const isBoldActive = $derived.by(() => {
-  void editorState.current; // Trigger reactivity
-  return editor.isActive("bold");
-});
-const isItalicActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("italic");
-});
-const isStrikeActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("strike");
-});
-const isUnderlineActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("underline");
-});
-const isCodeActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("code");
-});
-const isLinkActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("link");
-});
-const isSuperscriptActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("superscript");
-});
-const isSubscriptActive = $derived.by(() => {
-  void editorState.current;
-  return editor.isActive("subscript");
-});
+const filteredActions = $derived(
+  filterVizelBubbleMenuActions(createVizelBubbleMenuActions(locale), editor)
+);
+const linkAction = $derived(filteredActions.find((a) => a.id === "link"));
+const markGroups = $derived(
+  groupVizelBubbleMenuActions(filteredActions.filter((a) => a.id !== "link"))
+);
 
-const hasSuperscript = $derived(editor.extensionManager.extensions.some((ext) => ext.name === "superscript"));
-const hasSubscript = $derived(editor.extensionManager.extensions.some((ext) => ext.name === "subscript"));
+// Reading `editorState.current` inside the derived isActive map registers the
+// version counter as a tracked dependency so re-renders happen on every
+// selection change. The value itself is discarded.
+const isActive = $derived.by(() => {
+  void editorState.current;
+  return (actionId: string): boolean => {
+    const action = filteredActions.find((a) => a.id === actionId);
+    return action ? action.isActive(editor) : false;
+  };
+});
 </script>
 
 {#if showLinkEditor}
@@ -73,75 +60,30 @@ const hasSubscript = $derived(editor.extensionManager.extensions.some((ext) => e
   <div class="vizel-bubble-menu-toolbar {className ?? ''}">
     <VizelNodeSelector {editor} />
     <VizelBubbleMenuDivider />
-    <VizelBubbleMenuButton
-      action="bold"
-      isActive={isBoldActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.bold ?? "Bold", "Mod+B")}
-      onclick={() => editor.chain().focus().toggleBold().run()}
-    >
-      <VizelIcon name="bold" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="italic"
-      isActive={isItalicActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.italic ?? "Italic", "Mod+I")}
-      onclick={() => editor.chain().focus().toggleItalic().run()}
-    >
-      <VizelIcon name="italic" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="strike"
-      isActive={isStrikeActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.strikethrough ?? "Strikethrough", "Mod+Shift+S")}
-      onclick={() => editor.chain().focus().toggleStrike().run()}
-    >
-      <VizelIcon name="strikethrough" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="underline"
-      isActive={isUnderlineActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.underline ?? "Underline", "Mod+U")}
-      onclick={() => editor.chain().focus().toggleUnderline().run()}
-    >
-      <VizelIcon name="underline" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="code"
-      isActive={isCodeActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.code ?? "Code", "Mod+E")}
-      onclick={() => editor.chain().focus().toggleCode().run()}
-    >
-      <VizelIcon name="code" />
-    </VizelBubbleMenuButton>
-    {#if hasSuperscript}
+    {#each markGroups as group, groupIndex (groupIndex)}
+      {#if groupIndex > 0}<VizelBubbleMenuDivider />{/if}
+      {#each group as action (action.id)}
+        <VizelBubbleMenuButton
+          action={action.id}
+          isActive={isActive(action.id)}
+          title={formatVizelTooltip(action.label, action.shortcut)}
+          onclick={() => action.run(editor)}
+        >
+          <VizelIcon name={action.icon} />
+        </VizelBubbleMenuButton>
+      {/each}
+    {/each}
+    {#if linkAction}
+      <VizelBubbleMenuDivider />
       <VizelBubbleMenuButton
-        action="superscript"
-        isActive={isSuperscriptActive}
-        title={formatVizelTooltip(locale?.bubbleMenu?.superscript ?? "Superscript", "Cmd+.")}
-        onclick={() => editor.chain().focus().toggleSuperscript().run()}
+        action={linkAction.id}
+        isActive={isActive(linkAction.id)}
+        title={formatVizelTooltip(linkAction.label, linkAction.shortcut)}
+        onclick={() => (showLinkEditor = true)}
       >
-        <VizelIcon name="superscript" />
+        <VizelIcon name={linkAction.icon} />
       </VizelBubbleMenuButton>
     {/if}
-    {#if hasSubscript}
-      <VizelBubbleMenuButton
-        action="subscript"
-        isActive={isSubscriptActive}
-        title={formatVizelTooltip(locale?.bubbleMenu?.subscript ?? "Subscript", "Cmd+,")}
-        onclick={() => editor.chain().focus().toggleSubscript().run()}
-      >
-        <VizelIcon name="subscript" />
-      </VizelBubbleMenuButton>
-    {/if}
-    <VizelBubbleMenuDivider />
-    <VizelBubbleMenuButton
-      action="link"
-      isActive={isLinkActive}
-      title={formatVizelTooltip(locale?.bubbleMenu?.link ?? "Link", "Mod+K")}
-      onclick={() => (showLinkEditor = true)}
-    >
-      <VizelIcon name="link" />
-    </VizelBubbleMenuButton>
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuColorPicker {editor} type="textColor" {...(locale ? { locale } : {})} />
     <VizelBubbleMenuColorPicker {editor} type="highlight" {...(locale ? { locale } : {})} />

--- a/packages/vue/src/components/VizelBubbleMenuDefault.vue
+++ b/packages/vue/src/components/VizelBubbleMenuDefault.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { type Editor, formatVizelTooltip, type VizelLocale } from "@vizel/core";
+import {
+  createVizelBubbleMenuActions,
+  type Editor,
+  filterVizelBubbleMenuActions,
+  formatVizelTooltip,
+  groupVizelBubbleMenuActions,
+  type VizelLocale,
+} from "@vizel/core";
 import { computed, ref } from "vue";
 import { useVizelState } from "../composables/useVizelState.ts";
 import VizelBubbleMenuButton from "./VizelBubbleMenuButton.vue";
@@ -22,49 +29,27 @@ export interface VizelBubbleMenuDefaultProps {
 
 const props = defineProps<VizelBubbleMenuDefaultProps>();
 
-// Subscribe to editor state changes to update active states
+// Subscribe to editor state changes so derived isActive flags refresh.
 const editorStateVersion = useVizelState(() => props.editor);
 
-// Create computed properties that depend on editorStateVersion to trigger re-renders
-const isBoldActive = computed(() => {
-  void editorStateVersion.value; // Trigger reactivity
-  return props.editor.isActive("bold");
-});
-const isItalicActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("italic");
-});
-const isStrikeActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("strike");
-});
-const isUnderlineActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("underline");
-});
-const isCodeActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("code");
-});
-const isLinkActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("link");
-});
-const isSuperscriptActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("superscript");
-});
-const isSubscriptActive = computed(() => {
-  void editorStateVersion.value;
-  return props.editor.isActive("subscript");
-});
+const filteredActions = computed(() =>
+  filterVizelBubbleMenuActions(createVizelBubbleMenuActions(props.locale), props.editor)
+);
+const linkAction = computed(() => filteredActions.value.find((a) => a.id === "link"));
+const markGroups = computed(() =>
+  groupVizelBubbleMenuActions(filteredActions.value.filter((a) => a.id !== "link"))
+);
 
-const hasSuperscript = computed(() =>
-  props.editor.extensionManager.extensions.some((ext) => ext.name === "superscript")
-);
-const hasSubscript = computed(() =>
-  props.editor.extensionManager.extensions.some((ext) => ext.name === "subscript")
-);
+// `isActive` reads from the editor state; tying it to `editorStateVersion`
+// (a Ref that ticks on every transaction) is what triggers a re-render when
+// the selection changes. The value itself is discarded.
+const isActive = computed(() => {
+  void editorStateVersion.value;
+  return (actionId: string) => {
+    const action = filteredActions.value.find((a) => a.id === actionId);
+    return action ? action.isActive(props.editor) : false;
+  };
+});
 
 const showLinkEditor = ref(false);
 </script>
@@ -80,73 +65,30 @@ const showLinkEditor = ref(false);
   <div v-else :class="['vizel-bubble-menu-toolbar', $props.class]">
     <VizelNodeSelector :editor="props.editor" />
     <VizelBubbleMenuDivider />
-    <VizelBubbleMenuButton
-      action="bold"
-      :is-active="isBoldActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.bold ?? 'Bold', 'Mod+B')"
-      @click="props.editor.chain().focus().toggleBold().run()"
-    >
-      <VizelIcon name="bold" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="italic"
-      :is-active="isItalicActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.italic ?? 'Italic', 'Mod+I')"
-      @click="props.editor.chain().focus().toggleItalic().run()"
-    >
-      <VizelIcon name="italic" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="strike"
-      :is-active="isStrikeActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.strikethrough ?? 'Strikethrough', 'Mod+Shift+S')"
-      @click="props.editor.chain().focus().toggleStrike().run()"
-    >
-      <VizelIcon name="strikethrough" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="underline"
-      :is-active="isUnderlineActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.underline ?? 'Underline', 'Mod+U')"
-      @click="props.editor.chain().focus().toggleUnderline().run()"
-    >
-      <VizelIcon name="underline" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      action="code"
-      :is-active="isCodeActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.code ?? 'Code', 'Mod+E')"
-      @click="props.editor.chain().focus().toggleCode().run()"
-    >
-      <VizelIcon name="code" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      v-if="hasSuperscript"
-      action="superscript"
-      :is-active="isSuperscriptActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.superscript ?? 'Superscript', 'Cmd+.')"
-      @click="props.editor.chain().focus().toggleSuperscript().run()"
-    >
-      <VizelIcon name="superscript" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuButton
-      v-if="hasSubscript"
-      action="subscript"
-      :is-active="isSubscriptActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.subscript ?? 'Subscript', 'Cmd+,')"
-      @click="props.editor.chain().focus().toggleSubscript().run()"
-    >
-      <VizelIcon name="subscript" />
-    </VizelBubbleMenuButton>
-    <VizelBubbleMenuDivider />
-    <VizelBubbleMenuButton
-      action="link"
-      :is-active="isLinkActive"
-      :title="formatVizelTooltip(props.locale?.bubbleMenu?.link ?? 'Link', 'Mod+K')"
-      @click="showLinkEditor = true"
-    >
-      <VizelIcon name="link" />
-    </VizelBubbleMenuButton>
+    <template v-for="(group, groupIndex) in markGroups" :key="`group-${groupIndex}`">
+      <VizelBubbleMenuDivider v-if="groupIndex > 0" />
+      <VizelBubbleMenuButton
+        v-for="action in group"
+        :key="action.id"
+        :action="action.id"
+        :is-active="isActive(action.id)"
+        :title="formatVizelTooltip(action.label, action.shortcut)"
+        @click="action.run(props.editor)"
+      >
+        <VizelIcon :name="action.icon" />
+      </VizelBubbleMenuButton>
+    </template>
+    <template v-if="linkAction">
+      <VizelBubbleMenuDivider />
+      <VizelBubbleMenuButton
+        :action="linkAction.id"
+        :is-active="isActive(linkAction.id)"
+        :title="formatVizelTooltip(linkAction.label, linkAction.shortcut)"
+        @click="showLinkEditor = true"
+      >
+        <VizelIcon :name="linkAction.icon" />
+      </VizelBubbleMenuButton>
+    </template>
     <VizelBubbleMenuDivider />
     <VizelBubbleMenuColorPicker :editor="props.editor" type="textColor" v-bind="props.locale ? { locale: props.locale } : {}" />
     <VizelBubbleMenuColorPicker :editor="props.editor" type="highlight" v-bind="props.locale ? { locale: props.locale } : {}" />


### PR DESCRIPTION
## Summary

Add `createVizelBubbleMenuActions(locale)` to `@vizel/core/toolbar`,
mirroring the existing `createVizelToolbarActions` shape. The helper
returns a `readonly VizelBubbleMenuAction[]` with `id`, `label`,
`icon`, `group`, `shortcut`, `isActive(editor)`, `run(editor)`, plus
an optional `requiresExtension` precondition.

Two siblings handle the rest:

- `filterVizelBubbleMenuActions(actions, editor)` — drops actions
  whose declared extension is absent (so superscript/subscript opt
  out cleanly when those extensions aren't loaded)
- `groupVizelBubbleMenuActions(actions)` — visual grouping for
  dividers between groups

## Result

The three framework `VizelBubbleMenuDefault` components collapse from
~150 lines of repeated buttons (eight identical
`editor.chain().focus().toggleX().run()` callbacks, eight identical
`editor.isActive('x')` derives, two `extensionManager.extensions.some(...)`
checks) to a small iteration over the action list.

The `link` action is plucked out and rendered specially because its
activation opens the in-bubble link editor instead of running a Tiptap
command. No visual or behavioral changes.

Refs: B21, B28 from the v2.x architecture audit.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None — the bubble-menu surface (buttons rendered, order, behaviors) is
unchanged from a consumer's perspective. Power users that wired into
internal exports gain a stable typed surface via the new
`VizelBubbleMenuAction` type and `createVizelBubbleMenuActions`
helper.
