### PR TITLE
refactor: rename VizelSlashMenuRendererOptions to VizelSuggestionRendererOptions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -354,6 +354,7 @@ export type {
   VizelMarkdownSyncResult,
   VizelSlashCommandOptions,
   VizelSlashMenuRendererOptions,
+  VizelSuggestionRendererOptions,
 } from "./types.ts";
 // =============================================================================
 // Utilities

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -293,12 +293,24 @@ export interface VizelEditorState {
 }
 
 /**
- * Options for creating a slash menu renderer
+ * Options shared by every Tiptap suggestion renderer (slash menu, mention
+ * menu, future suggestion-driven surfaces).
+ *
+ * Renamed from `VizelSlashMenuRendererOptions` in v2.0 because the same
+ * shape is reused by `createVizelMentionMenuRenderer`. The old name is
+ * still exported as a deprecated alias for one minor cycle.
  */
-export interface VizelSlashMenuRendererOptions {
+export interface VizelSuggestionRendererOptions {
   /** Custom class name for the menu */
   className?: string;
 }
+
+/**
+ * @deprecated Use {@link VizelSuggestionRendererOptions} instead.
+ * Kept as a type alias for one minor cycle so existing consumers can
+ * migrate without an immediate type error. The shape is identical.
+ */
+export type VizelSlashMenuRendererOptions = VizelSuggestionRendererOptions;
 
 /**
  * Options for creating a Vizel editor instance with framework hooks/composables/runes.

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -4,7 +4,7 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelMentionItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { createElement, type RefObject } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -29,7 +29,7 @@ import { VizelMentionMenu, type VizelMentionMenuRef } from "../components/VizelM
  * ```
  */
 export function createVizelMentionMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelMentionItem>> {
   return {
     render: () => {

--- a/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
@@ -4,13 +4,13 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelSlashCommandItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { createElement, type RefObject } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { VizelSlashMenu, type VizelSlashMenuRef } from "../components/VizelSlashMenu.tsx";
 
-export type { VizelSlashMenuRendererOptions };
+export type { VizelSuggestionRendererOptions };
 
 /**
  * Creates a suggestion render configuration for the SlashCommand extension.
@@ -31,7 +31,7 @@ export type { VizelSlashMenuRendererOptions };
  * ```
  */
 export function createVizelSlashMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelSlashCommandItem>> {
   return {
     render: () => {

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,7 +1,7 @@
 export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.ts";
 export {
   createVizelSlashMenuRenderer,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -119,5 +119,5 @@ export {
   useVizelTheme,
   useVizelThemeSafe,
   useVizelVersionHistory,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./hooks/index.ts";

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -116,5 +116,5 @@ export {
   createVizelVersionHistory,
   getVizelTheme,
   getVizelThemeSafe,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./runes/index.js";

--- a/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
+++ b/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
@@ -4,12 +4,12 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelMentionItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { mount, unmount } from "svelte";
 import VizelMentionMenu, { type VizelMentionMenuRef } from "../components/VizelMentionMenu.svelte";
 
-export type { VizelSlashMenuRendererOptions };
+export type { VizelSuggestionRendererOptions };
 
 /**
  * Creates a suggestion render configuration for the Mention extension.
@@ -34,7 +34,7 @@ export type { VizelSlashMenuRendererOptions };
  * ```
  */
 export function createVizelMentionMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelMentionItem>> {
   return {
     render: () => {

--- a/packages/svelte/src/runes/createVizelSlashMenuRenderer.svelte.ts
+++ b/packages/svelte/src/runes/createVizelSlashMenuRenderer.svelte.ts
@@ -4,12 +4,12 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelSlashCommandItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { mount, unmount } from "svelte";
 import VizelSlashMenu, { type VizelSlashMenuRef } from "../components/VizelSlashMenu.svelte";
 
-export type { VizelSlashMenuRendererOptions };
+export type { VizelSuggestionRendererOptions };
 
 /**
  * Creates a suggestion render configuration for the SlashCommand extension.
@@ -34,7 +34,7 @@ export type { VizelSlashMenuRendererOptions };
  * ```
  */
 export function createVizelSlashMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelSlashCommandItem>> {
   return {
     render: () => {

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -23,7 +23,7 @@ export {
 export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.svelte.js";
 export {
   createVizelSlashMenuRenderer,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./createVizelSlashMenuRenderer.svelte.js";
 export { createVizelState } from "./createVizelState.svelte.js";
 export {

--- a/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
@@ -4,7 +4,7 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelMentionItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { type App, createApp, h, ref } from "vue";
 import { VizelMentionMenu } from "../components/index.ts";
@@ -32,7 +32,7 @@ interface VizelMentionMenuRef {
  * ```
  */
 export function createVizelMentionMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelMentionItem>> {
   return {
     render: () => {

--- a/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
@@ -4,12 +4,12 @@ import {
   type SuggestionOptions,
   type SuggestionProps,
   type VizelSlashCommandItem,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "@vizel/core";
 import { type App, createApp, h, ref } from "vue";
 import { VizelSlashMenu } from "../components/index.ts";
 
-export type { VizelSlashMenuRendererOptions };
+export type { VizelSuggestionRendererOptions };
 
 interface VizelSlashMenuRef {
   onKeyDown: (event: KeyboardEvent) => boolean;
@@ -34,7 +34,7 @@ interface VizelSlashMenuRef {
  * ```
  */
 export function createVizelSlashMenuRenderer(
-  options: VizelSlashMenuRendererOptions = {}
+  options: VizelSuggestionRendererOptions = {}
 ): Partial<SuggestionOptions<VizelSlashCommandItem>> {
   return {
     render: () => {

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -1,7 +1,7 @@
 export { createVizelMentionMenuRenderer } from "./createVizelMentionMenuRenderer.ts";
 export {
   createVizelSlashMenuRenderer,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
 export {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -117,5 +117,5 @@ export {
   useVizelTheme,
   useVizelThemeSafe,
   useVizelVersionHistory,
-  type VizelSlashMenuRendererOptions,
+  type VizelSuggestionRendererOptions,
 } from "./composables/index.ts";


### PR DESCRIPTION
## Summary

The same options shape (`{ className?: string }`) is used by both
`createVizelSlashMenuRenderer` and `createVizelMentionMenuRenderer`,
and any future suggestion-driven surface would reuse it again. The
slash-flavored name was misleading; this PR renames it to the
suggestion-renderer-flavored `VizelSuggestionRendererOptions`.

| Package | Behavior |
|---------|----------|
| `@vizel/core` | Exports the new `VizelSuggestionRendererOptions` type AND keeps `VizelSlashMenuRendererOptions` as a `@deprecated` type alias for the v2.x migration window. |
| `@vizel/react`, `@vizel/vue`, `@vizel/svelte` | Renderer factories now accept `VizelSuggestionRendererOptions`. Framework packages re-export only the new name. |

Consumers importing the old name from a framework package will see a
type error and should rename their import; consumers importing from
`@vizel/core` keep working via the deprecated alias.

## Breaking Changes

Consumers importing `VizelSlashMenuRendererOptions` from
`@vizel/react`, `@vizel/vue`, or `@vizel/svelte` must rename to
`VizelSuggestionRendererOptions`.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Refs: M5 from the v2.x audit.
