### PR TITLE
refactor: extract useLatest helper and adopt dismissible controller in Vue block menu

### DIFF
--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
 import { useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import { useLatest } from "../hooks/useLatest.ts";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
 import { VizelBlockMenu } from "./VizelBlockMenu.tsx";
 import { VizelBubbleMenu } from "./VizelBubbleMenu.tsx";
@@ -180,27 +181,18 @@ export function Vizel({
   const isUpdatingFromMarkdownRef = useRef(false);
 
   // Keep refs for every value accessed in the editor's lifecycle callbacks.
-  // `useVizelEditor` reads options once at mount, so without refs each
-  // callback would be frozen to the closure values from the first render —
-  // re-renders that pass a fresh handler would be silently ignored.
-  const markdownRef = useRef(markdown);
-  markdownRef.current = markdown;
-  const onMarkdownChangeRef = useRef(onMarkdownChange);
-  onMarkdownChangeRef.current = onMarkdownChange;
-  const onUpdateRef = useRef(onUpdate);
-  onUpdateRef.current = onUpdate;
-  const onCreateRef = useRef(onCreate);
-  onCreateRef.current = onCreate;
-  const onDestroyRef = useRef(onDestroy);
-  onDestroyRef.current = onDestroy;
-  const onSelectionUpdateRef = useRef(onSelectionUpdate);
-  onSelectionUpdateRef.current = onSelectionUpdate;
-  const onFocusRef = useRef(onFocus);
-  onFocusRef.current = onFocus;
-  const onBlurRef = useRef(onBlur);
-  onBlurRef.current = onBlur;
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  // `useVizelEditor` reads options once at mount, so without `useLatest`
+  // each callback would be frozen to the closure values from the first
+  // render — re-renders that pass a fresh handler would be silently ignored.
+  const markdownRef = useLatest(markdown);
+  const onMarkdownChangeRef = useLatest(onMarkdownChange);
+  const onUpdateRef = useLatest(onUpdate);
+  const onCreateRef = useLatest(onCreate);
+  const onDestroyRef = useLatest(onDestroy);
+  const onSelectionUpdateRef = useLatest(onSelectionUpdate);
+  const onFocusRef = useLatest(onFocus);
+  const onBlurRef = useLatest(onBlur);
+  const onErrorRef = useLatest(onError);
 
   const editor = useVizelEditor({
     ...(initialContent !== undefined && { initialContent }),

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -3,6 +3,7 @@ export {
   createVizelSlashMenuRenderer,
   type VizelSuggestionRendererOptions,
 } from "./createVizelSlashMenuRenderer.ts";
+export { useLatest } from "./useLatest.ts";
 export { type UseVizelAutoSaveResult, useVizelAutoSave } from "./useVizelAutoSave.ts";
 export {
   type UseVizelCollaborationResult,

--- a/packages/react/src/hooks/useLatest.ts
+++ b/packages/react/src/hooks/useLatest.ts
@@ -1,0 +1,28 @@
+import { type RefObject, useRef } from "react";
+
+/**
+ * Track the latest value in a stable `RefObject`.
+ *
+ * Each render synchronously updates `ref.current` to the passed value,
+ * so any closure that reads `ref.current` later observes the most recent
+ * value without having to depend on it in a dependency array.
+ *
+ * This is the React idiom for "callback that should not stale" — used
+ * throughout `Vizel.tsx` for lifecycle callbacks (`onUpdate`, `onError`,
+ * etc.) that flow into `useVizelEditor` (which captures options once at
+ * mount). Without it, passing a fresh handler on every render would be
+ * silently ignored.
+ *
+ * @example
+ * ```tsx
+ * const onUpdate = useLatest(props.onUpdate);
+ * useEffect(() => {
+ *   editor.on("update", (e) => onUpdate.current?.(e));
+ * }, [editor]);
+ * ```
+ */
+export function useLatest<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -2,6 +2,7 @@
 import {
   clampMenuPosition,
   createVizelBlockMenuActions,
+  createVizelDismissibleController,
   createVizelNodeTypes,
   type Editor,
   getVizelTurnIntoOptions,
@@ -173,57 +174,18 @@ watch(showTurnInto, (isOpen) => {
   });
 });
 
-let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
-let escapeHandler: ((e: KeyboardEvent) => void) | null = null;
-
-function addCloseListeners() {
-  removeCloseListeners();
-
-  outsideClickHandler = (e: MouseEvent) => {
-    if (!(e.target instanceof Node)) return;
-    if (
-      menuRef.value &&
-      !menuRef.value.contains(e.target) &&
-      !submenuRef.value?.contains(e.target)
-    ) {
-      close();
-    }
-  };
-
-  escapeHandler = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
-
-  if (outsideClickHandler) {
-    document.addEventListener("mousedown", outsideClickHandler);
-  }
-  if (escapeHandler) {
-    document.addEventListener("keydown", escapeHandler);
-  }
-}
-
-function removeCloseListeners() {
-  if (outsideClickHandler) {
-    document.removeEventListener("mousedown", outsideClickHandler);
-    outsideClickHandler = null;
-  }
-  if (escapeHandler) {
-    document.removeEventListener("keydown", escapeHandler);
-    escapeHandler = null;
-  }
-}
-
-// Watch menuState to manage close listeners
+// Manage outside-click + Escape dismissal declaratively through the shared
+// `createVizelDismissibleController` helper. Cleanup runs automatically
+// when the menu closes (via the `onCleanup` argument) and on unmount.
 watch(
   menuState,
-  (state) => {
-    if (state) {
-      addCloseListeners();
-    } else {
-      removeCloseListeners();
-    }
+  (state, _prev, onCleanup) => {
+    if (!state) return;
+    const dispose = createVizelDismissibleController({
+      getElements: () => [menuRef.value, submenuRef.value],
+      onDismiss: close,
+    });
+    onCleanup(dispose);
   },
   { flush: "post" }
 );
@@ -234,7 +196,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   document.removeEventListener(VIZEL_BLOCK_MENU_EVENT, handleOpen);
-  removeCloseListeners();
 });
 </script>
 


### PR DESCRIPTION
## Summary

Two small polish items from the v2.x audit grouped because each is
self-contained and improves consistency without changing behavior.

| ID | Change |
|----|--------|
| **L7** | New `useLatest` hook in `@vizel/react/hooks` that captures the "always-latest ref" pattern: `useRef(value); ref.current = value;` returns a stable `RefObject<T>`. The `Vizel` component swaps its eight inline `useRef`/assign pairs over to `useLatest` calls, shedding the 16-line boilerplate while preserving the semantics. |
| **L8** | `@vizel/vue` `VizelBlockMenu` replaces its hand-rolled `addCloseListeners` / `removeCloseListeners` pair (two `document.addEventListener` calls, two cleanup branches, manual remove on every state transition) with a single `watch` whose `onCleanup` registers the disposer returned by `createVizelDismissibleController`. The same primitive now backs all three frameworks' BlockMenu dismissal. |

## Test Plan

- [x] `pnpm lint` clean (pre-existing complexity warning unrelated).
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None — both changes preserve external behavior.

Refs: L7, L8 from the v2.x audit.
