### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Vizel are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-05-15
 
 This release is the v2.x rework that aligns React, Vue, and Svelte adapters
 around a shared, framework-agnostic core. Behavior remains backwards-compatible
@@ -67,6 +67,36 @@ context APIs by hand.
 - `createVizelBubbleMenuActions(locale)` + `filterVizelBubbleMenuActions` +
   `groupVizelBubbleMenuActions` + `vizelDefaultBubbleMenuActions` —
   bubble-menu action list, mirroring the existing toolbar-actions shape.
+- `@vizel/core/skeletons/` module exposing declarative UI scaffolding
+  for the menu and form components. Each framework's component is now a
+  thin transformer that maps the spec to its native template:
+  - `VizelMenuSpec<TData>` — generic spec describing root container ARIA,
+    sections (optionally headed), and per-item attrs (`role`, `id`,
+    `aria-selected`, `aria-haspopup`, `aria-expanded`, `tabIndex`).
+  - `buildVizelMentionMenuSkeleton(items, selectedIndex, locale)` —
+    flat listbox spec for `@vizel/{react,vue,svelte}` `VizelMentionMenu`.
+  - `buildVizelSlashMenuSkeleton(items, selectedIndex, options)` +
+    `getNextVizelSlashMenuGroupIndex(spec, currentIndex)` — grouped
+    listbox spec for `VizelSlashMenu` plus the Tab-to-next-group
+    navigation helper.
+  - `buildVizelBlockMenuSkeleton(actions, turnIntoOptions, showTurnInto,
+    locale)` — main menu + submenu trigger + submenu spec for
+    `VizelBlockMenu`.
+  - `buildVizelToolbarDropdownSkeleton(dropdown, editor, isOpen,
+    focusedIndex)` — trigger + listbox-popover spec for
+    `VizelToolbarDropdown`.
+  - `buildVizelNodeSelectorSkeleton(editor, nodeTypes, isOpen,
+    focusedIndex, locale)` — trigger + listbox-popover spec for
+    `VizelNodeSelector` with active-node-type detection and locale-aware
+    aria-label template.
+  - `resolveVizelLinkEditorLabels(locale)` +
+    `buildVizelLinkEditorViewState(editor, url, enableEmbed)` +
+    `applyVizelLinkEdit(editor, params, canEmbed)` — labels, derived
+    visibility flags, and the chain-command apply logic for
+    `VizelLinkEditor`.
+  - `buildVizelFindReplaceViewState(state, noResultsLabel)` and
+    `buildVizelFindReplaceViewStateFromLocale(state, locale)` — derived
+    match-counter / replace-mode / disabled flags for `VizelFindReplace`.
 
 ### Changed
 
@@ -106,6 +136,13 @@ context APIs by hand.
 - **Bubble-menu defaults.** Each framework's `VizelBubbleMenuDefault`
   collapses from ~150 lines of repeated buttons to an iteration over the
   shared `createVizelBubbleMenuActions(locale)` list.
+- **UI skeletonization.** The DOM scaffolding for `VizelMentionMenu`,
+  `VizelSlashMenu`, `VizelBlockMenu`, `VizelToolbarDropdown`,
+  `VizelNodeSelector`, `VizelLinkEditor`, and `VizelFindReplace` is now
+  declared in `@vizel/core/skeletons/`. Each framework component is a
+  thin transformer that maps the spec to its native template instead of
+  duplicating ARIA wiring, identifier schemes, and view-state
+  derivations three times.
 
 ### Fixed
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/core",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/react",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/svelte",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/vue",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Finalizes the v2.0.0 release:

- Bumps `@vizel/core`, `@vizel/react`, `@vizel/vue`, and
  `@vizel/svelte` from `1.4.0` to `2.0.0`.
- Renames `## [Unreleased]` to `## [2.0.0] - 2026-05-15` in the
  changelog.
- Records Phase 7 (UI skeletonization) in the changelog. The
  scaffolding for `VizelMentionMenu`, `VizelSlashMenu`,
  `VizelBlockMenu`, `VizelToolbarDropdown`, `VizelNodeSelector`,
  `VizelLinkEditor`, and `VizelFindReplace` now lives in
  `@vizel/core/skeletons/`, with each framework component acting as
  a thin transformer over the spec.

## Breaking Changes

The breaking changes are unchanged from the existing "Breaking
changes" section of the changelog and are limited to:

- Menu ref signatures (`onKeyDown` accepts the raw `KeyboardEvent`).
- Svelte `getVizelContext()` / `getVizelContextSafe()` return shape.
- `INVALID_CONFIG` error on conflicting `initialContent` /
  `initialMarkdown`.

See the `## [2.0.0] - 2026-05-15` → `### Breaking changes` section
of `CHANGELOG.md` for migration diffs.

## Test Plan

- [x] `pnpm typecheck` clean across all four packages.
- [x] `pnpm install` succeeds with the bumped versions.
- [ ] CI `pnpm test:ct` green for React / Vue / Svelte × Chromium / Firefox / WebKit.

Closes the cross-framework parity audit that ran across PRs
#410 — #443.
