### PR TITLE
refactor: extract VizelMentionMenu DOM skeleton into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -305,6 +305,19 @@ export {
   VizelPluginManager,
   validateVizelPlugin,
 } from "./plugin-system.ts";
+
+// =============================================================================
+// UI Skeletons
+// =============================================================================
+export {
+  buildVizelMentionMenuSkeleton,
+  type VizelMentionItemView,
+  type VizelMenuItemAttrs,
+  type VizelMenuItemSpec,
+  type VizelMenuRootAttrs,
+  type VizelMenuSectionSpec,
+  type VizelMenuSpec,
+} from "./skeletons/index.ts";
 // =============================================================================
 // Theme
 // =============================================================================

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -1,0 +1,11 @@
+export {
+  buildVizelMentionMenuSkeleton,
+  type VizelMentionItemView,
+} from "./mention-menu.ts";
+export type {
+  VizelMenuItemAttrs,
+  VizelMenuItemSpec,
+  VizelMenuRootAttrs,
+  VizelMenuSectionSpec,
+  VizelMenuSpec,
+} from "./types.ts";

--- a/packages/core/src/skeletons/mention-menu.ts
+++ b/packages/core/src/skeletons/mention-menu.ts
@@ -1,0 +1,66 @@
+import type { VizelMentionItem } from "../extensions/mention.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelMenuSpec } from "./types.ts";
+
+/**
+ * Item-data shape surfaced to the framework `VizelMentionMenu` component.
+ *
+ * Carries the original `VizelMentionItem` plus the selection flag so the
+ * component renders avatar + label + description without re-deriving
+ * `isSelected` from `selectedIndex`.
+ */
+export interface VizelMentionItemView {
+  /** The item as supplied by the consumer. */
+  item: VizelMentionItem;
+  /** Whether this item is the keyboard-active selection. */
+  isSelected: boolean;
+}
+
+/**
+ * Build a {@link VizelMenuSpec} for the mention autocomplete menu.
+ *
+ * Mention menus are flat (no groups), use `role="listbox"`, and address
+ * the active option through `aria-activedescendant`. The locale provides
+ * the container's `aria-label`; framework components render the item
+ * view (avatar + label + description) themselves using the supplied
+ * `data` field.
+ *
+ * Returning an empty `sections` array signals the empty / no-results
+ * state — the component renders a localized empty-state element.
+ */
+export function buildVizelMentionMenuSkeleton(
+  items: readonly VizelMentionItem[],
+  selectedIndex: number,
+  locale: VizelLocale | undefined
+): VizelMenuSpec<VizelMentionItemView> {
+  const ariaLabel = locale?.mentionMenu?.ariaLabel ?? "Mentions";
+  const activeItem = items[selectedIndex];
+  const activeId = activeItem ? `vizel-mention-${activeItem.id}` : undefined;
+
+  return {
+    root: {
+      role: "listbox",
+      "aria-label": ariaLabel,
+      ...(activeId && { "aria-activedescendant": activeId }),
+    },
+    sections:
+      items.length === 0
+        ? []
+        : [
+            {
+              key: "default",
+              items: items.map((item, index) => ({
+                key: item.id,
+                index,
+                data: { item, isSelected: index === selectedIndex },
+                attrs: {
+                  role: "option",
+                  "aria-selected": index === selectedIndex,
+                  id: `vizel-mention-${item.id}`,
+                  tabIndex: -1,
+                },
+              })),
+            },
+          ],
+  };
+}

