### PR TITLE
refactor(svelte): apply Option B return-type symmetry

### DIFF
--- a/.claude/rules/packages/svelte.md
+++ b/.claude/rules/packages/svelte.md
@@ -216,10 +216,13 @@ the page and corrupt sessions when more than one suggestion is open.
 - `VizelProvider` calls `setContext()`.
 - Consumers call `getVizelContext()` for required access or `getVizelContextSafe()` for optional access.
 
+`getVizelContext()` returns a reactive accessor (`{ readonly current: Editor | null }`). Keep the accessor bound and read `.current` inside reactive scopes so the read registers as a dependency.
+
 ```typescript
 import { getVizelContext } from "@vizel/svelte";
 
-const { editor } = getVizelContext();
+const context = getVizelContext();
+// Read context.current inside $derived, $effect, or templates.
 ```
 
 ## Event Handling

--- a/apps/demo/svelte/src/ThemeToggle.svelte
+++ b/apps/demo/svelte/src/ThemeToggle.svelte
@@ -4,7 +4,7 @@ import { getVizelTheme } from "@vizel/svelte";
 const themeState = getVizelTheme();
 
 function toggleTheme() {
-  themeState.setTheme(themeState.resolvedTheme === "dark" ? "light" : "dark");
+  themeState.setTheme(themeState.current === "dark" ? "light" : "dark");
 }
 </script>
 
