### PR TITLE
feat(i18n,docs): mention-menu locale, markdown debounce=0 fix, framework guide expansion

### DIFF
--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -101,12 +101,20 @@ import { Vizel } from '@vizel/react';
 | `enableEmbed` | `boolean` | - | Enable embed in links |
 | `extensions` | `Extensions` | - | Additional Tiptap extensions |
 | `transformDiagramsOnImport` | `boolean` | `true` | Transform diagram code blocks on import |
-| `onUpdate` | `Function` | - | Update callback |
-| `onCreate` | `Function` | - | Create callback |
-| `onDestroy` | `Function` | - | Destroy callback |
-| `onSelectionUpdate` | `Function` | - | Selection change callback |
-| `onFocus` | `Function` | - | Focus callback |
-| `onBlur` | `Function` | - | Blur callback |
+| `markdown` | `string` | - | Controlled-mode Markdown value. Pair with `onMarkdownChange` to drive the editor from external state. |
+| `flavor` | `VizelMarkdownFlavor` | `"gfm"` | Markdown output flavor (`"commonmark"`, `"gfm"`, `"obsidian"`, `"docusaurus"`). |
+| `locale` | `VizelLocale` | - | Localized UI strings. Use `createVizelLocale()` to merge a partial override with the English default. |
+| `toolbarContent` | `ReactNode` | - | Custom toolbar content. When provided alongside `showToolbar`, replaces the default toolbar body. |
+| `bubbleMenuContent` | `ReactNode` | - | Custom bubble-menu content. When provided alongside `showBubbleMenu`, replaces the default body. |
+| `ref` | `Ref<VizelRef>` | - | Forwarded ref exposing the underlying `Editor` instance. |
+| `onMarkdownChange` | `(markdown: string) => void` | - | Fired when editor content changes in controlled mode (use with `markdown`). |
+| `onUpdate` | `(props: { editor }) => void` | - | Update callback |
+| `onCreate` | `(props: { editor }) => void` | - | Create callback |
+| `onDestroy` | `() => void` | - | Destroy callback |
+| `onSelectionUpdate` | `(props: { editor }) => void` | - | Selection change callback |
+| `onFocus` | `(props: { editor }) => void` | - | Focus callback |
+| `onBlur` | `(props: { editor }) => void` | - | Blur callback |
+| `onError` | `(error: VizelError) => void` | - | Fired when an editor operation surfaces a `VizelError`. Narrow with `isVizelError(error)` to inspect the structured `code` field. |
 
 ## Hooks
 

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -102,12 +102,17 @@ All-in-one editor component with built-in bubble menu.
 | `enableEmbed` | `boolean` | - | Enable embed in links |
 | `extensions` | `Extensions` | - | Additional Tiptap extensions |
 | `transformDiagramsOnImport` | `boolean` | `true` | Transform diagram code blocks on import |
-| `onUpdate` | `Function` | - | Update callback |
-| `onCreate` | `Function` | - | Create callback |
-| `onDestroy` | `Function` | - | Destroy callback |
-| `onSelectionUpdate` | `Function` | - | Selection change callback |
-| `onFocus` | `Function` | - | Focus callback |
-| `onBlur` | `Function` | - | Blur callback |
+| `flavor` | `VizelMarkdownFlavor` | `"gfm"` | Markdown output flavor (`"commonmark"`, `"gfm"`, `"obsidian"`, `"docusaurus"`). |
+| `locale` | `VizelLocale` | - | Localized UI strings. Use `createVizelLocale()` to merge a partial override with the English default. |
+| `toolbar` | `Snippet<[{ editor }]>` | - | Custom toolbar snippet rendered inside `<VizelToolbar>` when `showToolbar` is true. |
+| `bubbleMenu` | `Snippet<[{ editor }]>` | - | Custom bubble-menu snippet rendered inside `<VizelBubbleMenu>` when `showBubbleMenu` is true. |
+| `onUpdate` | `(props: { editor }) => void` | - | Update callback |
+| `onCreate` | `(props: { editor }) => void` | - | Create callback |
+| `onDestroy` | `() => void` | - | Destroy callback |
+| `onSelectionUpdate` | `(props: { editor }) => void` | - | Selection change callback |
+| `onFocus` | `(props: { editor }) => void` | - | Focus callback |
+| `onBlur` | `(props: { editor }) => void` | - | Blur callback |
+| `onError` | `(error: VizelError) => void` | - | Fired when an editor operation surfaces a `VizelError`. Narrow with `isVizelError(error)` to inspect the structured `code` field. |
 
 ## Runes
 

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -106,18 +106,29 @@ import { Vizel } from '@vizel/vue';
 | `enableEmbed` | `boolean` | - | Enable embed in links |
 | `extensions` | `Extensions` | - | Additional Tiptap extensions |
 | `transformDiagramsOnImport` | `boolean` | `true` | Transform diagram code blocks on import |
