### PR TITLE
refactor(core): rename block-menu builder *Skeleton to *Spec

### DIFF
--- a/packages/core/src/builders/block-menu.ts
+++ b/packages/core/src/builders/block-menu.ts
@@ -83,7 +83,7 @@ export interface VizelBlockMenuSpec {
  * @param showTurnInto  Whether the submenu is currently open.
  * @param locale  Optional locale for translated labels.
  */
-export function buildVizelBlockMenuSkeleton(
+export function buildVizelBlockMenuSpec(
   actions: readonly VizelBlockMenuAction[],
   turnIntoOptions: readonly VizelNodeTypeOption[],
   showTurnInto: boolean,

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -1,5 +1,5 @@
 export {
-  buildVizelBlockMenuSkeleton,
+  buildVizelBlockMenuSpec,
   type VizelBlockMenuItemView,
   type VizelBlockMenuSpec,
   type VizelBlockMenuSubmenuTriggerSpec,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export {
 // =============================================================================
 export {
   applyVizelLinkEdit,
-  buildVizelBlockMenuSkeleton,
+  buildVizelBlockMenuSpec,
   buildVizelFindReplaceViewState,
   buildVizelFindReplaceViewStateFromLocale,
   buildVizelLinkEditorViewState,

--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@vizel/core";
 import {
-  buildVizelBlockMenuSkeleton,
+  buildVizelBlockMenuSpec,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelNodeTypes,
@@ -44,7 +44,7 @@ interface BlockMenuState extends VizelBlockMenuOpenDetail {
 /**
  * Block context menu that appears when clicking the drag handle.
  * DOM/ARIA scaffolding (sections, submenu trigger, submenu list) comes
- * from `@vizel/core`'s `buildVizelBlockMenuSkeleton`; the React
+ * from `@vizel/core`'s `buildVizelBlockMenuSpec`; the React
  * component owns positioning, focus management, and runtime action
  * binding.
  */
@@ -160,7 +160,7 @@ export function VizelBlockMenu({
   );
 
   const spec = useMemo(
-    () => buildVizelBlockMenuSkeleton(effectiveActions, turnIntoOptions, showTurnInto, locale),
+    () => buildVizelBlockMenuSpec(effectiveActions, turnIntoOptions, showTurnInto, locale),
     [effectiveActions, turnIntoOptions, showTurnInto, locale]
   );
 

--- a/packages/svelte/src/components/VizelBlockMenu.svelte
+++ b/packages/svelte/src/components/VizelBlockMenu.svelte
@@ -22,7 +22,7 @@ export interface VizelBlockMenuProps {
 
 <script lang="ts">
 import {
-  buildVizelBlockMenuSkeleton,
+  buildVizelBlockMenuSpec,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelNodeTypes,
@@ -67,7 +67,7 @@ const turnIntoOptions = $derived(
 );
 
 const spec = $derived(
-  buildVizelBlockMenuSkeleton(effectiveActions, turnIntoOptions, showTurnInto, locale),
+  buildVizelBlockMenuSpec(effectiveActions, turnIntoOptions, showTurnInto, locale),
 );
 
 function close() {

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  buildVizelBlockMenuSkeleton,
+  buildVizelBlockMenuSpec,
   clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelDismissibleController,
@@ -69,7 +69,7 @@ const turnIntoOptions = computed(() =>
 );
 
 const spec = computed(() =>
-  buildVizelBlockMenuSkeleton(
+  buildVizelBlockMenuSpec(
     effectiveActions.value,
     turnIntoOptions.value,
     showTurnInto.value,


### PR DESCRIPTION
## Summary

Renames `buildVizelBlockMenuSkeleton` to `buildVizelBlockMenuSpec` to match the canonical `*Spec` suffix established by PRs #449 (spec types) and #450 (menu builders).

**Rename-only change.** The function still returns the existing `VizelBlockMenuSpec` shape (popover trigger + main menu + optional turn-into submenu).

## Section 2c scope

This is the third sub-PR of Section 2:

| Sub | PR | Status |
|-----|-----|--------|
| 2a | #449 | ✅ merged (additive spec types) |
| 2b | #450 | ✅ merged (menu builders renamed) |
| **2c (this PR)** | — | block-menu builder renamed |
| 2d | — | pending (form-style builders migration to `VizelFormSpec<TFields>`) |

The follow-up Section 9 (VizelCommand abstraction) wires this builder to the new runtime command type. Until Section 9 ships, the block-menu builder retains its existing item-view payload types.

## Spec section

Section 2 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#2-builder-type-normalization).

## Test Plan

- [x] `pnpm typecheck` passes (all four packages).
- [x] `pnpm lint` passes (pre-existing demo warning unrelated).
- [x] Pre-push hook validates typecheck.
- [ ] CI runs `pnpm test:ct` for all three frameworks (rename-only).

## Files changed

6 files: 1 builder (`block-menu.ts`), 2 index files (`builders/index.ts`, `core/index.ts`), 3 framework components (`VizelBlockMenu.{tsx,vue,svelte}`).