@@ -12,7 +12,7 @@ function toggleTheme() {
   type="button"
   class="theme-toggle"
   onclick={toggleTheme}
-  aria-label={`Switch to ${themeState.resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
+  aria-label={`Switch to ${themeState.current === 'dark' ? 'light' : 'dark'} mode`}
 >
-  {themeState.resolvedTheme === "dark" ? "☀️" : "🌙"}
+  {themeState.current === "dark" ? "☀️" : "🌙"}
 </button>

--- a/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenuDefault.svelte
@@ -42,11 +42,11 @@ const markGroups = $derived(
   groupVizelBubbleMenuActions(filteredActions.filter((a) => a.id !== "link"))
 );
 
-// Reading `editorState.current` inside the derived isActive map registers the
+// Reading `editorState.version` inside the derived isActive map registers the
 // version counter as a tracked dependency so re-renders happen on every
 // selection change. The value itself is discarded.
 const isActive = $derived.by(() => {
-  void editorState.current;
+  void editorState.version;
   return (actionId: string): boolean => {
     const action = filteredActions.find((a) => a.id === actionId);
     return action ? action.isActive(editor) : false;

--- a/packages/svelte/src/components/VizelNodeSelector.svelte
+++ b/packages/svelte/src/components/VizelNodeSelector.svelte
@@ -31,7 +31,7 @@ let dropdownRef: HTMLDivElement | undefined = $state();
 let triggerRef: HTMLButtonElement | undefined = $state();
 
 const spec = $derived.by(() => {
-  void editorState.current;
+  void editorState.version;
   return buildVizelNodeSelectorSpec(editor, effectiveNodeTypes, isOpen, focusedIndex, locale);
 });
 

--- a/packages/svelte/src/components/VizelToolbarDefault.svelte
+++ b/packages/svelte/src/components/VizelToolbarDefault.svelte
@@ -40,7 +40,7 @@ const effectiveActions = $derived(actions ?? (locale ? createVizelToolbarActions
 const editorState = createVizelState(() => editor);
 
 const groups = $derived.by(() => {
-  void editorState.current;
+  void editorState.version;
   return groupVizelToolbarActions(effectiveActions);
 });
 </script>

--- a/packages/svelte/src/runes/createVizelEditorState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditorState.svelte.ts
@@ -31,8 +31,8 @@ export function createVizelEditorState(getEditor: () => Editor | null | undefine
 
   return {
     get current() {
-      // Access state.current to establish reactivity dependency
-      void state.current;
+      // Access state.version to establish reactivity dependency
+      void state.version;
       return getVizelEditorState(getEditor());
     },
   };

--- a/packages/svelte/src/runes/createVizelMarkdown.svelte.ts
+++ b/packages/svelte/src/runes/createVizelMarkdown.svelte.ts
@@ -18,7 +18,7 @@ export interface CreateVizelMarkdownResult {
    * Current markdown content (reactive getter).
    * Updates with debounce when editor content changes.
    */
-  readonly markdown: string;
+  readonly current: string;
   /**
    * Set markdown content to the editor.
    * Automatically transforms diagram code blocks if transformDiagrams is enabled.
@@ -54,7 +54,7 @@ export interface CreateVizelMarkdownResult {
  *
  * <VizelEditor editor={editorState.current} />
  * <textarea
- *   value={markdownState.markdown}
+ *   value={markdownState.current}
  *   oninput={(e) => markdownState.setMarkdown(e.currentTarget.value)}
  * />
  * {#if markdownState.isPending}
@@ -175,7 +175,7 @@ export function createVizelMarkdown(
   };
 
   return {
-    get markdown() {
+    get current() {
       return markdown;
     },
     setMarkdown,

--- a/packages/svelte/src/runes/createVizelState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelState.svelte.ts
@@ -7,20 +7,27 @@ import { createVizelEditorTransactionStore, type Editor } from "@vizel/core";
  * subscribe/version-counter mechanics are shared with the React and
  * Vue adapters.
  *
+ * The exposed field is named `version` (not `current`) because the value is
+ * an opaque monotonic counter, not the editor itself. The Svelte editor
+ * accessor (`createVizelEditor().current`) already owns the `current` slot
+ * for the editor instance; this rune sits next to it as a sibling reactive
+ * read, so a distinct name avoids the implication of a "current editor"
+ * dual.
+ *
  * @param getEditor - A function that returns the editor instance
- * @returns An object with a `current` getter for the update count
+ * @returns An object with a `version` getter for the update count
  *
  * @example
  * ```svelte
  * <script lang="ts">
  * const state = createVizelState(() => editor);
- * // Access state.current to trigger reactivity
+ * // Access state.version to trigger reactivity
  * </script>
- * <button class:active={state.current >= 0 && editor.isActive('bold')}>Bold</button>
+ * <button class:active={state.version >= 0 && editor.isActive('bold')}>Bold</button>
  * ```
  */
 export function createVizelState(getEditor: () => Editor | null | undefined): {
-  readonly current: number;
+  readonly version: number;
 } {
   let updateCount = $state(0);
 
@@ -35,7 +42,7 @@ export function createVizelState(getEditor: () => Editor | null | undefined): {
   });
 
   return {
-    get current() {
+    get version() {
       return updateCount;
     },
   };

--- a/packages/svelte/src/runes/getVizelTheme.ts
+++ b/packages/svelte/src/runes/getVizelTheme.ts
@@ -1,11 +1,27 @@
-import type { VizelThemeState } from "@vizel/core";
+import type { VizelResolvedTheme, VizelThemeState } from "@vizel/core";
 import { getContext } from "svelte";
 import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
 
 /**
- * Get theme state and controls from context
+ * Public return shape for `getVizelTheme`.
  *
- * Must be used within a VizelThemeProvider
+ * The flat `{ current, setTheme }` shape mirrors the React hook and Vue
+ * composable. `current` is the currently applied (resolved) theme so a
+ * toggle is a one-liner. `setTheme` accepts only concrete
+ * `VizelResolvedTheme` values because entering "system" mode is the
+ * provider's `defaultTheme` concern, not a runtime toggle.
+ */
+export interface GetVizelThemeResult {
+  /** Currently applied theme (resolved from the user's preference). */
+  readonly current: VizelResolvedTheme;
+  /** Switch the editor theme to a concrete value. */
+  setTheme: (next: VizelResolvedTheme) => void;
+}
+
+/**
+ * Get the editor theme and a setter from context.
+ *
+ * Must be used within a `VizelThemeProvider`.
  *
  * @example
  * ```svelte
@@ -13,24 +29,49 @@ import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
  * const theme = getVizelTheme();
  * </script>
  *
- * <button onclick={() => theme.setTheme(theme.resolvedTheme === 'dark' ? 'light' : 'dark')}>
+ * <button onclick={() => theme.setTheme(theme.current === 'dark' ? 'light' : 'dark')}>
  *   Toggle theme
  * </button>
  * ```
  */
-export function getVizelTheme(): VizelThemeState {
+export function getVizelTheme(): GetVizelThemeResult {
   const context = getContext<VizelThemeState | undefined>(VIZEL_THEME_CONTEXT_KEY);
 
   if (!context) {
     throw new Error("getVizelTheme must be used within a VizelThemeProvider");
   }
 
-  return context;
+  // Surface the resolved theme through the public `current` field. The
+  // underlying `VizelThemeState` keeps `theme` (user setting) and
+  // `resolvedTheme` (applied) separate; v2 collapses both into a single
+  // observable so the toggle pattern stays a one-liner.
+  //
+  // `setTheme` is re-wrapped so the parameter type is physically narrowed
+  // to `VizelResolvedTheme`. The underlying `context.setTheme` accepts the
+  // wider `VizelTheme` (including "system"), and contravariant assignment
+  // would let an `as VizelTheme` cast slip through; the wrapper closes
+  // that hole.
+  return {
+    get current() {
+      return context.resolvedTheme;
+    },
+    setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+  };
 }
 
 /**
- * Get theme state safely (returns null if not in provider)
+ * Get the editor theme safely (returns `null` outside a provider).
+ *
+ * Symmetric with {@link getVizelTheme} — the only difference is whether
+ * the absence of a `VizelThemeProvider` is fatal.
  */
-export function getVizelThemeSafe(): VizelThemeState | null {
-  return getContext<VizelThemeState | undefined>(VIZEL_THEME_CONTEXT_KEY) ?? null;
+export function getVizelThemeSafe(): GetVizelThemeResult | null {
+  const context = getContext<VizelThemeState | undefined>(VIZEL_THEME_CONTEXT_KEY);
+  if (!context) return null;
+  return {
+    get current() {
+      return context.resolvedTheme;
+    },
+    setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+  };
 }

--- a/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
+++ b/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
@@ -15,25 +15,25 @@ const editor = createVizelEditor({
 const actualEditor = $derived(nullEditor ? null : editor.current);
 const editorStateRune = createVizelState(() => actualEditor);
 
-// Depend on editorStateRune.current to trigger re-evaluation when editor state changes
+// Depend on editorStateRune.version to trigger re-evaluation when editor state changes
 const isBoldActive = $derived.by(() => {
-  void editorStateRune.current;
+  void editorStateRune.version;
   return actualEditor?.isActive("bold") ?? false;
 });
 const isItalicActive = $derived.by(() => {
-  void editorStateRune.current;
+  void editorStateRune.version;
   return actualEditor?.isActive("italic") ?? false;
 });
 
 // Use getVizelEditorState to get full state including character/word counts
 const fullEditorState = $derived.by(() => {
-  void editorStateRune.current;
+  void editorStateRune.version;
   return getVizelEditorState(actualEditor);
 });
 </script>
 
 <VizelProvider editor={actualEditor}>
-  <div data-testid="update-count">{editorStateRune.current}</div>
+  <div data-testid="update-count">{editorStateRune.version}</div>
   <div data-testid="bold-active">{String(isBoldActive)}</div>
   <div data-testid="italic-active">{String(isItalicActive)}</div>
   <div data-testid="character-count">{fullEditorState.characterCount}</div>

--- a/tests/ct/svelte/specs/ThemeContent.svelte
+++ b/tests/ct/svelte/specs/ThemeContent.svelte
@@ -4,12 +4,18 @@ import { getVizelTheme } from "@vizel/svelte";
 const themeState = getVizelTheme();
 
 function toggleTheme() {
-  themeState.setTheme(themeState.resolvedTheme === "dark" ? "light" : "dark");
+  themeState.setTheme(themeState.current === "dark" ? "light" : "dark");
 }
 </script>
 
+<!--
+  The v2 rune collapses `theme` (user setting) and `resolvedTheme` (applied)
+  into a single resolved value. Render the same source under both legacy
+  testids so existing scenarios keep passing without depending on the
+  removed `VizelThemeState` shape.
+-->
 <div data-testid="theme-content">
-  <span data-testid="current-theme">{themeState.theme}</span>
-  <span data-testid="resolved-theme">{themeState.resolvedTheme}</span>
+  <span data-testid="current-theme">{themeState.current}</span>
+  <span data-testid="resolved-theme">{themeState.current}</span>
   <button type="button" data-testid="toggle-theme" onclick={toggleTheme}>Toggle</button>
 </div>

--- a/tests/ct/svelte/specs/VizelRefStateFixture.svelte
+++ b/tests/ct/svelte/specs/VizelRefStateFixture.svelte
@@ -16,9 +16,9 @@ let editor = $state<Editor | null>(null);
 // The updateCount changes on every editor transaction
 const updateCount = createVizelState(() => editor);
 
-// Use $derived.by to access updateCount.current and create dependency
+// Use $derived.by to access updateCount.version and create dependency
 const editorState = $derived.by(() => {
-  void updateCount.current; // Create dependency on updateCount
+  void updateCount.version; // Create dependency on updateCount
   return getVizelEditorState(editor);
 });
 


### PR DESCRIPTION
## Summary

Migrates the Svelte rune layer to the Option B (idiom-respecting) return types defined in Section 4 of the v2.0.0 spec. Consumer extras (`setMarkdown`, `isPending`, `hasUnsavedChanges`, `error`, `save`, `restore`) are preserved exactly as today — only field names / shapes change.

This is **PR 4d** of four — the final PR in Section 4. PR 4b (Vue, #460) and PR 4c (React, #461) merged earlier.

## Breaking changes

| Rune | Pre | Post |
|------|-----|------|
| `createVizelState` | `{ readonly current: number }` | `{ readonly version: number }` |
| `createVizelMarkdown` | `{ readonly markdown: string; setMarkdown; readonly isPending; flush }` | `{ readonly current: string; setMarkdown; readonly isPending; flush }` |
| `getVizelTheme` | full `VizelThemeState` | `{ readonly current: VizelResolvedTheme; setTheme: (next: VizelResolvedTheme) => void }` |

Unchanged (already matched spec): `createVizelEditor`, `createVizelEditorState`, `createVizelAutoSave`, `getVizelContext`.

Setting "system" theme at runtime through `getVizelTheme().setTheme(...)` is no longer possible — `VizelThemeProvider`'s `defaultTheme` prop handles the system mode. Mirrors the React/Vue PRs.

## Why rename fields?

- **`createVizelState`'s tick getter is now `version`** to distinguish the monotonic transaction counter from the editor-instance accessor (`current`) used elsewhere. The previous shared name caused confusion when both runes were used in the same component.
- **`createVizelMarkdown`'s value getter is now `current`** for consistency with every other rune in the package (`getVizelContext`, `getVizelTheme`, `createVizelEditorState`). Reading `.current` on a Vizel rune always returns its primary value.

## Defense-in-depth `setTheme` narrowing

`getVizelTheme` (and `getVizelThemeSafe`) wraps the underlying setter: `setTheme: (next: VizelResolvedTheme) => context.setTheme(next)`. The underlying provider's setter accepts the wider `VizelTheme` (including `"system"`); the wrapper makes the public narrowing structural rather than nominal. Same pattern as PRs 4b/4c.

## Internal consumers updated

`VizelBubbleMenuDefault.svelte`, `VizelNodeSelector.svelte`, `VizelToolbarDefault.svelte`, `createVizelEditorState.svelte.ts` — all read `editorState.version` (was `.current`).

## Doc updates

- `.claude/rules/packages/svelte.md` — `getVizelContext` example fixed (was destructuring `{ editor }`, which never matched the actual `{ readonly current }` shape).

## Caller updates

| File | Change |
|------|--------|
| `apps/demo/svelte/src/ThemeToggle.svelte` | Read `themeState.current` / `themeState.setTheme(...)`. |
| `tests/ct/svelte/specs/ThemeContent.svelte` | Read `.current`; both `current-theme` and `resolved-theme` data-testid spans render the same value. |
| `tests/ct/svelte/specs/{CreateEditorStateFixture,VizelRefStateFixture}.svelte` | Read `.version` (was `.current`). |

## Test Plan

- [x] `pnpm typecheck` passes across all four packages (504 Svelte files, 0 errors).
- [x] `pnpm lint` passes (3 pre-existing warnings unrelated).
- [x] `pnpm test:ct:svelte` — chromium passes 270/270.
- [ ] CI runs `pnpm test:ct` across all browsers for all 3 frameworks.

## Section 4 closes with this PR

After 4d merges, the Option B (idiom-respecting) return-type symmetry is complete across React, Vue, and Svelte. Every public hook / composable / rune now matches the [spec's Section 4 table](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#4-return-type-symmetry--option-b-idiom-respecting).

Spec: [Section 4](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#4-return-type-symmetry--option-b-idiom-respecting). Plan: [Section 4 sub-plan](../tree/main/docs/superpowers/plans/2026-05-16-vizel-v2-section-04-return-types.md).
