### PR TITLE
feat: mirror @vizel/core public API from framework packages

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,7 +1,8 @@
-import type { Editor, JSONContent } from "@tiptap/core";
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
+  createVizelFindReplaceExtension,
+  type Editor,
+  type JSONContent,
+  setVizelMarkdown,
   useVizelAutoSave,
   useVizelComment,
   useVizelEditorState,
@@ -9,6 +10,7 @@ import {
   useVizelVersionHistory,
   Vizel,
   VizelFindReplace,
+  type VizelMarkdownFlavor,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/react";

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-import type { Editor, JSONContent } from "@tiptap/core";
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
   createVizelAutoSave,
   createVizelComment,
   createVizelEditorState,
+  createVizelFindReplaceExtension,
   createVizelVersionHistory,
+  type Editor,
+  type JSONContent,
+  setVizelMarkdown,
   Vizel,
   VizelFindReplace,
+  type VizelMarkdownFlavor,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/svelte";

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import type { Editor, JSONContent } from "@tiptap/core";
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { createVizelFindReplaceExtension, setVizelMarkdown } from "@vizel/core";
 import {
+  createVizelFindReplaceExtension,
+  type Editor,
+  type JSONContent,
+  setVizelMarkdown,
   useVizelAutoSave,
   useVizelComment,
   useVizelEditorState,
   useVizelVersionHistory,
   Vizel,
   VizelFindReplace,
+  type VizelMarkdownFlavor,
   VizelSaveIndicator,
   VizelThemeProvider,
 } from "@vizel/vue";

--- a/docs/superpowers/plans/2026-05-16-vizel-v2-section-06-public-api.md
+++ b/docs/superpowers/plans/2026-05-16-vizel-v2-section-06-public-api.md
@@ -1,0 +1,74 @@
+# Section 6: Public API Surface Unification — Implementation Plan
+
+**Goal:** Make `@vizel/{react,vue,svelte}` self-sufficient for consumers. Add `export * from "@vizel/core"` to each framework's `index.ts`. Add Tiptap symbol re-exports. Tighten the parity script to enforce the mirror.
+
+**Architecture:** Three sub-PRs.
+
+- **6a** — Add `export * from "@vizel/core"` to each framework `index.ts`. Add Tiptap type re-exports to `@vizel/core/src/index.ts`. Update existing demo / test code that imported from `@vizel/core` directly (where the import could now resolve from the framework package).
+- **6b** — Tighten `scripts/check-cross-framework-parity.ts` (or split out a `scripts/check-reexport-mirror.ts`). The existing informational note becomes a hard error: every Core public symbol must appear in each framework's runtime exports.
+- **6c** — `package.json` subpath exports for CSS. Section 13 will further refine theming; this PR only declares the subpath exports so `import "@vizel/react/styles.css"` resolves. Defer the actual CSS split (variables.css, components.css) to Section 13.
+
+## Sub-PR 6a — `export *` mirror + Tiptap re-exports
+
+### Task 6a-1 — Add Tiptap type re-exports to `@vizel/core/src/index.ts`
+
+Add at the top of the file (before alphabetical local exports):
+
+```ts
+// Tiptap symbol re-exports — see Section 6 of the v2.0.0 spec.
+export type {
+  ChainedCommands,
+  Editor,
+  Extensions,
+  JSONContent,
+  Range,
+} from "@tiptap/core";
+```
+
+### Task 6a-2 — Add `export * from "@vizel/core"` to each framework `index.ts`
+
+For each of `packages/{react,vue,svelte}/src/index.ts`:
+
+- Insert `export * from "@vizel/core";` as the first export line (after any `"use client"` directive in React).
+- Audit for symbol conflicts: framework packages may locally export a symbol that also lives in Core (e.g. `VizelError`, helpers). Resolve by removing the local re-export of Core symbols.
+
+### Task 6a-3 — Update demo / test imports
+
+Demo apps (`apps/demo/{react,vue,svelte}`) and CT tests (`tests/ct/{react,vue,svelte}`) may import from `@vizel/core` directly. Where the import resolves equally well via the framework package, switch to the framework package for consistency with consumer guidance. Demos should model best practice.
+
+### Task 6a-4 — Open and merge PR 6a.
+
+## Sub-PR 6b — Enforce mirror in CI
+
+### Task 6b-1 — Promote the informational note to a hard error
+
+In `scripts/check-cross-framework-parity.ts`, replace the `note:` print about missing `export * from "@vizel/core"` with an exit-1 failure. Re-run on `main` (after 6a merges) and confirm it exits 0.
+
+### Task 6b-2 — Verify symbol-by-symbol mirror
+
+Extend the script (or add `scripts/check-reexport-mirror.ts`) that:
+
+1. Parses `@vizel/core/src/index.ts` and collects all exported symbols.
+2. Parses each framework's `dist/index.d.ts` (or `src/index.ts` if dist is unbuilt) and confirms every Core symbol is reachable.
+3. Fails with a list of missing symbols per framework.
+
+### Task 6b-3 — Open and merge PR 6b.
+
+## Sub-PR 6c — `package.json` subpath exports
+
+### Task 6c-1 — Add subpath exports to each framework `package.json`
+
+Add `./styles.css` to `exports` in each framework's `package.json`. The actual file may not exist yet at `dist/styles.css` (Section 13 splits CSS) — for 6c, ensure the existing single CSS bundle resolves through `./styles.css`. If consumers currently `import "@vizel/react/dist/styles.css"`, update the docs / demos to use the cleaner `import "@vizel/react/styles.css"`.
+
+### Task 6c-2 — Update demo CSS imports
+
+Each demo's entry file imports CSS — update to use the new subpath.
+
+### Task 6c-3 — Open and merge PR 6c.
+
+## Acceptance Criteria
+
+- Each framework `src/index.ts` starts with `export * from "@vizel/core"`.
+- `@vizel/core/src/index.ts` re-exports the 5 Tiptap types listed in the spec.
+- `scripts/check-cross-framework-parity.ts` fails if the mirror is removed.
+- `import "@vizel/react/styles.css"` resolves through the new subpath export.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,16 @@
 // =============================================================================
 // Tiptap Re-exports (for framework packages)
 // =============================================================================
-export type { Editor, Extensions, JSONContent } from "@tiptap/core";
+// Tiptap symbol re-exports — see Section 6 of the v2.0.0 spec. Consumers
+// can install only one Vizel framework package and import these without
+// adding @tiptap/core to their dependencies.
+export type {
+  ChainedCommands,
+  Editor,
+  Extensions,
+  JSONContent,
+  Range,
+} from "@tiptap/core";
 export { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
 export type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,11 @@ import { initVizelIconRenderer } from "@vizel/core";
 
 initVizelIconRenderer();
 
+// Re-export the full @vizel/core public API so consumers can install only
+// the framework package and import every shared symbol from one place.
+// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+export * from "@vizel/core";
+
 // Components
 export {
   useVizelContext,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -12,6 +12,11 @@ import { initVizelIconRenderer } from "@vizel/core";
 
 initVizelIconRenderer();
 
+// Re-export the full @vizel/core public API so consumers can install only
+// the framework package and import every shared symbol from one place.
+// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+export * from "@vizel/core";
+
 // Components
 export {
   getVizelContext,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -12,6 +12,11 @@ import { initVizelIconRenderer } from "@vizel/core";
 
 initVizelIconRenderer();
 
+// Re-export the full @vizel/core public API so consumers can install only
+// the framework package and import every shared symbol from one place.
+// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+export * from "@vizel/core";
+
 // Components
 export {
   provideVizelIcons,

--- a/tests/ct/react/specs/ColorPickerFixture.tsx
+++ b/tests/ct/react/specs/ColorPickerFixture.tsx
@@ -1,5 +1,9 @@
-import { VIZEL_HIGHLIGHT_COLORS, VIZEL_TEXT_COLORS } from "@vizel/core";
-import { VizelColorPicker, type VizelColorPickerProps } from "@vizel/react";
+import {
+  VIZEL_HIGHLIGHT_COLORS,
+  VIZEL_TEXT_COLORS,
+  VizelColorPicker,
+  type VizelColorPickerProps,
+} from "@vizel/react";
 import { useState } from "react";
 
 interface Props {

--- a/tests/ct/react/specs/MarkdownFixture.tsx
+++ b/tests/ct/react/specs/MarkdownFixture.tsx
@@ -1,5 +1,4 @@
-import { VizelMarkdown } from "@vizel/core";
-import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/react";
+import { useVizelEditor, VizelEditor, VizelMarkdown, VizelProvider } from "@vizel/react";
 import { useState } from "react";
 
 export function MarkdownFixture() {

--- a/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
+++ b/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
@@ -1,5 +1,4 @@
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/react";
+import { useVizelEditor, VizelEditor, type VizelMarkdownFlavor, VizelProvider } from "@vizel/react";
 import { useState } from "react";
 
 export interface MarkdownFlavorsFixtureProps {

--- a/tests/ct/react/specs/PortalFixture.tsx
+++ b/tests/ct/react/specs/PortalFixture.tsx
@@ -1,5 +1,4 @@
-import type { VizelPortalLayer } from "@vizel/core";
-import { VizelPortal } from "@vizel/react";
+import { VizelPortal, type VizelPortalLayer } from "@vizel/react";
 
 interface PortalFixtureProps {
   layer?: VizelPortalLayer;

--- a/tests/ct/react/specs/SaveIndicatorFixture.tsx
+++ b/tests/ct/react/specs/SaveIndicatorFixture.tsx
@@ -1,5 +1,4 @@
-import type { VizelSaveStatus } from "@vizel/core";
-import { VizelSaveIndicator } from "@vizel/react";
+import { VizelSaveIndicator, type VizelSaveStatus } from "@vizel/react";
 
 interface SaveIndicatorFixtureProps {
   status: VizelSaveStatus;

--- a/tests/ct/react/specs/ThemeProviderFixture.tsx
+++ b/tests/ct/react/specs/ThemeProviderFixture.tsx
@@ -1,5 +1,4 @@
-import type { VizelTheme } from "@vizel/core";
-import { useVizelTheme, VizelThemeProvider } from "@vizel/react";
+import { useVizelTheme, type VizelTheme, VizelThemeProvider } from "@vizel/react";
 
 interface ThemeProviderFixtureProps {
   defaultTheme?: VizelTheme;

--- a/tests/ct/react/specs/UseEditorStateFixture.tsx
+++ b/tests/ct/react/specs/UseEditorStateFixture.tsx
@@ -1,5 +1,10 @@
-import { getVizelEditorState } from "@vizel/core";
-import { useVizelEditor, useVizelState, VizelEditor, VizelProvider } from "@vizel/react";
+import {
+  getVizelEditorState,
+  useVizelEditor,
+  useVizelState,
+  VizelEditor,
+  VizelProvider,
+} from "@vizel/react";
 
 interface UseEditorStateFixtureProps {
   nullEditor?: boolean;

--- a/tests/ct/react/specs/UserFlowFixture.tsx
+++ b/tests/ct/react/specs/UserFlowFixture.tsx
@@ -1,9 +1,9 @@
-import { VizelMarkdown } from "@vizel/core";
 import {
   useVizelAutoSave,
   useVizelEditor,
   VizelBubbleMenu,
   VizelEditor,
+  VizelMarkdown,
   VizelProvider,
 } from "@vizel/react";
 import { useState } from "react";

--- a/tests/ct/react/specs/VizelRefStateFixture.tsx
+++ b/tests/ct/react/specs/VizelRefStateFixture.tsx
@@ -1,6 +1,4 @@
-import type { Editor } from "@tiptap/core";
-import { getVizelEditorState } from "@vizel/core";
-import { useVizelState, Vizel } from "@vizel/react";
+import { type Editor, getVizelEditorState, useVizelState, Vizel } from "@vizel/react";
 import { useState } from "react";
 
 interface VizelRefStateFixtureProps {

--- a/tests/ct/scenarios/save-indicator.scenario.ts
+++ b/tests/ct/scenarios/save-indicator.scenario.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
-import type { SaveStatus } from "@vizel/core";
+import type { VizelSaveStatus } from "@vizel/core";
 
 /**
  * Shared test scenarios for SaveIndicator component
@@ -10,7 +10,7 @@ import type { SaveStatus } from "@vizel/core";
  * Test that SaveIndicator renders correctly with each status
  */
 export async function testSaveIndicatorStatuses(
-  mount: (status: SaveStatus) => Promise<Locator>,
+  mount: (status: VizelSaveStatus) => Promise<Locator>,
   _page: Page
 ): Promise<void> {
   // Test 'saved' status

--- a/tests/ct/svelte/specs/ColorPickerFixture.svelte
+++ b/tests/ct/svelte/specs/ColorPickerFixture.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-import { VIZEL_HIGHLIGHT_COLORS, VIZEL_TEXT_COLORS, type VizelColorDefinition } from "@vizel/core";
-import { VizelColorPicker } from "@vizel/svelte";
+import {
+  VIZEL_HIGHLIGHT_COLORS,
+  VIZEL_TEXT_COLORS,
+  type VizelColorDefinition,
+  VizelColorPicker,
+} from "@vizel/svelte";
 
 interface Props {
   colors?: VizelColorDefinition[];

--- a/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
+++ b/tests/ct/svelte/specs/CreateEditorStateFixture.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-import { getVizelEditorState } from "@vizel/core";
-import { createVizelEditor, createVizelState, VizelEditor, VizelProvider } from "@vizel/svelte";
+import {
+  createVizelEditor,
+  createVizelState,
+  getVizelEditorState,
+  VizelEditor,
+  VizelProvider,
+} from "@vizel/svelte";
 
 interface Props {
   nullEditor?: boolean;

--- a/tests/ct/svelte/specs/MarkdownFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFixture.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { VizelMarkdown } from "@vizel/core";
-import { createVizelEditor, VizelEditor, VizelProvider } from "@vizel/svelte";
+import { createVizelEditor, VizelEditor, VizelMarkdown, VizelProvider } from "@vizel/svelte";
 
 let markdownOutput = $state("");
 

--- a/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { createVizelEditor, VizelEditor, VizelProvider } from "@vizel/svelte";
+import {
+  createVizelEditor,
+  VizelEditor,
+  type VizelMarkdownFlavor,
+  VizelProvider,
+} from "@vizel/svelte";
 
 interface Props {
   flavor?: VizelMarkdownFlavor;

--- a/tests/ct/svelte/specs/PortalFixture.svelte
+++ b/tests/ct/svelte/specs/PortalFixture.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import type { PortalLayer } from "@vizel/core";
-import { VizelPortal } from "@vizel/svelte";
+import { VizelPortal, type VizelPortalLayer } from "@vizel/svelte";
 
 interface Props {
-  layer?: PortalLayer;
+  layer?: VizelPortalLayer;
   disabled?: boolean;
   class?: string;
   withOverflowContainer?: boolean;

--- a/tests/ct/svelte/specs/UserFlowFixture.svelte
+++ b/tests/ct/svelte/specs/UserFlowFixture.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import { VizelMarkdown } from "@vizel/core";
 import {
   createVizelAutoSave,
   createVizelEditor,
   VizelBubbleMenu,
   VizelEditor,
+  VizelMarkdown,
   VizelProvider,
 } from "@vizel/svelte";
 

--- a/tests/ct/svelte/specs/VizelRefStateFixture.svelte
+++ b/tests/ct/svelte/specs/VizelRefStateFixture.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import type { Editor } from "@tiptap/core";
-import { getVizelEditorState } from "@vizel/core";
-import { createVizelState, Vizel } from "@vizel/svelte";
+import { createVizelState, type Editor, getVizelEditorState, Vizel } from "@vizel/svelte";
 
 interface Props {
   initialContent?: string;

--- a/tests/ct/vue/specs/ColorPickerFixture.vue
+++ b/tests/ct/vue/specs/ColorPickerFixture.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { VIZEL_HIGHLIGHT_COLORS, VIZEL_TEXT_COLORS, type VizelColorDefinition } from "@vizel/core";
-import { VizelColorPicker } from "@vizel/vue";
+import {
+  VIZEL_HIGHLIGHT_COLORS,
+  VIZEL_TEXT_COLORS,
+  type VizelColorDefinition,
+  VizelColorPicker,
+} from "@vizel/vue";
 import { computed, ref } from "vue";
 
 const props = withDefaults(

--- a/tests/ct/vue/specs/MarkdownFixture.vue
+++ b/tests/ct/vue/specs/MarkdownFixture.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { VizelMarkdown } from "@vizel/core";
-import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/vue";
+import { useVizelEditor, VizelEditor, VizelMarkdown, VizelProvider } from "@vizel/vue";
 import { ref } from "vue";
 
 const markdownOutput = ref("");

--- a/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
+++ b/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { VizelMarkdownFlavor } from "@vizel/core";
-import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/vue";
+import { useVizelEditor, VizelEditor, type VizelMarkdownFlavor, VizelProvider } from "@vizel/vue";
 import { ref } from "vue";
 
 const props = withDefaults(

--- a/tests/ct/vue/specs/PortalFixture.vue
+++ b/tests/ct/vue/specs/PortalFixture.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import type { PortalLayer } from "@vizel/core";
-import { VizelPortal } from "@vizel/vue";
+import { VizelPortal, type VizelPortalLayer } from "@vizel/vue";
 
 interface Props {
-  layer?: PortalLayer;
+  layer?: VizelPortalLayer;
   disabled?: boolean;
   class?: string;
   withOverflowContainer?: boolean;

--- a/tests/ct/vue/specs/UseEditorStateFixture.vue
+++ b/tests/ct/vue/specs/UseEditorStateFixture.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { getVizelEditorState } from "@vizel/core";
-import { useVizelEditor, useVizelState, VizelEditor, VizelProvider } from "@vizel/vue";
+import {
+  getVizelEditorState,
+  useVizelEditor,
+  useVizelState,
+  VizelEditor,
+  VizelProvider,
+} from "@vizel/vue";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/tests/ct/vue/specs/UserFlowFixture.vue
+++ b/tests/ct/vue/specs/UserFlowFixture.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { VizelMarkdown } from "@vizel/core";
 import {
   useVizelAutoSave,
   useVizelEditor,
   VizelBubbleMenu,
   VizelEditor,
+  VizelMarkdown,
   VizelProvider,
 } from "@vizel/vue";
 import { ref } from "vue";

--- a/tests/ct/vue/specs/VizelRefStateFixture.vue
+++ b/tests/ct/vue/specs/VizelRefStateFixture.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { Editor } from "@tiptap/core";
-import { getVizelEditorState } from "@vizel/core";
-import { useVizelState, Vizel } from "@vizel/vue";
+import { type Editor, getVizelEditorState, useVizelState, Vizel } from "@vizel/vue";
 import { computed, shallowRef } from "vue";
 
 interface Props {


### PR DESCRIPTION
## Summary

Makes `@vizel/{react,vue,svelte}` self-sufficient for consumers per Section 6 of the v2.0.0 spec. Adds `export * from "@vizel/core"` to each framework `index.ts` and extends the Tiptap type re-exports in `@vizel/core` to cover the 5 types listed in the spec.

This is **PR 6a** of three for Section 6. PR 6b promotes the parity script's `note:` line about the mirror to a hard error; PR 6c adds `package.json` subpath exports for CSS.

## Changes

### Core re-exports
- `packages/core/src/index.ts` — extends the existing Tiptap re-export block to cover all 5 spec'd types: `ChainedCommands`, `Editor`, `Extensions`, `JSONContent`, `Range`.

### Framework `index.ts` mirror
- `packages/react/src/index.ts` — `export * from "@vizel/core";` as the first export, after the existing `"use client";` directive.
- `packages/vue/src/index.ts` — same.
- `packages/svelte/src/index.ts` — same.

Each carries a `// biome-ignore lint/performance/noReExportAll: spec Section 6` annotation; the manual-list alternative would defeat the mirror invariant.

### Demo / test import migration
Every framework-scoped demo (`apps/demo/{react,vue,svelte}/`) and CT fixture now imports shared symbols from the framework package (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) rather than directly from `@vizel/core`. Framework-agnostic shared modules (`apps/demo/shared/*`, `tests/ct/scenarios/*`) intentionally keep their `@vizel/core` imports.

Two pre-existing broken imports surfaced and were fixed in the same pass:
- `PortalLayer` → `VizelPortalLayer` (Vue and Svelte `PortalFixture`)
- `SaveStatus` → `VizelSaveStatus` (`save-indicator.scenario.ts`)

The previous names were never exported; TypeScript was silently erasing the symbols as missing types.

## Test Plan

- [x] `pnpm typecheck` — clean across all 4 packages.
- [x] `pnpm lint` — 3 pre-existing warnings unrelated.
- [x] `pnpm build` — all 4 packages build successfully. `dist/index.{js,d.ts}` contain `export * from "@vizel/core"` for each framework.
- [x] `pnpm check:parity` — passes cleanly; the three "does not yet contain `export *`" informational notes from PR #464 are now silent.
- [ ] CI.

## Spec section

Section 6 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#6-public-api-surface-unification). Plan: [Section 6 sub-plan](../tree/main/docs/superpowers/plans/2026-05-16-vizel-v2-section-06-public-api.md).
