### PR TITLE
fix(core): surface slash command upload-image delete failures via console.warn

### DIFF
--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -285,11 +285,24 @@ export const defaultSlashCommands: SlashCommandItem[] = [
     group: "Media",
     keywords: ["picture", "photo", "upload", "file"],
     command: ({ editor, range }) => {
-      // Delete the slash command text first
+      // Delete the slash command text first.
+      //
+      // The catch is intentional: this command runs inside a synchronous user
+      // event handler (slash-menu Enter), and the file picker dialog MUST be
+      // opened on the same stack frame to avoid being blocked by the browser
+      // pop-up suppressor. If the Tiptap delete fails (e.g., the document was
+      // mutated between menu open and command run), we log a warning instead
+      // of throwing so the file picker still opens. Production logging hooks
+      // can pick the warning up via `console.warn`.
       try {
         editor.chain().focus().deleteRange(range).run();
-      } catch {
-        // Ignore errors from editor operations to ensure file picker opens
+      } catch (error) {
+        if (typeof console !== "undefined") {
+          console.warn(
+            "[Vizel] Failed to remove slash command text before opening file picker:",
+            error
+          );
+        }
       }
 
       // Open file picker dialog (must happen synchronously in user event handler)


### PR DESCRIPTION
## Summary

The Upload Image slash command silently swallowed any error thrown by
`editor.chain().focus().deleteRange(range).run()` before opening the
file picker. The empty `catch` block was deliberate — the dialog must
open synchronously in the user-gesture stack frame or the browser
pop-up blocker rejects it — but the swallow gave consumers no way to
learn that the document mutation failed.

Replace the empty catch with `console.warn(..., error)` so production
logging hooks (Sentry's `console.warn` integration, Logflare, etc.)
can pick up the failure. The pop-up-blocker constraint that motivates
the catch is now documented inline.

```diff
- try {
-   editor.chain().focus().deleteRange(range).run();
- } catch {
-   // Ignore errors from editor operations to ensure file picker opens
- }
+ try {
+   editor.chain().focus().deleteRange(range).run();
+ } catch (error) {
+   if (typeof console !== "undefined") {
+     console.warn(
+       "[Vizel] Failed to remove slash command text before opening file picker:",
+       error
+     );
+   }
+ }
```

## Test Plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

## Breaking Changes

None. The file picker still opens unconditionally; the only new
externally-visible behavior is a `console.warn` when the prior
`deleteRange` would have already silently failed.

Refs: M6 from the v2.x audit.
