### PR TITLE
refactor(core): convert DismissibleController to mount/unmount contract

### DIFF
--- a/packages/core/src/controllers/dismissibleController.ts
+++ b/packages/core/src/controllers/dismissibleController.ts
@@ -20,33 +20,47 @@ export interface VizelDismissibleControllerOptions {
 }
 
 /**
- * Wire up "click-outside" + Escape dismissal listeners.
+ * Returned by {@link createVizelDismissibleController}.
  *
- * Encapsulates the three-step pattern of (1) attaching a `mousedown`
- * listener on `document` that compares the event target against the
- * supplied element references and (2) attaching a `keydown` listener
- * that observes Escape, plus (3) detaching both on disposal.
+ * Follows the canonical controller contract: `mount()` activates the DOM
+ * listeners, `unmount()` removes them. Both methods are idempotent and
+ * Server-Side Rendering (SSR) safe (no-op when `document` is absent).
+ */
+export interface VizelDismissibleController {
+  /** Attach the outside-click and Escape listeners to `document`. */
+  readonly mount: () => void;
+  /** Remove the attached listeners. Safe to call multiple times. */
+  readonly unmount: () => void;
+}
+
+/**
+ * Build a controller that dismisses a popup on outside-click or Escape.
  *
- * Returns a disposer. Framework adapters call this inside their effect
- * primitive and return the disposer for cleanup.
+ * The factory itself has no side effects, making it Server-Side Rendering
+ * (SSR) safe to invoke during component setup. `mount()` attaches a
+ * `mousedown` listener on `document` that compares the event target
+ * against the supplied element references, plus a `keydown` listener that
+ * observes Escape. `unmount()` detaches both. Both methods are idempotent.
  *
  * @example
  * ```tsx
  * // React adapter:
- * useEffect(() =>
- *   createVizelDismissibleController({
+ * useEffect(() => {
+ *   const controller = createVizelDismissibleController({
  *     getElements: () => [popoverRef.current, triggerRef.current],
  *     onDismiss: () => setOpen(false),
- *   }),
- * []);
+ *   });
+ *   controller.mount();
+ *   return () => controller.unmount();
+ * }, []);
  * ```
  */
 export function createVizelDismissibleController(
   options: VizelDismissibleControllerOptions
-): () => void {
+): VizelDismissibleController {
   const { getElements, onDismiss, dismissOnEscape = true } = options;
 
-  const handleMouseDown = (event: MouseEvent) => {
+  const handleMouseDown = (event: MouseEvent): void => {
     if (!(event.target instanceof Node)) return;
     const target = event.target;
     for (const el of getElements()) {
@@ -55,21 +69,33 @@ export function createVizelDismissibleController(
     onDismiss();
   };
 
-  const handleKeyDown = (event: KeyboardEvent) => {
+  const handleKeyDown = (event: KeyboardEvent): void => {
     if (event.key === "Escape") {
       onDismiss();
     }
   };
 
-  document.addEventListener("mousedown", handleMouseDown);
-  if (dismissOnEscape) {
-    document.addEventListener("keydown", handleKeyDown);
-  }
+  let isMounted = false;
 
-  return () => {
-    document.removeEventListener("mousedown", handleMouseDown);
-    if (dismissOnEscape) {
-      document.removeEventListener("keydown", handleKeyDown);
-    }
+  return {
+    mount: (): void => {
+      // SSR guard: skip DOM work when `document` is unavailable.
+      if (typeof document === "undefined") return;
+      if (isMounted) return;
+      document.addEventListener("mousedown", handleMouseDown);
+      if (dismissOnEscape) {
+        document.addEventListener("keydown", handleKeyDown);
+      }
+      isMounted = true;
+    },
+    unmount: (): void => {
+      if (typeof document === "undefined") return;
+      if (!isMounted) return;
+      document.removeEventListener("mousedown", handleMouseDown);
+      if (dismissOnEscape) {
+        document.removeEventListener("keydown", handleKeyDown);
+      }
+      isMounted = false;
+    },
   };
 }

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -1,5 +1,6 @@
 export {
   createVizelDismissibleController,
+  type VizelDismissibleController,
   type VizelDismissibleControllerOptions,
 } from "./dismissibleController.ts";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,6 +114,7 @@ export {
   createVizelDismissibleController,
   createVizelEditorSubscription,
   createVizelEditorTransactionStore,
+  type VizelDismissibleController,
   type VizelDismissibleControllerOptions,
   type VizelEditorEventName,
   type VizelEditorSubscriptionOptions,

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -177,11 +177,12 @@ watch(
   menuState,
   (state, _prev, onCleanup) => {
     if (!state) return;
-    const dispose = createVizelDismissibleController({
+    const controller = createVizelDismissibleController({
       getElements: () => [menuRef.value, submenuRef.value],
       onDismiss: close,
     });
-    onCleanup(dispose);
+    controller.mount();
+    onCleanup(() => controller.unmount());
   },
   { flush: "post" }
 );


### PR DESCRIPTION
## Summary

Migrates `createVizelDismissibleController` to the canonical `{ mount, unmount }` controller contract defined in Section 3 of the v2.0.0 design spec. Adds Server-Side Rendering (SSR) guards. Idempotent on both `mount()` and `unmount()`.

### API change (breaking)

```typescript
// Before
const dispose = createVizelDismissibleController({ ... });
// later
dispose();

// After
const controller = createVizelDismissibleController({ ... });
controller.mount();
// later
controller.unmount();
```

The factory is now pure: calling it carries no side effects. `mount()` attaches listeners (and short-circuits during SSR); `unmount()` removes them. Both methods are idempotent.

### Caller updates

Vue `VizelBlockMenu.vue` is the only caller in the codebase and is updated to the new API.

## Section 3 scope

Section 3 of the v2.0.0 redesign normalizes ten DOM-owning controllers under a single contract. This PR is **sub-PR 3a**, the first in the series:

| Sub | Status | Controllers |
|-----|--------|-------------|
| **3a (this PR)** | — | DismissibleController |
| 3b | pending | EditorSubscription, EditorTransactionStore, RelativeTimeTicker, SystemThemeListener |
| 3c | pending | New Listbox + Grid controllers (replaces the listboxController shim) |
| 3d | pending | New Popover controller |
| 3e | pending | FW component `document.addEventListener` removal (15+ files) |

## Spec section

Section 3 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#3-controller-type-normalization).

## Test Plan

- [x] `pnpm typecheck` passes across all four packages.
- [x] `pnpm lint` passes (pre-existing demo warning unrelated).
- [x] Pre-push hook validates typecheck + lint.
- [ ] CI runs `pnpm test:ct` for all three frameworks. Vue BlockMenu CT exercises the dismiss-on-outside-click flow.

## Files changed

- `packages/core/src/controllers/dismissibleController.ts`: rewrites the controller to `{ mount, unmount }`.
- `packages/core/src/controllers/index.ts`: exports the new `VizelDismissibleController` interface.
- `packages/core/src/index.ts`: surfaces the new interface from the Controllers re-export block.
- `packages/vue/src/components/VizelBlockMenu.vue`: switches the caller to `controller.mount()` / `controller.unmount()`.
