### PR TITLE
refactor: extract VizelSlashMenu DOM skeleton into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -311,12 +311,16 @@ export {
 // =============================================================================
 export {
   buildVizelMentionMenuSkeleton,
+  buildVizelSlashMenuSkeleton,
+  getNextVizelSlashMenuGroupIndex,
   type VizelMentionItemView,
   type VizelMenuItemAttrs,
   type VizelMenuItemSpec,
   type VizelMenuRootAttrs,
   type VizelMenuSectionSpec,
   type VizelMenuSpec,
+  type VizelSlashItemView,
+  type VizelSlashMenuSkeletonOptions,
 } from "./skeletons/index.ts";
 // =============================================================================
 // Theme

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -2,6 +2,12 @@ export {
   buildVizelMentionMenuSkeleton,
   type VizelMentionItemView,
 } from "./mention-menu.ts";
+export {
+  buildVizelSlashMenuSkeleton,
+  getNextVizelSlashMenuGroupIndex,
+  type VizelSlashItemView,
+  type VizelSlashMenuSkeletonOptions,
+} from "./slash-menu.ts";
 export type {
   VizelMenuItemAttrs,
   VizelMenuItemSpec,

--- a/packages/core/src/skeletons/slash-menu.ts
+++ b/packages/core/src/skeletons/slash-menu.ts
@@ -1,0 +1,111 @@
+import {
+  groupSlashCommands as groupVizelSlashCommands,
+  type SlashCommandItem as VizelSlashCommandItem,
+} from "../commands/slash-items.ts";
+import type { VizelMenuSpec } from "./types.ts";
+
+/**
+ * Item-data shape surfaced to the framework `VizelSlashMenu` component.
+ *
+ * Carries the original `VizelSlashCommandItem` plus the selection flag so
+ * the component can render its default `VizelSlashMenuItem` (or a
+ * consumer-supplied custom renderer) without re-deriving `isSelected`
+ * from `selectedIndex`.
+ */
+export interface VizelSlashItemView {
+  /** The slash-command item as supplied by the consumer. */
+  item: VizelSlashCommandItem;
+  /** Whether this item is the keyboard-active selection. */
+  isSelected: boolean;
+}
+
+/**
+ * Options accepted by {@link buildVizelSlashMenuSkeleton}.
+ */
+export interface VizelSlashMenuSkeletonOptions {
+  /**
+   * Whether to render items grouped by category. When `false`, or when
+   * `items.length <= 5` (typically fuzzy-search results), grouping is
+   * collapsed to a single un-headed section.
+   *
+   * @default true
+   */
+  showGroups?: boolean;
+  /** Custom group display order. Forwarded to `groupVizelSlashCommands`. */
+  groupOrder?: string[];
+}
+
+/**
+ * Build a {@link VizelMenuSpec} for the slash command menu.
+ *
+ * Slash menus use `role="listbox"` and may render multiple sections
+ * (groups) each with a header label. Items defer their own role / ARIA
+ * to the framework `VizelSlashMenuItem` component (which is itself a
+ * `role="option"` button), so the spec-level item `attrs` are empty —
+ * the spec carries identity (key, index) and view data only.
+ *
+ * The empty `sections` array represents the no-items state; the
+ * component renders its default `VizelSlashMenuEmpty` (or a custom
+ * `renderEmpty`).
+ */
+export function buildVizelSlashMenuSkeleton(
+  items: readonly VizelSlashCommandItem[],
+  selectedIndex: number,
+  options: VizelSlashMenuSkeletonOptions = {}
+): VizelMenuSpec<VizelSlashItemView> {
+  const { showGroups = true, groupOrder } = options;
+  const rootAttrs = { role: "listbox", "aria-label": "Commands" } as const;
+
+  if (items.length === 0) {
+    return { root: rootAttrs, sections: [] };
+  }
+
+  const groups =
+    !showGroups || items.length <= 5
+      ? [{ name: "", items: [...items] }]
+      : groupVizelSlashCommands([...items], groupOrder);
+
+  let globalIndex = 0;
+  const sections = groups.map((group, gIndex) => {
+    const sectionItems = group.items.map((item) => {
+      const index = globalIndex++;
+      return {
+        key: item.id,
+        index,
+        data: { item, isSelected: index === selectedIndex },
+        attrs: {},
+      };
+    });
+    return {
+      key: group.name || `__ungrouped_${gIndex}`,
+      ...(group.name && { header: { label: group.name } }),
+      items: sectionItems,
+    };
+  });
+
+  return { root: rootAttrs, sections };
+}
+
+/**
+ * Compute the next-group jump target for Tab-key navigation.
+ *
+ * Given the current spec and the global `currentIndex`, return the
+ * global index of the first item in the *next* section (wrapping
+ * around). When the spec has zero or one section, the current index
+ * is returned unchanged.
+ */
+export function getNextVizelSlashMenuGroupIndex(
+  spec: VizelMenuSpec<VizelSlashItemView>,
+  currentIndex: number
+): number {
+  if (spec.sections.length <= 1) return currentIndex;
+
+  const curSectionIdx = spec.sections.findIndex((section) =>
+    section.items.some((slot) => slot.index === currentIndex)
+  );
+  if (curSectionIdx === -1) return currentIndex;
+
+  const nextSectionIdx = (curSectionIdx + 1) % spec.sections.length;
+  const nextSection = spec.sections[nextSectionIdx];
+  return nextSection?.items[0]?.index ?? currentIndex;
+}

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -1,6 +1,6 @@
 import {
-  groupVizelSlashCommands,
-  type VizelSlashCommandGroup,
+  buildVizelSlashMenuSkeleton,
+  getNextVizelSlashMenuGroupIndex,
   type VizelSlashCommandItem,
 } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
@@ -41,21 +41,12 @@ export interface VizelSlashMenuProps {
 
 /**
  * Slash command menu component for displaying command suggestions.
- * Supports grouping, keyboard navigation, and fuzzy search highlighting.
  *
- * @example
- * ```tsx
- * // Basic usage via createVizelSlashMenuRenderer
- * import { SlashCommand, createVizelSlashMenuRenderer } from '@vizel/react';
- *
- * const editor = useEditor({
- *   extensions: [
- *     SlashCommand.configure({
- *       suggestion: createVizelSlashMenuRenderer(),
- *     }),
- *   ],
- * });
- * ```
+ * DOM scaffolding (listbox container, section grouping, item identity
+ * + index) comes from `@vizel/core`'s `buildVizelSlashMenuSkeleton`;
+ * this component is the React-flavored binding that maps the spec to
+ * JSX. Item rendering (icon + title + description + shortcut) stays in
+ * `VizelSlashMenuItem`, which keeps `role="option"` ownership.
  */
 export function VizelSlashMenu({
   ref,
@@ -70,26 +61,26 @@ export function VizelSlashMenu({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-  // Group items when showGroups is true and there are enough items
-  const groups = useMemo<VizelSlashCommandGroup[]>(() => {
-    if (!showGroups || items.length <= 5) {
-      // Don't group if explicitly disabled or few items (likely search results)
-      return [{ name: "", items }];
-    }
-    return groupVizelSlashCommands(items, groupOrder);
-  }, [items, showGroups, groupOrder]);
+  const spec = useMemo(
+    () =>
+      buildVizelSlashMenuSkeleton(items, selectedIndex, {
+        showGroups,
+        ...(groupOrder && { groupOrder }),
+      }),
+    [items, selectedIndex, showGroups, groupOrder]
+  );
 
-  // Flatten for navigation
-  const flatItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+  const flatItemCount = useMemo(
+    () => spec.sections.reduce((sum, section) => sum + section.items.length, 0),
+    [spec]
+  );
 
-  // Trim refs array when items count decreases to prevent stale references
   useEffect(() => {
-    if (itemRefs.current.length > flatItems.length) {
-      itemRefs.current.length = flatItems.length;
+    if (itemRefs.current.length > flatItemCount) {
+      itemRefs.current.length = flatItemCount;
     }
-  }, [flatItems.length]);
+  }, [flatItemCount]);
 
-  // Scroll selected item into view when selection changes
   useEffect(() => {
     const selectedElement = itemRefs.current[selectedIndex];
     if (selectedElement) {
@@ -97,152 +88,96 @@ export function VizelSlashMenu({
     }
   }, [selectedIndex]);
 
-  const selectItem = useCallback(
-    (index: number) => {
-      const item = flatItems[index];
-      if (item) {
-        onSelect(item);
-      }
-    },
-    [flatItems, onSelect]
-  );
-
-  const upHandler = useCallback(() => {
-    setSelectedIndex((index) => (index + flatItems.length - 1) % flatItems.length);
-  }, [flatItems.length]);
-
-  const downHandler = useCallback(() => {
-    setSelectedIndex((index) => (index + 1) % flatItems.length);
-  }, [flatItems.length]);
-
-  const enterHandler = useCallback(() => {
-    selectItem(selectedIndex);
-  }, [selectItem, selectedIndex]);
-
-  // Navigate to next group with Tab
-  const tabHandler = useCallback(() => {
-    if (groups.length <= 1) return;
-
-    let currentGroupIndex = 0;
-    let itemCount = 0;
-    for (let i = 0; i < groups.length; i++) {
-      const group = groups[i];
-      if (!group) continue;
-      if (selectedIndex < itemCount + group.items.length) {
-        currentGroupIndex = i;
-        break;
-      }
-      itemCount += group.items.length;
-    }
-
-    // Move to next group
-    const nextGroupIndex = (currentGroupIndex + 1) % groups.length;
-    let nextIndex = 0;
-    for (let i = 0; i < nextGroupIndex; i++) {
-      const group = groups[i];
-      if (group) {
-        nextIndex += group.items.length;
-      }
-    }
-    setSelectedIndex(nextIndex);
-  }, [groups, selectedIndex]);
-
-  // Reset selection when items change (tracked via groups length)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional dependency on groups to reset selection
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when items change
   useEffect(() => {
     setSelectedIndex(0);
-  }, [groups]);
+  }, [items]);
+
+  const selectItem = useCallback(
+    (index: number) => {
+      const slot = spec.sections.flatMap((s) => s.items).find((s) => s.index === index);
+      if (slot) {
+        onSelect(slot.data.item);
+      }
+    },
+    [spec, onSelect]
+  );
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
       if (event.key === "ArrowUp") {
-        upHandler();
+        setSelectedIndex((i) => (i + flatItemCount - 1) % flatItemCount);
         return true;
       }
-
       if (event.key === "ArrowDown") {
-        downHandler();
+        setSelectedIndex((i) => (i + 1) % flatItemCount);
         return true;
       }
-
       if (event.key === "Enter") {
-        enterHandler();
+        selectItem(selectedIndex);
         return true;
       }
-
       if (event.key === "Tab") {
         event.preventDefault();
-        tabHandler();
+        setSelectedIndex(getNextVizelSlashMenuGroupIndex(spec, selectedIndex));
         return true;
       }
-
       return false;
     },
   }));
 
-  if (flatItems.length === 0) {
+  if (spec.sections.length === 0) {
     return (
       <div
         className={`vizel-slash-menu ${className ?? ""}`}
         data-vizel-slash-menu=""
         role="listbox"
-        aria-label="Commands"
+        aria-label={spec.root["aria-label"]}
       >
         {renderEmpty?.() ?? <VizelSlashMenuEmpty />}
       </div>
     );
   }
 
-  // Render with groups
-  let globalIndex = 0;
-
   return (
     <div
       className={`vizel-slash-menu ${className ?? ""}`}
       data-vizel-slash-menu=""
       role="listbox"
-      aria-label="Commands"
+      aria-label={spec.root["aria-label"]}
     >
-      {groups.map((group) => {
-        const groupItems = group.items.map((item) => {
-          const index = globalIndex++;
-          const isSelected = index === selectedIndex;
-          const onClick = () => selectItem(index);
-
-          if (renderItem) {
-            return (
-              <div
-                key={item.id}
-                ref={(el) => {
-                  itemRefs.current[index] = el;
-                }}
-              >
-                {renderItem({ item, isSelected, onClick })}
-              </div>
-            );
-          }
-
+      {spec.sections.map((section) => {
+        const renderedItems = section.items.map((slot) => {
+          const onClick = () => selectItem(slot.index);
+          const content = renderItem ? (
+            renderItem({ item: slot.data.item, isSelected: slot.data.isSelected, onClick })
+          ) : (
+            <VizelSlashMenuItem
+              item={slot.data.item}
+              isSelected={slot.data.isSelected}
+              onClick={onClick}
+            />
+          );
           return (
             <div
-              key={item.id}
+              key={slot.key}
               ref={(el) => {
-                itemRefs.current[index] = el;
+                itemRefs.current[slot.index] = el;
               }}
             >
-              <VizelSlashMenuItem item={item} isSelected={isSelected} onClick={onClick} />
+              {content}
             </div>
           );
         });
 
-        // If no group name, just render items
-        if (!group.name) {
-          return groupItems;
+        if (!section.header) {
+          return renderedItems;
         }
 
         return (
-          <div key={group.name} className="vizel-slash-menu-group" data-vizel-slash-menu-group>
-            <div className="vizel-slash-menu-group-header">{group.name}</div>
-            {groupItems}
+          <div key={section.key} className="vizel-slash-menu-group" data-vizel-slash-menu-group="">
+            <div className="vizel-slash-menu-group-header">{section.header.label}</div>
+            {renderedItems}
           </div>
         );
       })}

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -34,7 +34,7 @@ export interface VizelSlashMenuProps {
 </script>
 
 <script lang="ts">
-import { groupVizelSlashCommands, type VizelSlashCommandGroup } from "@vizel/core";
+import { buildVizelSlashMenuSkeleton, getNextVizelSlashMenuGroupIndex } from "@vizel/core";
 import { tick } from "svelte";
 import VizelSlashMenuItem from "./VizelSlashMenuItem.svelte";
 import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.svelte";
@@ -53,25 +53,23 @@ let {
 let selectedIndex = $state(0);
 let itemRefs: (HTMLElement | null)[] = $state([]);
 
+const spec = $derived(
+  buildVizelSlashMenuSkeleton(items, selectedIndex, {
+    showGroups,
+    ...(groupOrder && { groupOrder }),
+  })
+);
+
+const flatItemCount = $derived(
+  spec.sections.reduce((sum, section) => sum + section.items.length, 0)
+);
+
 // Clean up itemRefs when items decrease
 $effect(() => {
-  const length = flatItems.length;
-  if (itemRefs.length > length) {
-    itemRefs.length = length;
+  if (itemRefs.length > flatItemCount) {
+    itemRefs.length = flatItemCount;
   }
 });
-
-// Group items when showGroups is true and there are enough items
-const groups = $derived.by<VizelSlashCommandGroup[]>(() => {
-  if (!showGroups || items.length <= 5) {
-    // Don't group if explicitly disabled or few items (likely search results)
-    return [{ name: "", items }];
-  }
-  return groupVizelSlashCommands(items, groupOrder);
-});
-
-// Flatten for navigation
-const flatItems = $derived(groups.flatMap((g) => g.items));
 
 // Reset selection when items change
 $effect(() => {
@@ -91,74 +89,30 @@ $effect(() => {
 });
 
 function selectItem(index: number) {
-  const item = flatItems[index];
-  if (item) {
-    onselect?.(item);
+  const slot = spec.sections.flatMap((section) => section.items).find((s) => s.index === index);
+  if (slot) {
+    onselect?.(slot.data.item);
   }
-}
-
-// Navigate to next group with Tab
-function tabHandler() {
-  if (groups.length <= 1) return;
-
-  let currentGroupIndex = 0;
-  let itemCount = 0;
-  for (let i = 0; i < groups.length; i++) {
-    const group = groups[i];
-    if (!group) continue;
-    if (selectedIndex < itemCount + group.items.length) {
-      currentGroupIndex = i;
-      break;
-    }
-    itemCount += group.items.length;
-  }
-
-  // Move to next group
-  const nextGroupIndex = (currentGroupIndex + 1) % groups.length;
-  let nextIndex = 0;
-  for (let i = 0; i < nextGroupIndex; i++) {
-    const group = groups[i];
-    if (group) {
-      nextIndex += group.items.length;
-    }
-  }
-  selectedIndex = nextIndex;
-}
-
-// Calculate global index for items
-function getGlobalIndex(groupIndex: number, itemIndex: number): number {
-  let index = 0;
-  for (let i = 0; i < groupIndex; i++) {
-    const group = groups[i];
-    if (group) {
-      index += group.items.length;
-    }
-  }
-  return index + itemIndex;
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
   if (event.key === "ArrowUp") {
-    selectedIndex = (selectedIndex + flatItems.length - 1) % flatItems.length;
+    selectedIndex = (selectedIndex + flatItemCount - 1) % flatItemCount;
     return true;
   }
-
   if (event.key === "ArrowDown") {
-    selectedIndex = (selectedIndex + 1) % flatItems.length;
+    selectedIndex = (selectedIndex + 1) % flatItemCount;
     return true;
   }
-
   if (event.key === "Enter") {
     selectItem(selectedIndex);
     return true;
   }
-
   if (event.key === "Tab") {
     event.preventDefault();
-    tabHandler();
+    selectedIndex = getNextVizelSlashMenuGroupIndex(spec, selectedIndex);
     return true;
   }
-
   return false;
 }
 
@@ -173,54 +127,57 @@ if (ref) {
 }
 </script>
 
-<div class="vizel-slash-menu {className ?? ''}" data-vizel-slash-menu role="listbox" aria-label="Commands">
-  {#if flatItems.length === 0}
+<div
+  class="vizel-slash-menu {className ?? ''}"
+  data-vizel-slash-menu
+  role={spec.root.role}
+  aria-label={spec.root["aria-label"]}
+>
+  {#if spec.sections.length === 0}
     {#if renderEmpty}
       {@render renderEmpty()}
     {:else}
       <VizelSlashMenuEmpty />
     {/if}
   {:else}
-    {#each groups as group, groupIndex (group.name || groupIndex)}
-      {#if group.name}
-        <!-- Group with header -->
+    {#each spec.sections as section (section.key)}
+      {#if section.header}
+        <!-- Section with header -->
         <div class="vizel-slash-menu-group" data-vizel-slash-menu-group>
-          <div class="vizel-slash-menu-group-header">{group.name}</div>
-          {#each group.items as item, itemIndex (item.id)}
-            {@const globalIdx = getGlobalIndex(groupIndex, itemIndex)}
-            <div bind:this={itemRefs[globalIdx]}>
+          <div class="vizel-slash-menu-group-header">{section.header.label}</div>
+          {#each section.items as slot (slot.key)}
+            <div bind:this={itemRefs[slot.index]}>
               {#if renderItem}
                 {@render renderItem({
-                  item,
-                  isSelected: globalIdx === selectedIndex,
-                  onclick: () => selectItem(globalIdx),
+                  item: slot.data.item,
+                  isSelected: slot.data.isSelected,
+                  onclick: () => selectItem(slot.index),
                 })}
               {:else}
                 <VizelSlashMenuItem
-                  {item}
-                  isSelected={globalIdx === selectedIndex}
-                  onclick={() => selectItem(globalIdx)}
+                  item={slot.data.item}
+                  isSelected={slot.data.isSelected}
+                  onclick={() => selectItem(slot.index)}
                 />
               {/if}
             </div>
           {/each}
         </div>
       {:else}
-        <!-- Items without group header -->
-        {#each group.items as item, itemIndex (item.id)}
-          {@const globalIdx = getGlobalIndex(groupIndex, itemIndex)}
-          <div bind:this={itemRefs[globalIdx]}>
+        <!-- Items without section header -->
+        {#each section.items as slot (slot.key)}
+          <div bind:this={itemRefs[slot.index]}>
             {#if renderItem}
               {@render renderItem({
-                item,
-                isSelected: globalIdx === selectedIndex,
-                onclick: () => selectItem(globalIdx),
+                item: slot.data.item,
+                isSelected: slot.data.isSelected,
+                onclick: () => selectItem(slot.index),
               })}
             {:else}
               <VizelSlashMenuItem
-                {item}
-                isSelected={globalIdx === selectedIndex}
-                onclick={() => selectItem(globalIdx)}
+                item={slot.data.item}
+                isSelected={slot.data.isSelected}
+                onclick={() => selectItem(slot.index)}
               />
             {/if}
           </div>

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
-  groupVizelSlashCommands,
-  type VizelSlashCommandGroup,
+  buildVizelSlashMenuSkeleton,
+  getNextVizelSlashMenuGroupIndex,
   type VizelSlashCommandItem,
 } from "@vizel/core";
 import { computed, nextTick, ref, useSlots, watch } from "vue";
@@ -45,29 +45,25 @@ const slots = useSlots();
 const selectedIndex = ref(0);
 const itemRefs = ref<(HTMLElement | null)[]>([]);
 
-// Group items when showGroups is true and there are enough items
-const groups = computed<VizelSlashCommandGroup[]>(() => {
-  if (!props.showGroups || props.items.length <= 5) {
-    // Don't group if explicitly disabled or few items (likely search results)
-    return [{ name: "", items: props.items }];
-  }
-  return groupVizelSlashCommands(props.items, props.groupOrder);
-});
+const spec = computed(() =>
+  buildVizelSlashMenuSkeleton(props.items, selectedIndex.value, {
+    showGroups: props.showGroups,
+    ...(props.groupOrder && { groupOrder: props.groupOrder }),
+  })
+);
 
-// Flatten for navigation
-const flatItems = computed(() => groups.value.flatMap((g) => g.items));
+const flatItemCount = computed(() =>
+  spec.value.sections.reduce((sum, section) => sum + section.items.length, 0)
+);
 
-// Reset selection and refs when items change
 watch(
   () => props.items,
   () => {
     selectedIndex.value = 0;
-    // Reset refs array to prevent stale references
     itemRefs.value = [];
   }
 );
 
-// Scroll selected item into view when selection changes
 watch(selectedIndex, async (newIndex) => {
   await nextTick();
   const selectedElement = itemRefs.value[newIndex];
@@ -77,138 +73,100 @@ watch(selectedIndex, async (newIndex) => {
 });
 
 function selectItem(index: number) {
-  const item = flatItems.value[index];
-  if (item) {
-    emit("select", item);
+  const slot = spec.value.sections
+    .flatMap((section) => section.items)
+    .find((s) => s.index === index);
+  if (slot) {
+    emit("select", slot.data.item);
   }
-}
-
-// Navigate to next group with Tab
-function tabHandler() {
-  if (groups.value.length <= 1) return;
-
-  let currentGroupIndex = 0;
-  let itemCount = 0;
-  for (let i = 0; i < groups.value.length; i++) {
-    const group = groups.value[i];
-    if (!group) continue;
-    if (selectedIndex.value < itemCount + group.items.length) {
-      currentGroupIndex = i;
-      break;
-    }
-    itemCount += group.items.length;
-  }
-
-  // Move to next group
-  const nextGroupIndex = (currentGroupIndex + 1) % groups.value.length;
-  let nextIndex = 0;
-  for (let i = 0; i < nextGroupIndex; i++) {
-    const group = groups.value[i];
-    if (group) {
-      nextIndex += group.items.length;
-    }
-  }
-  selectedIndex.value = nextIndex;
 }
 
 function handleKeyDown(event: KeyboardEvent): boolean {
+  const count = flatItemCount.value;
   if (event.key === "ArrowUp") {
-    selectedIndex.value =
-      (selectedIndex.value + flatItems.value.length - 1) % flatItems.value.length;
+    selectedIndex.value = (selectedIndex.value + count - 1) % count;
     return true;
   }
-
   if (event.key === "ArrowDown") {
-    selectedIndex.value = (selectedIndex.value + 1) % flatItems.value.length;
+    selectedIndex.value = (selectedIndex.value + 1) % count;
     return true;
   }
-
   if (event.key === "Enter") {
     selectItem(selectedIndex.value);
     return true;
   }
-
   if (event.key === "Tab") {
     event.preventDefault();
-    tabHandler();
+    selectedIndex.value = getNextVizelSlashMenuGroupIndex(spec.value, selectedIndex.value);
     return true;
   }
-
   return false;
 }
 
-// Expose handleKeyDown for parent components
 defineExpose({
   onKeyDown: handleKeyDown,
 });
-
-// Calculate global index for items
-function getGlobalIndex(groupIndex: number, itemIndex: number): number {
-  let index = 0;
-  for (let i = 0; i < groupIndex; i++) {
-    const group = groups.value[i];
-    if (group) {
-      index += group.items.length;
-    }
-  }
-  return index + itemIndex;
-}
 </script>
 
 <template>
-  <div :class="['vizel-slash-menu', $props.class]" data-vizel-slash-menu role="listbox" aria-label="Commands">
-    <template v-if="flatItems.length === 0">
+  <div
+    :class="['vizel-slash-menu', $props.class]"
+    data-vizel-slash-menu
+    :role="spec.root.role"
+    :aria-label="spec.root['aria-label']"
+  >
+    <template v-if="spec.sections.length === 0">
       <slot v-if="slots.empty" name="empty" />
       <VizelSlashMenuEmpty v-else />
     </template>
     <template v-else>
-      <template v-for="(group, groupIndex) in groups" :key="group.name || groupIndex">
-        <!-- Group with header -->
+      <template v-for="section in spec.sections" :key="section.key">
+        <!-- Section with header -->
         <div
-          v-if="group.name"
+          v-if="section.header"
           class="vizel-slash-menu-group"
           data-vizel-slash-menu-group
         >
-          <div class="vizel-slash-menu-group-header">{{ group.name }}</div>
+          <div class="vizel-slash-menu-group-header">{{ section.header.label }}</div>
           <div
-            v-for="(item, itemIndex) in group.items"
-            :key="item.id"
-            :ref="(el) => (itemRefs[getGlobalIndex(groupIndex, itemIndex)] = el as HTMLElement)"
+            v-for="slot in section.items"
+            :key="slot.key"
+            :ref="(el) => (itemRefs[slot.index] = el as HTMLElement)"
           >
             <slot
               v-if="slots.item"
               name="item"
-              :item="item"
-              :is-selected="getGlobalIndex(groupIndex, itemIndex) === selectedIndex"
-              :on-click="() => selectItem(getGlobalIndex(groupIndex, itemIndex))"
+              :item="slot.data.item"
+              :is-selected="slot.data.isSelected"
+              :on-click="() => selectItem(slot.index)"
             />
             <VizelSlashMenuItem
               v-else
-              :item="item"
-              :is-selected="getGlobalIndex(groupIndex, itemIndex) === selectedIndex"
-              @click="selectItem(getGlobalIndex(groupIndex, itemIndex))"
+              :item="slot.data.item"
+              :is-selected="slot.data.isSelected"
+              @click="selectItem(slot.index)"
             />
           </div>
         </div>
-        <!-- Items without group header -->
+        <!-- Items without section header -->
         <template v-else>
           <div
-            v-for="(item, itemIndex) in group.items"
-            :key="item.id"
-            :ref="(el) => (itemRefs[getGlobalIndex(groupIndex, itemIndex)] = el as HTMLElement)"
+            v-for="slot in section.items"
+            :key="slot.key"
+            :ref="(el) => (itemRefs[slot.index] = el as HTMLElement)"
           >
             <slot
               v-if="slots.item"
               name="item"
-              :item="item"
-              :is-selected="getGlobalIndex(groupIndex, itemIndex) === selectedIndex"
-              :on-click="() => selectItem(getGlobalIndex(groupIndex, itemIndex))"
+              :item="slot.data.item"
+              :is-selected="slot.data.isSelected"
+              :on-click="() => selectItem(slot.index)"
             />
             <VizelSlashMenuItem
               v-else
-              :item="item"
-              :is-selected="getGlobalIndex(groupIndex, itemIndex) === selectedIndex"
-              @click="selectItem(getGlobalIndex(groupIndex, itemIndex))"
+              :item="slot.data.item"
+              :is-selected="slot.data.isSelected"
+              @click="selectItem(slot.index)"
             />
           </div>
         </template>


### PR DESCRIPTION
## Summary

Phase 7 step 2 of the v2.x audit. The React/Vue/Svelte
`VizelSlashMenu` components shared the same listbox/section/option
DOM shape, the `groupVizelSlashCommands` invocation, and the
Tab-to-next-group navigation algorithm — three copies of the same
algorithm. This PR moves that scaffolding into
`@vizel/core/skeletons/slash-menu`.

### What `@vizel/core/skeletons/slash-menu` owns

- `buildVizelSlashMenuSkeleton(items, selectedIndex, options)` returns
  a `VizelMenuSpec<VizelSlashItemView>` describing:
  - root container attrs (`role="listbox"`, `aria-label="Commands"`),
  - one or more sections (with `header.label` when grouped),
  - per-item identity: `key` (item.id), `index` (global), `data`
    (`{ item, isSelected }`).
- `getNextVizelSlashMenuGroupIndex(spec, currentIndex)` — the
  framework-agnostic Tab handler. Given the spec and the current
  global selection, it returns the first item of the next section,
  wrapping around.

### What the framework component still owns

Item rendering remains in `VizelSlashMenuItem` (which keeps
`role="option"` ownership). The component:

1. Derives the spec from props with the framework's memo primitive
   (`useMemo` / `computed` / `$derived`).
2. Iterates `spec.sections` to render group headers / items.
3. Reads `slot.data.item`, `slot.data.isSelected`, `slot.index` for
   each rendered item.
4. Delegates the Tab branch of `onKeyDown` to
   `getNextVizelSlashMenuGroupIndex`.

Custom `renderItem` / `renderEmpty` props (React render prop / Vue
slot / Svelte snippet) are preserved.

## Breaking Changes

None at the consumer level — `VizelSlashMenu` props/refs are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 2 of 7.
