### PR TITLE
refactor: extract VizelToolbarDropdown DOM skeleton into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -313,6 +313,7 @@ export {
   buildVizelBlockMenuSkeleton,
   buildVizelMentionMenuSkeleton,
   buildVizelSlashMenuSkeleton,
+  buildVizelToolbarDropdownSkeleton,
   getNextVizelSlashMenuGroupIndex,
   type VizelBlockMenuItemView,
   type VizelBlockMenuSpec,
@@ -326,6 +327,9 @@ export {
   type VizelMenuSpec,
   type VizelSlashItemView,
   type VizelSlashMenuSkeletonOptions,
+  type VizelToolbarDropdownItemView,
+  type VizelToolbarDropdownSpec,
+  type VizelToolbarDropdownTriggerSpec,
 } from "./skeletons/index.ts";
 // =============================================================================
 // Theme

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -15,6 +15,12 @@ export {
   type VizelSlashItemView,
   type VizelSlashMenuSkeletonOptions,
 } from "./slash-menu.ts";
+export {
+  buildVizelToolbarDropdownSkeleton,
+  type VizelToolbarDropdownItemView,
+  type VizelToolbarDropdownSpec,
+  type VizelToolbarDropdownTriggerSpec,
+} from "./toolbar-dropdown.ts";
 export type {
   VizelMenuItemAttrs,
   VizelMenuItemSpec,

--- a/packages/core/src/skeletons/toolbar-dropdown.ts
+++ b/packages/core/src/skeletons/toolbar-dropdown.ts
@@ -1,0 +1,123 @@
+import type { Editor } from "@tiptap/core";
+import type { VizelIconName } from "../icons/types.ts";
+import type { VizelToolbarAction, VizelToolbarDropdownAction } from "../toolbar/actions.ts";
+import type { VizelMenuItemAttrs, VizelMenuSpec } from "./types.ts";
+
+/**
+ * Item-data shape surfaced to the framework `VizelToolbarDropdown`
+ * component for each option in the popover listbox.
+ *
+ * The skeleton pre-evaluates `isActive` and `isEnabled` against the
+ * runtime editor so the component renders without recomputing those
+ * predicates inline. `isFocused` mirrors the component's keyboard
+ * navigation cursor and drives the `is-focused` className.
+ */
+export interface VizelToolbarDropdownItemView {
+  /** The option as supplied by the consumer. */
+  option: VizelToolbarAction;
+  /** Whether this option is currently the active formatting state. */
+  isActive: boolean;
+  /** Whether this option's `run` can fire (drives `disabled`). */
+  isEnabled: boolean;
+  /** Whether this option is the keyboard-focused row. */
+  isFocused: boolean;
+}
+
+/**
+ * Trigger button metadata. The trigger advertises the popover as a
+ * listbox via `aria-haspopup="listbox"` and reflects the open state in
+ * `aria-expanded`. The visible icon + label follow the currently-active
+ * option (when `getActiveOption` is supplied) — for an unset state the
+ * dropdown's own icon + label are used.
+ */
+export interface VizelToolbarDropdownTriggerSpec {
+  /** Icon name rendered inside the trigger. */
+  iconName: VizelIconName;
+  /** Localized title / tooltip for the trigger button. */
+  label: string;
+  /** ARIA attrs for the trigger button. */
+  attrs: {
+    "aria-haspopup": "listbox";
+    "aria-expanded": boolean;
+  };
+}
+
+/**
+ * The complete toolbar-dropdown skeleton: trigger + popover.
+ *
+ * The popover is a `VizelMenuSpec<VizelToolbarDropdownItemView>` so it
+ * reuses the menu-spec iteration shape. The popover's `sections` always
+ * contains exactly one section (flat listbox).
+ */
+export interface VizelToolbarDropdownSpec {
+  /** Trigger button metadata. */
+  trigger: VizelToolbarDropdownTriggerSpec;
+  /** Popover listbox spec. */
+  popover: VizelMenuSpec<VizelToolbarDropdownItemView>;
+}
+
+/**
+ * Build a {@link VizelToolbarDropdownSpec} for the toolbar dropdown.
+ *
+ * @param dropdown  The dropdown action definition (id, options, getActiveOption).
+ * @param editor    Current editor instance — used to pre-evaluate
+ *                  `isActive` / `isEnabled` for each option and to resolve
+ *                  the active-option icon / label for the trigger.
+ * @param isOpen    Whether the popover is currently open.
+ * @param focusedIndex Index of the keyboard-focused option.
+ */
+export function buildVizelToolbarDropdownSkeleton(
+  dropdown: VizelToolbarDropdownAction,
+  editor: Editor,
+  isOpen: boolean,
+  focusedIndex: number
+): VizelToolbarDropdownSpec {
+  const activeOption = dropdown.getActiveOption?.(editor);
+  const trigger: VizelToolbarDropdownTriggerSpec = {
+    iconName: activeOption?.icon ?? dropdown.icon,
+    label: activeOption?.label ?? dropdown.label,
+    attrs: {
+      "aria-haspopup": "listbox",
+      "aria-expanded": isOpen,
+    },
+  };
+
+  const focusedOptionId = dropdown.options[focusedIndex]?.id;
+  const activedescendant = focusedOptionId
+    ? `vizel-dropdown-${dropdown.id}-${focusedOptionId}`
+    : undefined;
+
+  const popover: VizelMenuSpec<VizelToolbarDropdownItemView> = {
+    root: {
+      role: "listbox",
+      "aria-label": dropdown.label,
+      tabIndex: 0,
+      ...(activedescendant && { "aria-activedescendant": activedescendant }),
+    },
+    sections: [
+      {
+        key: "options",
+        items: dropdown.options.map((option, index) => {
+          const isActive = option.isActive(editor);
+          const isEnabled = option.isEnabled(editor);
+          const isFocused = index === focusedIndex;
+          const attrs: VizelMenuItemAttrs = {
+            id: `vizel-dropdown-${dropdown.id}-${option.id}`,
+            role: "option",
+            "aria-selected": isActive,
+            tabIndex: -1,
+            ...(isEnabled ? {} : { "aria-disabled": true }),
+          };
+          return {
+            key: option.id,
+            index,
+            data: { option, isActive, isEnabled, isFocused },
+            attrs,
+          };
+        }),
+      },
+    ],
+  };
+
+  return { trigger, popover };
+}

--- a/packages/react/src/components/VizelToolbarDropdown.tsx
+++ b/packages/react/src/components/VizelToolbarDropdown.tsx
@@ -1,6 +1,6 @@
 import type { Editor, VizelToolbarDropdownAction } from "@vizel/core";
-import { formatVizelTooltip } from "@vizel/core";
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { buildVizelToolbarDropdownSkeleton, formatVizelTooltip } from "@vizel/core";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
 export interface VizelToolbarDropdownProps {
@@ -11,6 +11,11 @@ export interface VizelToolbarDropdownProps {
 
 /**
  * A dropdown toolbar button that shows a popover with nested actions.
+ *
+ * DOM/ARIA scaffolding (trigger + listbox popover) comes from
+ * `@vizel/core`'s `buildVizelToolbarDropdownSkeleton`. The component
+ * owns popover open/close state, outside-click + Escape dismissal,
+ * keyboard navigation, and binding `onClick` to each option's `run`.
  */
 export function VizelToolbarDropdown({
   editor,
@@ -21,10 +26,6 @@ export function VizelToolbarDropdown({
   const [focusedIndex, setFocusedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-
-  const activeOption = dropdown.getActiveOption?.(editor);
-  const triggerIcon = activeOption?.icon ?? dropdown.icon;
-  const triggerLabel = activeOption?.label ?? dropdown.label;
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -55,10 +56,14 @@ export function VizelToolbarDropdown({
     };
   }, [isOpen, close]);
 
-  // Reset focused index when opening
   useEffect(() => {
     if (isOpen) setFocusedIndex(0);
   }, [isOpen]);
+
+  const spec = useMemo(
+    () => buildVizelToolbarDropdownSkeleton(dropdown, editor, isOpen, focusedIndex),
+    [dropdown, editor, isOpen, focusedIndex]
+  );
 
   const optionCount = dropdown.options.length;
 
@@ -115,11 +120,11 @@ export function VizelToolbarDropdown({
         className="vizel-toolbar-dropdown-trigger"
         onClick={() => setIsOpen((prev) => !prev)}
         onKeyDown={handleTriggerKeyDown}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        title={triggerLabel}
+        aria-haspopup={spec.trigger.attrs["aria-haspopup"]}
+        aria-expanded={spec.trigger.attrs["aria-expanded"]}
+        title={spec.trigger.label}
       >
-        <VizelIcon name={triggerIcon} />
+        <VizelIcon name={spec.trigger.iconName} />
         <span className="vizel-toolbar-dropdown-chevron">
           <VizelIcon name="chevronDown" />
         </span>
@@ -129,34 +134,35 @@ export function VizelToolbarDropdown({
         <div
           className="vizel-toolbar-dropdown-popover"
           role="listbox"
-          aria-label={dropdown.label}
-          aria-activedescendant={`vizel-dropdown-${dropdown.id}-${dropdown.options[focusedIndex]?.id}`}
-          tabIndex={0}
+          aria-label={spec.popover.root["aria-label"]}
+          {...(spec.popover.root["aria-activedescendant"] && {
+            "aria-activedescendant": spec.popover.root["aria-activedescendant"],
+          })}
+          tabIndex={spec.popover.root.tabIndex}
           onKeyDown={handleListKeyDown}
         >
-          {dropdown.options.map((option, index) => {
-            const active = option.isActive(editor);
-            return (
+          {spec.popover.sections.flatMap((section) =>
+            section.items.map((slot) => (
               <button
-                key={option.id}
-                id={`vizel-dropdown-${dropdown.id}-${option.id}`}
+                key={slot.key}
+                id={slot.attrs.id}
                 type="button"
                 role="option"
-                aria-selected={active}
-                className={`vizel-toolbar-dropdown-option ${active ? "is-active" : ""} ${index === focusedIndex ? "is-focused" : ""}`}
+                aria-selected={slot.attrs["aria-selected"]}
+                className={`vizel-toolbar-dropdown-option ${slot.data.isActive ? "is-active" : ""} ${slot.data.isFocused ? "is-focused" : ""}`}
                 onClick={() => {
-                  option.run(editor);
+                  slot.data.option.run(editor);
                   close();
                 }}
-                disabled={!option.isEnabled(editor)}
-                title={formatVizelTooltip(option.label, option.shortcut)}
-                tabIndex={-1}
+                disabled={!slot.data.isEnabled}
+                title={formatVizelTooltip(slot.data.option.label, slot.data.option.shortcut)}
+                tabIndex={slot.attrs.tabIndex}
               >
-                <VizelIcon name={option.icon} />
-                <span>{option.label}</span>
+                <VizelIcon name={slot.data.option.icon} />
+                <span>{slot.data.option.label}</span>
               </button>
-            );
-          })}
+            ))
+          )}
         </div>
       )}
     </div>

--- a/packages/svelte/src/components/VizelToolbarDropdown.svelte
+++ b/packages/svelte/src/components/VizelToolbarDropdown.svelte
@@ -9,7 +9,7 @@ export interface VizelToolbarDropdownProps {
 </script>
 
 <script lang="ts">
-import { formatVizelTooltip } from "@vizel/core";
+import { buildVizelToolbarDropdownSkeleton, formatVizelTooltip } from "@vizel/core";
 import VizelIcon from "./VizelIcon.svelte";
 
 let {
@@ -23,9 +23,9 @@ let focusedIndex = $state(0);
 let containerEl: HTMLDivElement | undefined = $state(undefined);
 let triggerEl: HTMLButtonElement | undefined = $state(undefined);
 
-const activeOption = $derived(dropdown.getActiveOption?.(editor));
-const triggerIcon = $derived(activeOption?.icon ?? dropdown.icon);
-const triggerLabel = $derived(activeOption?.label ?? dropdown.label);
+const spec = $derived(
+  buildVizelToolbarDropdownSkeleton(dropdown, editor, isOpen, focusedIndex)
+);
 
 function close() {
   isOpen = false;
@@ -119,13 +119,13 @@ $effect(() => {
     bind:this={triggerEl}
     type="button"
     class="vizel-toolbar-dropdown-trigger"
-    aria-haspopup="listbox"
-    aria-expanded={isOpen}
-    title={triggerLabel}
+    aria-haspopup={spec.trigger.attrs["aria-haspopup"]}
+    aria-expanded={spec.trigger.attrs["aria-expanded"]}
+    title={spec.trigger.label}
     onclick={toggle}
     onkeydown={handleTriggerKeyDown}
   >
-    <VizelIcon name={triggerIcon} />
+    <VizelIcon name={spec.trigger.iconName} />
     <span class="vizel-toolbar-dropdown-chevron">
       <VizelIcon name="chevronDown" />
     </span>
@@ -135,26 +135,28 @@ $effect(() => {
     <div
       class="vizel-toolbar-dropdown-popover"
       role="listbox"
-      aria-label={dropdown.label}
-      aria-activedescendant={`vizel-dropdown-${dropdown.id}-${dropdown.options[focusedIndex]?.id}`}
-      tabindex="0"
+      aria-label={spec.popover.root["aria-label"]}
+      aria-activedescendant={spec.popover.root["aria-activedescendant"]}
+      tabindex={spec.popover.root.tabIndex}
       onkeydown={handleListKeyDown}
     >
-      {#each dropdown.options as option, index (option.id)}
-        <button
-          id={`vizel-dropdown-${dropdown.id}-${option.id}`}
-          type="button"
-          role="option"
-          aria-selected={option.isActive(editor)}
-          class="vizel-toolbar-dropdown-option {option.isActive(editor) ? 'is-active' : ''} {index === focusedIndex ? 'is-focused' : ''}"
-          disabled={!option.isEnabled(editor)}
-          title={formatVizelTooltip(option.label, option.shortcut)}
-          tabindex={-1}
-          onclick={() => handleOptionClick(option)}
-        >
-          <VizelIcon name={option.icon} />
-          <span>{option.label}</span>
-        </button>
+      {#each spec.popover.sections as section (section.key)}
+        {#each section.items as slot (slot.key)}
+          <button
+            id={slot.attrs.id}
+            type="button"
+            role="option"
+            aria-selected={slot.attrs["aria-selected"]}
+            class="vizel-toolbar-dropdown-option {slot.data.isActive ? 'is-active' : ''} {slot.data.isFocused ? 'is-focused' : ''}"
+            disabled={!slot.data.isEnabled}
+            title={formatVizelTooltip(slot.data.option.label, slot.data.option.shortcut)}
+            tabindex={slot.attrs.tabIndex}
+            onclick={() => handleOptionClick(slot.data.option)}
+          >
+            <VizelIcon name={slot.data.option.icon} />
+            <span>{slot.data.option.label}</span>
+          </button>
+        {/each}
       {/each}
     </div>
   {/if}

--- a/packages/vue/src/components/VizelToolbarDropdown.vue
+++ b/packages/vue/src/components/VizelToolbarDropdown.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Editor, VizelToolbarDropdownAction } from "@vizel/core";
-import { formatVizelTooltip } from "@vizel/core";
+import { buildVizelToolbarDropdownSkeleton, formatVizelTooltip } from "@vizel/core";
 import { computed, onBeforeUnmount, ref, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -17,9 +17,9 @@ const focusedIndex = ref(0);
 const containerRef = ref<HTMLDivElement | null>(null);
 const triggerRef = ref<HTMLButtonElement | null>(null);
 
-const activeOption = computed(() => props.dropdown.getActiveOption?.(props.editor));
-const triggerIcon = computed(() => activeOption.value?.icon ?? props.dropdown.icon);
-const triggerLabel = computed(() => activeOption.value?.label ?? props.dropdown.label);
+const spec = computed(() =>
+  buildVizelToolbarDropdownSkeleton(props.dropdown, props.editor, isOpen.value, focusedIndex.value)
+);
 
 function close() {
   isOpen.value = false;
@@ -118,13 +118,13 @@ onBeforeUnmount(() => {
       ref="triggerRef"
       type="button"
       class="vizel-toolbar-dropdown-trigger"
-      aria-haspopup="listbox"
-      :aria-expanded="isOpen"
-      :title="triggerLabel"
+      :aria-haspopup="spec.trigger.attrs['aria-haspopup']"
+      :aria-expanded="spec.trigger.attrs['aria-expanded']"
+      :title="spec.trigger.label"
       @click="toggle"
       @keydown="handleTriggerKeyDown"
     >
-      <VizelIcon :name="triggerIcon" />
+      <VizelIcon :name="spec.trigger.iconName" />
       <span class="vizel-toolbar-dropdown-chevron">
         <VizelIcon name="chevronDown" />
       </span>
@@ -134,27 +134,29 @@ onBeforeUnmount(() => {
       v-if="isOpen"
       class="vizel-toolbar-dropdown-popover"
       role="listbox"
-      :aria-label="props.dropdown.label"
-      :aria-activedescendant="`vizel-dropdown-${props.dropdown.id}-${props.dropdown.options[focusedIndex]?.id}`"
-      tabindex="0"
+      :aria-label="spec.popover.root['aria-label']"
+      :aria-activedescendant="spec.popover.root['aria-activedescendant']"
+      :tabindex="spec.popover.root.tabIndex"
       @keydown="handleListKeyDown"
     >
-      <button
-        v-for="(option, index) in props.dropdown.options"
-        :id="`vizel-dropdown-${props.dropdown.id}-${option.id}`"
-        :key="option.id"
-        type="button"
-        role="option"
-        :aria-selected="option.isActive(props.editor)"
-        :class="['vizel-toolbar-dropdown-option', option.isActive(props.editor) && 'is-active', index === focusedIndex && 'is-focused']"
-        :disabled="!option.isEnabled(props.editor)"
-        :title="formatVizelTooltip(option.label, option.shortcut)"
-        tabindex="-1"
-        @click="handleOptionClick(option)"
-      >
-        <VizelIcon :name="option.icon" />
-        <span>{{ option.label }}</span>
-      </button>
+      <template v-for="section in spec.popover.sections" :key="section.key">
+        <button
+          v-for="slot in section.items"
+          :id="slot.attrs.id"
+          :key="slot.key"
+          type="button"
+          role="option"
+          :aria-selected="slot.attrs['aria-selected']"
+          :class="['vizel-toolbar-dropdown-option', slot.data.isActive && 'is-active', slot.data.isFocused && 'is-focused']"
+          :disabled="!slot.data.isEnabled"
+          :title="formatVizelTooltip(slot.data.option.label, slot.data.option.shortcut)"
+          :tabindex="slot.attrs.tabIndex"
+          @click="handleOptionClick(slot.data.option)"
+        >
+          <VizelIcon :name="slot.data.option.icon" />
+          <span>{{ slot.data.option.label }}</span>
+        </button>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Phase 7 step 4 of the v2.x audit. The React/Vue/Svelte
`VizelToolbarDropdown` components shared the same trigger-button +
listbox-popover shape, the `vizel-dropdown-${id}-${option.id}` id
scheme for `aria-activedescendant`, the per-option `isActive` /
`isEnabled` / `isFocused` flag derivation, and the active-option-as-
trigger fallback. `@vizel/core/skeletons/toolbar-dropdown` now owns it.

### What `@vizel/core/skeletons/toolbar-dropdown` owns

- `VizelToolbarDropdownSpec`:
  - `trigger`: `iconName`, `label` (active-option-aware), and ARIA
    attrs (`aria-haspopup="listbox"`, `aria-expanded`),
  - `popover`: a `VizelMenuSpec<VizelToolbarDropdownItemView>` with
    one section containing the options. Each option carries:
    - `attrs`: `id`, `role`, `aria-selected`, `aria-disabled`, `tabIndex`,
    - `data`: `option`, pre-evaluated `isActive` / `isEnabled` /
      `isFocused` flags.
- `buildVizelToolbarDropdownSkeleton(dropdown, editor, isOpen,
  focusedIndex)` evaluates the option predicates against the live
  editor so framework components don't recompute them inline.

### What the framework component still owns

Popover open/close state, outside-click + Escape dismissal, keyboard
navigation, and binding click handlers to `option.run(editor)`. The
component derives the spec via its memo primitive and reads
`spec.trigger.*` / `slot.attrs.*` / `slot.data.*` for rendering.

## Breaking Changes

None at the consumer level — `VizelToolbarDropdown` props are
unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 4 of 7.
