### PR TITLE
refactor: extract VizelFindReplace view-state helper into @vizel/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -312,6 +312,8 @@ export {
 export {
   applyVizelLinkEdit,
   buildVizelBlockMenuSkeleton,
+  buildVizelFindReplaceViewState,
+  buildVizelFindReplaceViewStateFromLocale,
   buildVizelLinkEditorViewState,
   buildVizelMentionMenuSkeleton,
   buildVizelNodeSelectorSkeleton,
@@ -323,6 +325,7 @@ export {
   type VizelBlockMenuSpec,
   type VizelBlockMenuSubmenuTriggerSpec,
   type VizelBlockMenuTurnIntoItemView,
+  type VizelFindReplaceViewState,
   type VizelLinkEditorLabels,
   type VizelLinkEditorViewState,
   type VizelLinkSubmitParams,

--- a/packages/core/src/skeletons/find-replace.ts
+++ b/packages/core/src/skeletons/find-replace.ts
@@ -1,0 +1,67 @@
+import type { VizelFindReplaceState } from "../extensions/find-replace.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+
+/**
+ * Derived display state for the `VizelFindReplace` panel. Each
+ * framework component recomputes this whenever the plugin state
+ * changes, then drives rendering off the boolean / string fields
+ * instead of duplicating the `matchCount > 0 ? "${i}/${n}" :
+ * noResults` ternary in three places.
+ */
+export interface VizelFindReplaceViewState {
+  /** Whether the panel is open (mirrors `state.isOpen`). */
+  isOpen: boolean;
+  /** Whether the replace input row should be rendered. */
+  isReplaceMode: boolean;
+  /** Total number of matches. */
+  matchCount: number;
+  /** 1-based index of the active match (0 when no active match). */
+  currentMatch: number;
+  /** Display string for the match counter (e.g. `"1/5"` or `"No matches"`). */
+  matchCountDisplay: string;
+  /** Whether navigation/replace buttons should be disabled. */
+  isDisabled: boolean;
+}
+
+/**
+ * Compute the find-replace panel display state.
+ *
+ * Accepts the live plugin state (or `null` while the editor hasn't
+ * registered the plugin yet) plus the resolved `noResults` label —
+ * the latter is the only piece of locale data the counter cares
+ * about, so the helper takes a string rather than a full locale to
+ * keep the unit testable.
+ */
+export function buildVizelFindReplaceViewState(
+  state: VizelFindReplaceState | null,
+  noResultsLabel: string
+): VizelFindReplaceViewState {
+  const isOpen = state?.isOpen ?? false;
+  const isReplaceMode = state?.mode === "replace";
+  const matchCount = state?.matches.length ?? 0;
+  const activeIndex = state?.activeIndex ?? -1;
+  const currentMatch = activeIndex >= 0 ? activeIndex + 1 : 0;
+  const matchCountDisplay = matchCount > 0 ? `${currentMatch}/${matchCount}` : noResultsLabel;
+
+  return {
+    isOpen,
+    isReplaceMode,
+    matchCount,
+    currentMatch,
+    matchCountDisplay,
+    isDisabled: matchCount === 0,
+  };
+}
+
+/**
+ * Convenience overload that resolves the `noResults` label from a
+ * full locale. Equivalent to calling
+ * `buildVizelFindReplaceViewState(state, locale?.findReplace?.noResults
+ * ?? "No matches")`.
+ */
+export function buildVizelFindReplaceViewStateFromLocale(
+  state: VizelFindReplaceState | null,
+  locale: VizelLocale | undefined
+): VizelFindReplaceViewState {
+  return buildVizelFindReplaceViewState(state, locale?.findReplace?.noResults ?? "No matches");
+}

--- a/packages/core/src/skeletons/index.ts
+++ b/packages/core/src/skeletons/index.ts
@@ -6,6 +6,11 @@ export {
   type VizelBlockMenuTurnIntoItemView,
 } from "./block-menu.ts";
 export {
+  buildVizelFindReplaceViewState,
+  buildVizelFindReplaceViewStateFromLocale,
+  type VizelFindReplaceViewState,
+} from "./find-replace.ts";
+export {
   applyVizelLinkEdit,
   buildVizelLinkEditorViewState,
   resolveVizelLinkEditorLabels,

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -1,4 +1,5 @@
 import {
+  buildVizelFindReplaceViewState,
   type Editor,
   getVizelFindReplaceState,
   resolveVizelFindReplaceLabels,
@@ -10,6 +11,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -133,13 +135,14 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
     [handleFindNext, handleFindPrevious, handleClose]
   );
 
-  if (!state?.isOpen) {
+  const view = useMemo(
+    () => buildVizelFindReplaceViewState(state, labels.noResults),
+    [state, labels.noResults]
+  );
+
+  if (!view.isOpen) {
     return null;
   }
-
-  const matchCount = state.matches.length;
-  const currentMatch = state.activeIndex >= 0 ? state.activeIndex + 1 : 0;
-  const isReplaceMode = state.mode === "replace";
 
   return (
     <div
@@ -159,13 +162,13 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
           aria-label={labels.findTextAriaLabel}
         />
         <span className="vizel-find-replace-count" aria-live="polite">
-          {matchCount > 0 ? `${currentMatch}/${matchCount}` : labels.noResults}
+          {view.matchCountDisplay}
         </span>
         <button
           type="button"
           className="vizel-find-replace-button"
           onClick={handleFindPrevious}
-          disabled={matchCount === 0}
+          disabled={view.isDisabled}
           aria-label={labels.findPreviousAriaLabel}
           title={labels.findPreviousTitle}
         >
@@ -175,7 +178,7 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
           type="button"
           className="vizel-find-replace-button"
           onClick={handleFindNext}
-          disabled={matchCount === 0}
+          disabled={view.isDisabled}
           aria-label={labels.findNextAriaLabel}
           title={labels.findNextTitle}
         >
@@ -192,7 +195,7 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
         </button>
       </div>
 
-      {isReplaceMode && (
+      {view.isReplaceMode && (
         <div className="vizel-find-replace-row">
           <input
             type="text"
@@ -207,7 +210,7 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
             type="button"
             className="vizel-find-replace-button"
             onClick={handleReplace}
-            disabled={matchCount === 0}
+            disabled={view.isDisabled}
             aria-label={labels.replaceAriaLabel}
             title={labels.replaceTitle}
           >
@@ -217,7 +220,7 @@ export function VizelFindReplace({ editor, className, locale, onClose }: VizelFi
             type="button"
             className="vizel-find-replace-button vizel-find-replace-button--primary"
             onClick={handleReplaceAll}
-            disabled={matchCount === 0}
+            disabled={view.isDisabled}
             aria-label={labels.replaceAllAriaLabel}
             title={labels.replaceAllTitle}
           >

--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -15,6 +15,7 @@ export interface VizelFindReplaceProps {
 
 <script lang="ts">
 import {
+  buildVizelFindReplaceViewState,
   getVizelFindReplaceState,
   resolveVizelFindReplaceLabels,
   type VizelFindReplaceState,
@@ -40,12 +41,8 @@ let caseSensitive = $state(false);
 let findReplaceState = $state(emptyState);
 let findInputRef: HTMLInputElement | null = $state(null);
 
-const matchCount = $derived(findReplaceState.matches.length);
-const currentMatch = $derived(
-  findReplaceState.activeIndex >= 0 ? findReplaceState.activeIndex + 1 : 0,
-);
-const isReplaceMode = $derived(findReplaceState.mode === "replace");
-const isOpen = $derived(findReplaceState.isOpen);
+const view = $derived(buildVizelFindReplaceViewState(findReplaceState, labels.noResults));
+const isOpen = $derived(view.isOpen);
 
 function updateFindReplaceState() {
   if (editor) {
@@ -153,12 +150,12 @@ function handleKeyDown(e: KeyboardEvent) {
         aria-label={labels.findTextAriaLabel}
       />
       <span class="vizel-find-replace-count" aria-live="polite">
-        {matchCount > 0 ? `${currentMatch}/${matchCount}` : labels.noResults}
+        {view.matchCountDisplay}
       </span>
       <button
         type="button"
         class="vizel-find-replace-button"
-        disabled={matchCount === 0}
+        disabled={view.isDisabled}
         aria-label={labels.findPreviousAriaLabel}
         title={labels.findPreviousTitle}
         onclick={handleFindPrevious}
@@ -168,7 +165,7 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button"
-        disabled={matchCount === 0}
+        disabled={view.isDisabled}
         aria-label={labels.findNextAriaLabel}
         title={labels.findNextTitle}
         onclick={handleFindNext}
@@ -186,7 +183,7 @@ function handleKeyDown(e: KeyboardEvent) {
       </button>
     </div>
 
-    {#if isReplaceMode}
+    {#if view.isReplaceMode}
       <div class="vizel-find-replace-row">
         <input
           type="text"
@@ -199,7 +196,7 @@ function handleKeyDown(e: KeyboardEvent) {
         <button
           type="button"
           class="vizel-find-replace-button"
-          disabled={matchCount === 0}
+          disabled={view.isDisabled}
           aria-label={labels.replaceAriaLabel}
           title={labels.replaceTitle}
           onclick={handleReplace}
@@ -209,7 +206,7 @@ function handleKeyDown(e: KeyboardEvent) {
         <button
           type="button"
           class="vizel-find-replace-button vizel-find-replace-button--primary"
-          disabled={matchCount === 0}
+          disabled={view.isDisabled}
           aria-label={labels.replaceAllAriaLabel}
           title={labels.replaceAllTitle}
           onclick={handleReplaceAll}

--- a/packages/vue/src/components/VizelFindReplace.vue
+++ b/packages/vue/src/components/VizelFindReplace.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  buildVizelFindReplaceViewState,
   type Editor,
   getVizelFindReplaceState,
   resolveVizelFindReplaceLabels,
@@ -29,13 +30,9 @@ const caseSensitive = ref(false);
 const state = ref<VizelFindReplaceState | null>(null);
 const findInputRef = ref<HTMLInputElement | null>(null);
 
-const matchCount = computed(() => state.value?.matches.length ?? 0);
-const currentMatch = computed(() =>
-  state.value && state.value.activeIndex >= 0 ? state.value.activeIndex + 1 : 0
-);
-const isReplaceMode = computed(() => state.value?.mode === "replace");
-const isOpen = computed(() => state.value?.isOpen ?? false);
 const labels = computed(() => resolveVizelFindReplaceLabels(props.locale?.findReplace));
+const view = computed(() => buildVizelFindReplaceViewState(state.value, labels.value.noResults));
+const isOpen = computed(() => view.value.isOpen);
 
 function updateState() {
   if (props.editor) {
@@ -150,12 +147,12 @@ function handleKeyDown(e: KeyboardEvent) {
         :aria-label="labels.findTextAriaLabel"
       />
       <span class="vizel-find-replace-count" aria-live="polite">
-        {{ matchCount > 0 ? `${currentMatch}/${matchCount}` : labels.noResults }}
+        {{ view.matchCountDisplay }}
       </span>
       <button
         type="button"
         class="vizel-find-replace-button"
-        :disabled="matchCount === 0"
+        :disabled="view.isDisabled"
         :aria-label="labels.findPreviousAriaLabel"
         :title="labels.findPreviousTitle"
         @click="handleFindPrevious"
@@ -165,7 +162,7 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button"
-        :disabled="matchCount === 0"
+        :disabled="view.isDisabled"
         :aria-label="labels.findNextAriaLabel"
         :title="labels.findNextTitle"
         @click="handleFindNext"
@@ -183,7 +180,7 @@ function handleKeyDown(e: KeyboardEvent) {
       </button>
     </div>
 
-    <div v-if="isReplaceMode" class="vizel-find-replace-row">
+    <div v-if="view.isReplaceMode" class="vizel-find-replace-row">
       <input
         type="text"
         class="vizel-find-replace-input"
@@ -195,7 +192,7 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button"
-        :disabled="matchCount === 0"
+        :disabled="view.isDisabled"
         :aria-label="labels.replaceAriaLabel"
         :title="labels.replaceTitle"
         @click="handleReplace"
@@ -205,7 +202,7 @@ function handleKeyDown(e: KeyboardEvent) {
       <button
         type="button"
         class="vizel-find-replace-button vizel-find-replace-button--primary"
-        :disabled="matchCount === 0"
+        :disabled="view.isDisabled"
         :aria-label="labels.replaceAllAriaLabel"
         :title="labels.replaceAllTitle"
         @click="handleReplaceAll"


### PR DESCRIPTION
## Summary

Phase 7 step 7 of the v2.x audit — the final UI-skeletonization
PR. `VizelFindReplace` already had locale labels centralized via
`resolveVizelFindReplaceLabels` and plugin state via
`getVizelFindReplaceState`. What remained duplicated was the
view-state derivation: the match counter, the replace-row
visibility predicate, the disabled-button predicate, and the
open-panel guard. This PR moves those into `@vizel/core`.

### What `@vizel/core/skeletons/find-replace` owns

- `buildVizelFindReplaceViewState(state, noResultsLabel)` returns a
  `VizelFindReplaceViewState` struct with:
  - `isOpen` — mirrors `state.isOpen`,
  - `isReplaceMode` — replaces `state?.mode === "replace"`,
  - `matchCount` / `currentMatch` — pulled from `state.matches.length`
    and `state.activeIndex`,
  - `matchCountDisplay` — replaces the
    `matchCount > 0 ? "${i}/${n}" : noResults` ternary,
  - `isDisabled` — replaces `matchCount === 0`.
- `buildVizelFindReplaceViewStateFromLocale(state, locale)` is the
  convenience overload for callers that haven't pre-resolved labels.

### What the framework component still owns

Plugin state subscription (`editor.on("transaction", ...)`), input
two-way binding, find/replace command invocation, focus management,
and case-sensitive toggle wiring. The component derives `view` once
via its memo primitive and reads `view.isDisabled` /
`view.isReplaceMode` / `view.matchCountDisplay` for rendering.

## Breaking Changes

None at the consumer level — `VizelFindReplace` props are unchanged.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm exec biome check .` clean (one pre-existing warning in
      `apps/demo/react/src/App.tsx` unrelated to this change).
- [x] `pnpm build` succeeds.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Phase 7 step 7 of 7 — UI skeletonization complete.