+| `flavor` | `VizelMarkdownFlavor` | `"gfm"` | Markdown output flavor (`"commonmark"`, `"gfm"`, `"obsidian"`, `"docusaurus"`). |
+| `locale` | `VizelLocale` | - | Localized UI strings. Use `createVizelLocale()` to merge a partial override with the English default. |
+
+#### Slots
+
+| Slot | Slot props | Description |
+|------|------------|-------------|
+| `toolbar` | `{ editor }` | Custom toolbar content. Renders inside `<VizelToolbar>` when `showToolbar` is true. |
+| `bubble-menu` | `{ editor }` | Custom bubble-menu content. Renders inside `<VizelBubbleMenu>` when `showBubbleMenu` is true. |
+| default | `{ editor }` | Additional content rendered inside the editor root. |
 
 #### Events
 
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `update` | `{ editor: Editor }` | Fires when content changes |
-| `update:markdown` | `string` | Fires when Markdown content changes |
+| `update:markdown` | `string` | Fires when Markdown content changes (paired with `v-model:markdown`) |
 | `create` | `{ editor: Editor }` | Fires when the editor initializes |
 | `destroy` | - | Fires when the editor destroys |
 | `selectionUpdate` | `{ editor: Editor }` | Fires when the selection changes |
 | `focus` | `{ editor: Editor }` | Fires when the editor gains focus |
 | `blur` | `{ editor: Editor }` | Fires when the editor loses focus |
+| `error` | `VizelError` | Fires when an editor operation surfaces a `VizelError`. Narrow with `isVizelError(error)` to inspect the structured `code` field. |
 
 ## Composables
 

--- a/packages/core/src/i18n/en.ts
+++ b/packages/core/src/i18n/en.ts
@@ -95,6 +95,11 @@ export const vizelEnLocale = {
     enterEmbedUrl: "Enter URL to embed:",
   },
 