--- a/packages/core/src/skeletons/types.ts
+++ b/packages/core/src/skeletons/types.ts
@@ -1,0 +1,98 @@
+/**
+ * UI skeleton specs.
+ *
+ * Each menu / form component in `@vizel/{react,vue,svelte}` is the same
+ * DOM shape with framework-specific templating. The spec types in this
+ * module describe that DOM shape declaratively so the structure, ARIA
+ * attributes, and identifiers live in one place. Each framework adapter
+ * is a thin transformer that maps the spec to its own template syntax.
+ *
+ * Specs do NOT include item *content* (icons, labels, descriptions) —
+ * those vary per surface (mention avatar + name, slash icon + title +
+ * description + shortcut, block-menu icon + label + shortcut, ...) and
+ * the component owns rendering the inner view. The spec owns the
+ * scaffolding around the items.
+ */
+
+/**
+ * ARIA attributes accepted on the menu root element.
+ */
+export interface VizelMenuRootAttrs {
+  role?: "listbox" | "menu";
+  /** Localized label announced by assistive tech. */
+  "aria-label"?: string;
+  /**
+   * Id of the currently focused option/menuitem. Set when the menu uses
+   * roving keyboard focus via `aria-activedescendant`.
+   */
+  "aria-activedescendant"?: string;
+  /** Optional explicit tabIndex on the root (useful for keyboard focus). */
+  tabIndex?: number;
+}
+
+/**
+ * ARIA attributes accepted on each item element inside the menu.
+ */
+export interface VizelMenuItemAttrs {
+  role?: "option" | "menuitem";
+  /** Whether this item is the active selection. */
+  "aria-selected"?: boolean;
+  /**
+   * Whether this item is disabled (skipped by keyboard navigation,
+   * non-activatable).
+   */
+  "aria-disabled"?: boolean;
+  /** Stable per-option id matching the root's `aria-activedescendant`. */
+  id?: string;
+  /** Item tabIndex; usually `-1` so the root owns keyboard focus. */
+  tabIndex?: number;
+}
+
+/**
+ * A single item slot in the menu spec.
+ *
+ * The spec carries the *identifying* shape: a stable key, ARIA attrs,
+ * selection / disabled flags, plus an `index` into the original item
+ * array so the framework component can call its existing
+ * `selectItem(index)` from the click / Enter handler. Item rendering
+ * (icon, label, description, etc.) is the component's job — the spec
+ * passes the original item view back through `data`.
+ */
+export interface VizelMenuItemSpec<TData> {
+  /** Stable key (used as React/Vue/Svelte iteration key). */
+  key: string;
+  /** Original-array index for activation wiring. */
+  index: number;
+  /** ARIA attributes for the item element. */
+  attrs: VizelMenuItemAttrs;
+  /** Item-specific data (label, icon name, etc.) passed to the consumer. */
+  data: TData;
+}
+
+/**
+ * A group of items rendered together, optionally preceded by a header.
+ *
+ * For ungrouped menus (e.g. mention suggestions), the spec carries a
+ * single section with no header.
+ */
+export interface VizelMenuSectionSpec<TData> {
+  /** Stable key (used as iteration key for the section element). */
+  key: string;
+  /** Group header label (omitted for ungrouped menus). */
+  header?: { label: string };
+  /** Items in this section. */
+  items: readonly VizelMenuItemSpec<TData>[];
+}
+
+/**
+ * The complete menu spec: root container attrs + sections.
+ *
+ * Empty menus (e.g. "no results" state) are represented by an empty
+ * `sections` array; the framework component renders an empty-state slot.
+ */
+export interface VizelMenuSpec<TData> {
+  /** ARIA attrs for the root container. */
+  root: VizelMenuRootAttrs;
+  /** Sections (groups) of items. Empty when there are no items. */
+  sections: readonly VizelMenuSectionSpec<TData>[];
+}

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -1,6 +1,11 @@
-import { resolveVizelListNavigation, type VizelLocale, type VizelMentionItem } from "@vizel/core";
+import {
+  buildVizelMentionMenuSkeleton,
+  resolveVizelListNavigation,
+  type VizelLocale,
+  type VizelMentionItem,
+} from "@vizel/core";
 import type { ReactNode, Ref } from "react";
