### PR TITLE
refactor(react): convert Vizel toolbarContent and bubbleMenuContent to render props

### DIFF
--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -104,8 +104,8 @@ import { Vizel } from '@vizel/react';
 | `markdown` | `string` | - | Controlled-mode Markdown value. Pair with `onMarkdownChange` to drive the editor from external state. |
 | `flavor` | `VizelMarkdownFlavor` | `"gfm"` | Markdown output flavor (`"commonmark"`, `"gfm"`, `"obsidian"`, `"docusaurus"`). |
 | `locale` | `VizelLocale` | - | Localized UI strings. Use `createVizelLocale()` to merge a partial override with the English default. |
-| `toolbarContent` | `ReactNode` | - | Custom toolbar content. When provided alongside `showToolbar`, replaces the default toolbar body. |
-| `bubbleMenuContent` | `ReactNode` | - | Custom bubble-menu content. When provided alongside `showBubbleMenu`, replaces the default body. |
+| `toolbarContent` | `(props: { editor }) => ReactNode` | - | Custom toolbar content as a render prop. The bound editor is passed in so the callback can drive Tiptap commands. Mirrors the Vue `<slot name="toolbar" :editor>` and Svelte `toolbar: Snippet<[{ editor }]>`. |
+| `bubbleMenuContent` | `(props: { editor }) => ReactNode` | - | Custom bubble-menu content as a render prop. Same shape as `toolbarContent`. |
 | `ref` | `Ref<VizelRef>` | - | Forwarded ref exposing the underlying `Editor` instance. |
 | `onMarkdownChange` | `(markdown: string) => void` | - | Fired when editor content changes in controlled mode (use with `markdown`). |
 | `onUpdate` | `(props: { editor }) => void` | - | Update callback |

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -60,14 +60,24 @@ export interface VizelProps {
   className?: string;
   /** Whether to show the toolbar (default: false) */
   showToolbar?: boolean;
-  /** Custom toolbar content */
-  toolbarContent?: ReactNode;
+  /**
+   * Custom toolbar content as a render prop.
+   * Receives the bound editor instance so the consumer can drive Tiptap
+   * commands from custom controls. Mirrors the Vue `<slot name="toolbar"
+   * :editor>` and the Svelte `toolbar: Snippet<[{ editor }]>`.
+   */
+  toolbarContent?: (props: { editor: Editor }) => ReactNode;
   /** Whether to show the bubble menu (default: true) */
   showBubbleMenu?: boolean;
   /** Enable embed option in bubble menu link editor (requires Embed extension) */
   enableEmbed?: boolean;
-  /** Custom bubble menu content */
-  bubbleMenuContent?: ReactNode;
+  /**
+   * Custom bubble menu content as a render prop.
+   * Receives the bound editor instance so the consumer can drive Tiptap
+   * commands from custom controls. Mirrors the Vue `<slot name="bubble-menu"
+   * :editor>` and the Svelte `bubbleMenu: Snippet<[{ editor }]>`.
+   */
+  bubbleMenuContent?: (props: { editor: Editor }) => ReactNode;
   /** Additional children to render inside the editor root */
   children?: ReactNode;
   /**
@@ -255,7 +265,7 @@ export function Vizel({
         editor &&
         (toolbarContent ? (
           <VizelToolbar editor={editor} {...localeProps}>
-            {toolbarContent}
+            {toolbarContent({ editor })}
           </VizelToolbar>
         ) : (
           <VizelToolbar editor={editor} {...localeProps} />
@@ -265,7 +275,7 @@ export function Vizel({
         editor &&
         (bubbleMenuContent ? (
           <VizelBubbleMenu editor={editor} enableEmbed={enableEmbed} {...localeProps}>
-            {bubbleMenuContent}
+            {bubbleMenuContent({ editor })}
           </VizelBubbleMenu>
         ) : (
           <VizelBubbleMenu editor={editor} enableEmbed={enableEmbed} {...localeProps} />


### PR DESCRIPTION
## Summary

The React `<Vizel>` component accepted `toolbarContent` /
`bubbleMenuContent` as plain `ReactNode`. That left consumers with no
way to access the bound editor instance from their custom content —
they had to capture a separate `ref` to the editor and thread it
through manually.

Vue and Svelte already expose the editor through the slot / snippet
argument (`<slot name="toolbar" :editor>` /
`Snippet<[{ editor }]>`). This PR aligns the React surface to the
same shape — a render prop receiving `{ editor }`:

```tsx
<Vizel
  showToolbar
  toolbarContent={({ editor }) => (
    <button onClick={() => editor.chain().focus().toggleBold().run()}>
      Bold
    </button>
  )}
/>
```

`docs/guide/react.md`'s prop table updates the `toolbarContent` /
`bubbleMenuContent` rows to the new render-prop signature.

## Breaking Changes

Consumers passing JSX directly to `toolbarContent` /
`bubbleMenuContent` must wrap it in a function:

```diff
- <Vizel toolbarContent={<MyToolbar />} />
+ <Vizel toolbarContent={() => <MyToolbar />} />
```

Most consumers will want to take the editor argument:
`toolbarContent={({ editor }) => ...}`.

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Refs: M8, M9 from the v2.x audit.
