### PR TITLE
refactor: extract VizelNodeSelector DOM skeleton into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -312,6 +312,7 @@ export {
 export {
   buildVizelBlockMenuSkeleton,
   buildVizelMentionMenuSkeleton,
+  buildVizelNodeSelectorSkeleton,
   buildVizelSlashMenuSkeleton,
   buildVizelToolbarDropdownSkeleton,
   getNextVizelSlashMenuGroupIndex,
@@ -325,6 +326,9 @@ export {
   type VizelMenuRootAttrs,
   type VizelMenuSectionSpec,
   type VizelMenuSpec,
+  type VizelNodeSelectorItemView,
+  type VizelNodeSelectorSpec,
+  type VizelNodeSelectorTriggerSpec,
   type VizelSlashItemView,
   type VizelSlashMenuSkeletonOptions,
   type VizelToolbarDropdownItemView,

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -10,6 +10,12 @@ export {
   type VizelMentionItemView,
 } from "./mention-menu.ts";
 export {
+  buildVizelNodeSelectorSkeleton,
+  type VizelNodeSelectorItemView,
+  type VizelNodeSelectorSpec,
+  type VizelNodeSelectorTriggerSpec,
+} from "./node-selector.ts";
+export {
   buildVizelSlashMenuSkeleton,
   getNextVizelSlashMenuGroupIndex,
   type VizelSlashItemView,

--- a/packages/core/src/skeletons/node-selector.ts
+++ b/packages/core/src/skeletons/node-selector.ts
@@ -1,0 +1,117 @@
+import type { Editor } from "@tiptap/core";
+import type { VizelNodeTypeOption } from "../extensions/node-types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelMenuItemAttrs, VizelMenuSpec } from "./types.ts";
+
+/**
+ * Item-data shape surfaced for each block-type option in the
+ * `VizelNodeSelector` popover.
+ *
+ * The skeleton pre-evaluates `isActive` against the runtime editor and
+ * exposes the keyboard-focused row via `isFocused`.
+ */
+export interface VizelNodeSelectorItemView {
+  /** The node-type option as supplied by the consumer. */
+  nodeType: VizelNodeTypeOption;
+  /** Whether this node type matches the current selection. */
+  isActive: boolean;
+  /** Whether this row is the keyboard-focused option. */
+  isFocused: boolean;
+}
+
+/**
+ * Trigger button metadata. The trigger displays the currently-active
+ * block type's icon + label, falls back to the locale-aware "Text"
+ * label when no node type matches, and advertises the popover as a
+ * listbox.
+ */
+export interface VizelNodeSelectorTriggerSpec {
+  /** Icon name for the currently active block type. */
+  iconName: VizelNodeTypeOption["icon"];
+  /** Label for the currently active block type. */
+  label: string;
+  /** Localized title attribute ("Change block type"). */
+  title: string;
+  /** Localized aria-label ("Current block type: <label>"). */
+  ariaLabel: string;
+  /** ARIA attrs for the trigger button. */
+  attrs: {
+    "aria-haspopup": "listbox";
+    "aria-expanded": boolean;
+  };
+}
+
+/**
+ * The complete node-selector skeleton: trigger + popover.
+ */
+export interface VizelNodeSelectorSpec {
+  /** Trigger button metadata. */
+  trigger: VizelNodeSelectorTriggerSpec;
+  /** Popover listbox spec. */
+  popover: VizelMenuSpec<VizelNodeSelectorItemView>;
+}
+
+/**
+ * Build a {@link VizelNodeSelectorSpec} for the node-type selector.
+ *
+ * @param editor       Current editor instance — used to compute the
+ *                     active node type and per-row `isActive`.
+ * @param nodeTypes    Available node type options.
+ * @param isOpen       Whether the popover is currently open.
+ * @param focusedIndex Index of the keyboard-focused row.
+ * @param locale       Optional locale for translated labels.
+ */
+export function buildVizelNodeSelectorSkeleton(
+  editor: Editor,
+  nodeTypes: readonly VizelNodeTypeOption[],
+  isOpen: boolean,
+  focusedIndex: number,
+  locale: VizelLocale | undefined
+): VizelNodeSelectorSpec {
+  const activeNodeType = nodeTypes.find((type) => type.isActive(editor));
+  const currentLabel = activeNodeType?.label ?? locale?.nodeTypes.text ?? "Text";
+  const currentIcon = activeNodeType?.icon ?? "paragraph";
+  const title = locale?.nodeSelector.changeBlockType ?? "Change block type";
+  const ariaLabelTemplate = locale?.nodeSelector.currentBlockType ?? "Current block type: {type}";
+
+  const trigger: VizelNodeSelectorTriggerSpec = {
+    iconName: currentIcon,
+    label: currentLabel,
+    title,
+    ariaLabel: ariaLabelTemplate.replace("{type}", currentLabel),
+    attrs: {
+      "aria-haspopup": "listbox",
+      "aria-expanded": isOpen,
+    },
+  };
+
+  const popover: VizelMenuSpec<VizelNodeSelectorItemView> = {
+    root: {
+      role: "listbox",
+      "aria-label": locale?.nodeSelector.blockTypes ?? "Block types",
+      tabIndex: -1,
+    },
+    sections: [
+      {
+        key: "node-types",
+        items: nodeTypes.map((nodeType, index) => {
+          const isActive = nodeType.isActive(editor);
+          const isFocused = index === focusedIndex;
+          const attrs: VizelMenuItemAttrs = {
+            role: "option",
+            "aria-selected": isActive,
+            tabIndex: isFocused ? 0 : -1,
+          };
+          return {
+            key: nodeType.name,
+            index,
+            data: { nodeType, isActive, isFocused },
+            attrs,
+          };
+        }),
+      },
+    ],
+  };
+
+  return { trigger, popover };
+}

--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -1,12 +1,12 @@
 import {
+  buildVizelNodeSelectorSkeleton,
   createVizelNodeTypes,
   type Editor,
-  getVizelActiveNodeType,
   type VizelLocale,
   type VizelNodeTypeOption,
   vizelDefaultNodeTypes,
 } from "@vizel/core";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useVizelState } from "../hooks/useVizelState.ts";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -23,12 +23,11 @@ export interface VizelNodeSelectorProps {
 
 /**
  * A dropdown selector for changing block node types.
- * Displays the current node type and allows transformation to other types.
  *
- * @example
- * ```tsx
- * <VizelNodeSelector editor={editor} />
- * ```
+ * DOM/ARIA scaffolding (trigger + listbox popover) comes from
+ * `@vizel/core`'s `buildVizelNodeSelectorSkeleton`. The component owns
+ * popover open/close state, outside-click dismissal, keyboard
+ * navigation, and binding `nodeType.command(editor)` to each option.
  */
 export function VizelNodeSelector({
   editor,
@@ -38,7 +37,6 @@ export function VizelNodeSelector({
 }: VizelNodeSelectorProps) {
   const effectiveNodeTypes =
     nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes);
-  // Subscribe to editor state changes
   useVizelState(editor);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -47,11 +45,11 @@ export function VizelNodeSelector({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const activeNodeType = getVizelActiveNodeType(editor, effectiveNodeTypes);
-  const currentLabel = activeNodeType?.label ?? locale?.nodeTypes.text ?? "Text";
-  const currentIcon = activeNodeType?.icon ?? "paragraph";
+  const spec = useMemo(
+    () => buildVizelNodeSelectorSkeleton(editor, effectiveNodeTypes, isOpen, focusedIndex, locale),
+    [editor, effectiveNodeTypes, isOpen, focusedIndex, locale]
+  );
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     if (!isOpen) return;
 
@@ -66,14 +64,12 @@ export function VizelNodeSelector({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
-  // Focus the dropdown when it opens to ensure keyboard navigation works
   useEffect(() => {
     if (isOpen && dropdownRef.current) {
       dropdownRef.current.focus();
     }
   }, [isOpen]);
 
-  // Handle keyboard navigation
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (!isOpen) {
       if (event.key === "Enter" || event.key === " " || event.key === "ArrowDown") {
@@ -118,7 +114,6 @@ export function VizelNodeSelector({
         setFocusedIndex(effectiveNodeTypes.length - 1);
         break;
       default:
-        // Allow other keys to propagate
         break;
     }
   };
@@ -141,18 +136,15 @@ export function VizelNodeSelector({
         className="vizel-node-selector-trigger"
         onClick={() => setIsOpen(!isOpen)}
         onKeyDown={handleKeyDown}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-label={(locale?.nodeSelector.currentBlockType ?? "Current block type: {type}").replace(
-          "{type}",
-          currentLabel
-        )}
-        title={locale?.nodeSelector.changeBlockType ?? "Change block type"}
+        aria-haspopup={spec.trigger.attrs["aria-haspopup"]}
+        aria-expanded={spec.trigger.attrs["aria-expanded"]}
+        aria-label={spec.trigger.ariaLabel}
+        title={spec.trigger.title}
       >
         <span className="vizel-node-selector-icon">
-          <VizelIcon name={currentIcon} />
+          <VizelIcon name={spec.trigger.iconName} />
         </span>
-        <span className="vizel-node-selector-label">{currentLabel}</span>
+        <span className="vizel-node-selector-label">{spec.trigger.label}</span>
         <span className="vizel-node-selector-chevron" aria-hidden="true">
           <VizelIcon name="chevronDown" />
         </span>
@@ -163,38 +155,35 @@ export function VizelNodeSelector({
           ref={dropdownRef}
           className="vizel-node-selector-dropdown"
           role="listbox"
-          aria-label={locale?.nodeSelector.blockTypes ?? "Block types"}
+          aria-label={spec.popover.root["aria-label"]}
           data-vizel-node-selector-dropdown
-          tabIndex={-1}
+          tabIndex={spec.popover.root.tabIndex}
           onKeyDown={handleKeyDown}
         >
-          {effectiveNodeTypes.map((nodeType, index) => {
-            const isActive = nodeType.isActive(editor);
-            const isFocused = index === focusedIndex;
-
-            return (
+          {spec.popover.sections.flatMap((section) =>
+            section.items.map((slot) => (
               <button
-                key={nodeType.name}
+                key={slot.key}
                 type="button"
                 role="option"
-                aria-selected={isActive}
-                className={`vizel-node-selector-option ${isActive ? "is-active" : ""} ${isFocused ? "is-focused" : ""}`}
-                onClick={() => handleSelectNodeType(nodeType)}
-                onMouseEnter={() => setFocusedIndex(index)}
-                tabIndex={isFocused ? 0 : -1}
+                aria-selected={slot.attrs["aria-selected"]}
+                className={`vizel-node-selector-option ${slot.data.isActive ? "is-active" : ""} ${slot.data.isFocused ? "is-focused" : ""}`}
+                onClick={() => handleSelectNodeType(slot.data.nodeType)}
+                onMouseEnter={() => setFocusedIndex(slot.index)}
+                tabIndex={slot.attrs.tabIndex}
               >
                 <span className="vizel-node-selector-option-icon">
-                  <VizelIcon name={nodeType.icon} />
+                  <VizelIcon name={slot.data.nodeType.icon} />
                 </span>
-                <span className="vizel-node-selector-option-label">{nodeType.label}</span>
-                {isActive && (
+                <span className="vizel-node-selector-option-label">{slot.data.nodeType.label}</span>
+                {slot.data.isActive && (
                   <span className="vizel-node-selector-check" aria-hidden="true">
                     <VizelIcon name="check" />
                   </span>
                 )}
               </button>
-            );
-          })}
+            ))
+          )}
         </div>
       )}
     </div>

--- a/packages/svelte/src/components/VizelNodeSelector.svelte
+++ b/packages/svelte/src/components/VizelNodeSelector.svelte
@@ -14,7 +14,7 @@ export interface VizelNodeSelectorProps {
 </script>
 
 <script lang="ts">
-import { createVizelNodeTypes, vizelDefaultNodeTypes, getVizelActiveNodeType } from "@vizel/core";
+import { buildVizelNodeSelectorSkeleton, createVizelNodeTypes, vizelDefaultNodeTypes } from "@vizel/core";
 import { createVizelState } from "../runes/createVizelState.svelte.js";
 import VizelIcon from "./VizelIcon.svelte";
 
@@ -22,7 +22,6 @@ let { editor, nodeTypes, class: className, locale }: VizelNodeSelectorProps = $p
 
 const effectiveNodeTypes = $derived(nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes));
 
-// Subscribe to editor state changes
 const editorState = createVizelState(() => editor);
 
 let isOpen = $state(false);
@@ -31,15 +30,11 @@ let containerRef: HTMLDivElement | undefined = $state();
 let dropdownRef: HTMLDivElement | undefined = $state();
 let triggerRef: HTMLButtonElement | undefined = $state();
 
-const activeNodeType = $derived.by(() => {
-  void editorState.current; // Trigger reactivity
-  return getVizelActiveNodeType(editor, effectiveNodeTypes);
+const spec = $derived.by(() => {
+  void editorState.current;
+  return buildVizelNodeSelectorSkeleton(editor, effectiveNodeTypes, isOpen, focusedIndex, locale);
 });
 
-const currentLabel = $derived(activeNodeType?.label ?? (locale?.nodeTypes.text ?? "Text"));
-const currentIcon = $derived(activeNodeType?.icon ?? "paragraph");
-
-// Close dropdown when clicking outside
 function handleClickOutside(event: MouseEvent) {
   if (!(event.target instanceof Node)) return;
   if (containerRef && !containerRef.contains(event.target)) {
@@ -53,7 +48,6 @@ $effect(() => {
   return () => document.removeEventListener("mousedown", handleClickOutside);
 });
 
-// Focus the dropdown when it opens to ensure keyboard navigation works
 $effect(() => {
   if (isOpen && dropdownRef) {
     dropdownRef.focus();
@@ -102,7 +96,6 @@ function handleKeyDown(event: KeyboardEvent) {
       focusedIndex = effectiveNodeTypes.length - 1;
       break;
     default:
-      // Allow other keys to propagate
       break;
   }
 }
@@ -111,11 +104,6 @@ function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
   nodeType.command(editor);
   isOpen = false;
   triggerRef?.focus();
-}
-
-function isNodeTypeActive(nodeType: VizelNodeTypeOption): boolean {
-  void editorState.current; // Trigger reactivity
-  return nodeType.isActive(editor);
 }
 </script>
 
@@ -128,54 +116,55 @@ function isNodeTypeActive(nodeType: VizelNodeTypeOption): boolean {
     bind:this={triggerRef}
     type="button"
     class="vizel-node-selector-trigger"
-    aria-haspopup="listbox"
-    aria-expanded={isOpen}
-    aria-label={(locale?.nodeSelector.currentBlockType ?? "Current block type: {type}").replace("{type}", currentLabel)}
-    title={locale?.nodeSelector.changeBlockType ?? "Change block type"}
+    aria-haspopup={spec.trigger.attrs["aria-haspopup"]}
+    aria-expanded={spec.trigger.attrs["aria-expanded"]}
+    aria-label={spec.trigger.ariaLabel}
+    title={spec.trigger.title}
     onclick={() => (isOpen = !isOpen)}
     onkeydown={handleKeyDown}
   >
     <span class="vizel-node-selector-icon">
-      <VizelIcon name={currentIcon} />
+      <VizelIcon name={spec.trigger.iconName} />
     </span>
-    <span class="vizel-node-selector-label">{currentLabel}</span>
+    <span class="vizel-node-selector-label">{spec.trigger.label}</span>
     <span class="vizel-node-selector-chevron" aria-hidden="true">
       <VizelIcon name="chevronDown" />
     </span>
   </button>
 
   {#if isOpen}
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
     <div
       bind:this={dropdownRef}
       class="vizel-node-selector-dropdown"
       role="listbox"
-      aria-label={locale?.nodeSelector.blockTypes ?? "Block types"}
+      aria-label={spec.popover.root["aria-label"]}
       data-vizel-node-selector-dropdown
-      tabindex="-1"
+      tabindex={spec.popover.root.tabIndex}
       onkeydown={handleKeyDown}
     >
-      {#each effectiveNodeTypes as nodeType, index}
-        {@const active = isNodeTypeActive(nodeType)}
-        {@const focused = index === focusedIndex}
-        <button
-          type="button"
-          role="option"
-          aria-selected={active}
-          class="vizel-node-selector-option {active ? 'is-active' : ''} {focused ? 'is-focused' : ''}"
-          tabindex={focused ? 0 : -1}
-          onclick={() => handleSelectNodeType(nodeType)}
-          onmouseenter={() => (focusedIndex = index)}
-        >
-          <span class="vizel-node-selector-option-icon">
-            <VizelIcon name={nodeType.icon} />
-          </span>
-          <span class="vizel-node-selector-option-label">{nodeType.label}</span>
-          {#if active}
-            <span class="vizel-node-selector-check" aria-hidden="true">
-              <VizelIcon name="check" />
+      {#each spec.popover.sections as section (section.key)}
+        {#each section.items as slot (slot.key)}
+          <button
+            type="button"
+            role="option"
+            aria-selected={slot.attrs["aria-selected"]}
+            class="vizel-node-selector-option {slot.data.isActive ? 'is-active' : ''} {slot.data.isFocused ? 'is-focused' : ''}"
+            tabindex={slot.attrs.tabIndex}
+            onclick={() => handleSelectNodeType(slot.data.nodeType)}
+            onmouseenter={() => (focusedIndex = slot.index)}
+          >
+            <span class="vizel-node-selector-option-icon">
+              <VizelIcon name={slot.data.nodeType.icon} />
             </span>
-          {/if}
-        </button>
+            <span class="vizel-node-selector-option-label">{slot.data.nodeType.label}</span>
+            {#if slot.data.isActive}
+              <span class="vizel-node-selector-check" aria-hidden="true">
+                <VizelIcon name="check" />
+              </span>
+            {/if}
+          </button>
+        {/each}
       {/each}
     </div>
   {/if}

--- a/packages/vue/src/components/VizelNodeSelector.vue
+++ b/packages/vue/src/components/VizelNodeSelector.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import {
+  buildVizelNodeSelectorSkeleton,
   createVizelNodeTypes,
   type Editor,
-  getVizelActiveNodeType,
   type VizelLocale,
   type VizelNodeTypeOption,
   vizelDefaultNodeTypes,
@@ -29,7 +29,6 @@ const effectiveNodeTypes = computed(
     props.nodeTypes ?? (props.locale ? createVizelNodeTypes(props.locale) : vizelDefaultNodeTypes)
 );
 
-// Subscribe to editor state changes
 const editorStateVersion = useVizelState(() => props.editor);
 
 const isOpen = ref(false);
@@ -38,17 +37,17 @@ const containerRef = ref<HTMLDivElement | null>(null);
 const dropdownRef = ref<HTMLDivElement | null>(null);
 const triggerRef = ref<HTMLButtonElement | null>(null);
 
-const activeNodeType = computed(() => {
-  void editorStateVersion.value; // Trigger reactivity
-  return getVizelActiveNodeType(props.editor, effectiveNodeTypes.value);
+const spec = computed(() => {
+  void editorStateVersion.value;
+  return buildVizelNodeSelectorSkeleton(
+    props.editor,
+    effectiveNodeTypes.value,
+    isOpen.value,
+    focusedIndex.value,
+    props.locale
+  );
 });
 
-const currentLabel = computed(
-  () => activeNodeType.value?.label ?? props.locale?.nodeTypes.text ?? "Text"
-);
-const currentIcon = computed(() => activeNodeType.value?.icon ?? "paragraph");
-
-// Close dropdown when clicking outside
 function handleClickOutside(event: MouseEvent) {
   if (!(event.target instanceof Node)) return;
   if (containerRef.value && !containerRef.value.contains(event.target)) {
@@ -68,7 +67,6 @@ onBeforeUnmount(() => {
   document.removeEventListener("mousedown", handleClickOutside);
 });
 
-// Focus the dropdown when it opens to ensure keyboard navigation works
 watch(isOpen, (newValue) => {
   if (newValue) {
     void nextTick(() => {
@@ -121,7 +119,6 @@ function handleKeyDown(event: KeyboardEvent) {
       focusedIndex.value = effectiveNodeTypes.value.length - 1;
       break;
     default:
-      // Allow other keys to propagate
       break;
   }
 }
@@ -130,11 +127,6 @@ function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
   nodeType.command(props.editor);
   isOpen.value = false;
   triggerRef.value?.focus();
-}
-
-function isNodeTypeActive(nodeType: VizelNodeTypeOption): boolean {
-  void editorStateVersion.value; // Trigger reactivity
-  return nodeType.isActive(props.editor);
 }
 </script>
 
@@ -148,17 +140,17 @@ function isNodeTypeActive(nodeType: VizelNodeTypeOption): boolean {
       ref="triggerRef"
       type="button"
       class="vizel-node-selector-trigger"
-      aria-haspopup="listbox"
-      :aria-expanded="isOpen"
-      :aria-label="(props.locale?.nodeSelector.currentBlockType ?? 'Current block type: {type}').replace('{type}', currentLabel)"
-      :title="props.locale?.nodeSelector.changeBlockType ?? 'Change block type'"
+      :aria-haspopup="spec.trigger.attrs['aria-haspopup']"
+      :aria-expanded="spec.trigger.attrs['aria-expanded']"
+      :aria-label="spec.trigger.ariaLabel"
+      :title="spec.trigger.title"
       @click="isOpen = !isOpen"
       @keydown="handleKeyDown"
     >
       <span class="vizel-node-selector-icon">
-        <VizelIcon :name="currentIcon" />
+        <VizelIcon :name="spec.trigger.iconName" />
       </span>
-      <span class="vizel-node-selector-label">{{ currentLabel }}</span>
+      <span class="vizel-node-selector-label">{{ spec.trigger.label }}</span>
       <span class="vizel-node-selector-chevron" aria-hidden="true">
         <VizelIcon name="chevronDown" />
       </span>
@@ -169,38 +161,40 @@ function isNodeTypeActive(nodeType: VizelNodeTypeOption): boolean {
       ref="dropdownRef"
       class="vizel-node-selector-dropdown"
       role="listbox"
-      :aria-label="props.locale?.nodeSelector.blockTypes ?? 'Block types'"
+      :aria-label="spec.popover.root['aria-label']"
       data-vizel-node-selector-dropdown
-      tabindex="-1"
+      :tabindex="spec.popover.root.tabIndex"
       @keydown="handleKeyDown"
     >
-      <button
-        v-for="(nodeType, index) in effectiveNodeTypes"
-        :key="nodeType.name"
-        type="button"
-        role="option"
-        :aria-selected="isNodeTypeActive(nodeType)"
-        :class="[
-          'vizel-node-selector-option',
-          { 'is-active': isNodeTypeActive(nodeType) },
-          { 'is-focused': index === focusedIndex },
-        ]"
-        :tabindex="index === focusedIndex ? 0 : -1"
-        @click="handleSelectNodeType(nodeType)"
-        @mouseenter="focusedIndex = index"
-      >
-        <span class="vizel-node-selector-option-icon">
-          <VizelIcon :name="nodeType.icon" />
-        </span>
-        <span class="vizel-node-selector-option-label">{{ nodeType.label }}</span>
-        <span
-          v-if="isNodeTypeActive(nodeType)"
-          class="vizel-node-selector-check"
-          aria-hidden="true"
+      <template v-for="section in spec.popover.sections" :key="section.key">
+        <button
+          v-for="slot in section.items"
+          :key="slot.key"
+          type="button"
+          role="option"
+          :aria-selected="slot.attrs['aria-selected']"
+          :class="[
+            'vizel-node-selector-option',
+            { 'is-active': slot.data.isActive },
+            { 'is-focused': slot.data.isFocused },
+          ]"
+          :tabindex="slot.attrs.tabIndex"
+          @click="handleSelectNodeType(slot.data.nodeType)"
+          @mouseenter="focusedIndex = slot.index"
         >
-          <VizelIcon name="check" />
-        </span>
-      </button>
+          <span class="vizel-node-selector-option-icon">
+            <VizelIcon :name="slot.data.nodeType.icon" />
+          </span>
+          <span class="vizel-node-selector-option-label">{{ slot.data.nodeType.label }}</span>
+          <span
+            v-if="slot.data.isActive"
+            class="vizel-node-selector-check"
+            aria-hidden="true"
+          >
+            <VizelIcon name="check" />
+          </span>
+        </button>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Phase 7 step 5 of the v2.x audit. The React/Vue/Svelte
`VizelNodeSelector` components shared the same trigger + listbox-
popover shape, the active-node-type detection via
`getVizelActiveNodeType` + locale-aware "Text" fallback, the
`"Current block type: {type}"` aria-label template, and the per-
option `isActive` / focused-row flag computation. The shared
scaffolding now lives in `@vizel/core/skeletons/node-selector`.

### What `@vizel/core/skeletons/node-selector` owns

- `VizelNodeSelectorSpec`:
  - `trigger`: icon name, label (active type or "Text" fallback),
    localized `title` ("Change block type"), computed `ariaLabel`
    ("Current block type: <label>"), and ARIA attrs
    (`aria-haspopup="listbox"`, `aria-expanded`),
  - `popover`: a `VizelMenuSpec<VizelNodeSelectorItemView>` with one
    section carrying each node-type option. Each option's `data`
    carries `nodeType`, pre-evaluated `isActive`, and `isFocused`;
    `attrs` carries `role="option"`, `aria-selected`, and a roving
    `tabIndex` (0 for focused, -1 otherwise).
- `buildVizelNodeSelectorSkeleton(editor, nodeTypes, isOpen,
  focusedIndex, locale)` evaluates the predicates against the live
  editor so framework components don't recompute them inline.

### What the framework component still owns

Popover open/close state, outside-click dismissal, keyboard
navigation, mouse-hover focus tracking, dropdown focus
management, and binding `nodeType.command(editor)` to each option.
The component derives the spec via its memo primitive and reads
`spec.trigger.*` / `slot.attrs.*` / `slot.data.*` for rendering.

## Breaking Changes

None at the consumer level — `VizelNodeSelector` props are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 5 of 7.
