### PR TITLE
refactor: extract VizelBlockMenu DOM skeleton into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,9 +310,14 @@ export {
 // UI Skeletons
 // =============================================================================
 export {
+  buildVizelBlockMenuSkeleton,
   buildVizelMentionMenuSkeleton,
   buildVizelSlashMenuSkeleton,
   getNextVizelSlashMenuGroupIndex,
+  type VizelBlockMenuItemView,
+  type VizelBlockMenuSpec,
+  type VizelBlockMenuSubmenuTriggerSpec,
+  type VizelBlockMenuTurnIntoItemView,
   type VizelMentionItemView,
   type VizelMenuItemAttrs,
   type VizelMenuItemSpec,

--- a/packages/core/src/skeletons/block-menu.ts
+++ b/packages/core/src/skeletons/block-menu.ts
@@ -1,0 +1,144 @@
+import { groupVizelBlockMenuActions, type VizelBlockMenuAction } from "../extensions/block-menu.ts";
+import type { VizelNodeTypeOption } from "../extensions/node-types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelMenuItemAttrs, VizelMenuSectionSpec, VizelMenuSpec } from "./types.ts";
+
+/**
+ * Item-data shape surfaced to the framework `VizelBlockMenu` component for
+ * each block action.
+ *
+ * The action itself is the source of truth for icon name, label, optional
+ * shortcut, and `isEnabled` predicate — the component reads those off
+ * `data.action` at render time. The skeleton owns identity (key, index)
+ * and the structural flags that drive styling (`isDestructive`).
+ */
+export interface VizelBlockMenuItemView {
+  /** The block-menu action as supplied by the consumer. */
+  action: VizelBlockMenuAction;
+  /**
+   * Whether this action is destructive (currently only `id === "delete"`).
+   * Maps to the `is-destructive` class in the default theme.
+   */
+  isDestructive: boolean;
+}
+
+/**
+ * Item-data shape surfaced for each "Turn into" submenu entry.
+ */
+export interface VizelBlockMenuTurnIntoItemView {
+  nodeType: VizelNodeTypeOption;
+}
+
+/**
+ * The submenu trigger metadata. The trigger is a `role="menuitem"` button
+ * rendered after the action groups, opens the "Turn into" submenu, and
+ * advertises that via `aria-haspopup` + `aria-expanded`.
+ */
+export interface VizelBlockMenuSubmenuTriggerSpec {
+  /** Stable key (used as iteration key when needed). */
+  key: string;
+  /** Localized trigger label (e.g. "Turn into"). */
+  label: string;
+  /** Icon name rendered before the label. */
+  iconName: "arrowRightLeft";
+  /** ARIA attrs for the trigger button. */
+  attrs: VizelMenuItemAttrs;
+}
+
+/**
+ * The complete block-menu skeleton: main menu + submenu trigger + submenu.
+ *
+ * The main menu's `sections` come from `groupVizelBlockMenuActions`. The
+ * framework component renders a divider between adjacent sections. The
+ * submenu trigger sits after all action sections; the submenu itself is
+ * rendered conditionally when `showTurnInto` is `true` and it has items.
+ */
+export interface VizelBlockMenuSpec {
+  /** Main menu root attrs (`role="menu"`, `aria-label`). */
+  root: { role: "menu"; "aria-label": string; tabIndex: -1 };
+  /** Action groups (rendered with a divider between adjacent sections). */
+  sections: readonly VizelMenuSectionSpec<VizelBlockMenuItemView>[];
+  /** "Turn into" submenu trigger. */
+  submenuTrigger: VizelBlockMenuSubmenuTriggerSpec;
+  /**
+   * "Turn into" submenu spec. Empty `sections` array means the consumer
+   * should skip rendering the submenu (no available target node types).
+   */
+  submenu: VizelMenuSpec<VizelBlockMenuTurnIntoItemView>;
+}
+
+/**
+ * Build a {@link VizelBlockMenuSpec} for the block context menu.
+ *
+ * The skeleton owns: container ARIA, grouping of actions into sections,
+ * `is-destructive` flag derivation, submenu trigger ARIA wiring
+ * (`aria-haspopup` + `aria-expanded`), and submenu list shape.
+ *
+ * The framework component owns: positioning, focus management, event
+ * binding, and computing per-action `disabled` state (which requires the
+ * runtime editor + node, not available here).
+ *
+ * @param actions  Resolved block-menu actions (already locale-applied).
+ * @param turnIntoOptions  Filtered list of available "Turn into" targets.
+ * @param showTurnInto  Whether the submenu is currently open.
+ * @param locale  Optional locale for translated labels.
+ */
+export function buildVizelBlockMenuSkeleton(
+  actions: readonly VizelBlockMenuAction[],
+  turnIntoOptions: readonly VizelNodeTypeOption[],
+  showTurnInto: boolean,
+  locale: VizelLocale | undefined
+): VizelBlockMenuSpec {
+  const menuLabel = locale?.blockMenu.label ?? "Block menu";
+  const turnIntoLabel = locale?.blockMenu.turnInto ?? "Turn into";
+
+  const groups = groupVizelBlockMenuActions(actions);
+  let globalIndex = 0;
+  const sections: VizelMenuSectionSpec<VizelBlockMenuItemView>[] = groups.map(
+    (group, groupIndex) => ({
+      key: `group-${groupIndex}`,
+      items: group.map((action) => ({
+        key: action.id,
+        index: globalIndex++,
+        data: { action, isDestructive: action.id === "delete" },
+        attrs: { role: "menuitem" satisfies "menuitem" } as VizelMenuItemAttrs,
+      })),
+    })
+  );
+
+  const submenuTrigger: VizelBlockMenuSubmenuTriggerSpec = {
+    key: "submenu-trigger-turn-into",
+    label: turnIntoLabel,
+    iconName: "arrowRightLeft",
+    attrs: {
+      role: "menuitem",
+      "aria-haspopup": "menu",
+      "aria-expanded": showTurnInto,
+    },
+  };
+
+  const submenu: VizelMenuSpec<VizelBlockMenuTurnIntoItemView> = {
+    root: { role: "menu", "aria-label": turnIntoLabel },
+    sections:
+      turnIntoOptions.length === 0
+        ? []
+        : [
+            {
+              key: "turn-into-options",
+              items: turnIntoOptions.map((nodeType, index) => ({
+                key: nodeType.name,
+                index,
+                data: { nodeType },
+                attrs: { role: "menuitem" },
+              })),
+            },
+          ],
+  };
+
+  return {
+    root: { role: "menu", "aria-label": menuLabel, tabIndex: -1 },
+    sections,
+    submenuTrigger,
+    submenu,
+  };
+}

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -1,4 +1,11 @@
 export {
+  buildVizelBlockMenuSkeleton,
+  type VizelBlockMenuItemView,
+  type VizelBlockMenuSpec,
+  type VizelBlockMenuSubmenuTriggerSpec,
+  type VizelBlockMenuTurnIntoItemView,
+} from "./block-menu.ts";
+export {
   buildVizelMentionMenuSkeleton,
   type VizelMentionItemView,
 } from "./mention-menu.ts";

--- a/packages/core/src/skeletons/types.ts
+++ b/packages/core/src/skeletons/types.ts
@@ -42,6 +42,16 @@ export interface VizelMenuItemAttrs {
    * non-activatable).
    */
   "aria-disabled"?: boolean;
+  /**
+   * Marks a menuitem that opens a popup (submenu). The value names the
+   * popup's role; for nested menus this is typically `"menu"`.
+   */
+  "aria-haspopup"?: "menu" | "true";
+  /**
+   * Whether the popup associated with this item is currently open.
+   * Set together with `aria-haspopup`.
+   */
+  "aria-expanded"?: boolean;
   /** Stable per-option id matching the root's `aria-activedescendant`. */
   id?: string;
   /** Item tabIndex; usually `-1` so the root owns keyboard focus. */

--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -1,10 +1,10 @@
 import type { Editor } from "@vizel/core";
 import {
+  buildVizelBlockMenuSkeleton,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelNodeTypes,
   getVizelTurnIntoOptions,
-  groupVizelBlockMenuActions,
   shouldFlipSubmenu,
   VIZEL_BLOCK_MENU_EVENT,
   type VizelBlockMenuAction,
@@ -43,7 +43,10 @@ interface BlockMenuState extends VizelBlockMenuOpenDetail {
 
 /**
  * Block context menu that appears when clicking the drag handle.
- * Renders via fixed positioning near the drag handle.
+ * DOM/ARIA scaffolding (sections, submenu trigger, submenu list) comes
+ * from `@vizel/core`'s `buildVizelBlockMenuSkeleton`; the React
+ * component owns positioning, focus management, and runtime action
+ * binding.
  */
 export function VizelBlockMenu({
   editor: editorProp,
@@ -54,10 +57,6 @@ export function VizelBlockMenu({
 }: VizelBlockMenuProps): ReactNode {
   const context = useVizelContextSafe();
   const boundEditor: Editor | null = editorProp ?? context?.editor ?? null;
-  // Memoize so locale-derived defaults aren't recomputed on every render.
-  // createVizelBlockMenuActions / createVizelNodeTypes build new arrays each
-  // call, which would invalidate downstream memos (groupVizelBlockMenuActions,
-  // getVizelTurnIntoOptions) needlessly.
   const effectiveActions = useMemo(
     () => actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions),
     [actions, locale]
@@ -80,14 +79,10 @@ export function VizelBlockMenu({
     menuEditorRef.current = null;
   }, []);
 
-  // Listen for block menu open events from the drag handle
   useEffect(() => {
     const handler = (e: Event) => {
       if (!(e instanceof CustomEvent)) return;
       const detail = e.detail as VizelBlockMenuOpenDetail;
-      // When this menu is bound to an editor (via prop or VizelProvider
-      // context), ignore events from any other editor on the page. This
-      // prevents sibling editors from cross-triggering each other's menus.
       if (boundEditor && detail.editor !== boundEditor) return;
       menuEditorRef.current = detail.editor;
       setMenuState({
@@ -97,7 +92,6 @@ export function VizelBlockMenu({
       });
       setShowTurnInto(false);
 
-      // Clamp menu position to viewport after DOM render
       requestAnimationFrame(() => {
         const el = menuRef.current;
         if (!el) return;
@@ -110,7 +104,6 @@ export function VizelBlockMenu({
     return () => document.removeEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
   }, [boundEditor]);
 
-  // Focus first menuitem when menu opens
   useEffect(() => {
     if (!(menuState && menuRef.current)) return;
     const firstItem = menuRef.current.querySelector<HTMLButtonElement>(
@@ -119,7 +112,6 @@ export function VizelBlockMenu({
     firstItem?.focus();
   }, [menuState]);
 
-  // Close on outside click
   useEffect(() => {
     if (!menuState) return;
 
@@ -149,7 +141,6 @@ export function VizelBlockMenu({
     };
   }, [menuState, close]);
 
-  // Detect whether the submenu should flip to the left side
   useEffect(() => {
     if (!(showTurnInto && menuRef.current)) {
       setSubmenuFlipped(false);
@@ -163,11 +154,19 @@ export function VizelBlockMenu({
     });
   }, [showTurnInto]);
 
+  const turnIntoOptions = useMemo(
+    () => (menuState ? getVizelTurnIntoOptions(menuState.editor, effectiveNodeTypes) : []),
+    [menuState, effectiveNodeTypes]
+  );
+
+  const spec = useMemo(
+    () => buildVizelBlockMenuSkeleton(effectiveActions, turnIntoOptions, showTurnInto, locale),
+    [effectiveActions, turnIntoOptions, showTurnInto, locale]
+  );
+
   if (!menuState) return null;
 
   const { editor, pos, node } = menuState;
-  const groups = groupVizelBlockMenuActions(effectiveActions);
-  const turnIntoOptions = getVizelTurnIntoOptions(editor, effectiveNodeTypes);
 
   const handleAction = (action: VizelBlockMenuAction) => {
     action.run(editor, pos, node);
@@ -207,7 +206,6 @@ export function VizelBlockMenu({
   };
 
   const handleTurnInto = (nodeType: VizelNodeTypeOption) => {
-    // Select the block first, then apply the transformation
     editor.chain().focus().setNodeSelection(pos).run();
     nodeType.command(editor);
     close();
@@ -219,77 +217,81 @@ export function VizelBlockMenu({
       className={`vizel-block-menu ${className ?? ""}`}
       style={{ left: menuState.x, top: menuState.y }}
       role="menu"
-      aria-label={locale?.blockMenu.label ?? "Block menu"}
+      aria-label={spec.root["aria-label"]}
       data-vizel-block-menu=""
-      tabIndex={-1}
+      tabIndex={spec.root.tabIndex}
       onKeyDown={handleMenuKeyDown}
     >
-      {groups.map((group, groupIndex) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: groups are derived from a stable action list whose ordering is fixed at locale resolution time; the first-item `group` string we used before collided for two groups whose first member landed in the same category. Matches the Vue/Svelte block-menu key strategy.
-        <div key={groupIndex}>
-          {groupIndex > 0 && <div className="vizel-block-menu-divider" />}
-          {group.map((action) => (
-            <button
-              key={action.id}
-              type="button"
-              className={`vizel-block-menu-item${action.id === "delete" ? " is-destructive" : ""}`}
-              role="menuitem"
-              onClick={() => handleAction(action)}
-              disabled={action.isEnabled ? !action.isEnabled(editor, node) : false}
-            >
-              <span className="vizel-block-menu-item-icon">
-                <VizelIcon name={action.icon} />
-              </span>
-              <span className="vizel-block-menu-item-label">{action.label}</span>
-              {action.shortcut && (
-                <span className="vizel-block-menu-item-shortcut">{action.shortcut}</span>
-              )}
-            </button>
-          ))}
+      {spec.sections.map((section, sectionIndex) => (
+        <div key={section.key}>
+          {sectionIndex > 0 && <div className="vizel-block-menu-divider" />}
+          {section.items.map((slot) => {
+            const disabled = slot.data.action.isEnabled
+              ? !slot.data.action.isEnabled(editor, node)
+              : false;
+            return (
+              <button
+                key={slot.key}
+                type="button"
+                className={`vizel-block-menu-item${slot.data.isDestructive ? " is-destructive" : ""}`}
+                role={slot.attrs.role}
+                onClick={() => handleAction(slot.data.action)}
+                disabled={disabled}
+              >
+                <span className="vizel-block-menu-item-icon">
+                  <VizelIcon name={slot.data.action.icon} />
+                </span>
+                <span className="vizel-block-menu-item-label">{slot.data.action.label}</span>
+                {slot.data.action.shortcut && (
+                  <span className="vizel-block-menu-item-shortcut">
+                    {slot.data.action.shortcut}
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
       ))}
 
-      {/* Turn into submenu trigger */}
       <div className="vizel-block-menu-divider" />
       <button
         type="button"
         className="vizel-block-menu-item vizel-block-menu-submenu-trigger"
-        role="menuitem"
-        aria-haspopup="menu"
-        aria-expanded={showTurnInto}
+        role={spec.submenuTrigger.attrs.role}
+        aria-haspopup={spec.submenuTrigger.attrs["aria-haspopup"]}
+        aria-expanded={spec.submenuTrigger.attrs["aria-expanded"]}
         onMouseEnter={() => setShowTurnInto(true)}
         onClick={() => setShowTurnInto(!showTurnInto)}
       >
         <span className="vizel-block-menu-item-icon">
-          <VizelIcon name="arrowRightLeft" />
+          <VizelIcon name={spec.submenuTrigger.iconName} />
         </span>
-        <span className="vizel-block-menu-item-label">
-          {locale?.blockMenu.turnInto ?? "Turn into"}
-        </span>
+        <span className="vizel-block-menu-item-label">{spec.submenuTrigger.label}</span>
       </button>
 
-      {/* Turn into submenu */}
-      {showTurnInto && turnIntoOptions.length > 0 && (
+      {showTurnInto && spec.submenu.sections.length > 0 && (
         <div
           ref={submenuRef}
           className={`vizel-block-menu-submenu${submenuFlipped ? " vizel-block-menu-submenu--left" : ""}`}
           role="menu"
-          aria-label={locale?.blockMenu.turnInto ?? "Turn into"}
+          aria-label={spec.submenu.root["aria-label"]}
         >
-          {turnIntoOptions.map((nodeType) => (
-            <button
-              key={nodeType.name}
-              type="button"
-              className="vizel-block-menu-item"
-              role="menuitem"
-              onClick={() => handleTurnInto(nodeType)}
-            >
-              <span className="vizel-block-menu-item-icon">
-                <VizelIcon name={nodeType.icon} />
-              </span>
-              <span className="vizel-block-menu-item-label">{nodeType.label}</span>
-            </button>
-          ))}
+          {spec.submenu.sections.flatMap((section) =>
+            section.items.map((slot) => (
+              <button
+                key={slot.key}
+                type="button"
+                className="vizel-block-menu-item"
+                role={slot.attrs.role}
+                onClick={() => handleTurnInto(slot.data.nodeType)}
+              >
+                <span className="vizel-block-menu-item-icon">
+                  <VizelIcon name={slot.data.nodeType.icon} />
+                </span>
+                <span className="vizel-block-menu-item-label">{slot.data.nodeType.label}</span>
+              </button>
+            ))
+          )}
         </div>
       )}
     </div>

--- a/packages/svelte/src/components/VizelBlockMenu.svelte
+++ b/packages/svelte/src/components/VizelBlockMenu.svelte
@@ -22,10 +22,10 @@ export interface VizelBlockMenuProps {
 
 <script lang="ts">
 import {
+  buildVizelBlockMenuSkeleton,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelNodeTypes,
-  groupVizelBlockMenuActions,
   getVizelTurnIntoOptions,
   shouldFlipSubmenu,
   VIZEL_BLOCK_MENU_EVENT,
@@ -62,12 +62,12 @@ let submenuFlipped = $state(false);
 let menuRef = $state<HTMLDivElement | null>(null);
 let submenuRef = $state<HTMLDivElement | null>(null);
 
-const groups = $derived(
-  menuState ? groupVizelBlockMenuActions(effectiveActions) : [],
-);
-
 const turnIntoOptions = $derived(
   menuState ? getVizelTurnIntoOptions(menuState.editor, effectiveNodeTypes) : [],
+);
+
+const spec = $derived(
+  buildVizelBlockMenuSkeleton(effectiveActions, turnIntoOptions, showTurnInto, locale),
 );
 
 function close() {
@@ -123,24 +123,18 @@ function handleMenuKeyDown(e: KeyboardEvent) {
   }
 }
 
-// Focus first menuitem when menu opens
 $effect(() => {
   if (!menuState || !menuRef) return;
-  // Use tick to wait for DOM render
   const firstItem = menuRef.querySelector<HTMLButtonElement>(
     '[role="menuitem"]:not([disabled])'
   );
   firstItem?.focus();
 });
 
-// Manage event listeners
 $effect(() => {
   const handleOpen = (e: Event) => {
     if (!(e instanceof CustomEvent)) return;
     const detail = e.detail as VizelBlockMenuOpenDetail;
-    // When this menu is bound to an editor (via prop or VizelProvider
-    // context), ignore events from any other editor on the page. This
-    // prevents sibling editors from cross-triggering each other's menus.
     if (boundEditor && detail.editor !== boundEditor) return;
     menuState = {
       ...detail,
@@ -149,7 +143,6 @@ $effect(() => {
     };
     showTurnInto = false;
 
-    // Clamp menu position to viewport after Svelte renders
     void tick().then(() => {
       const el = menuRef;
       if (!el || !menuState) return;
@@ -164,7 +157,6 @@ $effect(() => {
   };
 });
 
-// Close on outside click / Escape when menu is open
 $effect(() => {
   if (!menuState) return;
 
@@ -194,7 +186,6 @@ $effect(() => {
   };
 });
 
-// Detect whether the submenu should flip to the left side
 $effect(() => {
   if (!showTurnInto || !menuRef) {
     submenuFlipped = false;
@@ -210,34 +201,35 @@ $effect(() => {
 </script>
 
 {#if menuState}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     bind:this={menuRef}
     class="vizel-block-menu {className ?? ''}"
     style="left: {menuState.x}px; top: {menuState.y}px;"
-    role="menu"
-    aria-label={locale?.blockMenu.label ?? "Block menu"}
+    role={spec.root.role}
+    aria-label={spec.root["aria-label"]}
     data-vizel-block-menu
-    tabindex="-1"
+    tabindex={spec.root.tabIndex}
     onkeydown={handleMenuKeyDown}
   >
-    {#each groups as group, groupIndex (groupIndex)}
-      {#if groupIndex > 0}
+    {#each spec.sections as section, sectionIndex (section.key)}
+      {#if sectionIndex > 0}
         <div class="vizel-block-menu-divider"></div>
       {/if}
-      {#each group as action (action.id)}
+      {#each section.items as slot (slot.key)}
         <button
           type="button"
-          class="vizel-block-menu-item{action.id === 'delete' ? ' is-destructive' : ''}"
-          role="menuitem"
-          disabled={action.isEnabled ? !action.isEnabled(menuState.editor, menuState.node) : false}
-          onclick={() => handleAction(action)}
+          class="vizel-block-menu-item{slot.data.isDestructive ? ' is-destructive' : ''}"
+          role={slot.attrs.role}
+          disabled={slot.data.action.isEnabled ? !slot.data.action.isEnabled(menuState.editor, menuState.node) : false}
+          onclick={() => handleAction(slot.data.action)}
         >
           <span class="vizel-block-menu-item-icon">
-            <VizelIcon name={action.icon} />
+            <VizelIcon name={slot.data.action.icon} />
           </span>
-          <span class="vizel-block-menu-item-label">{action.label}</span>
-          {#if action.shortcut}
-            <span class="vizel-block-menu-item-shortcut">{action.shortcut}</span>
+          <span class="vizel-block-menu-item-label">{slot.data.action.label}</span>
+          {#if slot.data.action.shortcut}
+            <span class="vizel-block-menu-item-shortcut">{slot.data.action.shortcut}</span>
           {/if}
         </button>
       {/each}
@@ -248,38 +240,40 @@ $effect(() => {
     <button
       type="button"
       class="vizel-block-menu-item vizel-block-menu-submenu-trigger"
-      role="menuitem"
-      aria-haspopup="menu"
-      aria-expanded={showTurnInto}
+      role={spec.submenuTrigger.attrs.role}
+      aria-haspopup={spec.submenuTrigger.attrs["aria-haspopup"]}
+      aria-expanded={spec.submenuTrigger.attrs["aria-expanded"]}
       onmouseenter={() => { showTurnInto = true; }}
       onclick={() => { showTurnInto = !showTurnInto; }}
     >
       <span class="vizel-block-menu-item-icon">
-        <VizelIcon name="arrowRightLeft" />
+        <VizelIcon name={spec.submenuTrigger.iconName} />
       </span>
-      <span class="vizel-block-menu-item-label">{locale?.blockMenu.turnInto ?? "Turn into"}</span>
+      <span class="vizel-block-menu-item-label">{spec.submenuTrigger.label}</span>
     </button>
 
     <!-- Turn into submenu -->
-    {#if showTurnInto && turnIntoOptions.length > 0}
+    {#if showTurnInto && spec.submenu.sections.length > 0}
       <div
         bind:this={submenuRef}
         class="vizel-block-menu-submenu{submenuFlipped ? ' vizel-block-menu-submenu--left' : ''}"
-        role="menu"
-        aria-label={locale?.blockMenu.turnInto ?? "Turn into"}
+        role={spec.submenu.root.role}
+        aria-label={spec.submenu.root["aria-label"]}
       >
-        {#each turnIntoOptions as nodeType (nodeType.name)}
-          <button
-            type="button"
-            class="vizel-block-menu-item"
-            role="menuitem"
-            onclick={() => handleTurnInto(nodeType)}
-          >
-            <span class="vizel-block-menu-item-icon">
-              <VizelIcon name={nodeType.icon} />
-            </span>
-            <span class="vizel-block-menu-item-label">{nodeType.label}</span>
-          </button>
+        {#each spec.submenu.sections as section (section.key)}
+          {#each section.items as slot (slot.key)}
+            <button
+              type="button"
+              class="vizel-block-menu-item"
+              role={slot.attrs.role}
+              onclick={() => handleTurnInto(slot.data.nodeType)}
+            >
+              <span class="vizel-block-menu-item-icon">
+                <VizelIcon name={slot.data.nodeType.icon} />
+              </span>
+              <span class="vizel-block-menu-item-label">{slot.data.nodeType.label}</span>
+            </button>
+          {/each}
         {/each}
       </div>
     {/if}

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import {
+  buildVizelBlockMenuSkeleton,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelDismissibleController,
   createVizelNodeTypes,
   type Editor,
   getVizelTurnIntoOptions,
-  groupVizelBlockMenuActions,
   shouldFlipSubmenu,
   VIZEL_BLOCK_MENU_EVENT,
   type VizelBlockMenuAction,
@@ -64,12 +64,17 @@ const submenuFlipped = ref(false);
 const menuRef = ref<HTMLDivElement | null>(null);
 const submenuRef = ref<HTMLDivElement | null>(null);
 
-const groups = computed(() =>
-  menuState.value ? groupVizelBlockMenuActions(effectiveActions.value) : []
-);
-
 const turnIntoOptions = computed(() =>
   menuState.value ? getVizelTurnIntoOptions(menuState.value.editor, effectiveNodeTypes.value) : []
+);
+
+const spec = computed(() =>
+  buildVizelBlockMenuSkeleton(
+    effectiveActions.value,
+    turnIntoOptions.value,
+    showTurnInto.value,
+    props.locale
+  )
 );
 
 function close() {
@@ -96,9 +101,6 @@ function handleTurnInto(nodeType: VizelNodeTypeOption) {
 function handleOpen(e: Event) {
   if (!(e instanceof CustomEvent)) return;
   const detail = e.detail as VizelBlockMenuOpenDetail;
-  // When this menu is bound to an editor (via prop or VizelProvider
-  // context), ignore events from any other editor on the page. This
-  // prevents sibling editors from cross-triggering each other's menus.
   if (boundEditor.value && detail.editor !== boundEditor.value) return;
   menuState.value = {
     ...detail,
@@ -107,7 +109,6 @@ function handleOpen(e: Event) {
   };
   showTurnInto.value = false;
 
-  // Clamp menu position to viewport after Vue renders
   void nextTick(() => {
     const el = menuRef.value;
     if (!(el && menuState.value)) return;
@@ -148,7 +149,6 @@ function handleMenuKeyDown(e: KeyboardEvent) {
   }
 }
 
-// Focus first menuitem when menu opens
 watch(menuState, (state) => {
   if (state) {
     void nextTick(() => {
@@ -160,7 +160,6 @@ watch(menuState, (state) => {
   }
 });
 
-// Detect whether the submenu should flip to the left side
 watch(showTurnInto, (isOpen) => {
   if (!(isOpen && menuRef.value)) {
     submenuFlipped.value = false;
@@ -174,9 +173,6 @@ watch(showTurnInto, (isOpen) => {
   });
 });
 
-// Manage outside-click + Escape dismissal declaratively through the shared
-// `createVizelDismissibleController` helper. Cleanup runs automatically
-// when the menu closes (via the `onCleanup` argument) and on unmount.
 watch(
   menuState,
   (state, _prev, onCleanup) => {
@@ -205,28 +201,28 @@ onBeforeUnmount(() => {
     ref="menuRef"
     :class="['vizel-block-menu', $props.class]"
     :style="{ left: menuState.x + 'px', top: menuState.y + 'px' }"
-    role="menu"
-    :aria-label="props.locale?.blockMenu.label ?? 'Block menu'"
+    :role="spec.root.role"
+    :aria-label="spec.root['aria-label']"
     data-vizel-block-menu
-    tabindex="-1"
+    :tabindex="spec.root.tabIndex"
     @keydown="handleMenuKeyDown"
   >
-    <template v-for="(group, groupIndex) in groups" :key="groupIndex">
-      <div v-if="groupIndex > 0" class="vizel-block-menu-divider" />
+    <template v-for="(section, sectionIndex) in spec.sections" :key="section.key">
+      <div v-if="sectionIndex > 0" class="vizel-block-menu-divider" />
       <button
-        v-for="action in group"
-        :key="action.id"
+        v-for="slot in section.items"
+        :key="slot.key"
         type="button"
-        :class="['vizel-block-menu-item', { 'is-destructive': action.id === 'delete' }]"
-        role="menuitem"
-        :disabled="action.isEnabled ? !action.isEnabled(menuState.editor, menuState.node) : false"
-        @click="handleAction(action)"
+        :class="['vizel-block-menu-item', { 'is-destructive': slot.data.isDestructive }]"
+        :role="slot.attrs.role"
+        :disabled="slot.data.action.isEnabled ? !slot.data.action.isEnabled(menuState.editor, menuState.node) : false"
+        @click="handleAction(slot.data.action)"
       >
         <span class="vizel-block-menu-item-icon">
-          <VizelIcon :name="action.icon" />
+          <VizelIcon :name="slot.data.action.icon" />
         </span>
-        <span class="vizel-block-menu-item-label">{{ action.label }}</span>
-        <span v-if="action.shortcut" class="vizel-block-menu-item-shortcut">{{ action.shortcut }}</span>
+        <span class="vizel-block-menu-item-label">{{ slot.data.action.label }}</span>
+        <span v-if="slot.data.action.shortcut" class="vizel-block-menu-item-shortcut">{{ slot.data.action.shortcut }}</span>
       </button>
     </template>
 
@@ -235,39 +231,41 @@ onBeforeUnmount(() => {
     <button
       type="button"
       class="vizel-block-menu-item vizel-block-menu-submenu-trigger"
-      role="menuitem"
-      aria-haspopup="menu"
-      :aria-expanded="showTurnInto"
+      :role="spec.submenuTrigger.attrs.role"
+      :aria-haspopup="spec.submenuTrigger.attrs['aria-haspopup']"
+      :aria-expanded="spec.submenuTrigger.attrs['aria-expanded']"
       @mouseenter="showTurnInto = true"
       @click="showTurnInto = !showTurnInto"
     >
       <span class="vizel-block-menu-item-icon">
-        <VizelIcon name="arrowRightLeft" />
+        <VizelIcon :name="spec.submenuTrigger.iconName" />
       </span>
-      <span class="vizel-block-menu-item-label">{{ props.locale?.blockMenu.turnInto ?? 'Turn into' }}</span>
+      <span class="vizel-block-menu-item-label">{{ spec.submenuTrigger.label }}</span>
     </button>
 
     <!-- Turn into submenu -->
     <div
-      v-if="showTurnInto && turnIntoOptions.length > 0"
+      v-if="showTurnInto && spec.submenu.sections.length > 0"
       ref="submenuRef"
       :class="['vizel-block-menu-submenu', { 'vizel-block-menu-submenu--left': submenuFlipped }]"
-      role="menu"
-      :aria-label="props.locale?.blockMenu.turnInto ?? 'Turn into'"
+      :role="spec.submenu.root.role"
+      :aria-label="spec.submenu.root['aria-label']"
     >
-      <button
-        v-for="nodeType in turnIntoOptions"
-        :key="nodeType.name"
-        type="button"
-        class="vizel-block-menu-item"
-        role="menuitem"
-        @click="handleTurnInto(nodeType)"
-      >
-        <span class="vizel-block-menu-item-icon">
-          <VizelIcon :name="nodeType.icon" />
-        </span>
-        <span class="vizel-block-menu-item-label">{{ nodeType.label }}</span>
-      </button>
+      <template v-for="section in spec.submenu.sections" :key="section.key">
+        <button
+          v-for="slot in section.items"
+          :key="slot.key"
+          type="button"
+          class="vizel-block-menu-item"
+          :role="slot.attrs.role"
+          @click="handleTurnInto(slot.data.nodeType)"
+        >
+          <span class="vizel-block-menu-item-icon">
+            <VizelIcon :name="slot.data.nodeType.icon" />
+          </span>
+          <span class="vizel-block-menu-item-label">{{ slot.data.nodeType.label }}</span>
+        </button>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Phase 7 step 3 of the v2.x audit. The React/Vue/Svelte
`VizelBlockMenu` components shared the same `role="menu"` container,
action-group rendering, divider placement, submenu trigger ARIA
wiring (`aria-haspopup="menu"` + `aria-expanded`), and "Turn into"
submenu shape — three copies of the same scaffolding. This PR moves
that scaffolding into `@vizel/core/skeletons/block-menu`.

### What `@vizel/core/skeletons/block-menu` owns

- `VizelBlockMenuSpec`:
  - `root`: `role="menu"`, `aria-label`, `tabIndex: -1`,
  - `sections`: groups of actions, each section gets a stable `key` so
    the framework component can place a divider before adjacent
    sections (`groupIndex > 0`),
  - per-item `attrs.role="menuitem"`,
  - per-item `data` carries the original `action` plus `isDestructive`
    (`id === "delete"`) for `is-destructive` className wiring,
  - `submenuTrigger`: a fully-formed spec for the "Turn into" button
    with `aria-haspopup="menu"` and `aria-expanded` reflecting state,
  - `submenu`: a nested `VizelMenuSpec<VizelBlockMenuTurnIntoItemView>`.
- `buildVizelBlockMenuSkeleton(actions, turnIntoOptions, showTurnInto,
  locale)` is the builder. Consumers pre-filter the turn-into options
  via the existing `getVizelTurnIntoOptions(editor, nodeTypes)` so the
  skeleton stays editor-free.

### Spec type extension

`VizelMenuItemAttrs` gains optional `aria-haspopup` /
`aria-expanded` fields. This is forward-looking — step 4
(ToolbarDropdown) reuses the same shape for its trigger.

### What the framework component still owns

Positioning (`clampMenuPosition`), focus management, outside-click +
Escape dismissal, submenu flip detection (`shouldFlipSubmenu`), and
the runtime `action.isEnabled(editor, node)` evaluation (which needs
live editor + node state). The component derives the spec via its
memo primitive and iterates `spec.sections` / `spec.submenuTrigger` /
`spec.submenu` to render the menu.

## Breaking Changes

None at the consumer level — `VizelBlockMenu` props are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 3 of 7.