+  mentionMenu: {
+    ariaLabel: "Mentions",
+    noResults: "No results",
+  },
+
   findReplace: {
     label: "Find and Replace",
     findPlaceholder: "Find...",

--- a/packages/core/src/i18n/types.ts
+++ b/packages/core/src/i18n/types.ts
@@ -110,6 +110,14 @@ export interface VizelLocale {
     enterEmbedUrl: string;
   };
 
+  /** Mention autocomplete menu */
+  mentionMenu: {
+    /** Menu container aria-label */
+    ariaLabel: string;
+    /** Message shown when no mention candidates match the query */
+    noResults: string;
+  };
+
   /** Find and replace panel */
   findReplace: {
     /** Panel aria-label */

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -222,6 +222,15 @@ export function createVizelMarkdownSyncHandlers(
 
   const handleUpdate = (editor: Editor): void => {
     if (debounceMs === 0) {
+      // Cancel any in-flight debounced timer so `pending` doesn't stay true
+      // after a subsequent `debounceMs === 0` call. The previous shape left
+      // a stale `setTimeout` running, which made `isPending()` lie about
+      // the export status.
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      pending = false;
       currentMarkdown = getVizelMarkdown(editor);
       return;
     }

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -1,4 +1,4 @@
-import { resolveVizelListNavigation, type VizelMentionItem } from "@vizel/core";
+import { resolveVizelListNavigation, type VizelLocale, type VizelMentionItem } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 
@@ -21,6 +21,8 @@ export interface VizelMentionMenuProps {
   onSelect: (item: VizelMentionItem) => void;
   /** Custom class name for the menu container */
   className?: string;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
 }
 
 /**
@@ -32,6 +34,7 @@ export function VizelMentionMenu({
   items,
   onSelect,
   className,
+  locale,
 }: VizelMentionMenuProps): ReactNode {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -81,10 +84,18 @@ export function VizelMentionMenu({
     },
   }));
 
+  const ariaLabel = locale?.mentionMenu?.ariaLabel ?? "Mentions";
+  const noResultsText = locale?.mentionMenu?.noResults ?? "No results";
+
   if (items.length === 0) {
     return (
-      <div className={`vizel-mention-menu ${className ?? ""}`} data-vizel-mention-menu="">
-        <div className="vizel-mention-menu-empty">No results</div>
+      <div
+        className={`vizel-mention-menu ${className ?? ""}`}
+        data-vizel-mention-menu=""
+        role="listbox"
+        aria-label={ariaLabel}
+      >
+        <div className="vizel-mention-menu-empty">{noResultsText}</div>
       </div>
     );
   }
@@ -98,7 +109,7 @@ export function VizelMentionMenu({
       className={`vizel-mention-menu ${className ?? ""}`}
       data-vizel-mention-menu=""
       role="listbox"
-      aria-label="Mentions"
+      aria-label={ariaLabel}
       {...(activeOptionId && { "aria-activedescendant": activeOptionId })}
     >
       {items.map((item, index) => {

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-import type { VizelMentionItem } from "@vizel/core";
+import type { VizelLocale, VizelMentionItem } from "@vizel/core";
 
 export interface VizelMentionMenuRef {
   onKeyDown?: (event: KeyboardEvent) => boolean;
@@ -9,6 +9,8 @@ export interface VizelMentionMenuProps {
   items: VizelMentionItem[];
   class?: string;
   onselect?: (item: VizelMentionItem) => void;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
   /**
    * Mutable ref object the component populates with imperative handles
    * (notably `onKeyDown`). Pass an object; this component assigns to its
@@ -29,6 +31,7 @@ let {
   items,
   class: className,
   onselect,
+  locale,
   ref,
 }: VizelMentionMenuProps = $props();
 
@@ -92,11 +95,11 @@ if (ref) {
   class="vizel-mention-menu {className ?? ''}"
   data-vizel-mention-menu
   role="listbox"
-  aria-label="Mentions"
+  aria-label={locale?.mentionMenu?.ariaLabel ?? "Mentions"}
   aria-activedescendant={items[selectedIndex]?.id ? `vizel-mention-${items[selectedIndex]?.id}` : undefined}
 >
   {#if items.length === 0}
-    <div class="vizel-mention-menu-empty">No results</div>
+    <div class="vizel-mention-menu-empty">{locale?.mentionMenu?.noResults ?? "No results"}</div>
   {:else}
     {#each items as item, index (item.id)}
       <div

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { resolveVizelListNavigation, type VizelMentionItem } from "@vizel/core";
+import { resolveVizelListNavigation, type VizelLocale, type VizelMentionItem } from "@vizel/core";
 import { computed, nextTick, ref, watch } from "vue";
 
 export interface VizelMentionMenuRef {
@@ -9,6 +9,8 @@ export interface VizelMentionMenuRef {
 export interface VizelMentionMenuProps {
   items: VizelMentionItem[];
   class?: string;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
 }
 
 const props = defineProps<VizelMentionMenuProps>();
@@ -69,11 +71,11 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
     :class="['vizel-mention-menu', props.class]"
     data-vizel-mention-menu
     role="listbox"
-    aria-label="Mentions"
+    :aria-label="props.locale?.mentionMenu?.ariaLabel ?? 'Mentions'"
     :aria-activedescendant="activeOptionId"
   >
     <div v-if="items.length === 0" class="vizel-mention-menu-empty">
-      No results
+      {{ props.locale?.mentionMenu?.noResults ?? 'No results' }}
     </div>
     <template v-else>
       <div


### PR DESCRIPTION
## Summary

Three loosely-related v2.x polish items grouped into one PR because
each individual change is small.

| ID | Area | Change |
|----|------|--------|
| **M13** | i18n + 3 FW `VizelMentionMenu` | Add a `mentionMenu` namespace to `VizelLocale` (`ariaLabel`, `noResults`) and wire it through the three components. The container's `aria-label` and the empty-state text now resolve from the supplied locale instead of being hard-coded \"Mentions\" / \"No results\". |
| **H12** | `@vizel/core` `createVizelMarkdownSyncHandlers` | When invoked with `debounceMs === 0`, cancel any in-flight debounced timer and clear the `pending` flag. The previous shape left a stale `setTimeout` running, so `isPending()` could continue reporting `true` after a synchronous update. |
| **M10 / M12** | `docs/guide/{react,vue,svelte}.md` | Document the previously-missing `<Vizel>` public surface: `markdown` / `onMarkdownChange` controlled-mode, `flavor`, `locale`, custom toolbar / bubble-menu content (slots / snippets / render props), and the `onError` / `@error` callback that delivers `VizelError` instances. |

## Breaking Changes

None. `locale.mentionMenu` is purely additive — consumers who omit
the namespace get the English defaults via fallback expressions.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.
