### PR TITLE
docs: provider fallback, Svelte $state factories, custom item renderers

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -70,6 +70,24 @@ interface VizelBubbleMenuProps {
 }
 ```
 
+### Custom Item Renderers
+
+Components that iterate a list (e.g. `VizelSlashMenu`, `VizelMentionMenu`)
+expose an item-level customization seam through whatever the framework's
+idiomatic slot mechanism is. Consumers may swap the rendering of a
+single item, but the menu container's structure, keyboard handlers, and
+ARIA wiring stay owned by the component.
+
+| Framework | API form |
+|-----------|----------|
+| React | `renderItem?: (item, state) => ReactNode` prop |
+| Vue | `<slot name="item" :item="..." :is-selected="..." />` |
+| Svelte | `renderItem?: Snippet<[{ item, isSelected, onclick }]>` |
+
+The cross-framework concept is identical — give the consumer the item
+data plus the selection state and let them return a node — only the
+binding form differs to honor each framework's slot idiom.
+
 ## State Management Equivalence
 
 Each framework exposes equivalent state primitives under its idiomatic naming.

--- a/.claude/rules/packages/svelte.md
+++ b/.claude/rules/packages/svelte.md
@@ -181,6 +181,36 @@ $effect(() => {
 });
 ```
 
+### `$state` Inside Factory Functions
+
+The renderer factories (`createVizelSlashMenuRenderer`,
+`createVizelMentionMenuRenderer`) declare `$state` inside the
+function body — once per suggestion session, not at module scope.
+This is intentional: each session needs its own reactive `items` /
+`onselect` slot that can be mutated as Tiptap pushes updates, and
+the mount target's lifetime matches the session.
+
+```typescript
+export function createVizelSlashMenuRenderer(options = {}) {
+  return {
+    render: () => {
+      // Each render() call opens a new suggestion session and gets
+      // its own $state container.
+      const menuState = $state<{ items: VizelSlashCommandItem[]; onselect: ... }>({
+        items: [],
+        onselect: () => {},
+      });
+      // ...
+    },
+  };
+}
+```
+
+The Svelte 5 compiler accepts this pattern (the function is invoked
+inside a component lifecycle). Do not lift the `$state` to module
+scope — that would share the same container across every editor in
+the page and corrupt sessions when more than one suggestion is open.
+
 ## Context
 
 - `VizelProvider` calls `setContext()`.

--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -304,19 +304,25 @@ function App() {
 
 This component renders the editor content area.
 
+When wrapped in a `VizelProvider`, the `editor` prop is optional — the component falls back to the editor injected through context. Pass `editor` explicitly to bind a specific instance (useful when multiple editors live on the same page).
+
 ```tsx
-<VizelEditor 
-  editor={editor} 
-  className="my-editor"
-/>
+// With provider context
+<VizelProvider editor={editor}>
+  <VizelEditor className="my-editor" />
+</VizelProvider>
+
+// Or explicitly
+<VizelEditor editor={editor} className="my-editor" />
 ```
 
 #### Props
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `editor` | `Editor \| null` | Editor instance |
+| `editor` | `Editor \| null` | Editor instance. Defaults to the value provided by `VizelProvider` when omitted. |
 | `className` | `string` | Custom class name |
+| `ref` | `Ref<VizelExposed>` | Forwarded ref exposing the container DOM element. |
 
 ### VizelBubbleMenu
 


### PR DESCRIPTION
## Summary

Three small doc additions that close the v2.x audit's lower-priority
documentation gaps.

| ID | Where | Change |
|----|-------|--------|
| **L9** | `docs/guide/react.md` | `VizelEditor`'s `editor` prop is optional when wrapped in a `VizelProvider`. The example shows both forms (provider injection + explicit prop), and the prop table calls out the context fallback. |
| **L13** | `.claude/rules/packages/svelte.md` | New "`\$state` Inside Factory Functions" section documents the intentional per-session `\$state` containers inside the slash / mention renderer factories, with a warning against lifting them to module scope. |
| **M2** | `.claude/rules/cross-framework.md` | New "Custom Item Renderers" table maps the renderer-slot API to each framework's idiom (React `renderItem` prop, Vue `<slot name="item">`, Svelte `renderItem` Snippet). |

## Test Plan

- [x] Docs only — `pnpm lint` / `typecheck` / `build` unaffected.

## Breaking Changes

None — pure documentation.
