### PR TITLE
feat(core): add Popover controller

### DIFF
--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -19,6 +19,12 @@ export {
   type VizelListboxControllerOptions,
 } from "./listboxController.ts";
 export {
+  createVizelPopoverController,
+  type VizelPopoverController,
+  type VizelPopoverControllerOptions,
+  type VizelPopoverPlacement,
+} from "./popoverController.ts";
+export {
   createVizelEditorTransactionStore,
   type VizelEditorTransactionStore,
 } from "./transactionStore.ts";

--- a/packages/core/src/controllers/popoverController.ts
+++ b/packages/core/src/controllers/popoverController.ts
@@ -1,0 +1,194 @@
+import { createVizelDismissibleController } from "./dismissibleController.ts";
+
+/**
+ * Side of the anchor the body prefers to sit on. The controller falls
+ * back to the opposite side when the preferred side would overflow the
+ * viewport.
+ */
+export type VizelPopoverPlacement =
+  | "bottom-start"
+  | "bottom-end"
+  | "top-start"
+  | "top-end"
+  | "right-start"
+  | "left-start";
+
+/**
+ * Options for {@link createVizelPopoverController}.
+ */
+export interface VizelPopoverControllerOptions {
+  /** Returns the anchor element the body positions against. */
+  getAnchor: () => HTMLElement | null;
+  /** Returns the floating body element to position. */
+  getBody: () => HTMLElement | null;
+  /** Preferred placement; defaults to `"bottom-start"`. */
+  placement?: VizelPopoverPlacement;
+  /** Pixel offset between the anchor and the body. Defaults to 4. */
+  offset?: number;
+  /** Called when the controller decides the popover should close. */
+  onDismiss: () => void;
+  /** Whether Escape dismisses (default: true). */
+  dismissOnEscape?: boolean;
+  /**
+   * Whether `window` `resize` and `scroll` events trigger a reposition.
+   * Defaults to true. Set to false for popovers anchored to fixed
+   * elements that do not move.
+   */
+  repositionOnWindowEvents?: boolean;
+}
+
+/**
+ * Returned by {@link createVizelPopoverController}.
+ *
+ * Combines positioning and dismissal under one mount/unmount lifecycle.
+ * `updatePosition()` is exposed so callers can trigger a reposition
+ * explicitly after layout-affecting changes that the window listeners
+ * miss (e.g. the body's content changing height).
+ */
+export interface VizelPopoverController {
+  /** Activate listeners and place the body. */
+  readonly mount: () => void;
+  /** Detach listeners. Idempotent. */
+  readonly unmount: () => void;
+  /** Recompute and apply the body's position against the anchor. */
+  readonly updatePosition: () => void;
+}
+
+/**
+ * Build a controller for an anchored popover.
+ *
+ * The controller composes three concerns under one `{ mount, unmount }`
+ * lifecycle:
+ *
+ * 1. **Positioning.** On `mount()` and whenever the window resizes or
+ *    scrolls (configurable), the body is positioned against the anchor
+ *    using the chosen placement, with viewport-edge fallback when the
+ *    preferred side would overflow.
+ * 2. **Outside-click dismissal.** A click whose target is contained
+ *    neither in the anchor nor in the body invokes `onDismiss`.
+ * 3. **Escape dismissal.** Pressing Escape invokes `onDismiss`.
+ *
+ * Items 2 and 3 use {@link createVizelDismissibleController} under the
+ * hood, so the dismissal behavior matches the rest of the library.
+ * Positioning writes `top` and `left` inline styles on the body
+ * element.
+ *
+ * Server-Side Rendering (SSR) safe: every method short-circuits when
+ * `document` is unavailable.
+ */
+export function createVizelPopoverController(
+  options: VizelPopoverControllerOptions
+): VizelPopoverController {
+  const {
+    getAnchor,
+    getBody,
+    placement = "bottom-start",
+    offset = 4,
+    onDismiss,
+    dismissOnEscape = true,
+    repositionOnWindowEvents = true,
+  } = options;
+
+  const dismissible = createVizelDismissibleController({
+    getElements: () => [getAnchor(), getBody()],
+    onDismiss,
+    dismissOnEscape,
+  });
+
+  const updatePosition = (): void => {
+    if (typeof window === "undefined") return;
+    const anchor = getAnchor();
+    const body = getBody();
+    if (!(anchor && body)) return;
+
+    const anchorRect = anchor.getBoundingClientRect();
+    const bodyRect = body.getBoundingClientRect();
+    const viewport = { width: window.innerWidth, height: window.innerHeight };
+
+    let top = 0;
+    let left = 0;
+
+    switch (placement) {
+      case "bottom-start":
+        top = anchorRect.bottom + offset;
+        left = anchorRect.left;
+        if (top + bodyRect.height > viewport.height) {
+          top = anchorRect.top - bodyRect.height - offset;
+        }
+        break;
+      case "bottom-end":
+        top = anchorRect.bottom + offset;
+        left = anchorRect.right - bodyRect.width;
+        if (top + bodyRect.height > viewport.height) {
+          top = anchorRect.top - bodyRect.height - offset;
+        }
+        break;
+      case "top-start":
+        top = anchorRect.top - bodyRect.height - offset;
+        left = anchorRect.left;
+        if (top < 0) {
+          top = anchorRect.bottom + offset;
+        }
+        break;
+      case "top-end":
+        top = anchorRect.top - bodyRect.height - offset;
+        left = anchorRect.right - bodyRect.width;
+        if (top < 0) {
+          top = anchorRect.bottom + offset;
+        }
+        break;
+      case "right-start":
+        top = anchorRect.top;
+        left = anchorRect.right + offset;
+        if (left + bodyRect.width > viewport.width) {
+          left = anchorRect.left - bodyRect.width - offset;
+        }
+        break;
+      case "left-start":
+        top = anchorRect.top;
+        left = anchorRect.left - bodyRect.width - offset;
+        if (left < 0) {
+          left = anchorRect.right + offset;
+        }
+        break;
+    }
+
+    // Clamp horizontally inside the viewport (vertical handled above).
+    left = Math.max(0, Math.min(left, viewport.width - bodyRect.width));
+
+    body.style.position = "fixed";
+    body.style.top = `${top}px`;
+    body.style.left = `${left}px`;
+  };
+
+  const handleReposition = (): void => {
+    updatePosition();
+  };
+
+  let isMounted = false;
+
+  return {
+    mount: (): void => {
+      if (typeof document === "undefined") return;
+      if (isMounted) return;
+      dismissible.mount();
+      updatePosition();
+      if (repositionOnWindowEvents) {
+        window.addEventListener("resize", handleReposition);
+        window.addEventListener("scroll", handleReposition, true);
+      }
+      isMounted = true;
+    },
+    unmount: (): void => {
+      if (typeof document === "undefined") return;
+      if (!isMounted) return;
+      dismissible.unmount();
+      if (repositionOnWindowEvents) {
+        window.removeEventListener("resize", handleReposition);
+        window.removeEventListener("scroll", handleReposition, true);
+      }
+      isMounted = false;
+    },
+    updatePosition,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   createVizelEditorTransactionStore,
   createVizelGridController,
   createVizelListboxController,
+  createVizelPopoverController,
   type VizelDismissibleController,
   type VizelDismissibleControllerOptions,
   type VizelEditorEventName,
@@ -126,6 +127,9 @@ export {
   type VizelGridControllerOptions,
   type VizelListboxController,
   type VizelListboxControllerOptions,
+  type VizelPopoverController,
+  type VizelPopoverControllerOptions,
+  type VizelPopoverPlacement,
 } from "./controllers/index.ts";
 // =============================================================================
 // Extensions


### PR DESCRIPTION
## Summary

Adds `createVizelPopoverController` — a new controller that combines positioning, outside-click dismissal, and Escape dismissal under a single `{ mount, unmount }` lifecycle. The controller composes the existing `DismissibleController` for dismissal and adds viewport-aware positioning.

## API

```typescript
const controller = createVizelPopoverController({
  getAnchor: () => triggerRef.current,
  getBody: () => bodyRef.current,
  placement: "bottom-start",
  offset: 4,
  onDismiss: () => setOpen(false),
});
controller.mount();
// later
controller.unmount();
```

### Supported placements

- `bottom-start` (default), `bottom-end`
- `top-start`, `top-end`
- `right-start`, `left-start`

Each placement falls back to the opposite side when the preferred placement would overflow the viewport. Horizontal positions clamp inside the viewport bounds.

### Behavior

1. **Positioning** — writes `top` / `left` inline styles on the body element. Reposition fires on `window` `resize` and `scroll` (toggle via `repositionOnWindowEvents`). `updatePosition()` is exposed for callers that need to trigger a reposition explicitly after a content-size change.
2. **Outside-click dismissal** — clicks whose target is contained neither in the anchor nor in the body invoke `onDismiss`.
3. **Escape dismissal** — pressing Escape invokes `onDismiss`. Toggle via `dismissOnEscape`.

Server-Side Rendering (SSR) safe: every method short-circuits when `document` is unavailable.

## Section 3 progress

| Sub | PR | Status | Controllers |
|-----|----|--------|-------------|
| 3a | #453 | ✅ merged | DismissibleController |
| 3b | #454 | ✅ merged | SystemThemeListener, RelativeTimeTicker |
| 3c | #455 | ✅ merged | Listbox, Grid |
| **3d (this PR)** | — | — | Popover |
| 3e | — | pending | FW component `document.addEventListener` removal |

After Section 3e merges, Section 3 closes the controller layer and Section 4 (return type symmetry — Option B) begins.

## Spec section

Section 3 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#3-controller-type-normalization).

## Test Plan

- [x] `pnpm typecheck` passes across all four packages.
- [x] `pnpm lint` passes (pre-existing demo warning unrelated).
- [x] Pre-push hook validates typecheck.
- [ ] CI runs `pnpm test:ct` for all three frameworks. No callers yet; Section 3e wires the controller into framework components.

## Files changed

3 files modified:

- `packages/core/src/controllers/popoverController.ts`: **new**, ~200 lines.
- `packages/core/src/controllers/index.ts`: exports the new controller.
- `packages/core/src/index.ts`: surfaces the new controller from the Controllers re-export block.
