### PR TITLE
refactor: extract VizelLinkEditor form helpers into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,16 +310,22 @@ export {
 // UI Skeletons
 // =============================================================================
 export {
+  applyVizelLinkEdit,
   buildVizelBlockMenuSkeleton,
+  buildVizelLinkEditorViewState,
   buildVizelMentionMenuSkeleton,
   buildVizelNodeSelectorSkeleton,
   buildVizelSlashMenuSkeleton,
   buildVizelToolbarDropdownSkeleton,
   getNextVizelSlashMenuGroupIndex,
+  resolveVizelLinkEditorLabels,
   type VizelBlockMenuItemView,
   type VizelBlockMenuSpec,
   type VizelBlockMenuSubmenuTriggerSpec,
   type VizelBlockMenuTurnIntoItemView,
+  type VizelLinkEditorLabels,
+  type VizelLinkEditorViewState,
+  type VizelLinkSubmitParams,
   type VizelMentionItemView,
   type VizelMenuItemAttrs,
   type VizelMenuItemSpec,

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -6,6 +6,14 @@ export {
   type VizelBlockMenuTurnIntoItemView,
 } from "./block-menu.ts";
 export {
+  applyVizelLinkEdit,
+  buildVizelLinkEditorViewState,
+  resolveVizelLinkEditorLabels,
+  type VizelLinkEditorLabels,
+  type VizelLinkEditorViewState,
+  type VizelLinkSubmitParams,
+} from "./link-editor.ts";
+export {
   buildVizelMentionMenuSkeleton,
   type VizelMentionItemView,
 } from "./mention-menu.ts";

--- a/packages/core/src/skeletons/link-editor.ts
+++ b/packages/core/src/skeletons/link-editor.ts
@@ -1,0 +1,159 @@
+import type { Editor } from "@tiptap/core";
+import { detectVizelEmbedProvider } from "../extensions/embed.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+
+/**
+ * Localized labels for the `VizelLinkEditor` form, resolved from a
+ * `VizelLocale` (with sensible English fallbacks).
+ *
+ * Each framework's `VizelLinkEditor` reads these strings directly
+ * rather than re-evaluating the `locale?.linkEditor?.* ?? "..."`
+ * chain inline. This guarantees the three frameworks ship identical
+ * label strings and consolidates the fallback list to one place.
+ */
+export interface VizelLinkEditorLabels {
+  urlAriaLabel: string;
+  urlPlaceholder: string;
+  apply: string;
+  applyAriaLabel: string;
+  removeLink: string;
+  removeLinkAriaLabel: string;
+  openInNewTab: string;
+  visit: string;
+  visitTitle: string;
+  embedAsRichContent: string;
+}
+
+/**
+ * Resolve the link-editor labels from a locale (or fall back to English).
+ */
+export function resolveVizelLinkEditorLabels(
+  locale: VizelLocale | undefined
+): VizelLinkEditorLabels {
+  const le = locale?.linkEditor;
+  return {
+    // The URL input's aria-label has no locale field today — the
+    // component baselines have always shipped "Link URL". Keep it
+    // hardcoded here so framework components can drop the inline literal.
+    urlAriaLabel: "Link URL",
+    urlPlaceholder: le?.urlPlaceholder ?? "Enter URL...",
+    apply: le?.apply ?? "Apply",
+    applyAriaLabel: le?.applyAriaLabel ?? "Apply link",
+    removeLink: le?.removeLink ?? "Remove link",
+    removeLinkAriaLabel: le?.removeLinkAriaLabel ?? "Remove link",
+    openInNewTab: le?.openInNewTab ?? "Open in new tab",
+    visit: le?.visit ?? "Visit",
+    visitTitle: le?.visitTitle ?? "Open URL in new tab",
+    embedAsRichContent: le?.embedAsRichContent ?? "Embed as rich content",
+  };
+}
+
+/**
+ * Derived display state for the `VizelLinkEditor` form. The framework
+ * component recomputes this whenever `url` (or the editor selection)
+ * changes, then drives conditional rendering from the boolean flags.
+ */
+export interface VizelLinkEditorViewState {
+  /** Initial URL extracted from the current link mark (empty if none). */
+  initialUrl: string;
+  /** Initial open-in-new-tab flag derived from `target === "_blank"`. */
+  initialOpenInNewTab: boolean;
+  /** Whether the editor has the embed extension loaded. */
+  canEmbed: boolean;
+  /** Whether the current URL matches a known embed provider. */
+  isEmbedProvider: boolean;
+  /** Whether the remove button should be rendered (link mark present). */
+  showRemoveButton: boolean;
+  /** Whether the visit button should be rendered (URL non-empty). */
+  showVisitButton: boolean;
+  /** Whether the embed-as-rich-content toggle should be rendered. */
+  showEmbedToggle: boolean;
+}
+
+/**
+ * Compute the link-editor display state from the live editor + URL input.
+ *
+ * @param editor       Current editor instance.
+ * @param url          Current value of the URL input (may be untrimmed).
+ * @param enableEmbed  Whether the consumer wants the embed toggle.
+ */
+export function buildVizelLinkEditorViewState(
+  editor: Editor,
+  url: string,
+  enableEmbed: boolean
+): VizelLinkEditorViewState {
+  const linkAttrs = editor.getAttributes("link");
+  const initialUrl = (linkAttrs.href as string | undefined) ?? "";
+  const initialOpenInNewTab = linkAttrs.target === "_blank";
+  const canEmbed =
+    enableEmbed && editor.extensionManager.extensions.some((ext) => ext.name === "embed");
+  const trimmed = url.trim();
+  const isEmbedProvider = trimmed ? detectVizelEmbedProvider(trimmed) !== null : false;
+
+  return {
+    initialUrl,
+    initialOpenInNewTab,
+    canEmbed,
+    isEmbedProvider,
+    showRemoveButton: Boolean(initialUrl),
+    showVisitButton: trimmed.length > 0,
+    showEmbedToggle: canEmbed && isEmbedProvider,
+  };
+}
+
+/**
+ * Parameters accepted by {@link applyVizelLinkEdit}.
+ */
+export interface VizelLinkSubmitParams {
+  /** URL entered into the input (will be trimmed). */
+  url: string;
+  /** Whether the link should open in a new tab. */
+  openInNewTab: boolean;
+  /** Whether to convert the link to an embed (requires `canEmbed`). */
+  asEmbed: boolean;
+}
+
+/**
+ * Apply the link-editor submission to the editor.
+ *
+ * An empty (trimmed) URL removes the current link. When `asEmbed` is
+ * true and the embed extension is loaded (`canEmbed`), the link is
+ * removed and an embed is inserted instead. Otherwise the link mark
+ * is set with the appropriate `target`.
+ *
+ * @returns The trimmed URL that was applied (empty string when removed).
+ */
+export function applyVizelLinkEdit(
+  editor: Editor,
+  params: VizelLinkSubmitParams,
+  canEmbed: boolean
+): string {
+  const trimmed = params.url.trim();
+  if (!trimmed) {
+    editor.chain().focus().unsetLink().run();
+    return "";
+  }
+  if (params.asEmbed && canEmbed) {
+    // setEmbed is provided by the embed extension; the canEmbed guard
+    // above ensures it exists, but TypeScript can't statically prove
+    // that from the embed extension's loose typing. The cast is
+    // narrow and lives next to the guard.
+    (
+      editor.chain().focus().unsetLink() as ReturnType<typeof editor.chain> & {
+        setEmbed: (attrs: { url: string }) => ReturnType<typeof editor.chain>;
+      }
+    )
+      .setEmbed({ url: trimmed })
+      .run();
+    return trimmed;
+  }
+  editor
+    .chain()
+    .focus()
+    .setLink({
+      href: trimmed,
+      target: params.openInNewTab ? "_blank" : null,
+    })
+    .run();
+  return trimmed;
+}

--- a/packages/react/src/components/VizelLinkEditor.tsx
+++ b/packages/react/src/components/VizelLinkEditor.tsx
@@ -1,4 +1,10 @@
-import { detectVizelEmbedProvider, type Editor, type VizelLocale } from "@vizel/core";
+import {
+  applyVizelLinkEdit,
+  buildVizelLinkEditorViewState,
+  type Editor,
+  resolveVizelLinkEditorLabels,
+  type VizelLocale,
+} from "@vizel/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -14,26 +20,11 @@ export interface VizelLinkEditorProps {
 
 /**
  * A link editor component for editing hyperlinks in the VizelBubbleMenu.
- * Provides an input field for URL entry, open-in-new-tab toggle, visit button,
- * and buttons to apply or remove the link.
- * Optionally supports converting links to embeds when the Embed extension is loaded.
  *
- * @example
- * ```tsx
- * const [showLinkEditor, setShowLinkEditor] = useState(false);
- *
- * {showLinkEditor ? (
- *   <VizelLinkEditor
- *     editor={editor}
- *     onClose={() => setShowLinkEditor(false)}
- *     enableEmbed
- *   />
- * ) : (
- *   <VizelBubbleMenuButton onClick={() => setShowLinkEditor(true)}>
- *     Link
- *   </VizelBubbleMenuButton>
- * )}
- * ```
+ * Localized labels, view-state derivation (initial values from the link
+ * mark, embed-toggle visibility, etc.), and the editor-command logic
+ * for applying the form come from `@vizel/core`'s link-editor
+ * skeleton helpers. The component owns input state and event wiring.
  */
 export function VizelLinkEditor({
   editor,
@@ -42,34 +33,26 @@ export function VizelLinkEditor({
   enableEmbed = false,
   locale,
 }: VizelLinkEditorProps) {
-  const linkAttrs = editor.getAttributes("link");
-  const currentHref = linkAttrs.href || "";
-  const [url, setUrl] = useState(currentHref);
-  const [openInNewTab, setOpenInNewTab] = useState(linkAttrs.target === "_blank");
+  const labels = useMemo(() => resolveVizelLinkEditorLabels(locale), [locale]);
+  const initialState = useMemo(
+    () => buildVizelLinkEditorViewState(editor, "", enableEmbed),
+    [editor, enableEmbed]
+  );
+  const [url, setUrl] = useState(initialState.initialUrl);
+  const [openInNewTab, setOpenInNewTab] = useState(initialState.initialOpenInNewTab);
   const [asEmbed, setAsEmbed] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Check if embed extension is available
-  const canEmbed = useMemo(() => {
-    if (!enableEmbed) return false;
-    // Check if setEmbed command exists (embed extension is loaded)
-    const extensionManager = editor.extensionManager;
-    return extensionManager.extensions.some((ext) => ext.name === "embed");
-  }, [editor, enableEmbed]);
+  const viewState = useMemo(
+    () => buildVizelLinkEditorViewState(editor, url, enableEmbed),
+    [editor, url, enableEmbed]
+  );
 
-  // Check if URL is a known embed provider
-  const isEmbedProvider = useMemo(() => {
-    if (!url.trim()) return false;
-    return detectVizelEmbedProvider(url.trim()) !== null;
-  }, [url]);
-
-  // Auto-focus input on mount
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  // Handle click outside to close
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (!(event.target instanceof Node)) return;
@@ -78,7 +61,6 @@ export function VizelLinkEditor({
       }
     };
 
-    // Handle Escape key to close
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
@@ -87,11 +69,9 @@ export function VizelLinkEditor({
       }
     };
 
-    // Use setTimeout to avoid immediate trigger from the click that opened the editor
     const timeoutId = setTimeout(() => {
       document.addEventListener("mousedown", handleClickOutside);
     }, 0);
-    // Use capture phase so this handler runs before VizelBubbleMenu's handler
     document.addEventListener("keydown", handleKeyDown, true);
 
     return () => {
@@ -104,30 +84,10 @@ export function VizelLinkEditor({
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      const trimmedUrl = url.trim();
-
-      if (!trimmedUrl) {
-        editor.chain().focus().unsetLink().run();
-        onClose?.();
-        return;
-      }
-
-      if (asEmbed && canEmbed) {
-        // Remove the link first, then insert embed
-        editor.chain().focus().unsetLink().setEmbed({ url: trimmedUrl }).run();
-      } else {
-        editor
-          .chain()
-          .focus()
-          .setLink({
-            href: trimmedUrl,
-            target: openInNewTab ? "_blank" : null,
-          })
-          .run();
-      }
+      applyVizelLinkEdit(editor, { url, openInNewTab, asEmbed }, viewState.canEmbed);
       onClose?.();
     },
-    [editor, url, openInNewTab, asEmbed, canEmbed, onClose]
+    [editor, url, openInNewTab, asEmbed, viewState.canEmbed, onClose]
   );
 
   const handleRemove = useCallback(() => {
@@ -150,25 +110,25 @@ export function VizelLinkEditor({
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          placeholder={locale?.linkEditor?.urlPlaceholder ?? "Enter URL..."}
+          placeholder={labels.urlPlaceholder}
           className="vizel-link-input"
-          aria-label="Link URL"
+          aria-label={labels.urlAriaLabel}
         />
         <button
           type="submit"
           className="vizel-link-button"
-          title={locale?.linkEditor?.apply ?? "Apply"}
-          aria-label={locale?.linkEditor?.applyAriaLabel ?? "Apply link"}
+          title={labels.apply}
+          aria-label={labels.applyAriaLabel}
         >
           <VizelIcon name="check" />
         </button>
-        {currentHref && (
+        {viewState.showRemoveButton && (
           <button
             type="button"
             onClick={handleRemove}
             className="vizel-link-button vizel-link-remove"
-            title={locale?.linkEditor?.removeLink ?? "Remove link"}
-            aria-label={locale?.linkEditor?.removeLinkAriaLabel ?? "Remove link"}
+            title={labels.removeLink}
+            aria-label={labels.removeLinkAriaLabel}
           >
             <VizelIcon name="x" />
           </button>
@@ -181,21 +141,21 @@ export function VizelLinkEditor({
             checked={openInNewTab}
             onChange={(e) => setOpenInNewTab(e.target.checked)}
           />
-          <span>{locale?.linkEditor?.openInNewTab ?? "Open in new tab"}</span>
+          <span>{labels.openInNewTab}</span>
         </label>
-        {url.trim() && (
+        {viewState.showVisitButton && (
           <button
             type="button"
             onClick={handleVisit}
             className="vizel-link-visit"
-            title={locale?.linkEditor?.visitTitle ?? "Open URL in new tab"}
+            title={labels.visitTitle}
           >
             <VizelIcon name="externalLink" />
-            <span>{locale?.linkEditor?.visit ?? "Visit"}</span>
+            <span>{labels.visit}</span>
           </button>
         )}
       </div>
-      {canEmbed && isEmbedProvider && (
+      {viewState.showEmbedToggle && (
         <div className="vizel-link-editor-embed-toggle">
           <input
             type="checkbox"
@@ -203,9 +163,7 @@ export function VizelLinkEditor({
             checked={asEmbed}
             onChange={(e) => setAsEmbed(e.target.checked)}
           />
-          <label htmlFor="vizel-embed-toggle">
-            {locale?.linkEditor?.embedAsRichContent ?? "Embed as rich content"}
-          </label>
+          <label htmlFor="vizel-embed-toggle">{labels.embedAsRichContent}</label>
         </div>
       )}
     </form>

--- a/packages/svelte/src/components/VizelLinkEditor.svelte
+++ b/packages/svelte/src/components/VizelLinkEditor.svelte
@@ -16,7 +16,11 @@ export interface VizelLinkEditorProps {
 </script>
 
 <script lang="ts">
-import { detectVizelEmbedProvider } from "@vizel/core";
+import {
+  applyVizelLinkEdit,
+  buildVizelLinkEditorViewState,
+  resolveVizelLinkEditorLabels,
+} from "@vizel/core";
 import { untrack } from "svelte";
 import VizelIcon from "./VizelIcon.svelte";
 
@@ -30,27 +34,16 @@ let {
 
 let formElement: HTMLFormElement;
 let inputElement: HTMLInputElement;
-let linkAttrs = $derived(editor.getAttributes("link"));
-let currentHref = $derived(linkAttrs.href || "");
-let url = $state(untrack(() => editor.getAttributes("link").href || ""));
-let openInNewTab = $state(untrack(() => editor.getAttributes("link").target === "_blank"));
+
+const labels = $derived(resolveVizelLinkEditorLabels(locale));
+let url = $state(untrack(() => buildVizelLinkEditorViewState(editor, "", enableEmbed).initialUrl));
+let openInNewTab = $state(
+  untrack(() => buildVizelLinkEditorViewState(editor, "", enableEmbed).initialOpenInNewTab)
+);
 let asEmbed = $state(false);
 
-// Check if embed extension is available
-const canEmbed = $derived.by(() => {
-  if (!enableEmbed) return false;
-  // Check if embed extension is loaded
-  const extensionManager = editor.extensionManager;
-  return extensionManager.extensions.some((ext) => ext.name === "embed");
-});
+const viewState = $derived(buildVizelLinkEditorViewState(editor, url, enableEmbed));
 
-// Check if URL is a known embed provider
-const isEmbedProvider = $derived.by(() => {
-  if (!url.trim()) return false;
-  return detectVizelEmbedProvider(url.trim()) !== null;
-});
-
-// Handle click outside to close
 function handleClickOutside(event: MouseEvent) {
   if (!(event.target instanceof Node)) return;
   if (formElement && !formElement.contains(event.target)) {
@@ -58,7 +51,6 @@ function handleClickOutside(event: MouseEvent) {
   }
 }
 
-// Handle Escape key to close
 function handleKeyDown(event: KeyboardEvent) {
   if (event.key === "Escape") {
     event.preventDefault();
@@ -70,11 +62,9 @@ function handleKeyDown(event: KeyboardEvent) {
 $effect(() => {
   inputElement?.focus();
 
-  // Use setTimeout to avoid immediate trigger from the click that opened the editor
   const timeoutId = setTimeout(() => {
     document.addEventListener("mousedown", handleClickOutside);
   }, 0);
-  // Use capture phase so this handler runs before BubbleMenu's handler
   document.addEventListener("keydown", handleKeyDown, true);
 
   return () => {
@@ -86,27 +76,7 @@ $effect(() => {
 
 function handleSubmit(e: Event) {
   e.preventDefault();
-  const trimmedUrl = url.trim();
-
-  if (!trimmedUrl) {
-    editor.chain().focus().unsetLink().run();
-    onclose?.();
-    return;
-  }
-
-  if (asEmbed && canEmbed) {
-    // Remove the link first, then insert embed
-    editor.chain().focus().unsetLink().setEmbed({ url: trimmedUrl }).run();
-  } else {
-    editor
-      .chain()
-      .focus()
-      .setLink({
-        href: trimmedUrl,
-        target: openInNewTab ? "_blank" : null,
-      })
-      .run();
-  }
+  applyVizelLinkEdit(editor, { url, openInNewTab, asEmbed }, viewState.canEmbed);
   onclose?.();
 }
 
@@ -133,19 +103,19 @@ function handleVisit() {
       bind:this={inputElement}
       bind:value={url}
       type="url"
-      placeholder={locale?.linkEditor?.urlPlaceholder ?? "Enter URL..."}
+      placeholder={labels.urlPlaceholder}
       class="vizel-link-input"
-      aria-label="Link URL"
+      aria-label={labels.urlAriaLabel}
     />
-    <button type="submit" class="vizel-link-button" title={locale?.linkEditor?.apply ?? "Apply"} aria-label={locale?.linkEditor?.applyAriaLabel ?? "Apply link"}>
+    <button type="submit" class="vizel-link-button" title={labels.apply} aria-label={labels.applyAriaLabel}>
       <VizelIcon name="check" />
     </button>
-    {#if currentHref}
+    {#if viewState.showRemoveButton}
       <button
         type="button"
         class="vizel-link-button vizel-link-remove"
-        title={locale?.linkEditor?.removeLink ?? "Remove link"}
-        aria-label={locale?.linkEditor?.removeLinkAriaLabel ?? "Remove link"}
+        title={labels.removeLink}
+        aria-label={labels.removeLinkAriaLabel}
         onclick={handleRemove}
       >
         <VizelIcon name="x" />
@@ -158,28 +128,28 @@ function handleVisit() {
         type="checkbox"
         bind:checked={openInNewTab}
       />
-      <span>{locale?.linkEditor?.openInNewTab ?? "Open in new tab"}</span>
+      <span>{labels.openInNewTab}</span>
     </label>
-    {#if url.trim()}
+    {#if viewState.showVisitButton}
       <button
         type="button"
         class="vizel-link-visit"
-        title={locale?.linkEditor?.visitTitle ?? "Open URL in new tab"}
+        title={labels.visitTitle}
         onclick={handleVisit}
       >
         <VizelIcon name="externalLink" />
-        <span>{locale?.linkEditor?.visit ?? "Visit"}</span>
+        <span>{labels.visit}</span>
       </button>
     {/if}
   </div>
-  {#if canEmbed && isEmbedProvider}
+  {#if viewState.showEmbedToggle}
     <div class="vizel-link-editor-embed-toggle">
       <input
         id="vizel-embed-toggle"
         type="checkbox"
         bind:checked={asEmbed}
       />
-      <label for="vizel-embed-toggle">{locale?.linkEditor?.embedAsRichContent ?? "Embed as rich content"}</label>
+      <label for="vizel-embed-toggle">{labels.embedAsRichContent}</label>
     </div>
   {/if}
 </form>

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-import { detectVizelEmbedProvider, type Editor, type VizelLocale } from "@vizel/core";
+import {
+  applyVizelLinkEdit,
+  buildVizelLinkEditorViewState,
+  type Editor,
+  resolveVizelLinkEditorLabels,
+  type VizelLocale,
+} from "@vizel/core";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -24,27 +30,17 @@ const emit = defineEmits<{
 
 const formRef = ref<HTMLFormElement | null>(null);
 const inputRef = ref<HTMLInputElement | null>(null);
-const linkAttrs = computed(() => props.editor.getAttributes("link"));
-const currentHref = computed(() => linkAttrs.value.href || "");
-const url = ref(currentHref.value);
-const openInNewTab = ref(linkAttrs.value.target === "_blank");
+
+const labels = computed(() => resolveVizelLinkEditorLabels(props.locale));
+const initialState = buildVizelLinkEditorViewState(props.editor, "", props.enableEmbed);
+const url = ref(initialState.initialUrl);
+const openInNewTab = ref(initialState.initialOpenInNewTab);
 const asEmbed = ref(false);
 
-// Check if embed extension is available
-const canEmbed = computed(() => {
-  if (!props.enableEmbed) return false;
-  // Check if embed extension is loaded
-  const extensionManager = props.editor.extensionManager;
-  return extensionManager.extensions.some((ext) => ext.name === "embed");
-});
+const viewState = computed(() =>
+  buildVizelLinkEditorViewState(props.editor, url.value, props.enableEmbed)
+);
 
-// Check if URL is a known embed provider
-const isEmbedProvider = computed(() => {
-  if (!url.value.trim()) return false;
-  return detectVizelEmbedProvider(url.value.trim()) !== null;
-});
-
-// Handle click outside to close
 function handleClickOutside(event: MouseEvent) {
   if (!(event.target instanceof Node)) return;
   if (formRef.value && !formRef.value.contains(event.target)) {
@@ -52,7 +48,6 @@ function handleClickOutside(event: MouseEvent) {
   }
 }
 
-// Handle Escape key to close
 function handleKeyDown(event: KeyboardEvent) {
   if (event.key === "Escape") {
     event.preventDefault();
@@ -64,12 +59,9 @@ function handleKeyDown(event: KeyboardEvent) {
 onMounted(() => {
   inputRef.value?.focus();
 
-  // Defer the outside-click listener until after the current event loop tick
-  // so the click that opened the editor doesn't immediately close it.
   void nextTick(() => {
     document.addEventListener("mousedown", handleClickOutside);
   });
-  // Use capture phase so this handler runs before BubbleMenu's handler
   document.addEventListener("keydown", handleKeyDown, true);
 });
 
@@ -80,27 +72,11 @@ onBeforeUnmount(() => {
 
 function handleSubmit(e: Event) {
   e.preventDefault();
-  const trimmedUrl = url.value.trim();
-
-  if (!trimmedUrl) {
-    props.editor.chain().focus().unsetLink().run();
-    emit("close");
-    return;
-  }
-
-  if (asEmbed.value && canEmbed.value) {
-    // Remove the link first, then insert embed
-    props.editor.chain().focus().unsetLink().setEmbed({ url: trimmedUrl }).run();
-  } else {
-    props.editor
-      .chain()
-      .focus()
-      .setLink({
-        href: trimmedUrl,
-        target: openInNewTab.value ? "_blank" : null,
-      })
-      .run();
-  }
+  applyVizelLinkEdit(
+    props.editor,
+    { url: url.value, openInNewTab: openInNewTab.value, asEmbed: asEmbed.value },
+    viewState.value.canEmbed
+  );
   emit("close");
 }
 
@@ -128,19 +104,24 @@ function handleVisit() {
         ref="inputRef"
         v-model="url"
         type="url"
-        :placeholder="props.locale?.linkEditor?.urlPlaceholder ?? 'Enter URL...'"
+        :placeholder="labels.urlPlaceholder"
         class="vizel-link-input"
-        aria-label="Link URL"
+        :aria-label="labels.urlAriaLabel"
       />
-      <button type="submit" class="vizel-link-button" :title="props.locale?.linkEditor?.apply ?? 'Apply'" :aria-label="props.locale?.linkEditor?.applyAriaLabel ?? 'Apply link'">
+      <button
+        type="submit"
+        class="vizel-link-button"
+        :title="labels.apply"
+        :aria-label="labels.applyAriaLabel"
+      >
         <VizelIcon name="check" />
       </button>
       <button
-        v-if="currentHref"
+        v-if="viewState.showRemoveButton"
         type="button"
         class="vizel-link-button vizel-link-remove"
-        :title="props.locale?.linkEditor?.removeLink ?? 'Remove link'"
-        :aria-label="props.locale?.linkEditor?.removeLinkAriaLabel ?? 'Remove link'"
+        :title="labels.removeLink"
+        :aria-label="labels.removeLinkAriaLabel"
         @click="handleRemove"
       >
         <VizelIcon name="x" />
@@ -152,26 +133,26 @@ function handleVisit() {
           v-model="openInNewTab"
           type="checkbox"
         />
-        <span>{{ props.locale?.linkEditor?.openInNewTab ?? 'Open in new tab' }}</span>
+        <span>{{ labels.openInNewTab }}</span>
       </label>
       <button
-        v-if="url.trim()"
+        v-if="viewState.showVisitButton"
         type="button"
         class="vizel-link-visit"
-        :title="props.locale?.linkEditor?.visitTitle ?? 'Open URL in new tab'"
+        :title="labels.visitTitle"
         @click="handleVisit"
       >
         <VizelIcon name="externalLink" />
-        <span>{{ props.locale?.linkEditor?.visit ?? 'Visit' }}</span>
+        <span>{{ labels.visit }}</span>
       </button>
     </div>
-    <div v-if="canEmbed && isEmbedProvider" class="vizel-link-editor-embed-toggle">
+    <div v-if="viewState.showEmbedToggle" class="vizel-link-editor-embed-toggle">
       <input
         id="vizel-embed-toggle"
         v-model="asEmbed"
         type="checkbox"
       />
-      <label for="vizel-embed-toggle">{{ props.locale?.linkEditor?.embedAsRichContent ?? 'Embed as rich content' }}</label>
+      <label for="vizel-embed-toggle">{{ labels.embedAsRichContent }}</label>
     </div>
   </form>
 </template>


### PR DESCRIPTION
## Summary

Phase 7 step 6 of the v2.x audit. The React/Vue/Svelte
`VizelLinkEditor` forms shared a ten-line label-resolution chain
(`locale?.linkEditor?.X ?? "..."`), the same embed-extension
detection (`extensionManager.extensions.some(ext => ext.name ===
"embed")`), the same `detectVizelEmbedProvider` invocation, and the
same chain-command branching for "apply link / set embed / unset
link". `@vizel/core/skeletons/link-editor` now owns it.

### What `@vizel/core/skeletons/link-editor` owns

- `resolveVizelLinkEditorLabels(locale)` collapses the ten-line
  `?? "..."` chain into one call returning the
  `VizelLinkEditorLabels` struct each framework component reads from.
- `buildVizelLinkEditorViewState(editor, url, enableEmbed)` returns
  the initial URL / open-in-new-tab values plus the boolean flags
  (`canEmbed`, `isEmbedProvider`, `showRemoveButton`,
  `showVisitButton`, `showEmbedToggle`) that drive conditional
  rendering — instead of triplicating those derivations.
- `applyVizelLinkEdit(editor, params, canEmbed)` centralizes the
  empty-URL-removes-link / asEmbed-sets-embed / otherwise-setLink
  decision tree, including the narrow cast needed because the embed
  extension's chain typing isn't visible from `@vizel/core`.

### Why a non-spec shape

Forms intentionally skip the menu-style `VizelMenuSpec`. The DOM
varies less than the label fanout and per-state visibility flags,
which is what the helpers actually attack. The framework components
still own input two-way binding and event-listener plumbing — those
are framework-idiomatic and shouldn't move into core.

## Breaking Changes

None at the consumer level — `VizelLinkEditor` props are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 6 of 7.
