### PR TITLE
refactor(core): add required id field to VizelSlashCommandItem

### DIFF
--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -15,6 +15,15 @@ export interface SlashCommandRange {
  * Extended slash command item with enhanced features
  */
 export interface SlashCommandItem {
+  /**
+   * Stable identifier used as the React/Vue/Svelte list `key` and as the
+   * action lookup key. Must be unique within a single slash menu.
+   *
+   * The built-in items use camelCase ids (`heading1`, `bulletList`,
+   * `codeBlock`, etc.). Custom commands should adopt the same convention
+   * so they remain stable across locale-translated `title` changes.
+   */
+  id: string;
   /** Display title */
   title: string;
   /** Description of the command */
@@ -64,6 +73,7 @@ export interface SlashCommandSearchResult {
 export const defaultSlashCommands: SlashCommandItem[] = [
   // Text group
   {
+    id: "heading1",
     title: "Heading 1",
     description: "Large section heading",
     icon: "heading1",
@@ -75,6 +85,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "heading2",
     title: "Heading 2",
     description: "Medium section heading",
     icon: "heading2",
@@ -86,6 +97,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "heading3",
     title: "Heading 3",
     description: "Small section heading",
     icon: "heading3",
@@ -97,6 +109,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "heading4",
     title: "Heading 4",
     description: "Extra-small heading",
     icon: "heading4",
@@ -108,6 +121,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "heading5",
     title: "Heading 5",
     description: "Paragraph heading",
     icon: "heading5",
@@ -119,6 +133,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "heading6",
     title: "Heading 6",
     description: "Smallest heading",
     icon: "heading6",
@@ -131,6 +146,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   },
   // Lists group
   {
+    id: "bulletList",
     title: "Bullet List",
     description: "Create a simple bullet list",
     icon: "bulletList",
@@ -142,6 +158,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "numberedList",
     title: "Numbered List",
     description: "Create a numbered list",
     icon: "orderedList",
@@ -153,6 +170,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "taskList",
     title: "Task List",
     description: "Create a task list with checkboxes",
     icon: "taskList",
@@ -164,6 +182,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   },
   // Blocks group
   {
+    id: "quote",
     title: "Quote",
     description: "Capture a quote",
     icon: "blockquote",
@@ -175,6 +194,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "divider",
     title: "Divider",
     description: "Insert a horizontal divider",
     icon: "horizontalRule",
@@ -185,6 +205,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "details",
     title: "Details",
     description: "Collapsible content block",
     icon: "details",
@@ -199,6 +220,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "callout",
     title: "Callout",
     description: "Insert a callout block (info, tip, warning)",
     icon: "callout",
@@ -213,6 +235,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "codeBlock",
     title: "Code Block",
     description: "Insert a code snippet",
     icon: "codeBlock",
@@ -224,6 +247,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "table",
     title: "Table",
     description: "Insert a table",
     icon: "table",
@@ -240,6 +264,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   },
   // Media group
   {
+    id: "image",
     title: "Image",
     description: "Insert an image from URL",
     icon: "image",
@@ -253,6 +278,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "uploadImage",
     title: "Upload Image",
     description: "Upload an image from your device",
     icon: "imageUpload",
@@ -284,6 +310,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "embed",
     title: "Embed",
     description: "Embed a URL (YouTube, Twitter, etc.)",
     icon: "embed",
@@ -309,6 +336,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   },
   // Navigation group
   {
+    id: "tableOfContents",
     title: "Table of Contents",
     description: "Auto-generated list of headings",
     icon: "tableOfContents",
@@ -323,6 +351,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
   },
   // Advanced group
   {
+    id: "mathEquation",
     title: "Math Equation",
     description: "Insert a mathematical expression",
     icon: "mathBlock",
@@ -337,6 +366,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "inlineMath",
     title: "Inline Math",
     description: "Insert an inline math expression",
     icon: "mathInline",
@@ -351,6 +381,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "mermaidDiagram",
     title: "Mermaid Diagram",
     description: "Insert a Mermaid diagram",
     icon: "mermaid",
@@ -365,6 +396,7 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     },
   },
   {
+    id: "graphvizDiagram",
     title: "GraphViz Diagram",
     description: "Insert a GraphViz (DOT) diagram",
     icon: "graphviz",

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -212,7 +212,7 @@ export function VizelSlashMenu({
           if (renderItem) {
             return (
               <div
-                key={item.title}
+                key={item.id}
                 ref={(el) => {
                   itemRefs.current[index] = el;
                 }}
@@ -224,7 +224,7 @@ export function VizelSlashMenu({
 
           return (
             <div
-              key={item.title}
+              key={item.id}
               ref={(el) => {
                 itemRefs.current[index] = el;
               }}

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -186,7 +186,7 @@ if (ref) {
         <!-- Group with header -->
         <div class="vizel-slash-menu-group" data-vizel-slash-menu-group>
           <div class="vizel-slash-menu-group-header">{group.name}</div>
-          {#each group.items as item, itemIndex (item.title)}
+          {#each group.items as item, itemIndex (item.id)}
             {@const globalIdx = getGlobalIndex(groupIndex, itemIndex)}
             <div bind:this={itemRefs[globalIdx]}>
               {#if renderItem}
@@ -207,7 +207,7 @@ if (ref) {
         </div>
       {:else}
         <!-- Items without group header -->
-        {#each group.items as item, itemIndex (item.title)}
+        {#each group.items as item, itemIndex (item.id)}
           {@const globalIdx = getGlobalIndex(groupIndex, itemIndex)}
           <div bind:this={itemRefs[globalIdx]}>
             {#if renderItem}

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -172,7 +172,7 @@ function getGlobalIndex(groupIndex: number, itemIndex: number): number {
           <div class="vizel-slash-menu-group-header">{{ group.name }}</div>
           <div
             v-for="(item, itemIndex) in group.items"
-            :key="item.title"
+            :key="item.id"
             :ref="(el) => (itemRefs[getGlobalIndex(groupIndex, itemIndex)] = el as HTMLElement)"
           >
             <slot
@@ -194,7 +194,7 @@ function getGlobalIndex(groupIndex: number, itemIndex: number): number {
         <template v-else>
           <div
             v-for="(item, itemIndex) in group.items"
-            :key="item.title"
+            :key="item.id"
             :ref="(el) => (itemRefs[getGlobalIndex(groupIndex, itemIndex)] = el as HTMLElement)"
           >
             <slot


### PR DESCRIPTION
## Summary

The slash menu used `item.title` as its React/Vue/Svelte
reconciliation key. That broke two cases:

1. **Localized titles.** Switching locales translates `title`, so every
   item remounts on locale change.
2. **Collisions with custom commands.** Two providers contributing
   overlapping titles (e.g. both ship a "Code" item) collide silently
   in React/Svelte and trigger key-collision warnings in development.

Add a required `id: string` field to `VizelSlashCommandItem` and
switch the iteration keys to `item.id`. Each of the 23 built-in
commands gets a camelCase id matching its semantic role:

| Role | id |
|------|-----|
| Headings | `heading1` … `heading6` |
| Lists | `bulletList`, `numberedList`, `taskList` |
| Blocks | `quote`, `divider`, `details`, `callout`, `codeBlock`, `table` |
| Media | `image`, `uploadImage`, `embed` |
| Navigation | `tableOfContents` |
| Advanced | `mathEquation`, `inlineMath`, `mermaidDiagram`, `graphvizDiagram` |

## Breaking Changes

Consumers shipping custom slash commands must add an `id: string`
field. The recommended convention is camelCase matching the role
(`bookmark`, `databaseQuery`, ...). Built-in items keep their previous
behavior unchanged; the only consumer-visible difference is that
locale changes no longer remount every item.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Refs: M1, L2 from the v2.x audit.
