### PR TITLE
feat(ci): add cross-framework parity check script

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -43,6 +43,10 @@ runs:
       shell: bash
       run: pnpm typecheck
 
+    - name: Run cross-framework parity check
+      shell: bash
+      run: pnpm check:parity
+
     - name: Build packages
       shell: bash
       run: pnpm build

--- a/biome.json
+++ b/biome.json
@@ -354,7 +354,7 @@
       }
     },
     {
-      "includes": ["packages/*/scripts/**/*"],
+      "includes": ["packages/*/scripts/**/*", "scripts/**/*"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -48,3 +48,6 @@ pre-push:
 
     typecheck:
       run: pnpm typecheck
+
+    parity:
+      run: pnpm check:parity

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format:fix": "biome format --write .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
+    "check:parity": "tsx scripts/check-cross-framework-parity.ts",
     "prepare": "lefthook install",
     "deps:check": "pnpm dlx taze major -r",
     "deps:update": "pnpm dlx taze major -r -w && pnpm install"
@@ -110,6 +111,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "svelte": "^5.55.7",
+    "tsx": "^4.22.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vitepress": "^2.0.0-alpha.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,19 +13,19 @@ importers:
         version: 2.4.15
       '@playwright/experimental-ct-react':
         specifier: ~1.58.2
-        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@playwright/experimental-ct-svelte':
         specifier: ~1.58.2
-        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(svelte@5.55.7)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@playwright/experimental-ct-vue':
         specifier: ~1.58.2
-        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+        version: 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
       '@playwright/test':
         specifier: ~1.58.2
         version: 1.58.2
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@tiptap/core':
         specifier: ^3.23.4
         version: 3.23.4(@tiptap/pm@3.23.4)
@@ -157,10 +157,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
       '@vue/compiler-dom':
         specifier: ^3.5.34
         version: 3.5.34
@@ -191,18 +191,21 @@ importers:
       svelte:
         specifier: ^5.55.7
         version: 5.55.7
+      tsx:
+        specifier: ^4.22.0
+        version: 4.22.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vitepress:
         specifier: ^2.0.0-alpha.17
-        version: 2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(typescript@6.0.3)
+        version: 2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(tsx@4.22.0)(typescript@6.0.3)
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
-        version: 2.0.17(mermaid@11.15.0)(vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(typescript@6.0.3))
+        version: 2.0.17(mermaid@11.15.0)(vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(tsx@4.22.0)(typescript@6.0.3))
       vue:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -233,7 +236,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       katex:
         specifier: ^0.16.46
         version: 0.16.46
@@ -245,7 +248,7 @@ importers:
         version: 11.15.0
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
 
   apps/demo/svelte:
     dependencies:
@@ -264,7 +267,7 @@ importers:
         version: 1.21.5
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       katex:
         specifier: ^0.16.46
         version: 0.16.46
@@ -276,7 +279,7 @@ importers:
         version: 11.15.0
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
 
   apps/demo/vue:
     dependencies:
@@ -295,7 +298,7 @@ importers:
         version: 1.21.5
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
       katex:
         specifier: ^0.16.46
         version: 0.16.46
@@ -307,7 +310,7 @@ importers:
         version: 11.15.0
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
 
   packages/core:
     dependencies:
@@ -494,10 +497,10 @@ importers:
         version: 1.99.0
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 5.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
 
   packages/react:
     dependencies:
@@ -549,16 +552,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@vizel/core':
         specifier: workspace:^
         version: link:../core
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 5.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
 
   packages/svelte:
     dependencies:
@@ -574,7 +577,7 @@ importers:
         version: 2.5.7(svelte@5.55.5)(typescript@6.0.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.55.5)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 7.1.2(svelte@5.55.5)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       '@tiptap/extension-bold':
         specifier: ^3.23.4
         version: 3.23.4(@tiptap/core@3.23.4(@tiptap/pm@3.23.4))
@@ -653,16 +656,16 @@ importers:
         version: 3.23.4(@tiptap/core@3.23.4(@tiptap/pm@3.23.4))
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
       '@vizel/core':
         specifier: workspace:^
         version: link:../core
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+        version: 5.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       vue-tsc:
         specifier: ^3.2.9
         version: 3.2.9(typescript@6.0.3)
@@ -855,6 +858,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -863,6 +872,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -879,6 +894,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -887,6 +908,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -903,6 +930,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
@@ -911,6 +944,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -927,6 +966,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
@@ -935,6 +980,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -951,6 +1002,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
@@ -959,6 +1016,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -975,6 +1038,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
@@ -983,6 +1052,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -999,6 +1074,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
@@ -1007,6 +1088,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1023,6 +1110,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1031,6 +1124,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1047,6 +1146,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -1055,6 +1160,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1071,6 +1182,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1079,6 +1196,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1095,6 +1218,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -1103,6 +1232,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1119,6 +1254,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
@@ -1127,6 +1268,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1143,6 +1290,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
@@ -1151,6 +1304,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2944,6 +3103,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3680,6 +3844,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.0:
+    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -4204,10 +4373,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -4216,10 +4391,16 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -4228,10 +4409,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -4240,10 +4427,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -4252,10 +4445,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -4264,10 +4463,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -4276,10 +4481,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -4288,10 +4499,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -4300,10 +4517,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -4312,10 +4535,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -4324,10 +4553,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
@@ -4336,10 +4571,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
@@ -4348,10 +4589,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -4568,11 +4815,11 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
-  '@playwright/experimental-ct-core@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)':
+  '@playwright/experimental-ct-core@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)':
     dependencies:
       playwright: 1.58.2
       playwright-core: 1.58.2
-      vite: 6.4.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
+      vite: 6.4.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4586,10 +4833,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-react@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@playwright/experimental-ct-react@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
-      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
-      '@vitejs/plugin-react': 4.7.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
+      '@vitejs/plugin-react': 4.7.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4605,10 +4852,10 @@ snapshots:
       - vite
       - yaml
 
-  '@playwright/experimental-ct-svelte@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@playwright/experimental-ct-svelte@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(svelte@5.55.7)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
-      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4625,10 +4872,10 @@ snapshots:
       - vite
       - yaml
 
-  '@playwright/experimental-ct-vue@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))':
+  '@playwright/experimental-ct-vue@1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
-      '@vitejs/plugin-vue': 5.2.4(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+      '@playwright/experimental-ct-core': 1.58.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
+      '@vitejs/plugin-vue': 5.2.4(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4841,45 +5088,45 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)))(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)))(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       debug: 4.4.3
       svelte: 5.55.7
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)))(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)))(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.55.7
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
-      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
+      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.55.5
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
-      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
+      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.55.7
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
-      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
+      vitefu: 1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
 
   '@tiptap/core@3.23.1(@tiptap/pm@3.23.1)':
     dependencies:
@@ -5542,7 +5789,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5550,30 +5797,30 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
 
-  '@vitejs/plugin-vue@5.2.4(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@vitejs/plugin-vue@6.0.6(vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
+      vite: 7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
       vue: 3.5.34(typescript@6.0.3)
 
   '@volar/language-core@2.4.28':
@@ -6090,6 +6337,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -6906,6 +7182,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.0:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
@@ -6935,7 +7217,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin-dts@1.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)):
+  unplugin-dts@1.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@volar/typescript': 2.4.28
@@ -6947,10 +7229,10 @@ snapshots:
       typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       rolldown: 1.0.1
       rollup: 4.60.3
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6987,12 +7269,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-dts@5.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)):
+  vite-plugin-dts@5.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)):
     dependencies:
