### PR TITLE
docs(v2): add changelog and document the new core helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,124 @@
+# Changelog
+
+All notable changes to Vizel are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This release is the v2.x rework that aligns React, Vue, and Svelte adapters
+around a shared, framework-agnostic core. Behavior remains backwards-compatible
+for first-party consumers; the breaking changes listed below only affect
+power users who reach into low-level menu refs or call certain framework
+context APIs by hand.
+
+### Breaking changes
+
+- **Menu refs.** `VizelSlashMenuRef.onKeyDown` and `VizelMentionMenuRef.onKeyDown`
+  now accept a raw `KeyboardEvent` instead of the `{ event }` wrapper. The
+  Tiptap `SuggestionOptions.onKeyDown` contract is unchanged; only the
+  component ref surface is unified.
+  ```diff
+  - menuRef.current.onKeyDown({ event })
+  + menuRef.current.onKeyDown(event)
+  ```
+- **Svelte context.** `getVizelContext()` / `getVizelContextSafe()` now return
+  a `VizelContextAccessor` (`{ readonly current: Editor | null }`) instead of
+  a bare `() => Editor | null` getter function. This matches the documented
+  cross-framework rule and aligns with how `$state` runes surface values.
+  ```diff
+  - const editor = getVizelContext()();
+  + const editor = getVizelContext().current;
+  ```
+- **Invalid editor configuration.** Supplying both `initialContent` and
+  `initialMarkdown` to `createVizelEditorInstance` now throws a `VizelError`
+  with the new `INVALID_CONFIG` code (previously it logged a `console.warn`
+  and silently fell back to `initialMarkdown`). Programming errors fail
+  loudly so the misuse is caught on first run.
+
+### Added
+
+- `@vizel/core/interactions/` module exposing framework-agnostic state-machine
+  and event-subscription primitives:
+  - `createVizelEditorTransactionStore(getEditor)` — `{ subscribe, getVersion }`
+    store backing `useVizelState` / `createVizelState` across React, Vue, Svelte.
+  - `createVizelDismissibleController({ getElements, onDismiss })` — owns the
+    outside-click + Escape dismissal listeners with a disposer.
+  - `resolveVizelListNavigation` / `resolveVizelGridNavigation` — pure
+    keyboard-navigation resolvers (ArrowUp / ArrowDown / Home / End wrap and
+    2D grid traversal).
+  - `createVizelEditorSubscription({ getEditor, event, handler })` — one-line
+    Tiptap editor event listener with clean disposer.
+- `mountVizelEditorView(editor, container)` — appends `view.dom` to a
+  container element, sets the editable getter, and returns a disposer.
+  Replaces the three-step pattern hand-written by every framework's
+  `VizelEditor` component.
+- `createVizelRelativeTimeTicker({ getDate, getLocale, onTick })` and
+  `resolveVizelSaveIndicatorView(status, locale, lastSaved, relativeTime, showTimestamp)` —
+  pure helpers consumed by `VizelSaveIndicator` in all three frameworks.
+- `applyVizelColorToEditor(editor, type, color)` — single-call color apply
+  routing (textColor vs highlight, with `"inherit"` / `"transparent"`
+  remove sentinels).
+- `loadVizelEmbedScripts(container, provider?)` and
+  `resolveVizelEmbedView(data) → VizelEmbedViewModel` — embed script
+  re-parenting plus a discriminated union view-model resolver.
+- `resolveVizelFindReplaceLabels(locale)` — shared label resolver consumed
+  by the React, Vue, and Svelte `VizelFindReplace` components.
+- `createVizelBubbleMenuActions(locale)` + `filterVizelBubbleMenuActions` +
+  `groupVizelBubbleMenuActions` + `vizelDefaultBubbleMenuActions` —
+  bubble-menu action list, mirroring the existing toolbar-actions shape.
+
+### Changed
+
+- **Vue / Svelte `useVizelEditor` / `createVizelEditor`** now mirror the
+  `editable` prop through `editor.setEditable()` when it changes after
+  mount (previously React-only).
+- **Markdown sync runtime.** `useVizelMarkdown` in React and Vue now flush
+  any pending debounced markdown export before detaching from an editor,
+  matching the Svelte rune. Editor swaps and unmount no longer drop
+  unsynced markdown.
+- **Vue / Svelte `VizelProvider`** always emit the `vizel-root` class on
+  their wrapper element so the CSS variable scope (`.vizel-root { --vizel-* }`)
+  applies consistently with React.
+- **Svelte `VizelPortal`** migrates from a `use:portal` action (whose
+  closure captured `layer` / `className` at action creation) to a
+  `$effect`-based mount/attribute pair so prop changes propagate to the
+  wrapper element.
+- **Svelte `VizelBubbleMenu`** reads `shouldShow` with `untrack(...)` so
+  value updates flow through the wrapper closure without re-registering
+  the Tiptap plugin (matches the React `shouldShowRef` pattern).
+- **Vue `useVizelComment`** drops a dead options watcher and replaces the
+  `onMounted` + non-immediate watch split with a single
+  `watch(getEditor, ..., { immediate: true })`.
+- **Svelte `createVizelCollaboration`** no longer recreates handlers on
+  the `null → null` provider transition.
+- **Vue `VizelThemeProvider`** watches all three inputs (`resolvedTheme`,
+  `targetSelector`, `disableTransitionOnChange`) and re-applies the theme
+  on any change.
+- **Vue `Vizel.vue`** memoizes its locale-bound props object so child
+  toolbars / bubble-menus / block-menus no longer see a fresh identity
+  each render.
+- **React `VizelBlockMenu`** group key strategy aligned with Vue / Svelte
+  (`groupIndex` instead of `group[0]?.group`).
+- **MentionMenu accessibility.** Each framework's `VizelMentionMenu`
+  container now declares `role="listbox"`, `aria-label`, and
+  `aria-activedescendant`, with stable `id`s on each option.
+- **Bubble-menu defaults.** Each framework's `VizelBubbleMenuDefault`
+  collapses from ~150 lines of repeated buttons to an iteration over the
+  shared `createVizelBubbleMenuActions(locale)` list.
+
+### Fixed
+
+- **Vue `VizelSlashMenu` type lie.** The declared
+  `(props: { event }) => boolean` ref signature never matched the
+  underlying `defineExpose` body. Both now agree on
+  `(event: KeyboardEvent) => boolean`.
+- **`docs/guide/{react,vue,svelte}.md`** `VizelPortal` examples no longer
+  show a fictional `container` prop (the component exposes `layer` /
+  `class` / `disabled`).
+
+### Documentation
+
+- `.claude/rules/cross-framework.md` gains sections covering the Provider
+  Root Class convention, the Suggestion Menu Ref convention, and the
+  "Reactive vs Mount-time Editor Options" contract.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -283,6 +283,188 @@ formatVizelRelativeTime(new Date(Date.now() - 60000));
 // "1m ago"
 ```
 
+### createVizelRelativeTimeTicker
+
+Start an interval ticker that emits a relative-time string every `intervalMs` (default 10000) and once synchronously. Returns a disposer.
+
+```typescript
+import { createVizelRelativeTimeTicker } from '@vizel/core';
+
+const stop = createVizelRelativeTimeTicker({
+  getDate: () => lastSaved,
+  getLocale: () => locale,
+  onTick: (text) => { relativeTime = text; },
+});
+
+// Call stop() in your framework's cleanup hook.
+```
+
+### resolveVizelSaveIndicatorView
+
+Pure resolver that maps `(status, locale, lastSaved, relativeTime, showTimestamp)` to a view-model object `{ iconName, isSpinner, text, shouldShowTimestamp }`. Consumed by every framework's `VizelSaveIndicator`.
+
+### applyVizelColorToEditor
+
+Apply a color to the current selection. Routes through the appropriate Tiptap command and special-cases the `"inherit"` / `"transparent"` remove sentinels. Concrete colors are also recorded as recent picks.
+
+```typescript
+import { applyVizelColorToEditor } from '@vizel/core';
+
+applyVizelColorToEditor(editor, "textColor", "#FF0000");
+applyVizelColorToEditor(editor, "highlight", "transparent"); // unsets
+```
+
+### loadVizelEmbedScripts
+
+Re-parent any `<script>` tags inside an oEmbed container so the browser actually executes them (innerHTML-inserted scripts are inert). Invokes the Twitter widgets bootstrap when the provider is `"twitter"`.
+
+```typescript
+import { loadVizelEmbedScripts } from '@vizel/core';
+
+loadVizelEmbedScripts(containerEl, data.provider);
+```
+
+### resolveVizelEmbedView
+
+Resolve a `VizelEmbedData` value into a discriminated union view-model covering the five render branches (loading, oEmbed, OGP, title-link, plain-link). Framework components iterate the resolved variant.
+
+```typescript
+import { resolveVizelEmbedView, type VizelEmbedViewModel } from '@vizel/core';
+
+const view = resolveVizelEmbedView(data);
+switch (view.kind) {
+  case "loading": /* ... */ break;
+  case "oembed": /* view.html, view.isVideo */ break;
+  case "ogp": /* view.url, view.title, view.image, ... */ break;
+  case "title": /* view.url, view.title */ break;
+  case "link": /* view.url */ break;
+}
+```
+
+### resolveVizelFindReplaceLabels
+
+Returns a complete labels object for the find/replace UI, falling back to English defaults whenever the supplied partial locale omits a key.
+
+```typescript
+import { resolveVizelFindReplaceLabels } from '@vizel/core';
+
+const labels = resolveVizelFindReplaceLabels(locale?.findReplace);
+// labels.label, labels.findPlaceholder, labels.replaceAriaLabel, ...
+```
+
+### mountVizelEditorView
+
+Append a Tiptap editor's `view.dom` into a container element, mirror `isEditable`, and return a disposer that removes the DOM only when it is still parented to the container.
+
+```typescript
+import { mountVizelEditorView } from '@vizel/core';
+
+const dispose = mountVizelEditorView(editor, containerEl);
+// dispose() on unmount or editor swap.
+```
+
+---
+
+## Bubble-menu actions
+
+These exports mirror the toolbar-action helpers and drive every framework's `VizelBubbleMenuDefault`.
+
+### VizelBubbleMenuAction
+
+```typescript
+interface VizelBubbleMenuAction {
+  id: string;
+  label: string;
+  icon: VizelIconName;
+  group: string;
+  isActive: (editor: Editor) => boolean;
+  run: (editor: Editor) => void;
+  shortcut: string;
+  /** Optional precondition: drop the action when this extension is absent. */
+  requiresExtension?: string;
+}
+```
+
+### createVizelBubbleMenuActions
+
+Returns the default action list with locale-resolved labels (or English defaults when the locale is omitted).
+
+```typescript
+import { createVizelBubbleMenuActions } from '@vizel/core';
+
+const actions = createVizelBubbleMenuActions(locale);
+// [{ id: "bold", label: "Bold", icon: "bold", shortcut: "Mod+B", ... }, ...]
+```
+
+### filterVizelBubbleMenuActions
+
+Filters actions down to those whose `requiresExtension` precondition is satisfied by the supplied editor.
+
+```typescript
+import { filterVizelBubbleMenuActions } from '@vizel/core';
+
+const usable = filterVizelBubbleMenuActions(actions, editor);
+```
+
+### groupVizelBubbleMenuActions
+
+Groups actions for visual separation in the bubble menu (mirrors `groupVizelToolbarActions`).
+
+---
+
+## Interactions (framework-agnostic primitives)
+
+These exports live under `@vizel/core/interactions` and provide the state-machine + event-subscription primitives the React, Vue, and Svelte adapters share. They return plain objects with subscribe callbacks — no framework runtime imports.
+
+### createVizelEditorTransactionStore
+
+Returns `{ subscribe(cb), getVersion() }` that ticks a monotonically-incremented version counter on every Tiptap `transaction` event. Frameworks wire this into their reactivity primitive (`useSyncExternalStore`, `ref`, `$state`).
+
+```typescript
+import { createVizelEditorTransactionStore } from '@vizel/core';
+
+const store = createVizelEditorTransactionStore(() => editor);
+const unsubscribe = store.subscribe(() => { /* re-render */ });
+```
+
+### createVizelDismissibleController
+
+Attaches `mousedown` / `keydown` listeners that dismiss when the user clicks outside the supplied elements or presses Escape. Returns a disposer.
+
+```typescript
+import { createVizelDismissibleController } from '@vizel/core';
+
+const dispose = createVizelDismissibleController({
+  getElements: () => [popoverEl, triggerEl],
+  onDismiss: () => setOpen(false),
+});
+```
+
+### resolveVizelListNavigation / resolveVizelGridNavigation
+
+Pure resolvers that map a key (`ArrowUp` / `ArrowDown` / `Home` / `End`, plus `ArrowLeft` / `ArrowRight` for the grid variant) and the current index to the next focused index, or `null` when the key isn't handled.
+
+```typescript
+import { resolveVizelListNavigation, resolveVizelGridNavigation } from '@vizel/core';
+
+const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
+if (next !== null) setSelectedIndex(next);
+```
+
+### createVizelEditorSubscription
+
+Attach a Tiptap editor event listener with a clean disposer; supports an optional `fireImmediately` flag.
+
+```typescript
+import { createVizelEditorSubscription } from '@vizel/core';
+
+const dispose = createVizelEditorSubscription({
+  getEditor: () => editor,
+  event: "update",
+  handler: () => { /* ... */ },
+});
+```
+
 ---
 
 ## Theme Utilities


### PR DESCRIPTION
## Summary

Close out the v2.x rework with two pure-documentation additions:

- `CHANGELOG.md` at the repo root, with an `[Unreleased]` / v2.x
  section that enumerates the breaking changes (menu refs, Svelte
  context shape, `INVALID_CONFIG` throw), the new core helpers and
  interaction primitives, and the framework-level behavior changes
  shipped across PRs #413 – #425.
- `docs/api/core.md` entries for every newly-exposed helper:
  - `createVizelRelativeTimeTicker` / `resolveVizelSaveIndicatorView`
  - `applyVizelColorToEditor`
  - `loadVizelEmbedScripts` / `resolveVizelEmbedView` /
    `VizelEmbedViewModel`
  - `resolveVizelFindReplaceLabels`
  - `mountVizelEditorView`
  - Bubble-menu actions: `VizelBubbleMenuAction`,
    `createVizelBubbleMenuActions`, `filterVizelBubbleMenuActions`,
    `groupVizelBubbleMenuActions`, `vizelDefaultBubbleMenuActions`
  - Interactions module:
    `createVizelEditorTransactionStore`,
    `createVizelDismissibleController`,
    `resolveVizelListNavigation` / `resolveVizelGridNavigation`,
    `createVizelEditorSubscription`

## Test Plan

- [x] Docs only — `pnpm lint` / `typecheck` / `build` unaffected.

## Breaking Changes

None — pure documentation.