-import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 
 export interface VizelMentionMenuRef {
   /**
@@ -27,7 +32,11 @@ export interface VizelMentionMenuProps {
 
 /**
  * Mention autocomplete menu component.
- * Displays a list of mention suggestions with keyboard navigation.
+ *
+ * The DOM structure and ARIA wiring come from `@vizel/core`'s
+ * `buildVizelMentionMenuSkeleton`; this component is the React-flavored
+ * binding that maps the spec to JSX. Item rendering (avatar + label +
+ * description) is React-specific and stays here.
  */
 export function VizelMentionMenu({
   ref,
@@ -67,14 +76,10 @@ export function VizelMentionMenu({
     [items, onSelect]
   );
 
-  const enterHandler = useCallback(() => {
-    selectItem(selectedIndex);
-  }, [selectItem, selectedIndex]);
-
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
       if (event.key === "Enter") {
-        enterHandler();
+        selectItem(selectedIndex);
         return true;
       }
       const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
@@ -84,68 +89,71 @@ export function VizelMentionMenu({
     },
   }));
 
-  const ariaLabel = locale?.mentionMenu?.ariaLabel ?? "Mentions";
-  const noResultsText = locale?.mentionMenu?.noResults ?? "No results";
+  const spec = useMemo(
+    () => buildVizelMentionMenuSkeleton(items, selectedIndex, locale),
+    [items, selectedIndex, locale]
+  );
 
-  if (items.length === 0) {
+  if (spec.sections.length === 0) {
     return (
       <div
         className={`vizel-mention-menu ${className ?? ""}`}
         data-vizel-mention-menu=""
         role="listbox"
-        aria-label={ariaLabel}
+        aria-label={spec.root["aria-label"]}
       >
-        <div className="vizel-mention-menu-empty">{noResultsText}</div>
+        <div className="vizel-mention-menu-empty">
+          {locale?.mentionMenu?.noResults ?? "No results"}
+        </div>
       </div>
     );
   }
-
-  const activeOptionId = items[selectedIndex]
-    ? `vizel-mention-${items[selectedIndex].id}`
-    : undefined;
 
   return (
     <div
       className={`vizel-mention-menu ${className ?? ""}`}
       data-vizel-mention-menu=""
       role="listbox"
-      aria-label={ariaLabel}
-      {...(activeOptionId && { "aria-activedescendant": activeOptionId })}
+      aria-label={spec.root["aria-label"]}
+      {...(spec.root["aria-activedescendant"] && {
+        "aria-activedescendant": spec.root["aria-activedescendant"],
+      })}
     >
-      {items.map((item, index) => {
-        const isSelected = index === selectedIndex;
-        return (
+      {spec.sections.flatMap((section) =>
+        section.items.map((slot) => (
           <div
-            key={item.id}
-            id={`vizel-mention-${item.id}`}
+            key={slot.key}
+            id={slot.attrs.id}
             ref={(el) => {
-              itemRefs.current[index] = el;
+              itemRefs.current[slot.index] = el;
             }}
-            className={`vizel-mention-menu-item ${isSelected ? "is-selected" : ""}`}
-            onClick={() => selectItem(index)}
+            className={`vizel-mention-menu-item ${slot.data.isSelected ? "is-selected" : ""}`}
+            onClick={() => selectItem(slot.index)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") selectItem(index);
+              if (e.key === "Enter") selectItem(slot.index);
             }}
-            tabIndex={-1}
+            tabIndex={slot.attrs.tabIndex}
             role="option"
-            aria-selected={isSelected}
+            aria-selected={slot.attrs["aria-selected"]}
           >
             <div className="vizel-mention-menu-item-avatar">
-              {item.avatar ? (
-                <img src={item.avatar} alt={item.label} />
+              {slot.data.item.avatar ? (
+                <img src={slot.data.item.avatar} alt={slot.data.item.label} />
               ) : (
-                item.label.charAt(0).toUpperCase()
+                slot.data.item.label.charAt(0).toUpperCase()
               )}
             </div>
             <div className="vizel-mention-menu-item-content">
-              <div className="vizel-mention-menu-item-label">{item.label}</div>
-              {item.description && (
-                <div className="vizel-mention-menu-item-description">{item.description}</div>
+              <div className="vizel-mention-menu-item-label">{slot.data.item.label}</div>
+              {slot.data.item.description && (
+                <div className="vizel-mention-menu-item-description">
+                  {slot.data.item.description}
+                </div>
               )}
             </div>
           </div>
-        );
-      })}
+        ))
+      )}
     </div>
   );
 }

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -24,7 +24,7 @@ export interface VizelMentionMenuProps {
 </script>
 
 <script lang="ts">
-import { resolveVizelListNavigation } from "@vizel/core";
+import { buildVizelMentionMenuSkeleton, resolveVizelListNavigation } from "@vizel/core";
 import { tick } from "svelte";
 
 let {
@@ -37,6 +37,9 @@ let {
 
 let selectedIndex = $state(0);
 let itemRefs: (HTMLElement | null)[] = $state([]);
+
+const spec = $derived(buildVizelMentionMenuSkeleton(items, selectedIndex, locale));
+const slots = $derived(spec.sections.flatMap((section) => section.items));
 
 $effect(() => {
   if (itemRefs.length > items.length) {
@@ -94,35 +97,36 @@ if (ref) {
 <div
   class="vizel-mention-menu {className ?? ''}"
   data-vizel-mention-menu
-  role="listbox"
-  aria-label={locale?.mentionMenu?.ariaLabel ?? "Mentions"}
-  aria-activedescendant={items[selectedIndex]?.id ? `vizel-mention-${items[selectedIndex]?.id}` : undefined}
+  role={spec.root.role}
+  aria-label={spec.root["aria-label"]}
+  aria-activedescendant={spec.root["aria-activedescendant"]}
 >
-  {#if items.length === 0}
+  {#if spec.sections.length === 0}
     <div class="vizel-mention-menu-empty">{locale?.mentionMenu?.noResults ?? "No results"}</div>
   {:else}
-    {#each items as item, index (item.id)}
+    {#each slots as slot (slot.key)}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
       <div
-        id="vizel-mention-{item.id}"
-        bind:this={itemRefs[index]}
-        class="vizel-mention-menu-item {index === selectedIndex ? 'is-selected' : ''}"
-        role="option"
-        aria-selected={index === selectedIndex}
-        onclick={() => selectItem(index)}
-        onkeydown={(e) => { if (e.key === "Enter") selectItem(index); }}
-        tabindex={-1}
+        id={slot.attrs.id}
+        bind:this={itemRefs[slot.index]}
+        class="vizel-mention-menu-item {slot.data.isSelected ? 'is-selected' : ''}"
+        role={slot.attrs.role}
+        aria-selected={slot.attrs["aria-selected"]}
+        onclick={() => selectItem(slot.index)}
+        onkeydown={(e) => { if (e.key === "Enter") selectItem(slot.index); }}
+        tabindex={slot.attrs.tabIndex}
       >
         <div class="vizel-mention-menu-item-avatar">
-          {#if item.avatar}
-            <img src={item.avatar} alt={item.label} />
+          {#if slot.data.item.avatar}
+            <img src={slot.data.item.avatar} alt={slot.data.item.label} />
           {:else}
-            {item.label.charAt(0).toUpperCase()}
+            {slot.data.item.label.charAt(0).toUpperCase()}
           {/if}
         </div>
         <div class="vizel-mention-menu-item-content">
-          <div class="vizel-mention-menu-item-label">{item.label}</div>
-          {#if item.description}
-            <div class="vizel-mention-menu-item-description">{item.description}</div>
+          <div class="vizel-mention-menu-item-label">{slot.data.item.label}</div>
+          {#if slot.data.item.description}
+            <div class="vizel-mention-menu-item-description">{slot.data.item.description}</div>
           {/if}
         </div>
       </div>

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { resolveVizelListNavigation, type VizelLocale, type VizelMentionItem } from "@vizel/core";
+import {
+  buildVizelMentionMenuSkeleton,
+  resolveVizelListNavigation,
+  type VizelLocale,
+  type VizelMentionItem,
+} from "@vizel/core";
 import { computed, nextTick, ref, watch } from "vue";
 
 export interface VizelMentionMenuRef {
@@ -22,10 +27,11 @@ const emit = defineEmits<{
 const selectedIndex = ref(0);
 const itemRefs = ref<(HTMLElement | null)[]>([]);
 
-const activeOptionId = computed(() => {
-  const item = props.items[selectedIndex.value];
-  return item ? `vizel-mention-${item.id}` : undefined;
-});
+const spec = computed(() =>
+  buildVizelMentionMenuSkeleton(props.items, selectedIndex.value, props.locale)
+);
+
+const slots = computed(() => spec.value.sections.flatMap((section) => section.items));
 
 watch(
   () => props.items,
@@ -70,34 +76,34 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
   <div
     :class="['vizel-mention-menu', props.class]"
     data-vizel-mention-menu
-    role="listbox"
-    :aria-label="props.locale?.mentionMenu?.ariaLabel ?? 'Mentions'"
-    :aria-activedescendant="activeOptionId"
+    :role="spec.root.role"
+    :aria-label="spec.root['aria-label']"
+    :aria-activedescendant="spec.root['aria-activedescendant']"
   >
-    <div v-if="items.length === 0" class="vizel-mention-menu-empty">
+    <div v-if="spec.sections.length === 0" class="vizel-mention-menu-empty">
       {{ props.locale?.mentionMenu?.noResults ?? 'No results' }}
     </div>
     <template v-else>
       <div
-        v-for="(item, index) in items"
-        :key="item.id"
-        :id="`vizel-mention-${item.id}`"
-        :ref="(el) => { itemRefs[index] = el as HTMLElement | null }"
-        :class="['vizel-mention-menu-item', { 'is-selected': index === selectedIndex }]"
-        role="option"
-        :aria-selected="index === selectedIndex"
-        :tabindex="-1"
-        @click="selectItem(index)"
-        @keydown.enter="selectItem(index)"
+        v-for="slot in slots"
+        :key="slot.key"
+        :id="slot.attrs.id"
+        :ref="(el) => { itemRefs[slot.index] = el as HTMLElement | null }"
+        :class="['vizel-mention-menu-item', { 'is-selected': slot.data.isSelected }]"
+        :role="slot.attrs.role"
+        :aria-selected="slot.attrs['aria-selected']"
+        :tabindex="slot.attrs.tabIndex"
+        @click="selectItem(slot.index)"
+        @keydown.enter="selectItem(slot.index)"
       >
         <div class="vizel-mention-menu-item-avatar">
-          <img v-if="item.avatar" :src="item.avatar" :alt="item.label" />
-          <template v-else>{{ item.label.charAt(0).toUpperCase() }}</template>
+          <img v-if="slot.data.item.avatar" :src="slot.data.item.avatar" :alt="slot.data.item.label" />
+          <template v-else>{{ slot.data.item.label.charAt(0).toUpperCase() }}</template>
         </div>
         <div class="vizel-mention-menu-item-content">
-          <div class="vizel-mention-menu-item-label">{{ item.label }}</div>
-          <div v-if="item.description" class="vizel-mention-menu-item-description">
-            {{ item.description }}
+          <div class="vizel-mention-menu-item-label">{{ slot.data.item.label }}</div>
+          <div v-if="slot.data.item.description" class="vizel-mention-menu-item-description">
+            {{ slot.data.item.description }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Phase 7 of the v2.x audit ("UI skeletonization") moves the shared
DOM/ARIA scaffolding of menu/form components into `@vizel/core`. This
PR ships step 1 of 7: `VizelMentionMenu`.

The React/Vue/Svelte mention menus had three independent copies of the
same listbox/option structure, ARIA wiring, and `vizel-mention-${id}`
id scheme. Any divergence in that scaffolding was a parity bug waiting
to happen. The shared builder collapses them to one source of truth.

### What `@vizel/core/skeletons` owns

- `VizelMenuSpec<TData>` — declarative spec type for menus.
- `VizelMenuRootAttrs` / `VizelMenuItemAttrs` — ARIA attribute shapes.
- `VizelMenuSectionSpec<TData>` — group container (mention menu uses
  a single ungrouped section; SlashMenu in later steps will use
  multiple).
- `VizelMentionItemView = { item, isSelected }` — the per-item data
  the framework component receives via `slot.data`.
- `buildVizelMentionMenuSkeleton(items, selectedIndex, locale)` — the
  builder that returns the spec.

### What stays in the framework component

Item rendering (avatar + label + description) is intentionally NOT in
the spec — that view varies across mention / slash / block menus and
should stay framework-idiomatic. The component iterates
`spec.sections.flatMap(...)` and renders the item view, using
`slot.attrs` for ARIA, `slot.data.item` for the original item, and
`slot.index` for click / Enter activation.

### Why `index` instead of `onActivate` in the spec

The spec deliberately carries the original-array index rather than an
activation callback, so the framework component can keep its existing
`selectItem(index)` plumbing. This keeps the spec serializable and
framework-neutral.

## Breaking Changes

None at the consumer level — `VizelMentionMenu` props/refs are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 1 of 7. Remaining: SlashMenu, BlockMenu, ToolbarDropdown,
NodeSelector, LinkEditor form, FindReplace form.
