### PR TITLE
refactor(svelte): convert provider context to { get current() } accessor

### DIFF
--- a/packages/svelte/src/components/VizelBlockMenu.svelte
+++ b/packages/svelte/src/components/VizelBlockMenu.svelte
@@ -51,7 +51,7 @@ let {
 }: VizelBlockMenuProps = $props();
 
 const contextEditor = getVizelContextSafe();
-const boundEditor = $derived<Editor | null>(editorProp ?? contextEditor?.() ?? null);
+const boundEditor = $derived<Editor | null>(editorProp ?? contextEditor?.current ?? null);
 
 const effectiveActions = $derived(actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions));
 const effectiveNodeTypes = $derived(nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes));

--- a/packages/svelte/src/components/VizelBubbleMenu.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenu.svelte
@@ -43,7 +43,7 @@ let {
 }: VizelBubbleMenuProps = $props();
 
 const contextEditor = getVizelContextSafe();
-const editor = $derived(editorProp ?? contextEditor?.());
+const editor = $derived(editorProp ?? contextEditor?.current);
 
 let menuElement = $state<HTMLElement | null>(null);
 

--- a/packages/svelte/src/components/VizelContext.ts
+++ b/packages/svelte/src/components/VizelContext.ts
@@ -4,7 +4,21 @@ import { getContext } from "svelte";
 export const VIZEL_CONTEXT_KEY = Symbol("vizel-editor");
 
 /**
- * Get the editor instance from VizelProvider context.
+ * Reactive accessor object returned by {@link getVizelContext} and
+ * {@link getVizelContextSafe}.
+ *
+ * Reading `.current` from inside a reactive context (`$derived`, `$effect`,
+ * a template expression) registers the read as a dependency, so the
+ * consumer re-evaluates whenever the provided editor changes. Mirrors the
+ * Svelte 5 idiom for exposing runes through plain objects.
+ */
+export interface VizelContextAccessor {
+  /** The currently provided editor instance, or `null` when not ready. */
+  readonly current: Editor | null;
+}
+
+/**
+ * Get the editor instance accessor from VizelProvider context.
  *
  * @throws Error if used outside of VizelProvider
  *
@@ -13,26 +27,30 @@ export const VIZEL_CONTEXT_KEY = Symbol("vizel-editor");
  * <script lang="ts">
  * import { getVizelContext } from '@vizel/svelte';
  *
- * const getEditor = getVizelContext();
+ * const context = getVizelContext();
  * </script>
  *
- * <button onclick={() => getEditor()?.chain().focus().toggleBold().run()}>
+ * <button onclick={() => context.current?.chain().focus().toggleBold().run()}>
  *   Bold
  * </button>
  * ```
  */
-export function getVizelContext(): () => Editor | null {
-  const getEditor = getContext<(() => Editor | null) | undefined>(VIZEL_CONTEXT_KEY);
-  if (!getEditor) {
+export function getVizelContext(): VizelContextAccessor {
+  const accessor = getContext<VizelContextAccessor | undefined>(VIZEL_CONTEXT_KEY);
+  if (!accessor) {
     throw new Error("getVizelContext must be used within a VizelProvider");
   }
-  return getEditor;
+  return accessor;
 }
 
 /**
- * Get the editor instance from context.
- * Returns undefined if used outside of VizelProvider (does not throw).
+ * Get the editor instance accessor from context.
+ *
+ * Returns `undefined` when called outside of `VizelProvider` (does not
+ * throw). Mirrors {@link getVizelContext} but is non-throwing so optional
+ * consumers (e.g. components that work both inside and outside a provider)
+ * can fall back gracefully.
  */
-export function getVizelContextSafe(): (() => Editor | null) | undefined {
-  return getContext<(() => Editor | null) | undefined>(VIZEL_CONTEXT_KEY);
+export function getVizelContextSafe(): VizelContextAccessor | undefined {
+  return getContext<VizelContextAccessor | undefined>(VIZEL_CONTEXT_KEY);
 }

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -28,7 +28,7 @@ import { getVizelContextSafe } from "./VizelContext.js";
 let { editor: editorProp, class: className, ref }: VizelEditorProps = $props();
 
 const contextEditor = getVizelContextSafe();
-const editor = $derived(editorProp ?? contextEditor?.());
+const editor = $derived(editorProp ?? contextEditor?.current);
 
 let element: HTMLDivElement | null = $state(null);
 

--- a/packages/svelte/src/components/VizelProvider.svelte
+++ b/packages/svelte/src/components/VizelProvider.svelte
@@ -14,11 +14,20 @@ export interface VizelProviderProps {
 
 <script lang="ts">
 import { setContext } from "svelte";
-import { VIZEL_CONTEXT_KEY } from "./VizelContext.js";
+import { type VizelContextAccessor, VIZEL_CONTEXT_KEY } from "./VizelContext.js";
 
 let { editor, class: className, children }: VizelProviderProps = $props();
 
-setContext(VIZEL_CONTEXT_KEY, () => editor);
+// Provide a reactive accessor whose `current` getter reads the latest
+// `editor` prop. Consumers in reactive contexts (`$derived`, `$effect`,
+// templates) re-evaluate whenever the editor changes — same shape as a
+// `$state` rune surface, idiomatic for Svelte 5.
+const accessor: VizelContextAccessor = {
+  get current() {
+    return editor;
+  },
+};
+setContext(VIZEL_CONTEXT_KEY, accessor);
 
 // Always emit the `vizel-root` class so consumers get the CSS variable scope
 // for free (.vizel-root { --vizel-* }). Matches the React provider behavior.

--- a/packages/svelte/src/components/VizelToolbar.svelte
+++ b/packages/svelte/src/components/VizelToolbar.svelte
@@ -29,7 +29,7 @@ let {
 }: VizelToolbarProps = $props();
 
 const contextEditor = getVizelContextSafe();
-const editor = $derived(editorProp ?? contextEditor?.() ?? null);
+const editor = $derived(editorProp ?? contextEditor?.current ?? null);
 </script>
 
 {#if editor}


### PR DESCRIPTION
## Summary

Bring the Svelte provider context shape in line with the
`cross-framework.md` rule, which already documents the consumer
return type as `{ get current(): Editor | null }`. The previous
implementation exposed a bare `() => Editor | null` getter function
that consumers had to invoke with `contextEditor?.()` — it worked,
but it diverged from the React / Vue idioms (where the value is read
by property access, not a function call) and from the rune-style
getter object the rule already promised.

| Surface | Before | After |
|---------|--------|-------|
| `VizelContext.ts` | `getVizelContext(): () => Editor \| null` | `getVizelContext(): VizelContextAccessor` with `{ readonly current: Editor \| null }` |
| `VizelProvider.svelte` | `setContext(KEY, () => editor)` | `setContext(KEY, { get current() { return editor; } })` |
| Consumers (4 files) | `contextEditor?.()` | `contextEditor?.current` |

Reading `.current` from inside a reactive context (`\$derived`,
`\$effect`, template expression) registers the access as a tracked
dependency, so consumers re-evaluate whenever the provided editor
changes — identical to a `\$state` rune surface.

Refs: H4, L5 from the v2.x architecture audit.

## Breaking Changes

Svelte consumers calling `getVizelContext()` / `getVizelContextSafe()`
must update from `context()` to `context.current`. The shape is the
rune-flavored getter object that the documented rule has always
specified.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for Svelte × Chromium / Firefox / WebKit (Vue / React unaffected).