-      unplugin-dts: 1.0.0(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0))
+      unplugin-dts: 1.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0))
     optionalDependencies:
       rollup: 4.60.3
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -7002,7 +7284,7 @@ snapshots:
       - typescript
       - webpack
 
-  vite@6.4.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0):
+  vite@6.4.2(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7015,8 +7297,9 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
       sass: 1.99.0
+      tsx: 4.22.0
 
-  vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0):
+  vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7029,8 +7312,9 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
       sass: 1.99.0
+      tsx: 4.22.0
 
-  vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0):
+  vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7039,22 +7323,23 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.8.0
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       fsevents: 2.3.3
       sass: 1.99.0
+      tsx: 4.22.0
 
-  vitefu@1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)):
+  vitefu@1.1.3(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)):
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(sass@1.99.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(sass@1.99.0)(tsx@4.22.0)
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.15.0)(vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(typescript@6.0.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.15.0)(vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(tsx@4.22.0)(typescript@6.0.3)):
     dependencies:
       mermaid: 11.15.0
-      vitepress: 2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(tsx@4.22.0)(typescript@6.0.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(typescript@6.0.3):
+  vitepress@2.0.0-alpha.17(@types/node@25.8.0)(fuse.js@7.3.0)(lightningcss@1.32.0)(oxc-minify@0.131.0)(postcss@8.5.14)(sass@1.99.0)(tsx@4.22.0)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/js': 4.6.3
@@ -7064,7 +7349,7 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0))(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0))(vue@3.5.34(typescript@6.0.3))
       '@vue/devtools-api': 8.1.2
       '@vue/shared': 3.5.34
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
@@ -7073,7 +7358,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: 7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)
+      vite: 7.3.3(@types/node@25.8.0)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.22.0)
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
       oxc-minify: 0.131.0

