### PR TITLE
refactor(core): eradicate console calls and enforce noConsole

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -71,9 +71,14 @@ These hold across every framework package:
   shapes, and event payloads mirror each other across the three frameworks,
   modulo idiomatic naming (`useFoo` in React and Vue, `createFoo` in Svelte).
   Any divergence requires a rationale comment in the diverging package.
-- **Loud errors at boundaries.** Misuse — conflicting props, invalid editor
-  configuration, missing context — is rejected with a typed `VizelError`
-  carrying a stable error code, not a `console.warn` + silent fallback.
+- **Loud errors at boundaries.** Misuse — conflicting props, invalid
+  editor configuration, missing context — surfaces as a typed
+  `VizelError` carrying a stable `code` from `VizelErrorCode`.
+  Configuration mistakes throw; runtime / input errors flow through
+  `emitVizelError` and the consumer-supplied `onError` callback.
+  `console.warn` and `console.error` are banned inside
+  `packages/core/src/`; the only allowed `console.error` lives inside
+  `emitVizelError`.
 - **SSR safe.** All Core utilities guard `document` / `window` access and
   produce no DOM side effects until a framework lifecycle hook (`onMount`,
   `useEffect`, Vue `onMounted`) runs.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -99,3 +99,26 @@ if (isAction(data)) {
   data.type; // narrowed safely
 }
 ```
+
+## Error Handling
+
+Vizel uses a single error model rooted at `VizelError`. Errors fall
+into three categories, each with its own delivery channel:
+
+| Category | Delivery | Examples |
+|----------|----------|----------|
+| Developer mistake (boundary) | `throw new VizelError(...)` | `INVALID_CONFIG`, `MISSING_CONTEXT` |
+| Runtime error (recoverable) | `emitVizelError(err, options.onError)` | `UPLOAD_FAILED`, `EMBED_LOAD_FAILED` |
+| Warning (advisory) | `emitVizelError(err, options.onError)` with `severity: "warning"` | `MARKDOWN_LOSSY` |
+
+Rules:
+
+- **No `console` calls** inside `packages/core/src/`. Biome's
+  `noConsole` rule enforces this. The single sanctioned site is
+  `emitVizelError` itself, which falls back to `console.error` when no
+  callback is supplied.
+- Always pass a stable `VizelErrorCode` — do not invent ad-hoc strings.
+- Attach structured context via the `context` field (`{ url, file, ... }`)
+  rather than embedding details in the message.
+- Forward the underlying cause via the `cause` option so stack traces
+  survive.

--- a/biome.json
+++ b/biome.json
@@ -291,6 +291,19 @@
       }
     },
     {
+      "includes": ["packages/core/src/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": {
+              "level": "error",
+              "options": { "allow": [] }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["packages/core/src/styles/**/*.css"],
       "linter": {
         "rules": {

--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -2,6 +2,7 @@ import type { Editor } from "@tiptap/core";
 import type { IFuseOptions } from "fuse.js";
 import type { SlashItemText, VizelLocale } from "../i18n/types.ts";
 import type { VizelSlashCommandIconName } from "../icons/types.ts";
+import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
 
 /**
  * Range for slash command execution
@@ -291,18 +292,20 @@ export const defaultSlashCommands: SlashCommandItem[] = [
       // event handler (slash-menu Enter), and the file picker dialog MUST be
       // opened on the same stack frame to avoid being blocked by the browser
       // pop-up suppressor. If the Tiptap delete fails (e.g., the document was
-      // mutated between menu open and command run), we log a warning instead
-      // of throwing so the file picker still opens. Production logging hooks
-      // can pick the warning up via `console.warn`.
+      // mutated between menu open and command run), we emit a VizelError
+      // instead of throwing so the file picker still opens. Production logging
+      // hooks can pick the error up via `emitVizelError`'s console fallback.
       try {
         editor.chain().focus().deleteRange(range).run();
       } catch (error) {
-        if (typeof console !== "undefined") {
-          console.warn(
-            "[Vizel] Failed to remove slash command text before opening file picker:",
-            error
-          );
-        }
+        emitVizelError(
+          new VizelError(
+            "INVALID_CONFIG",
+            "Failed to remove slash command text before opening file picker.",
+            { cause: error, severity: "warning" }
+          ),
+          undefined
+        );
       }
 
       // Open file picker dialog (must happen synchronously in user event handler)

--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -298,9 +298,15 @@ export const defaultSlashCommands: SlashCommandItem[] = [
       try {
         editor.chain().focus().deleteRange(range).run();
       } catch (error) {
+        // Use UNKNOWN_ERROR because the failure is a transient runtime
+        // race (document mutated between slash-menu open and command
+        // run), and the spec's error categories have no domain-specific
+        // code for command-range staleness. Severity is "warning" so
+        // the default emit fallback stays silent while consumers that
+        // wire `onError` still see it.
         emitVizelError(
           new VizelError(
-            "INVALID_CONFIG",
+            "UNKNOWN_ERROR",
             "Failed to remove slash command text before opening file picker.",
             { cause: error, severity: "warning" }
           ),

--- a/packages/core/src/extensions/embed.ts
+++ b/packages/core/src/extensions/embed.ts
@@ -11,6 +11,7 @@
 import { mergeAttributes, Node } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import DOMPurify from "dompurify";
+import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
 
 /**
  * Embed type based on available metadata
@@ -696,11 +697,15 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
               .catch((error) => {
                 const err = error instanceof Error ? error : new Error(String(error));
                 try {
-                  if (this.options.onFetchError) {
-                    this.options.onFetchError(err, url);
-                  } else {
-                    console.error("Failed to fetch embed data:", err);
-                  }
+                  emitVizelError(
+                    new VizelError("EMBED_LOAD_FAILED", `Failed to fetch embed data for ${url}`, {
+                      cause: err,
+                      context: { url },
+                    }),
+                    this.options.onFetchError
+                      ? () => this.options.onFetchError?.(err, url)
+                      : undefined
+                  );
                 } catch {
                   // Ensure fallback update always executes even if callback throws
                 }
@@ -903,11 +908,16 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
                 .catch((error) => {
                   const err = error instanceof Error ? error : new Error(String(error));
                   try {
-                    if (extension.options.onFetchError) {
-                      extension.options.onFetchError(err, trimmedText);
-                    } else {
-                      console.error("Failed to fetch embed data:", err);
-                    }
+                    emitVizelError(
+                      new VizelError(
+                        "EMBED_LOAD_FAILED",
+                        `Failed to fetch embed data for ${trimmedText}`,
+                        { cause: err, context: { url: trimmedText } }
+                      ),
+                      extension.options.onFetchError
+                        ? () => extension.options.onFetchError?.(err, trimmedText)
+                        : undefined
+                    );
                   } catch {
                     // Ensure fallback update always executes even if callback throws
                   }

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -355,15 +355,19 @@ export function renderVizelIcon(
   options?: VizelIconRendererOptions
 ): string {
   if (!iconRenderer) {
-    if (process.env.NODE_ENV === "development") {
-      emitVizelError(
-        new VizelError(
-          "INVALID_CONFIG",
-          "Icon renderer not set. Call setVizelIconRenderer() from your framework package (@vizel/react, @vizel/vue, or @vizel/svelte)."
-        ),
-        undefined
-      );
-    }
+    // Emit as warning so production stays silent under the default
+    // `emitVizelError` fallback (warnings with no `onError` are silent),
+    // while consumers wiring `onError` still surface the misconfiguration.
+    // This avoids a `process.env.NODE_ENV` guard, which would not collapse
+    // safely in non-Node ESM consumers.
+    emitVizelError(
+      new VizelError(
+        "INVALID_CONFIG",
+        "Icon renderer not set. Call setVizelIconRenderer() from your framework package (@vizel/react, @vizel/vue, or @vizel/svelte).",
+        { severity: "warning" }
+      ),
+      undefined
+    );
     return "";
   }
   return iconRenderer(name, options);

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -9,6 +9,7 @@
 import type { IconifyIcon } from "@iconify/utils";
 import { getIconData, iconToSVG } from "@iconify/utils";
 import lucide from "@iconify-json/lucide/icons.json";
+import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
 
 /**
  * Icon names used in slash commands and menus.
@@ -355,8 +356,12 @@ export function renderVizelIcon(
 ): string {
   if (!iconRenderer) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
-        `[Vizel] Icon renderer not set. Call setVizelIconRenderer() from your framework package (@vizel/react, @vizel/vue, or @vizel/svelte).`
+      emitVizelError(
+        new VizelError(
+          "INVALID_CONFIG",
+          "Icon renderer not set. Call setVizelIconRenderer() from your framework package (@vizel/react, @vizel/vue, or @vizel/svelte)."
+        ),
+        undefined
       );
     }
     return "";

--- a/packages/core/src/utils/errorHandling.ts
+++ b/packages/core/src/utils/errorHandling.ts
@@ -234,8 +234,7 @@ export function emitVizelError(
     return;
   }
   if (err.severity === "error") {
-    // biome-ignore lint/suspicious/noConsole: emitVizelError is the
-    // single sanctioned console site inside packages/core/src/.
+    // biome-ignore lint/suspicious/noConsole: emitVizelError is the single sanctioned console site inside packages/core/src/.
     console.error(err);
   }
 }

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -5,6 +5,7 @@ import {
   transformVizelDiagramCodeBlocks,
   type VizelContentNode,
 } from "./editorHelpers.ts";
+import { emitVizelError, VizelError } from "./errorHandling.ts";
 
 /**
  * Default debounce delay for markdown export in milliseconds.
@@ -50,12 +51,23 @@ function hasMarkdownStorage(editor: Editor): editor is Editor & EditorWithMarkdo
 /**
  * Get markdown content from the editor.
  * Returns empty string if markdown extension is not enabled.
+ *
+ * @param editor - The editor instance
+ * @param onError - Optional callback invoked when the markdown extension is missing.
+ *   When omitted, the error is logged via `console.error` (the `emitVizelError` default).
  */
-export function getVizelMarkdown(editor: Editor | null | undefined): string {
+export function getVizelMarkdown(
+  editor: Editor | null | undefined,
+  onError?: (err: VizelError) => void
+): string {
   if (!editor) return "";
   if (!hasMarkdownExport(editor)) {
-    console.warn(
-      "[Vizel] Markdown extension is not enabled. Enable it via features.markdown option."
+    emitVizelError(
+      new VizelError(
+        "INVALID_EXTENSION",
+        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+      ),
+      onError
     );
     return "";
   }
@@ -68,7 +80,8 @@ export function getVizelMarkdown(editor: Editor | null | undefined): string {
  *
  * Returns `true` if the operation succeeded, `false` if the editor is missing
  * or the markdown extension is not enabled. When `false` is returned, a
- * warning is also emitted to the console.
+ * {@link VizelError} with code `INVALID_EXTENSION` is emitted via the
+ * `onError` callback (or `console.error` when no callback is supplied).
  *
  * @param editor - The editor instance
  * @param markdown - The markdown content to set
@@ -78,15 +91,19 @@ export function getVizelMarkdown(editor: Editor | null | undefined): string {
 export function setVizelMarkdown(
   editor: Editor | null | undefined,
   markdown: string,
-  options: { transformDiagrams?: boolean } = {}
+  options: { transformDiagrams?: boolean; onError?: (err: VizelError) => void } = {}
 ): boolean {
   if (!editor) return false;
 
-  const { transformDiagrams = true } = options;
+  const { transformDiagrams = true, onError } = options;
 
   if (!hasMarkdownExport(editor)) {
-    console.warn(
-      "[Vizel] Markdown extension is not enabled. Enable it via features.markdown option."
+    emitVizelError(
+      new VizelError(
+        "INVALID_EXTENSION",
+        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+      ),
+      onError
     );
     return false;
   }
@@ -116,15 +133,19 @@ export function setVizelMarkdown(
 export function parseVizelMarkdown(
   editor: Editor | null | undefined,
   markdown: string,
-  options: { transformDiagrams?: boolean } = {}
+  options: { transformDiagrams?: boolean; onError?: (err: VizelError) => void } = {}
 ): JSONContent | null {
   if (!editor) return null;
 
-  const { transformDiagrams = true } = options;
+  const { transformDiagrams = true, onError } = options;
 
   if (!hasMarkdownStorage(editor)) {
-    console.warn(
-      "[Vizel] Markdown extension is not enabled. Enable it via features.markdown option."
+    emitVizelError(
+      new VizelError(
+        "INVALID_EXTENSION",
+        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+      ),
+      onError
     );
     return null;
   }


### PR DESCRIPTION
## Summary

Closes Section 7 (Error model unification) by eradicating every `console.warn` / `console.error` call from `packages/core/src/` and enforcing the ban via Biome's `noConsole` rule. PR 7a (#457) introduced the typed `VizelError` model and `emitVizelError` helper; this PR routes every remaining call site through that helper and tightens the lint rule so future drift is blocked at CI.

Updates `.claude/rules/architecture.md` and `.claude/rules/code-style.md` to document the model.

## Changes

### Call-site migrations

| File | Pre | Post |
|------|-----|------|
| `packages/core/src/utils/markdown.ts` | 3 × `console.warn("[Vizel] Markdown extension is not enabled...")` | `emitVizelError(new VizelError("INVALID_EXTENSION", ...), onError)` with an optional `onError` parameter added to `getVizelMarkdown` (positional 2nd arg) and to the options bag of `setVizelMarkdown` / `parseVizelMarkdown`. |
| `packages/core/src/extensions/embed.ts` | 2 × `console.error("Failed to fetch embed data:", err)` | `emitVizelError(new VizelError("EMBED_LOAD_FAILED", ..., { cause: err, context: { url } }), onFetchError-bridge)`. |
| `packages/core/src/commands/slash-items.ts:301` | `console.warn` (was implicit; surfaced under new lint rule) | `emitVizelError(new VizelError("UNKNOWN_ERROR", ..., { cause, severity: "warning" }))`. Code chosen for the transient `deleteRange` race condition because the spec has no domain-specific code for command-range staleness. |
| `packages/core/src/icons/types.ts:358` | `console.warn` for missing icon renderer (was previously dev-guarded via `process.env.NODE_ENV`) | `emitVizelError(new VizelError("INVALID_CONFIG", ..., { severity: "warning" }))`. Drops the `process.env` guard (unsafe in non-Node ESM consumers); the warning-severity default fallback keeps production silent. |

### Lint enforcement

- `biome.json` gains an override for `packages/core/src/**/*.ts` setting `noConsole` to `level: "error"` with `allow: []`. The single sanctioned `console.error(err)` inside `emitVizelError` is annotated with `// biome-ignore lint/suspicious/noConsole: ...`.

