### PR TITLE
feat: add CSS subpath exports to framework packages

### DIFF
--- a/apps/demo/react/src/entry.tsx
+++ b/apps/demo/react/src/entry.tsx
@@ -1,5 +1,5 @@
-import "@vizel/core/styles.css";
-import "@vizel/core/mathematics.css";
+import "@vizel/react/styles.css";
+import "@vizel/react/mathematics.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 import "./styles.css";

--- a/apps/demo/svelte/src/entry.ts
+++ b/apps/demo/svelte/src/entry.ts
@@ -1,5 +1,5 @@
-import "@vizel/core/styles.css";
-import "@vizel/core/mathematics.css";
+import "@vizel/svelte/styles.css";
+import "@vizel/svelte/mathematics.css";
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./styles.css";

--- a/apps/demo/vue/src/entry.ts
+++ b/apps/demo/vue/src/entry.ts
@@ -1,5 +1,5 @@
-import "@vizel/core/styles.css";
-import "@vizel/core/mathematics.css";
+import "@vizel/vue/styles.css";
+import "@vizel/vue/mathematics.css";
 import { createApp } from "vue";
 import App from "./App.vue";
 import "./styles.css";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,13 +36,16 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css",
+    "./components.css": "./dist/components.css",
+    "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/copy-styles.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/react/scripts/copy-styles.mjs
+++ b/packages/react/scripts/copy-styles.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Post-build step: copy core CSS bundles into this package's dist/.
+ *
+ * The CSS source lives in @vizel/core/src/styles/ and is built into
+ * @vizel/core/dist/*.css. To let consumers write
+ * `import "@vizel/react/styles.css"` instead of pulling from
+ * @vizel/core directly, this script copies the built CSS into
+ * @vizel/react/dist/ where the package.json subpath exports point.
+ */
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, "../dist");
+const coreDistDir = resolve(here, "../../core/dist");
+
+const files = ["styles.css", "components.css", "mathematics.css"];
+
+await mkdir(distDir, { recursive: true });
+
+await Promise.all(
+  files.map(async (name) => {
+    const source = resolve(coreDistDir, name);
+    const target = resolve(distDir, name);
+    await copyFile(source, target);
+    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+  })
+);

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -39,13 +39,16 @@
       "svelte": "./dist/index.js",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css",
+    "./components.css": "./dist/components.css",
+    "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "svelte-package -i src -o dist && node scripts/compile-svelte.mjs",
+    "build": "svelte-package -i src -o dist && node scripts/compile-svelte.mjs && node scripts/copy-styles.mjs",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {

--- a/packages/svelte/scripts/copy-styles.mjs
+++ b/packages/svelte/scripts/copy-styles.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Post-build step: copy core CSS bundles into this package's dist/.
+ *
+ * The CSS source lives in @vizel/core/src/styles/ and is built into
+ * @vizel/core/dist/*.css. To let consumers write
+ * `import "@vizel/svelte/styles.css"` instead of pulling from
+ * @vizel/core directly, this script copies the built CSS into
+ * @vizel/svelte/dist/ where the package.json subpath exports point.
+ */
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, "../dist");
+const coreDistDir = resolve(here, "../../core/dist");
+
+const files = ["styles.css", "components.css", "mathematics.css"];
+
+await mkdir(distDir, { recursive: true });
+
+await Promise.all(
+  files.map(async (name) => {
+    const source = resolve(coreDistDir, name);
+    const target = resolve(distDir, name);
+    await copyFile(source, target);
+    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+  })
+);

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -36,13 +36,16 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css",
+    "./components.css": "./dist/components.css",
+    "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/copy-styles.mjs",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {

--- a/packages/vue/scripts/copy-styles.mjs
+++ b/packages/vue/scripts/copy-styles.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Post-build step: copy core CSS bundles into this package's dist/.
+ *
+ * The CSS source lives in @vizel/core/src/styles/ and is built into
+ * @vizel/core/dist/*.css. To let consumers write
+ * `import "@vizel/vue/styles.css"` instead of pulling from
+ * @vizel/core directly, this script copies the built CSS into
+ * @vizel/vue/dist/ where the package.json subpath exports point.
+ */
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, "../dist");
+const coreDistDir = resolve(here, "../../core/dist");
+
+const files = ["styles.css", "components.css", "mathematics.css"];
+
+await mkdir(distDir, { recursive: true });
+
+await Promise.all(
+  files.map(async (name) => {
+    const source = resolve(coreDistDir, name);
+    const target = resolve(distDir, name);
+    await copyFile(source, target);
+    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+  })
+);


### PR DESCRIPTION
## Summary

Adds `./styles.css`, `./components.css`, and `./mathematics.css` subpath exports to each framework package so consumers can write `import "@vizel/react/styles.css"` (and Vue / Svelte equivalents) instead of pulling CSS directly from `@vizel/core`.

This is **PR 6c** of three for Section 6, closing the section.

## Implementation

Each framework's Vite build does not emit CSS — the CSS source lives in `@vizel/core/src/styles/`. A small Node script (`packages/{react,vue,svelte}/scripts/copy-styles.mjs`) copies the 3 CSS files from `packages/core/dist/` into the framework's own `dist/` after the framework build runs. The framework `build` script chains the copy step:

```json
"build": "vite build && node scripts/copy-styles.mjs"
```

Each framework `package.json` gains:

```json
"./styles.css": "./dist/styles.css",
"./components.css": "./dist/components.css",
"./mathematics.css": "./dist/mathematics.css"
```

## Test Plan

- [x] `pnpm build` succeeds for all 4 packages.
- [x] Each `packages/{react,vue,svelte}/dist/` contains `styles.css`, `components.css`, `mathematics.css` after build.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean (3 pre-existing warnings unrelated).
- [x] Demo entries compile and run with the new subpaths.
- [ ] CI.

## Spec section

Section 6 of [the v2.0.0 design spec](../tree/main/docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md#6-public-api-surface-unification). Plan: [Section 6 sub-plan](../tree/main/docs/superpowers/plans/2026-05-16-vizel-v2-section-06-public-api.md).

After this PR merges, Section 6 closes. Next: Section 8 (Feature option grouping).