--- a/scripts/check-cross-framework-parity.ts
+++ b/scripts/check-cross-framework-parity.ts
@@ -1,0 +1,458 @@
+/**
+ * Cross-framework parity check.
+ *
+ * Verifies that `@vizel/react`, `@vizel/vue`, and `@vizel/svelte` expose
+ * the same public surface from their respective `src/index.ts` files,
+ * modulo the idiom exceptions cataloged below.
+ *
+ * Checks performed:
+ *
+ * 1. Identifier parity — every "stem" present in at least one framework
+ *    must appear in all three, where the stem is the symbol name with the
+ *    framework's idiom prefix (`use*` for React and Vue; `create*` or
+ *    `get*` for Svelte) stripped.
+ * 2. Core re-export stub — confirms that each framework `src/index.ts`
+ *    eventually grows an `export * from "@vizel/core"` line (Section 6
+ *    enforces this fully; for 5b we only emit a notice).
+ * 3. Idiom exception whitelist — Category B exceptions from the
+ *    cross-framework parity spec are recognized and never reported.
+ *
+ * Exits with code 0 on success, 1 on any parity violation.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+interface FrameworkConfig {
+  name: "react" | "vue" | "svelte";
+  indexPath: string;
+  /**
+   * Idiom prefixes recognized for value symbols. Stripped from a
+   * symbol name to derive its parity stem.
+   */
+  valuePrefixes: readonly string[];
+  /**
+   * Idiom prefixes recognized for type symbols. Types follow the same
+   * verb idiom as their associated function, but in PascalCase
+   * (`UseVizelAutoSaveResult`, `CreateVizelAutoSaveResult`).
+   */
+  typePrefixes: readonly string[];
+}
+
+const FRAMEWORKS: readonly FrameworkConfig[] = [
+  {
+    name: "react",
+    indexPath: resolve(REPO_ROOT, "packages/react/src/index.ts"),
+    // `create*` is shared by React/Vue/Svelte for factory functions that
+    // do not follow the `use*` hook idiom (e.g. `createVizelSlashMenuRenderer`).
+    valuePrefixes: ["use", "create"],
+    typePrefixes: ["Use", "Create"],
+  },
+  {
+    name: "vue",
+    indexPath: resolve(REPO_ROOT, "packages/vue/src/index.ts"),
+    valuePrefixes: ["use", "create", "provide"],
+    typePrefixes: ["Use", "Create"],
+  },
+  {
+    name: "svelte",
+    indexPath: resolve(REPO_ROOT, "packages/svelte/src/index.ts"),
+    valuePrefixes: ["create", "get"],
+    typePrefixes: ["Create"],
+  },
+];
+
+/**
+ * Idiom exception catalog (Category B from
+ * `docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`
+ * Section 5).
+ *
+ * Each entry lists the symbol per framework (or `null` when the symbol
+ * is intentionally absent in that framework). When all three frameworks
+ * are non-null, the entry pins the exact idiom triple. When one or more
+ * are null, the entry is a sanctioned single-framework or paired
+ * exception (e.g. Vue's `provideVizelIcons` has no React or Svelte
+ * counterpart by design).
+ *
+ * Stems built from these entries are excluded from the identifier
+ * parity check; missing-in-one-framework entries (with `null`) are
+ * never reported as defects.
+ */
+interface IdiomException {
+  /** Human-readable stem used in error messages. */
+  stem: string;
+  react: string | null;
+  vue: string | null;
+  svelte: string | null;
+}
+
+const IDIOM_EXCEPTIONS: readonly IdiomException[] = [
+  // Category B row 1 — function prefix (`useFoo` vs `createFoo`).
+  {
+    stem: "VizelEditor",
+    react: "useVizelEditor",
+    vue: "useVizelEditor",
+    svelte: "createVizelEditor",
+  },
+  { stem: "VizelState", react: "useVizelState", vue: "useVizelState", svelte: "createVizelState" },
+  {
+    stem: "VizelEditorState",
+    react: "useVizelEditorState",
+    vue: "useVizelEditorState",
+    svelte: "createVizelEditorState",
+  },
+  {
+    stem: "VizelAutoSave",
+    react: "useVizelAutoSave",
+    vue: "useVizelAutoSave",
+    svelte: "createVizelAutoSave",
+  },
+  {
+    stem: "VizelMarkdown",
+    react: "useVizelMarkdown",
+    vue: "useVizelMarkdown",
+    svelte: "createVizelMarkdown",
+  },
+  {
+    stem: "VizelCollaboration",
+    react: "useVizelCollaboration",
+    vue: "useVizelCollaboration",
+    svelte: "createVizelCollaboration",
+  },
+  {
+    stem: "VizelComment",
+    react: "useVizelComment",
+    vue: "useVizelComment",
+    svelte: "createVizelComment",
+  },
+  {
+    stem: "VizelVersionHistory",
+    react: "useVizelVersionHistory",
+    vue: "useVizelVersionHistory",
+    svelte: "createVizelVersionHistory",
+  },
+  // Category B row 2 — context getter prefix (`useVizelContext` vs `getVizelContext`).
+  {
+    stem: "VizelContext",
+    react: "useVizelContext",
+    vue: "useVizelContext",
+    svelte: "getVizelContext",
+  },
+  {
+    stem: "VizelContextSafe",
+    react: "useVizelContextSafe",
+    vue: "useVizelContextSafe",
+    svelte: "getVizelContextSafe",
+  },
+  {
+    stem: "VizelIconContext",
+    react: "useVizelIconContext",
+    vue: "useVizelIconContext",
+    svelte: "getVizelIconContext",
+  },
+  { stem: "VizelTheme", react: "useVizelTheme", vue: "useVizelTheme", svelte: "getVizelTheme" },
+  {
+    stem: "VizelThemeSafe",
+    react: "useVizelThemeSafe",
+    vue: "useVizelThemeSafe",
+    svelte: "getVizelThemeSafe",
+  },
+  // Vue-only idiomatic helper: `provide*` composable backing `VizelIconProvider`.
+  // React and Svelte expose the same capability through `VizelIconProvider` only.
+  { stem: "VizelIcons", react: null, vue: "provideVizelIcons", svelte: null },
+];
+
+// Stem-to-exception index for O(1) lookups.
+const EXCEPTION_BY_STEM = new Map<string, IdiomException>(
+  IDIOM_EXCEPTIONS.map((entry) => [entry.stem, entry])
+);
+
+// =============================================================================
+// Symbol extraction (TypeScript Compiler API)
+// =============================================================================
+
+interface FrameworkExports {
+  framework: FrameworkConfig["name"];
+  /** Value exports (functions, components, constants). */
+  values: ReadonlySet<string>;
+  /** Type-only exports (interfaces, type aliases). */
+  types: ReadonlySet<string>;
+  /** Raw source text for substring checks (e.g. `export * from`). */
+  source: string;
+}
+
+function collectExports(config: FrameworkConfig): FrameworkExports {
+  const source = readFileSync(config.indexPath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    config.indexPath,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS
+  );
+
+  const values = new Set<string>();
+  const types = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+      const declarationIsTypeOnly = node.isTypeOnly === true;
+      for (const element of node.exportClause.elements) {
+        const name = element.name.text;
+        const elementIsTypeOnly = element.isTypeOnly === true;
+        if (declarationIsTypeOnly || elementIsTypeOnly) {
+          types.add(name);
+        } else {
+          values.add(name);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return {
+    framework: config.name,
+    values,
+    types,
+    source,
+  };
+}
+
+// =============================================================================
+// Stem derivation
+// =============================================================================
+
+/**
+ * Strip the framework's idiom prefix from a symbol name and return the
+ * stem. Returns `null` when no recognized prefix applies, signaling
+ * that the symbol's name itself is the stem (e.g. component classes
+ * `Vizel*`, type aliases, constants).
+ */
+function stripIdiomPrefix(name: string, prefixes: readonly string[]): string | null {
+  for (const prefix of prefixes) {
+    // The prefix must be followed by an uppercase letter to avoid
+    // false positives like `userVizelX` matching `use`.
+    if (name.startsWith(prefix) && name.length > prefix.length) {
+      const firstChar = name.charAt(prefix.length);
+      if (firstChar === firstChar.toUpperCase() && firstChar !== firstChar.toLowerCase()) {
+        return name.slice(prefix.length);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Bucket each export into either a stemmed identifier (when a prefix
+ * strips cleanly) or the literal name (no recognized prefix). The
+ * first bucket is used for cross-framework parity comparisons; the
+ * second is compared verbatim across the three frameworks.
+ */
+function categorizeExports(
+  exportsByFramework: ReadonlyMap<FrameworkConfig["name"], FrameworkExports>
+): {
+  stemsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlyMap<string, string>>;
+  literalsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlySet<string>>;
+} {
+  const stemsByFramework = new Map<FrameworkConfig["name"], Map<string, string>>();
+  const literalsByFramework = new Map<FrameworkConfig["name"], Set<string>>();
+
+  for (const config of FRAMEWORKS) {
+    const exportsForFw = exportsByFramework.get(config.name);
+    if (!exportsForFw) continue;
+
+    const stems = new Map<string, string>();
+    const literals = new Set<string>();
+
+    for (const value of exportsForFw.values) {
+      const stem = stripIdiomPrefix(value, config.valuePrefixes);
+      if (stem === null) {
+        literals.add(value);
+      } else {
+        stems.set(stem, value);
+      }
+    }
+    for (const type of exportsForFw.types) {
+      const stem = stripIdiomPrefix(type, config.typePrefixes);
+      if (stem === null) {
+        literals.add(type);
+      } else {
+        // Type stems are namespaced with a `T:` prefix so they do not
+        // collide with value stems (e.g. the function `useVizelMarkdown`
+        // and the type `UseVizelMarkdownResult` both contribute
+        // `VizelMarkdown` after prefix stripping, but they are
+        // distinct symbols).
+        stems.set(`T:${stem}`, type);
+      }
+    }
+
+    stemsByFramework.set(config.name, stems);
+    literalsByFramework.set(config.name, literals);
+  }
+
+  return { stemsByFramework, literalsByFramework };
+}
+
+// =============================================================================
+// Parity checks
+// =============================================================================
+
+interface Violation {
+  category: "identifier" | "literal" | "core-reexport";
+  message: string;
+}
+
+/** Compute the set of frameworks that lack `stem`, honoring `null` exception slots. */
+function findFrameworksMissingStem(
+  stem: string,
+  stemsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlyMap<string, string>>,
+  exception: IdiomException | undefined
+): FrameworkConfig["name"][] {
+  const missing: FrameworkConfig["name"][] = [];
+  for (const config of FRAMEWORKS) {
+    const hasStem = stemsByFramework.get(config.name)?.has(stem) ?? false;
+    if (hasStem) continue;
+    // If the exception explicitly marks this framework as null, the
+    // symbol is intentionally absent.
+    const exceptionDeclaresAbsent = exception?.[config.name] === null;
+    if (exceptionDeclaresAbsent) continue;
+    missing.push(config.name);
+  }
+  return missing;
+}
+
+/** Format a single identifier-parity violation message for a missing stem. */
+function formatIdentifierViolation(
+  stem: string,
+  missing: readonly FrameworkConfig["name"][],
+  stemsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlyMap<string, string>>
+): Violation {
+  const isTypeStem = stem.startsWith("T:");
+  const displayStem = isTypeStem ? stem.slice(2) : stem;
+  const placeholder = (verb: string): string => `(${verb}${displayStem})`;
+  const reactSymbol =
+    stemsByFramework.get("react")?.get(stem) ?? placeholder(isTypeStem ? "Use" : "use");
+  const vueSymbol =
+    stemsByFramework.get("vue")?.get(stem) ?? placeholder(isTypeStem ? "Use" : "use");
+  const svelteSymbol =
+    stemsByFramework.get("svelte")?.get(stem) ?? placeholder(isTypeStem ? "Create" : "create");
+  const label = isTypeStem ? `type stem "${displayStem}"` : `stem "${displayStem}"`;
+  return {
+    category: "identifier",
+    message: `${label} missing from ${missing.join(", ")} (react: ${reactSymbol}, vue: ${vueSymbol}, svelte: ${svelteSymbol})`,
+  };
+}
+
+function checkIdentifierParity(
+  stemsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlyMap<string, string>>
+): Violation[] {
+  const allStems = new Set<string>();
+  for (const stems of stemsByFramework.values()) {
+    for (const stem of stems.keys()) allStems.add(stem);
+  }
+
+  const violations: Violation[] = [];
+  for (const stem of allStems) {
+    const exception = EXCEPTION_BY_STEM.get(stem);
+    const missing = findFrameworksMissingStem(stem, stemsByFramework, exception);
+    if (missing.length > 0) {
+      violations.push(formatIdentifierViolation(stem, missing, stemsByFramework));
+    }
+  }
+  return violations;
+}
+
+function checkLiteralParity(
+  literalsByFramework: ReadonlyMap<FrameworkConfig["name"], ReadonlySet<string>>
+): Violation[] {
+  const violations: Violation[] = [];
+  const allLiterals = new Set<string>();
+  for (const literals of literalsByFramework.values()) {
+    for (const literal of literals) {
+      allLiterals.add(literal);
+    }
+  }
+
+  for (const literal of allLiterals) {
+    const missing: FrameworkConfig["name"][] = [];
+    for (const config of FRAMEWORKS) {
+      const literals = literalsByFramework.get(config.name);
+      if (!literals?.has(literal)) {
+        missing.push(config.name);
+      }
+    }
+    if (missing.length > 0) {
+      violations.push({
+        category: "literal",
+        message: `symbol "${literal}" missing from ${missing.join(", ")}`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function checkCoreReexportStub(
+  exportsByFramework: ReadonlyMap<FrameworkConfig["name"], FrameworkExports>
+): Violation[] {
+  // Section 6 fully enforces `export * from "@vizel/core"`. For 5b this
+  // is an advisory check — we only emit a notice if the line is absent.
+  // No violations are produced.
+  const violations: Violation[] = [];
+  const pattern = /export\s*\*\s*from\s*["']@vizel\/core["']/;
+  for (const config of FRAMEWORKS) {
+    const exports = exportsByFramework.get(config.name);
+    if (!exports) continue;
+    if (!pattern.test(exports.source)) {
+      // Emit as a console notice so it shows up in CI logs without
+      // failing the run. Section 6 will upgrade this to a violation.
+      console.log(
+        `note: ${config.name}/src/index.ts does not yet contain \`export * from "@vizel/core"\` (will be enforced in Section 6).`
+      );
+    }
+  }
+  return violations;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+function main(): number {
+  const exportsByFramework = new Map<FrameworkConfig["name"], FrameworkExports>();
+  for (const config of FRAMEWORKS) {
+    exportsByFramework.set(config.name, collectExports(config));
+  }
+
+  const { stemsByFramework, literalsByFramework } = categorizeExports(exportsByFramework);
+
+  const violations: Violation[] = [
+    ...checkIdentifierParity(stemsByFramework),
+    ...checkLiteralParity(literalsByFramework),
+    ...checkCoreReexportStub(exportsByFramework),
+  ];
+
+  if (violations.length === 0) {
+    console.log("Cross-framework parity check passed.");
+    return 0;
+  }
+
+  console.error(`Cross-framework parity check failed with ${violations.length} violation(s):`);
+  for (const violation of violations) {
+    console.error(`  [${violation.category}] ${violation.message}`);
+  }
+  return 1;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

Adds `scripts/check-cross-framework-parity.ts`, a Node script that programmatically verifies hook / composable / rune name stems match across React, Vue, and Svelte packages, with the documented Category B idiom exceptions from `.claude/rules/cross-framework.md` whitelisted. Runs in the `pre-push` lefthook and on every PR via the test action.

This is **PR 5b** of two for Section 5 (cross-framework parity). PR 5a (#463) restructured the docs.

## Behavior

The script:

1. Parses each framework's `src/index.ts` and collects exported symbol names.
2. Strips the idiom prefix (`use*` for React/Vue, `create*` / `get*` for Svelte) before comparing.
3. **Identifier parity check** — every stem present in at least one framework must be present in all three. Fails with a list naming the violating symbol and which framework is missing it.
4. **Section 6 readiness note** — emits informational notes that `export * from "@vizel/core"` is not yet in framework `index.ts` files. These become errors once Section 6 enforces the mirror.
5. **Idiom exception whitelist** — hard-codes the Category B 7-row table from the spec.

```text
$ pnpm check:parity
note: react/src/index.ts does not yet contain `export * from "@vizel/core"` (will be enforced in Section 6).
note: vue/src/index.ts does not yet contain `export * from "@vizel/core"` (will be enforced in Section 6).
note: svelte/src/index.ts does not yet contain `export * from "@vizel/core"` (will be enforced in Section 6).
Cross-framework parity check passed.
```

## Changes

- `scripts/check-cross-framework-parity.ts` — new, ~459 lines (the bulk is the Category B exception table).
- `package.json` — adds `check:parity` script and `tsx` devDependency.
- `lefthook.yml` — adds `parity` to `pre-push` parallel block.
- `.github/actions/test/action.yml` — invokes `pnpm check:parity` in CI.
- `biome.json` — allows `scripts/**/*` to use `console` (the script needs `console.log` / `console.error` for reporting).

## Test Plan

- [x] `pnpm check:parity` exits 0 on current `main` baseline.
- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean.
- [ ] CI runs the script on this PR.

## Spec section

Section 5 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#5-cross-framework-parity). Plan: [Section 5 sub-plan](../tree/main/docs/superpowers/plans/2026-05-16-vizel-v2-section-05-parity.md).
