### PR TITLE
feat(core): add Listbox and Grid controllers

### DIFF
--- a/packages/core/src/controllers/gridController.ts
+++ b/packages/core/src/controllers/gridController.ts
@@ -1,0 +1,111 @@
+import { resolveVizelGridNavigation } from "../utils/keyboard-navigation.ts";
+
+/**
+ * Options for {@link createVizelGridController}.
+ */
+export interface VizelGridControllerOptions {
+  /** Returns the grid root element (or `null` before mount). */
+  getRoot: () => HTMLElement | null;
+  /** Number of columns per row. Required for two-dimensional traversal. */
+  columns: number;
+  /** Initial selected index in row-major order. Defaults to 0. */
+  initialIndex?: number;
+  /** Called with the next index whenever keyboard navigation changes the selection. */
+  onChange: (index: number) => void;
+  /**
+   * CSS selector for the cells inside the root. Defaults to
+   * `[role=gridcell]`, matching the canonical {@link VizelGridSpec}
+   * shape.
+   */
+  itemSelector?: string;
+}
+
+/**
+ * Returned by {@link createVizelGridController}.
+ *
+ * Mirrors the listbox controller's shape for consistency. `handleKey`
+ * lets a parent listener forward events without `mount()`-ing.
+ */
+export interface VizelGridController {
+  readonly mount: () => void;
+  readonly unmount: () => void;
+  readonly handleKey: (event: KeyboardEvent) => boolean;
+  readonly getSelectedIndex: () => number;
+  readonly setSelectedIndex: (index: number) => void;
+}
+
+/**
+ * Build a controller for two-dimensional grid keyboard navigation.
+ *
+ * The controller wraps the pure {@link resolveVizelGridNavigation}
+ * resolver with DOM-listener lifecycle management. `mount()` attaches
+ * a `keydown` listener to the root element; `unmount()` removes it.
+ * Both methods are idempotent and Server-Side Rendering (SSR) safe.
+ *
+ * Used by the color picker and other two-dimensional pickers that
+ * follow the {@link VizelGridSpec} shape from `@vizel/core`.
+ *
+ * @example
+ * ```tsx
+ * const controller = createVizelGridController({
+ *   getRoot: () => gridRef.current,
+ *   columns: 8,
+ *   onChange: setFocused,
+ * });
+ * controller.mount();
+ * ```
+ */
+export function createVizelGridController(
+  options: VizelGridControllerOptions
+): VizelGridController {
+  const {
+    getRoot,
+    columns,
+    initialIndex = 0,
+    onChange,
+    itemSelector = "[role=gridcell]",
+  } = options;
+
+  let selectedIndex = initialIndex;
+  let isMounted = false;
+
+  const handleKey = (event: KeyboardEvent): boolean => {
+    const root = getRoot();
+    if (!root) return false;
+    const items = root.querySelectorAll(itemSelector);
+    const next = resolveVizelGridNavigation(event.key, selectedIndex, items.length, columns);
+    if (next === null) return false;
+    selectedIndex = next;
+    onChange(selectedIndex);
+    return true;
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (handleKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  return {
+    mount: (): void => {
+      if (typeof document === "undefined") return;
+      if (isMounted) return;
+      const root = getRoot();
+      if (!root) return;
+      root.addEventListener("keydown", handleKeyDown);
+      isMounted = true;
+    },
+    unmount: (): void => {
+      if (typeof document === "undefined") return;
+      if (!isMounted) return;
+      getRoot()?.removeEventListener("keydown", handleKeyDown);
+      isMounted = false;
+    },
+    handleKey,
+    getSelectedIndex: () => selectedIndex,
+    setSelectedIndex: (index: number) => {
+      selectedIndex = index;
+    },
+  };
+}

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -9,6 +9,16 @@ export {
   type VizelEditorSubscriptionOptions,
 } from "./editorSubscription.ts";
 export {
+  createVizelGridController,
+  type VizelGridController,
+  type VizelGridControllerOptions,
+} from "./gridController.ts";
+export {
+  createVizelListboxController,
+  type VizelListboxController,
+  type VizelListboxControllerOptions,
+} from "./listboxController.ts";
+export {
   createVizelEditorTransactionStore,
   type VizelEditorTransactionStore,
 } from "./transactionStore.ts";

--- a/packages/core/src/controllers/listboxController.ts
+++ b/packages/core/src/controllers/listboxController.ts
@@ -1,9 +1,121 @@
+import { resolveVizelListNavigation } from "../utils/keyboard-navigation.ts";
+
 /**
- * Re-exports the pure keyboard navigation helpers. Kept here as a thin
- * shim until Section 3 of the v2.0.0 redesign introduces the actual
- * `createVizelListboxController` factory at this path.
+ * Options for {@link createVizelListboxController}.
  */
-export {
-  resolveVizelGridNavigation,
-  resolveVizelListNavigation,
-} from "../utils/keyboard-navigation.ts";
+export interface VizelListboxControllerOptions {
+  /** Returns the listbox root element (or `null` before mount). */
+  getRoot: () => HTMLElement | null;
+  /** Initial selected index. Defaults to 0. */
+  initialIndex?: number;
+  /** Called with the next index whenever keyboard navigation changes the selection. */
+  onChange: (index: number) => void;
+  /**
+   * CSS selector for the items inside the root. Defaults to
+   * `[role=option]`, matching the canonical {@link VizelMenuSpec}
+   * listbox shape.
+   */
+  itemSelector?: string;
+}
+
+/**
+ * Returned by {@link createVizelListboxController}.
+ *
+ * Follows the canonical controller contract. The `handleKey` escape
+ * hatch exists for cases where a parent owns the `keydown` listener
+ * (for example a Tiptap suggestion renderer that forwards events) and
+ * the controller is mounted only for the selection state.
+ */
+export interface VizelListboxController {
+  /** Attach the `keydown` listener to the root element. */
+  readonly mount: () => void;
+  /** Detach the listener. Idempotent. */
+  readonly unmount: () => void;
+  /**
+   * Forward a single `KeyboardEvent` and apply the resulting navigation
+   * if any. Returns `true` when the event was consumed (the caller
+   * should `event.preventDefault()` themselves) and `false` otherwise.
+   */
+  readonly handleKey: (event: KeyboardEvent) => boolean;
+  /** Read the current selected index. */
+  readonly getSelectedIndex: () => number;
+  /** Set the selected index directly (e.g. when an item is clicked). */
+  readonly setSelectedIndex: (index: number) => void;
+}
+
+/**
+ * Build a controller for a one-dimensional listbox keyboard navigation.
+ *
+ * The controller wraps the pure {@link resolveVizelListNavigation}
+ * resolver with DOM-listener lifecycle management. `mount()` attaches
+ * a `keydown` listener to the root element returned by `getRoot`;
+ * `unmount()` removes it. Both methods are idempotent and
+ * Server-Side Rendering (SSR) safe.
+ *
+ * The pure resolver remains exported from `utils/keyboard-navigation`
+ * for callers that want to handle key events themselves (the mention
+ * menu, suggestion renderers, etc.).
+ *
+ * @example
+ * ```tsx
+ * // React adapter:
+ * const rootRef = useRef<HTMLDivElement>(null);
+ * const [selected, setSelected] = useState(0);
+ * useEffect(() => {
+ *   const controller = createVizelListboxController({
+ *     getRoot: () => rootRef.current,
+ *     onChange: setSelected,
+ *   });
+ *   controller.mount();
+ *   return () => controller.unmount();
+ * }, []);
+ * ```
+ */
+export function createVizelListboxController(
+  options: VizelListboxControllerOptions
+): VizelListboxController {
+  const { getRoot, initialIndex = 0, onChange, itemSelector = "[role=option]" } = options;
+
+  let selectedIndex = initialIndex;
+  let isMounted = false;
+
+  const handleKey = (event: KeyboardEvent): boolean => {
+    const root = getRoot();
+    if (!root) return false;
+    const items = root.querySelectorAll(itemSelector);
+    const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
+    if (next === null) return false;
+    selectedIndex = next;
+    onChange(selectedIndex);
+    return true;
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (handleKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  return {
+    mount: (): void => {
+      if (typeof document === "undefined") return;
+      if (isMounted) return;
+      const root = getRoot();
+      if (!root) return;
+      root.addEventListener("keydown", handleKeyDown);
+      isMounted = true;
+    },
+    unmount: (): void => {
+      if (typeof document === "undefined") return;
+      if (!isMounted) return;
+      getRoot()?.removeEventListener("keydown", handleKeyDown);
+      isMounted = false;
+    },
+    handleKey,
+    getSelectedIndex: () => selectedIndex,
+    setSelectedIndex: (index: number) => {
+      selectedIndex = index;
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,11 +115,17 @@ export {
   createVizelDismissibleController,
   createVizelEditorSubscription,
   createVizelEditorTransactionStore,
+  createVizelGridController,
+  createVizelListboxController,
   type VizelDismissibleController,
   type VizelDismissibleControllerOptions,
   type VizelEditorEventName,
   type VizelEditorSubscriptionOptions,
   type VizelEditorTransactionStore,
+  type VizelGridController,
+  type VizelGridControllerOptions,
+  type VizelListboxController,
+  type VizelListboxControllerOptions,
 } from "./controllers/index.ts";
 // =============================================================================
 // Extensions


### PR DESCRIPTION
## Summary

Replaces the `listboxController.ts` shim left by Section 1 with the actual `createVizelListboxController` factory. Adds a new `createVizelGridController` for two-dimensional pickers (color picker, future emoji picker). Both controllers follow the canonical `{ mount, unmount }` contract.

### New controllers

| Controller | Wraps | Usage |
|-----------|-------|-------|
| `createVizelListboxController` | `resolveVizelListNavigation` (pure) | Listbox keyboard navigation (slash menu, mention menu, dropdown bodies, etc.) |
| `createVizelGridController` | `resolveVizelGridNavigation` (pure) | Two-dimensional cell grids (color picker, future emoji picker) |

### Contract

```typescript
interface VizelListboxController {
  readonly mount: () => void;
  readonly unmount: () => void;
  readonly handleKey: (event: KeyboardEvent) => boolean;
  readonly getSelectedIndex: () => number;
  readonly setSelectedIndex: (index: number) => void;
}
```

- The factory is pure (no side effects, SSR-safe).
- `mount()` attaches a `keydown` listener to the root element returned by `getRoot`. Skips silently when `document` is unavailable.
- `unmount()` removes the listener. Both methods are idempotent.
- `handleKey()` lets a parent listener forward a single event (used by Tiptap suggestion renderers that own the listener themselves).

The pure resolvers (`resolveVizelListNavigation` / `resolveVizelGridNavigation`) remain exported from `utils/keyboard-navigation` so the mention menu and other composed-keyboard callers do not need to mount a controller.

## Section 3 progress

| Sub | PR | Status | Controllers |
|-----|----|--------|-------------|
| 3a | #453 | ✅ merged | DismissibleController |
| 3b | #454 | ✅ merged | SystemThemeListener, RelativeTimeTicker |
| **3c (this PR)** | — | — | Listbox, Grid (new) |
| 3d | — | pending | Popover controller |
| 3e | — | pending | FW component `document.addEventListener` removal |

## Spec section

Section 3 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#3-controller-type-normalization).

## Test Plan

- [x] `pnpm typecheck` passes across all four packages.
- [x] `pnpm lint` passes (pre-existing demo warning unrelated).
- [x] Pre-push hook validates typecheck.
- [ ] CI runs `pnpm test:ct` for all three frameworks. No callers consume the new controllers yet; Section 3e wires them into framework components.

## Files changed

4 files modified:

- `packages/core/src/controllers/listboxController.ts`: replaces the shim with the actual factory.
- `packages/core/src/controllers/gridController.ts`: **new**.
- `packages/core/src/controllers/index.ts`: exports both new controllers.
- `packages/core/src/index.ts`: surfaces both controllers from the Controllers re-export block.
