### PR TITLE
docs: document state subscription tick rationale and fix useVizelMarkdown jsdoc

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -201,6 +201,31 @@ switch the editor between read-write and read-only modes.
 To change other options at runtime, use the corresponding Tiptap command
 (`editor.commands.setContent(...)`, `editor.commands.focus(...)`, etc.).
 
+## State Subscription Convention
+
+The `useVizelState` / `createVizelState` primitives in every framework
+wrap `createVizelEditorTransactionStore` from `@vizel/core`. They
+**increment a monotonic version counter** on every Tiptap `transaction`
+event and surface that counter through the framework's native
+reactivity primitive.
+
+The counter value itself is intentionally meaningless — the hook
+exists to force a re-render so that subsequent `editor.isActive(...)`
+or `editor.state.*` reads happen against the latest snapshot. Reading
+`editor.state.tr` directly inside `useSyncExternalStore`'s
+`getSnapshot` would return a fresh `Transaction` on every call (it is
+a getter that constructs new instances), so React tears down the
+subscription with an infinite loop. The version-counter indirection
+is the only stable shape that satisfies React's referential-stability
+contract while still triggering on every transaction.
+
+Consumers typically ignore the return value:
+
+```tsx
+useVizelState(editor); // just subscribe, throw away the tick
+return <button className={editor.isActive("bold") ? "active" : ""} />;
+```
+
 ## Adding a New Feature
 
 Follow this sequence to add a feature with consistent cross-framework support:

--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -38,7 +38,7 @@ export interface UseVizelMarkdownResult {
 /**
  * React hook for bidirectional Markdown synchronization with the editor.
  *
- * @param editor - The editor instance (or `null` while it is still initializing)
+ * @param editor - The editor instance, or `null`/`undefined` while it is still initializing.
  * @param options - Sync options
  * @returns Markdown state and control functions
  *


### PR DESCRIPTION
## Summary

Two micro-doc additions that pin down details the v2.x audit flagged.

| ID | Where | Change |
|----|-------|--------|
| **L6** | `.claude/rules/cross-framework.md` | New "State Subscription Convention" section explains why `useVizelState` / `createVizelState` expose a monotonic version counter instead of returning the editor's `state.tr`. Reading `state.tr` inside React's `useSyncExternalStore.getSnapshot` constructs a fresh `Transaction` on every call (it is a getter, not a property), violating the referential-stability contract and triggering an infinite render loop. The counter indirection is the only stable shape that lands the "force re-render on transaction" contract. |
| **M14** | `packages/react/src/hooks/useVizelMarkdown.ts` | Update the `@param editor` JSDoc from "(or `null` while it is still initializing)" to "(or `null`/`undefined` while it is still initializing)" so the doc matches the actual `Editor | null | undefined` parameter type. |

## Test Plan

- [x] Docs only — `pnpm lint` / `typecheck` / `build` unaffected.

## Breaking Changes

None — pure documentation.

Refs: L6, M14 from the v2.x audit.