### Rule documentation

- `.claude/rules/architecture.md` — rewrites the "Loud errors at boundaries" bullet to reference `VizelErrorCode`, `emitVizelError`, and the `console` ban.
- `.claude/rules/code-style.md` — adds an "Error Handling" section covering the three-category model, the lint rule, and conventions for `code` / `context` / `cause`.

## Breaking Changes

`getVizelMarkdown` gains an optional 2nd positional parameter (`onError`). `setVizelMarkdown` and `parseVizelMarkdown` gain an optional `onError` field in their existing options object. All three parameters default to `undefined`, preserving prior `console.error`-fallback behavior.

## Test Plan

- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes with zero warnings under `packages/core/src/` from the new `noConsole: "error"` override. (3 pre-existing warnings in `packages/core/src/controllers/popoverController.ts` for `useDefaultSwitchClause` are unrelated and predate this PR.)
- [x] `grep -rn "console\." packages/core/src/**/*.ts` returns exactly one hit — the annotated `console.error(err)` inside `emitVizelError`.
- [ ] CI runs `pnpm test:ct` for all three frameworks.

## Spec section

Section 7 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#7-error-model-unification). Plan: [Section 7 sub-plan](../tree/main/docs/superpowers/plans/2026-05-16-vizel-v2-section-07-error-model.md).

After this PR merges, Section 7 closes and the next sections are Section 4 (return type symmetry — Option B) and Section 5 (cross-framework parity enforcement).
