### PR TITLE
feat: group VizelFeatureOptions into content/interaction/collaboration

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -125,6 +125,11 @@ Heading.configure({
 | WikiLink | `extensions/wiki-link.ts` | Wiki-style internal links |
 | Comment | `extensions/comment.ts` | Text annotations and comments |
 
+The following extensions are part of the always-on core and are NOT
+gated by `VizelFeatureOptions`: Markdown, Link, CodeBlock. To configure
+them, use the corresponding top-level options on `VizelEditorOptions`
+(e.g. the Markdown flavor lives at `flavor`, not under `features`).
+
 ## Dependencies
 
 ### Allowed

--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -266,28 +266,33 @@ function AppContent() {
               enableEmbed
               extensions={findReplaceExtensions}
               features={{
-                markdown: true,
-                mathematics: true,
-                embed: true,
-                details: true,
-                diagram: true,
-                wikiLink: true,
-                comment: true,
-                callout: true,
-                tableOfContents: true,
-                superscript: true,
-                subscript: true,
-                typography: true,
-                mention: { items: mockMentionItems },
-                image: {
-                  onUpload: mockUploadImage,
-                  maxFileSize: 10 * 1024 * 1024, // 10MB
-                  onValidationError: (error) => {
-                    alert(`Validation error: ${error.message}`);
+                content: {
+                  mathematics: true,
+                  embed: true,
+                  details: true,
+                  diagram: true,
+                  wikiLink: true,
+                  callout: true,
+                  tableOfContents: true,
+                  superscript: true,
+                  subscript: true,
+                  image: {
+                    onUpload: mockUploadImage,
+                    maxFileSize: 10 * 1024 * 1024, // 10MB
+                    onValidationError: (error) => {
+                      alert(`Validation error: ${error.message}`);
+                    },
+                    onUploadError: (error) => {
+                      alert(`Upload failed: ${error.message}`);
+                    },
                   },
-                  onUploadError: (error) => {
-                    alert(`Upload failed: ${error.message}`);
-                  },
+                },
+                interaction: {
+                  typography: true,
+                  mention: { items: mockMentionItems },
+                },
+                collaboration: {
+                  comments: true,
                 },
               }}
               onCreate={({ editor: newEditor }) => {

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -214,24 +214,29 @@ function handleJsonChange(event: Event) {
           enableEmbed
           extensions={findReplaceExtensions}
           features={{
-            markdown: true,
-            mathematics: true,
-            embed: true,
-            details: true,
-            diagram: true,
-            wikiLink: true,
-            comment: true,
-            callout: true,
-            tableOfContents: true,
-            superscript: true,
-            subscript: true,
-            typography: true,
-            mention: { items: mockMentionItems },
-            image: {
-              onUpload: mockUploadImage,
-              maxFileSize: 10 * 1024 * 1024,
-              onValidationError: (error) => alert(`Validation error: ${error.message}`),
-              onUploadError: (error) => alert(`Upload failed: ${error.message}`),
+            content: {
+              mathematics: true,
+              embed: true,
+              details: true,
+              diagram: true,
+              wikiLink: true,
+              callout: true,
+              tableOfContents: true,
+              superscript: true,
+              subscript: true,
+              image: {
+                onUpload: mockUploadImage,
+                maxFileSize: 10 * 1024 * 1024,
+                onValidationError: (error) => alert(`Validation error: ${error.message}`),
+                onUploadError: (error) => alert(`Upload failed: ${error.message}`),
+              },
+            },
+            interaction: {
+              typography: true,
+              mention: { items: mockMentionItems },
+            },
+            collaboration: {
+              comments: true,
             },
           }}
           onCreate={handleCreate}

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -208,24 +208,29 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
               enable-embed
               :extensions="findReplaceExtensions"
               :features="{
-                markdown: true,
-                mathematics: true,
-                embed: true,
-                details: true,
-                diagram: true,
-                wikiLink: true,
-                comment: true,
-                callout: true,
-                tableOfContents: true,
-                superscript: true,
-                subscript: true,
-                typography: true,
-                mention: { items: mockMentionItems },
-                image: {
-                  onUpload: mockUploadImage,
-                  maxFileSize: 10 * 1024 * 1024,
-                  onValidationError: (error) => alert(`Validation error: ${error.message}`),
-                  onUploadError: (error) => alert(`Upload failed: ${error.message}`),
+                content: {
+                  mathematics: true,
+                  embed: true,
+                  details: true,
+                  diagram: true,
+                  wikiLink: true,
+                  callout: true,
+                  tableOfContents: true,
+                  superscript: true,
+                  subscript: true,
+                  image: {
+                    onUpload: mockUploadImage,
+                    maxFileSize: 10 * 1024 * 1024,
+                    onValidationError: (error) => alert(`Validation error: ${error.message}`),
+                    onUploadError: (error) => alert(`Upload failed: ${error.message}`),
+                  },
+                },
+                interaction: {
+                  typography: true,
+                  mention: { items: mockMentionItems },
+                },
+                collaboration: {
+                  comments: true,
                 },
               }"
               @create="handleCreate"

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -28,7 +28,6 @@ import type { VizelFlavorConfig, VizelMarkdownFlavor } from "../utils/markdown-f
 import { resolveVizelFlavorConfig } from "../utils/markdown-flavors.ts";
 import { createVizelCalloutExtension } from "./callout.ts";
 import { createVizelCharacterCountExtension } from "./character-count.ts";
-import type { VizelCodeBlockOptions } from "./code-block-lowlight.ts";
 import { createVizelCommentExtension } from "./comment.ts";
 import { createVizelDetailsExtensions } from "./details.ts";
 import { createVizelDiagramExtension } from "./diagram.ts";
@@ -109,7 +108,6 @@ function createBaseExtensions(
     Code,
     Italic,
     Strike,
-    Underline,
     // Functionality
     Dropcursor.configure({ color: "#3b82f6", width: 2 }),
     Gapcursor,
@@ -125,12 +123,13 @@ function createBaseExtensions(
 }
 
 /**
- * Add SlashCommand extension if enabled
+ * Add SlashMenu extension if enabled (enabled by default).
  */
-function addSlashCommandExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.slashCommand === false) return;
+function addSlashMenuExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const slashMenu = features.interaction?.slashMenu;
+  if (slashMenu === false) return;
 
-  const slashOptions = typeof features.slashCommand === "object" ? features.slashCommand : {};
+  const slashOptions = typeof slashMenu === "object" ? slashMenu : {};
   const items: VizelSlashCommandItem[] = slashOptions.items ?? vizelDefaultSlashCommands;
 
   extensions.push(
@@ -144,12 +143,13 @@ function addSlashCommandExtension(extensions: Extensions, features: VizelFeature
 }
 
 /**
- * Add Image extension if enabled
+ * Add Image extension if enabled (enabled by default).
  */
 function addImageExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.image === false) return;
+  const image = features.content?.image;
+  if (image === false) return;
 
-  const imageOptions = typeof features.image === "object" ? features.image : {};
+  const imageOptions = typeof image === "object" ? image : {};
   const onUpload = imageOptions.onUpload ?? vizelDefaultBase64Upload;
   const resizeEnabled = imageOptions.resize !== false;
 
@@ -172,104 +172,74 @@ function addImageExtension(extensions: Extensions, features: VizelFeatureOptions
 }
 
 /**
- * Add Markdown extension if enabled (enabled by default)
- */
-function addMarkdownExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.markdown === false) return;
-
-  const markdownOptions = typeof features.markdown === "object" ? features.markdown : {};
-  extensions.push(createVizelMarkdownExtension(markdownOptions));
-}
-
-/**
- * Add Task List extension if enabled
+ * Add Task List extension if enabled (enabled by default).
  */
 function addTaskListExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.taskList === false) return;
+  const taskList = features.content?.taskList;
+  if (taskList === false) return;
 
-  const taskListOptions = typeof features.taskList === "object" ? features.taskList : {};
+  const taskListOptions = typeof taskList === "object" ? taskList : {};
   extensions.push(...createVizelTaskListExtensions(taskListOptions));
 }
 
 /**
- * Add Character Count extension if enabled
+ * Add Character Count extension if enabled (enabled by default).
  */
 function addCharacterCountExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.characterCount === false) return;
+  const characterCount = features.interaction?.characterCount;
+  if (characterCount === false) return;
 
-  const characterCountOptions =
-    typeof features.characterCount === "object" ? features.characterCount : {};
+  const characterCountOptions = typeof characterCount === "object" ? characterCount : {};
   extensions.push(createVizelCharacterCountExtension(characterCountOptions));
 }
 
 /**
- * Add Text Color and Highlight extensions if enabled
+ * Add Text Color and Highlight extensions if enabled (enabled by default).
  */
 function addTextColorExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.textColor === false) return;
+  const textColor = features.content?.textColor;
+  if (textColor === false) return;
 
-  const textColorOptions = typeof features.textColor === "object" ? features.textColor : {};
+  const textColorOptions = typeof textColor === "object" ? textColor : {};
   extensions.push(...createVizelTextColorExtensions(textColorOptions));
 }
 
 /**
- * Add Code Block extension (with or without syntax highlighting).
+ * Add Code Block extension (always-on).
  * Async because lowlight is loaded dynamically as an optional dependency.
  */
-async function addCodeBlockExtension(
-  extensions: Extensions,
-  features: VizelFeatureOptions,
-  locale?: VizelLocale
-): Promise<void> {
-  // If codeBlock is explicitly set to false, don't add any code block extension
-  if (features.codeBlock === false) {
-    return;
-  }
-
-  // Dynamically import to avoid loading lowlight at module evaluation time
+async function addCodeBlockExtension(extensions: Extensions, locale?: VizelLocale): Promise<void> {
   const { createVizelCodeBlockExtension } = await import("./code-block-lowlight.ts");
-
-  // If codeBlock is enabled (true or options object), use syntax highlighting
-  if (features.codeBlock === true || typeof features.codeBlock === "object") {
-    const codeBlockOptions: VizelCodeBlockOptions =
-      typeof features.codeBlock === "object" ? features.codeBlock : {};
-    extensions.push(
-      ...(await createVizelCodeBlockExtension({
-        ...codeBlockOptions,
-        ...(locale !== undefined && { locale }),
-      }))
-    );
-  } else {
-    // Default: use syntax highlighting with default options
-    extensions.push(
-      ...(await createVizelCodeBlockExtension({
-        ...(locale !== undefined && { locale }),
-      }))
-    );
-  }
+  extensions.push(
+    ...(await createVizelCodeBlockExtension({
+      ...(locale !== undefined && { locale }),
+    }))
+  );
 }
 
 /**
- * Add Mathematics extension if enabled (enabled by default)
+ * Add Mathematics extension if enabled (enabled by default).
  */
 function addMathematicsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.mathematics === false) return;
+  const mathematics = features.content?.mathematics;
+  if (mathematics === false) return;
 
-  const mathOptions = typeof features.mathematics === "object" ? features.mathematics : {};
+  const mathOptions = typeof mathematics === "object" ? mathematics : {};
   extensions.push(...createVizelMathematicsExtensions(mathOptions));
 }
 
 /**
- * Add Drag Handle extension if enabled
+ * Add Drag Handle extension if enabled (enabled by default).
  */
 function addDragHandleExtension(
   extensions: Extensions,
   features: VizelFeatureOptions,
   locale?: VizelLocale
 ): void {
-  if (features.dragHandle === false) return;
+  const dragHandle = features.interaction?.dragHandle;
+  if (dragHandle === false) return;
 
-  const dragHandleOptions = typeof features.dragHandle === "object" ? features.dragHandle : {};
+  const dragHandleOptions = typeof dragHandle === "object" ? dragHandle : {};
   extensions.push(
     ...createVizelDragHandleExtensions({
       ...dragHandleOptions,
@@ -279,42 +249,46 @@ function addDragHandleExtension(
 }
 
 /**
- * Add Details extension if enabled (enabled by default)
+ * Add Details extension if enabled (enabled by default).
  */
 function addDetailsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.details === false) return;
+  const details = features.content?.details;
+  if (details === false) return;
 
-  const detailsOptions = typeof features.details === "object" ? features.details : {};
+  const detailsOptions = typeof details === "object" ? details : {};
   extensions.push(...createVizelDetailsExtensions(detailsOptions));
 }
 
 /**
- * Add Embed extension if enabled (enabled by default)
+ * Add Embed extension if enabled (enabled by default).
  */
 function addEmbedExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.embed === false) return;
+  const embed = features.content?.embed;
+  if (embed === false) return;
 
-  const embedOptions = typeof features.embed === "object" ? features.embed : {};
+  const embedOptions = typeof embed === "object" ? embed : {};
   extensions.push(createVizelEmbedExtension(embedOptions));
 }
 
 /**
- * Add Diagram extension if enabled (enabled by default)
+ * Add Diagram extension if enabled (enabled by default).
  */
 function addDiagramExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.diagram === false) return;
+  const diagram = features.content?.diagram;
+  if (diagram === false) return;
 
-  const diagramOptions = typeof features.diagram === "object" ? features.diagram : {};
+  const diagramOptions = typeof diagram === "object" ? diagram : {};
   extensions.push(createVizelDiagramExtension(diagramOptions));
 }
 
 /**
- * Add Table of Contents extension if enabled
+ * Add Table of Contents extension if enabled (enabled by default).
  */
 function addTableOfContentsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (features.tableOfContents === false) return;
+  const tableOfContents = features.content?.tableOfContents;
+  if (tableOfContents === false) return;
 
-  const tocOptions = typeof features.tableOfContents === "object" ? features.tableOfContents : {};
+  const tocOptions = typeof tableOfContents === "object" ? tableOfContents : {};
   extensions.push(createVizelTableOfContentsExtension(tocOptions));
 }
 
@@ -327,9 +301,10 @@ function addWikiLinkExtension(
   features: VizelFeatureOptions,
   flavorConfig: VizelFlavorConfig
 ): void {
-  if (!features.wikiLink) return;
+  const wikiLink = features.content?.wikiLink;
+  if (!wikiLink) return;
 
-  const wikiLinkOptions = typeof features.wikiLink === "object" ? features.wikiLink : {};
+  const wikiLinkOptions = typeof wikiLink === "object" ? wikiLink : {};
   extensions.push(
     createVizelWikiLinkExtension({
       ...wikiLinkOptions,
@@ -347,9 +322,10 @@ function addCalloutExtension(
   features: VizelFeatureOptions,
   flavorConfig: VizelFlavorConfig
 ): void {
-  if (features.callout === false) return;
+  const callout = features.content?.callout;
+  if (callout === false) return;
 
-  const calloutOptions = typeof features.callout === "object" ? features.callout : {};
+  const calloutOptions = typeof callout === "object" ? callout : {};
   extensions.push(
     createVizelCalloutExtension({
       ...calloutOptions,
@@ -359,22 +335,24 @@ function addCalloutExtension(
 }
 
 /**
- * Add Mention extension if enabled (disabled by default)
+ * Add Mention extension if enabled (disabled by default).
  */
 function addMentionExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (!features.mention) return;
+  const mention = features.interaction?.mention;
+  if (!mention) return;
 
-  const mentionOptions = typeof features.mention === "object" ? features.mention : {};
+  const mentionOptions = typeof mention === "object" ? mention : {};
   extensions.push(createVizelMentionExtension(mentionOptions));
 }
 
 /**
- * Add Comment extension if enabled (disabled by default)
+ * Add Comments extension if enabled (disabled by default).
  */
-function addCommentExtension(extensions: Extensions, features: VizelFeatureOptions): void {
-  if (!features.comment) return;
+function addCommentsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const comments = features.collaboration?.comments;
+  if (!comments) return;
 
-  const commentOptions = typeof features.comment === "object" ? features.comment : {};
+  const commentOptions = typeof comments === "object" ? comments : {};
   extensions.push(createVizelCommentExtension(commentOptions));
 }
 
@@ -391,14 +369,18 @@ function addCommentExtension(extensions: Extensions, features: VizelFeatureOptio
  * ```ts
  * const extensions = createVizelExtensions({
  *   features: {
- *     table: false,
- *     slashCommand: false,
- *     mathematics: false,
+ *     content: {
+ *       table: false,
+ *       mathematics: false,
+ *     },
+ *     interaction: {
+ *       slashMenu: false,
+ *     },
  *   },
  * });
  * ```
  *
- * @example Using Markdown support (enabled by default)
+ * @example Using Markdown support (always-on)
  * ```ts
  * const extensions = createVizelExtensions();
  *
@@ -411,12 +393,14 @@ function addCommentExtension(extensions: Extensions, features: VizelFeatureOptio
  * ```ts
  * const extensions = createVizelExtensions({
  *   features: {
- *     image: {
- *       onUpload: async (file) => {
- *         const formData = new FormData();
- *         formData.append('file', file);
- *         const res = await fetch('/api/upload', { method: 'POST', body: formData });
- *         return (await res.json()).url;
+ *     content: {
+ *       image: {
+ *         onUpload: async (file) => {
+ *           const formData = new FormData();
+ *           formData.append('file', file);
+ *           const res = await fetch('/api/upload', { method: 'POST', body: formData });
+ *           return (await res.json()).url;
+ *         },
  *       },
  *     },
  *   },
@@ -435,7 +419,7 @@ export async function createVizelExtensions(
   } = options;
 
   const flavorConfig = resolveVizelFlavorConfig(flavor);
-  const excludeHistory = features.collaboration === true;
+  const excludeHistory = Boolean(features.collaboration?.provider);
 
   const extensions: Extensions = [
     ...createBaseExtensions({ headingLevels, excludeHistory }),
@@ -446,21 +430,20 @@ export async function createVizelExtensions(
     }),
   ];
 
-  // Add optional features (sync)
-  addSlashCommandExtension(extensions, features);
+  // Always-on (no feature flag)
+  extensions.push(createVizelLinkExtension({}));
+  extensions.push(createVizelMarkdownExtension({}));
 
-  if (features.table !== false) {
-    const tableOptions = typeof features.table === "object" ? features.table : {};
+  // Opt-out content
+  const table = features.content?.table;
+  if (table !== false) {
+    const tableOptions = typeof table === "object" ? table : {};
     extensions.push(...createVizelTableExtensions(tableOptions));
   }
 
-  if (features.link !== false) {
-    const linkOptions = typeof features.link === "object" ? features.link : {};
-    extensions.push(createVizelLinkExtension(linkOptions));
-  }
-
+  // Opt-out / opt-in features
+  addSlashMenuExtension(extensions, features);
   addImageExtension(extensions, features);
-  addMarkdownExtension(extensions, features);
   addTaskListExtension(extensions, features);
   addCharacterCountExtension(extensions, features);
   addTextColorExtension(extensions, features);
@@ -473,21 +456,24 @@ export async function createVizelExtensions(
   addTableOfContentsExtension(extensions, features);
   addWikiLinkExtension(extensions, features, flavorConfig);
   addMentionExtension(extensions, features);
-  addCommentExtension(extensions, features);
+  addCommentsExtension(extensions, features);
 
-  // Add typography marks
-  if (features.superscript !== false) {
+  // Marks (default on, opt-out via content.*)
+  if (features.content?.underline !== false) {
+    extensions.push(Underline);
+  }
+  if (features.content?.superscript !== false) {
     extensions.push(Superscript);
   }
-  if (features.subscript !== false) {
+  if (features.content?.subscript !== false) {
     extensions.push(Subscript);
   }
-  if (features.typography !== false) {
+  if (features.interaction?.typography !== false) {
     extensions.push(Typography);
   }
 
-  // Add code block extension (async - lowlight is loaded dynamically)
-  await addCodeBlockExtension(extensions, features, locale);
+  // CodeBlock (always-on, async — lowlight is loaded dynamically)
+  await addCodeBlockExtension(extensions, locale);
 
   return extensions;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,14 +2,11 @@ import type { Editor, Extensions, JSONContent } from "@tiptap/core";
 import type { SuggestionOptions } from "@tiptap/suggestion";
 import type { VizelCalloutOptions } from "./extensions/callout.ts";
 import type { VizelCharacterCountOptions } from "./extensions/character-count.ts";
-import type { VizelCodeBlockOptions } from "./extensions/code-block-lowlight.ts";
 import type { VizelCommentMarkOptions } from "./extensions/comment.ts";
 import type { VizelDetailsOptions } from "./extensions/details.ts";
 import type { VizelDiagramOptions } from "./extensions/diagram.ts";
 import type { VizelDragHandleOptions } from "./extensions/drag-handle.ts";
 import type { VizelEmbedOptions } from "./extensions/embed.ts";
-import type { VizelLinkOptions } from "./extensions/link.ts";
-import type { VizelMarkdownOptions } from "./extensions/markdown.ts";
 import type { VizelMathematicsOptions } from "./extensions/mathematics.ts";
 import type { VizelMentionOptions } from "./extensions/mention.ts";
 import type { VizelSlashCommandItem } from "./extensions/slash-command.ts";
@@ -44,54 +41,76 @@ export interface VizelImageFeatureOptions extends Partial<VizelImageUploadPlugin
 /**
  * Feature configuration for Vizel editor.
  *
- * Each field accepts one of three forms:
+ * Features are grouped into three categories that answer different
+ * consumer questions:
  *
- * - `true` — enable the feature with default options (also the default when
- *   the field is omitted, except for `mention` and `collaboration` which
- *   default to `false`).
+ * - `content` — What can the document contain?
+ * - `interaction` — How does the user edit?
+ * - `collaboration` — Who edits together?
+ *
+ * Each field accepts one of:
+ *
+ * - `true` — enable the feature with default options.
  * - `false` — disable the feature.
- * - an options object — enable the feature with custom options.
+ * - an options object — enable with custom options.
  *
- * The `true`/options-object forms are equivalent in behavior; the latter is
- * preferred when overriding any non-default option.
+ * Always-on core (no opt-in needed): paragraph, heading, list,
+ * blockquote, bold/italic/strike/code marks, hard break, horizontal
+ * rule, link, code block (with lowlight), markdown import/export,
+ * undo/redo. These extensions load regardless of `features`.
  */
 export interface VizelFeatureOptions {
-  /** Slash command menu (type "/" to open) */
-  slashCommand?: VizelSlashCommandOptions | boolean;
-  /** Table support with column/row controls */
-  table?: VizelTableOptions | boolean;
-  /** Link extension with autolink and paste support */
-  link?: VizelLinkOptions | boolean;
+  readonly content?: VizelContentFeatureOptions;
+  readonly interaction?: VizelInteractionFeatureOptions;
+  readonly collaboration?: VizelCollaborationFeatureOptions;
+}
+
+/**
+ * Content features — what the document can contain.
+ */
+export interface VizelContentFeatureOptions {
   /** Image upload and resize */
-  image?: VizelImageFeatureOptions | boolean;
-  /** Markdown import/export support */
-  markdown?: VizelMarkdownOptions | boolean;
-  /** Task list (checkbox) support */
-  taskList?: VizelTaskListExtensionsOptions | boolean;
-  /** Character and word count tracking */
-  characterCount?: VizelCharacterCountOptions | boolean;
-  /** Text color and highlight support */
-  textColor?: VizelTextColorOptions | boolean;
-  /** Code block with syntax highlighting */
-  codeBlock?: VizelCodeBlockOptions | boolean;
+  readonly image?: VizelImageFeatureOptions | boolean;
+  /** Table support with column/row controls */
+  readonly table?: VizelTableOptions | boolean;
   /** Mathematics (LaTeX) support with KaTeX rendering */
-  mathematics?: VizelMathematicsOptions | boolean;
+  readonly mathematics?: VizelMathematicsOptions | boolean;
+  /** Diagram support (Mermaid, GraphViz) */
+  readonly diagram?: VizelDiagramOptions | boolean;
+  /** URL embedding with oEmbed/OGP support */
+  readonly embed?: VizelEmbedOptions | boolean;
+  /** Callout / admonition blocks (info, warning, danger, tip, note) */
+  readonly callout?: VizelCalloutOptions | boolean;
+  /** Collapsible content blocks (accordion) */
+  readonly details?: VizelDetailsOptions | boolean;
+  /** Text color and highlight support */
+  readonly textColor?: VizelTextColorOptions | boolean;
+  /** Underline mark (default-on) */
+  readonly underline?: boolean;
+  /** Superscript mark (e.g., x²) */
+  readonly superscript?: boolean;
+  /** Subscript mark (e.g., H₂O) */
+  readonly subscript?: boolean;
+  /** Task list (checkbox) support */
+  readonly taskList?: VizelTaskListExtensionsOptions | boolean;
+  /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
+  readonly wikiLink?: VizelWikiLinkOptions | boolean;
+  /** Table of Contents block that auto-collects headings */
+  readonly tableOfContents?: VizelTableOfContentsOptions | boolean;
+}
+
+/**
+ * Interaction features — how the user edits.
+ */
+export interface VizelInteractionFeatureOptions {
+  /** Slash command menu (type "/" to open) */
+  readonly slashMenu?: VizelSlashCommandOptions | boolean;
   /**
    * Per-item drag handle for reordering blocks and list items
    * (bullet, ordered, task) at any nesting depth, with Alt+Up/Down
    * keyboard shortcuts.
    */
-  dragHandle?: VizelDragHandleOptions | boolean;
-  /** URL embedding with oEmbed/OGP support */
-  embed?: VizelEmbedOptions | boolean;
-  /** Collapsible content blocks (accordion) */
-  details?: VizelDetailsOptions | boolean;
-  /** Callout / admonition blocks (info, warning, danger, tip, note) */
-  callout?: VizelCalloutOptions | boolean;
-  /** Diagram support (Mermaid, GraphViz) */
-  diagram?: VizelDiagramOptions | boolean;
-  /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
-  wikiLink?: VizelWikiLinkOptions | boolean;
+  readonly dragHandle?: VizelDragHandleOptions | boolean;
   /**
    * @mention autocomplete for user mentions.
    * Disabled by default — requires user-provided items function.
@@ -102,23 +121,26 @@ export interface VizelFeatureOptions {
    * }
    * ```
    */
-  mention?: VizelMentionOptions | boolean;
-  /** Table of Contents block that auto-collects headings */
-  tableOfContents?: VizelTableOfContentsOptions | boolean;
-  /** Comment/annotation marks for collaborative review workflows */
-  comment?: VizelCommentMarkOptions | boolean;
-  /** Superscript mark (e.g., x²) */
-  superscript?: boolean;
-  /** Subscript mark (e.g., H₂O) */
-  subscript?: boolean;
+  readonly mention?: VizelMentionOptions | boolean;
+  /** Character and word count tracking */
+  readonly characterCount?: VizelCharacterCountOptions | boolean;
   /** Typography auto-conversion (smart quotes, em-dashes, ellipsis, etc.) */
-  typography?: boolean;
+  readonly typography?: boolean;
+}
+
+/**
+ * Collaboration features — who edits together.
+ */
+export interface VizelCollaborationFeatureOptions {
+  /** Comment/annotation marks for collaborative review workflows */
+  readonly comments?: VizelCommentMarkOptions | boolean;
   /**
-   * Real-time collaboration mode.
-   * When enabled, the History extension is excluded (Yjs provides its own undo manager).
-   * Users must install and configure Yjs collaboration extensions separately.
+   * Enable collaboration mode. When set (any truthy value), the
+   * History extension is excluded — Yjs provides its own undo
+   * manager. In 8a this is a `boolean`; 8e replaces it with the
+   * structured `VizelCollaborationProvider` type.
    */
-  collaboration?: boolean;
+  readonly provider?: boolean;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,9 +60,12 @@ export interface VizelImageFeatureOptions extends Partial<VizelImageUploadPlugin
  * undo/redo. These extensions load regardless of `features`.
  */
 export interface VizelFeatureOptions {
-  readonly content?: VizelContentFeatureOptions;
-  readonly interaction?: VizelInteractionFeatureOptions;
-  readonly collaboration?: VizelCollaborationFeatureOptions;
+  /** Content features — what the document can contain. */
+  content?: VizelContentFeatureOptions;
+  /** Interaction features — how the user edits. */
+  interaction?: VizelInteractionFeatureOptions;
+  /** Collaboration features — who edits together. */
+  collaboration?: VizelCollaborationFeatureOptions;
 }
 
 /**
@@ -70,33 +73,33 @@ export interface VizelFeatureOptions {
  */
 export interface VizelContentFeatureOptions {
   /** Image upload and resize */
-  readonly image?: VizelImageFeatureOptions | boolean;
+  image?: VizelImageFeatureOptions | boolean;
   /** Table support with column/row controls */
-  readonly table?: VizelTableOptions | boolean;
+  table?: VizelTableOptions | boolean;
   /** Mathematics (LaTeX) support with KaTeX rendering */
-  readonly mathematics?: VizelMathematicsOptions | boolean;
+  mathematics?: VizelMathematicsOptions | boolean;
   /** Diagram support (Mermaid, GraphViz) */
-  readonly diagram?: VizelDiagramOptions | boolean;
+  diagram?: VizelDiagramOptions | boolean;
   /** URL embedding with oEmbed/OGP support */
-  readonly embed?: VizelEmbedOptions | boolean;
+  embed?: VizelEmbedOptions | boolean;
   /** Callout / admonition blocks (info, warning, danger, tip, note) */
-  readonly callout?: VizelCalloutOptions | boolean;
+  callout?: VizelCalloutOptions | boolean;
   /** Collapsible content blocks (accordion) */
-  readonly details?: VizelDetailsOptions | boolean;
+  details?: VizelDetailsOptions | boolean;
   /** Text color and highlight support */
-  readonly textColor?: VizelTextColorOptions | boolean;
+  textColor?: VizelTextColorOptions | boolean;
   /** Underline mark (default-on) */
-  readonly underline?: boolean;
+  underline?: boolean;
   /** Superscript mark (e.g., x²) */
-  readonly superscript?: boolean;
+  superscript?: boolean;
   /** Subscript mark (e.g., H₂O) */
-  readonly subscript?: boolean;
+  subscript?: boolean;
   /** Task list (checkbox) support */
-  readonly taskList?: VizelTaskListExtensionsOptions | boolean;
+  taskList?: VizelTaskListExtensionsOptions | boolean;
   /** Wiki links ([[page-name]], [[page|display text]]) for knowledge base use cases */
-  readonly wikiLink?: VizelWikiLinkOptions | boolean;
+  wikiLink?: VizelWikiLinkOptions | boolean;
   /** Table of Contents block that auto-collects headings */
-  readonly tableOfContents?: VizelTableOfContentsOptions | boolean;
+  tableOfContents?: VizelTableOfContentsOptions | boolean;
 }
 
 /**
@@ -104,13 +107,13 @@ export interface VizelContentFeatureOptions {
  */
 export interface VizelInteractionFeatureOptions {
   /** Slash command menu (type "/" to open) */
-  readonly slashMenu?: VizelSlashCommandOptions | boolean;
+  slashMenu?: VizelSlashCommandOptions | boolean;
   /**
    * Per-item drag handle for reordering blocks and list items
    * (bullet, ordered, task) at any nesting depth, with Alt+Up/Down
    * keyboard shortcuts.
    */
-  readonly dragHandle?: VizelDragHandleOptions | boolean;
+  dragHandle?: VizelDragHandleOptions | boolean;
   /**
    * @mention autocomplete for user mentions.
    * Disabled by default — requires user-provided items function.
@@ -121,11 +124,11 @@ export interface VizelInteractionFeatureOptions {
    * }
    * ```
    */
-  readonly mention?: VizelMentionOptions | boolean;
+  mention?: VizelMentionOptions | boolean;
   /** Character and word count tracking */
-  readonly characterCount?: VizelCharacterCountOptions | boolean;
+  characterCount?: VizelCharacterCountOptions | boolean;
   /** Typography auto-conversion (smart quotes, em-dashes, ellipsis, etc.) */
-  readonly typography?: boolean;
+  typography?: boolean;
 }
 
 /**
@@ -133,14 +136,14 @@ export interface VizelInteractionFeatureOptions {
  */
 export interface VizelCollaborationFeatureOptions {
   /** Comment/annotation marks for collaborative review workflows */
-  readonly comments?: VizelCommentMarkOptions | boolean;
+  comments?: VizelCommentMarkOptions | boolean;
   /**
-   * Enable collaboration mode. When set (any truthy value), the
-   * History extension is excluded — Yjs provides its own undo
-   * manager. In 8a this is a `boolean`; 8e replaces it with the
-   * structured `VizelCollaborationProvider` type.
+   * Enable collaboration mode. When set, the History extension is
+   * excluded — Yjs (or another CRDT provider) supplies its own undo
+   * manager. A future release replaces this `boolean` with a
+   * structured collaboration-provider type.
    */
-  readonly provider?: boolean;
+  provider?: boolean;
 }
 
 /**

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -130,7 +130,7 @@ export async function createVizelEditorInstance(
 
   // Extract image options for event handler registration
   const imageOptions: VizelImageFeatureOptions =
-    typeof features?.image === "object" ? features.image : {};
+    typeof features?.content?.image === "object" ? features.content.image : {};
 
   // Wrap onCreate to handle initialMarkdown. Tiptap's `setContent` resets the
   // selection to the end of the new document and triggers a scroll-into-view,

--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -58,9 +58,9 @@ export interface VizelResolveFeaturesOptions {
 }
 
 /**
- * Resolves feature options with default slash menu renderer.
- * If slashCommand is enabled but no suggestion renderer is provided,
- * automatically adds the provided renderer.
+ * Resolves feature options with a default slash menu renderer.
+ * If `interaction.slashMenu` is enabled but no suggestion renderer is
+ * provided, attaches the supplied default.
  */
 export function resolveVizelFeatures(
   options: VizelResolveFeaturesOptions
@@ -68,31 +68,32 @@ export function resolveVizelFeatures(
   const { features, createSlashMenuRenderer } = options;
 
   if (!features) {
-    // No features specified, use defaults with auto slash menu
     return {
-      slashCommand: {
-        suggestion: createSlashMenuRenderer(),
+      interaction: {
+        slashMenu: { suggestion: createSlashMenuRenderer() },
       },
     };
   }
 
-  if (features.slashCommand === false) {
-    // Slash command explicitly disabled
+  const interaction = features.interaction;
+  if (interaction?.slashMenu === false) {
     return features;
   }
 
-  const slashOptions = typeof features.slashCommand === "object" ? features.slashCommand : {};
+  const slashOptions = typeof interaction?.slashMenu === "object" ? interaction.slashMenu : {};
 
-  // If suggestion is already provided, use it; otherwise add default
   if (slashOptions.suggestion) {
     return features;
   }
 
   return {
     ...features,
-    slashCommand: {
-      ...slashOptions,
-      suggestion: createSlashMenuRenderer(),
+    interaction: {
+      ...interaction,
+      slashMenu: {
+        ...slashOptions,
+        suggestion: createSlashMenuRenderer(),
+      },
     },
   };
 }

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -65,7 +65,7 @@ export function getVizelMarkdown(
     emitVizelError(
       new VizelError(
         "INVALID_EXTENSION",
-        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+        "Markdown extension is not loaded on this editor. Ensure the editor was created with `createVizelExtensions` (Markdown is always-on)."
       ),
       onError
     );
@@ -101,7 +101,7 @@ export function setVizelMarkdown(
     emitVizelError(
       new VizelError(
         "INVALID_EXTENSION",
-        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+        "Markdown extension is not loaded on this editor. Ensure the editor was created with `createVizelExtensions` (Markdown is always-on)."
       ),
       onError
     );
@@ -143,7 +143,7 @@ export function parseVizelMarkdown(
     emitVizelError(
       new VizelError(
         "INVALID_EXTENSION",
-        "Markdown extension is not enabled. Enable it via the `features.markdown` option."
+        "Markdown extension is not loaded on this editor. Ensure the editor was created with `createVizelExtensions` (Markdown is always-on)."
       ),
       onError
     );

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -20,9 +20,11 @@ import { VizelMentionMenu, type VizelMentionMenuRef } from "../components/VizelM
  *
  * const editor = useVizelEditor({
  *   features: {
- *     mention: {
- *       items: async (query) => fetchUsers(query),
- *       suggestion: createVizelMentionMenuRenderer(),
+ *     interaction: {
+ *       mention: {
+ *         items: async (query) => fetchUsers(query),
+ *         suggestion: createVizelMentionMenuRenderer(),
+ *       },
  *     },
  *   },
  * });

--- a/packages/react/src/hooks/useVizelCollaboration.ts
+++ b/packages/react/src/hooks/useVizelCollaboration.ts
@@ -68,7 +68,7 @@ export interface UseVizelCollaborationResult {
  *   );
  *
  *   const editor = useVizelEditor({
- *     features: { collaboration: true },
+ *     features: { collaboration: { provider: true } },
  *     extensions: [
  *       Collaboration.configure({ document: doc }),
  *       CollaborationCursor.configure({

--- a/packages/react/src/hooks/useVizelComment.ts
+++ b/packages/react/src/hooks/useVizelComment.ts
@@ -54,7 +54,7 @@ export interface UseVizelCommentResult {
  * ```tsx
  * function Editor() {
  *   const editor = useVizelEditor({
- *     features: { comment: true },
+ *     features: { collaboration: { comments: true } },
  *   });
  *   const { comments, addComment, resolveComment, setActiveComment } =
  *     useVizelComment(editor, { key: "my-comments" });

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -59,7 +59,7 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
   const [editor, setEditor] = useState<Editor | null>(null);
 
   // Store image upload options for event handler
-  const imageOptions = typeof features?.image === "object" ? features.image : {};
+  const imageOptions = typeof features?.content?.image === "object" ? features.content.image : {};
   const imageOptionsRef = useRef(imageOptions);
   imageOptionsRef.current = imageOptions;
 

--- a/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
+++ b/packages/svelte/src/runes/createVizelCollaboration.svelte.ts
@@ -56,7 +56,7 @@ export interface CreateVizelCollaborationResult {
  * );
  *
  * const editor = createVizelEditor({
- *   features: { collaboration: true },
+ *   features: { collaboration: { provider: true } },
  *   extensions: [
  *     Collaboration.configure({ document: doc }),
  *     CollaborationCursor.configure({

--- a/packages/svelte/src/runes/createVizelComment.svelte.ts
+++ b/packages/svelte/src/runes/createVizelComment.svelte.ts
@@ -54,7 +54,7 @@ export interface CreateVizelCommentResult {
  * <script lang="ts">
  * import { createVizelEditor, createVizelComment } from "@vizel/svelte";
  *
- * const editor = createVizelEditor({ features: { comment: true } });
+ * const editor = createVizelEditor({ features: { collaboration: { comments: true } } });
  * const comment = createVizelComment(() => editor.current, { key: "my-comments" });
  * </script>
  *

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -64,7 +64,7 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
   const { features, extensions: additionalExtensions = [], ...editorOptions } = options;
 
   // Store image upload options for event handler
-  const imageOptions = typeof features?.image === "object" ? features.image : {};
+  const imageOptions = typeof features?.content?.image === "object" ? features.content.image : {};
 
   let editor = $state<Editor | null>(null);
 

--- a/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
+++ b/packages/svelte/src/runes/createVizelMentionMenuRenderer.svelte.ts
@@ -25,9 +25,11 @@ export type { VizelSuggestionRendererOptions };
  *
  * const editor = createVizelEditor({
  *   features: {
- *     mention: {
- *       items: async (query) => fetchUsers(query),
- *       suggestion: createVizelMentionMenuRenderer(),
+ *     interaction: {
+ *       mention: {
+ *         items: async (query) => fetchUsers(query),
+ *         suggestion: createVizelMentionMenuRenderer(),
+ *       },
  *     },
  *   },
  * });

--- a/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
@@ -23,9 +23,11 @@ interface VizelMentionMenuRef {
  *
  * const editor = useVizelEditor({
  *   features: {
- *     mention: {
- *       items: async (query) => fetchUsers(query),
- *       suggestion: createVizelMentionMenuRenderer(),
+ *     interaction: {
+ *       mention: {
+ *         items: async (query) => fetchUsers(query),
+ *         suggestion: createVizelMentionMenuRenderer(),
+ *       },
  *     },
  *   },
  * });

--- a/packages/vue/src/composables/useVizelCollaboration.ts
+++ b/packages/vue/src/composables/useVizelCollaboration.ts
@@ -57,7 +57,7 @@ export interface UseVizelCollaborationResult {
  * );
  *
  * const editor = useVizelEditor({
- *   features: { collaboration: true },
+ *   features: { collaboration: { provider: true } },
  *   extensions: [
  *     Collaboration.configure({ document: doc }),
  *     CollaborationCursor.configure({

--- a/packages/vue/src/composables/useVizelComment.ts
+++ b/packages/vue/src/composables/useVizelComment.ts
@@ -55,7 +55,7 @@ export interface UseVizelCommentResult {
  * <script setup lang="ts">
  * import { useVizelEditor, useVizelComment } from "@vizel/vue";
  *
- * const editor = useVizelEditor({ features: { comment: true } });
+ * const editor = useVizelEditor({ features: { collaboration: { comments: true } } });
  * const { comments, addComment, resolveComment, setActiveComment } =
  *   useVizelComment(() => editor.value, { key: "my-comments" });
  * </script>

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -64,7 +64,7 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
   const { features, extensions: additionalExtensions = [], ...editorOptions } = options;
 
   // Store image upload options for event handler
-  const imageOptions = typeof features?.image === "object" ? features.image : {};
+  const imageOptions = typeof features?.content?.image === "object" ? features.content.image : {};
 
   const editor = shallowRef<Editor | null>(null);
 

--- a/tests/ct/react/specs/DetailsFixture.tsx
+++ b/tests/ct/react/specs/DetailsFixture.tsx
@@ -13,7 +13,9 @@ export function DetailsFixture({
     placeholder,
     initialContent,
     features: {
-      details: true,
+      content: {
+        details: true,
+      },
     },
   });
 

--- a/tests/ct/react/specs/DiagramFixture.tsx
+++ b/tests/ct/react/specs/DiagramFixture.tsx
@@ -15,7 +15,9 @@ export function DiagramFixture({
     placeholder,
     initialContent,
     features: {
-      diagram: true,
+      content: {
+        diagram: true,
+      },
     },
   });
 

--- a/tests/ct/react/specs/EditorFixture.tsx
+++ b/tests/ct/react/specs/EditorFixture.tsx
@@ -15,7 +15,9 @@ export function EditorFixture({
     placeholder,
     initialContent,
     features: {
-      mathematics: true,
+      content: {
+        mathematics: true,
+      },
     },
   });
 

--- a/tests/ct/react/specs/EmbedFixture.tsx
+++ b/tests/ct/react/specs/EmbedFixture.tsx
@@ -13,7 +13,9 @@ export function EmbedFixture({
     placeholder,
     initialContent,
     features: {
-      embed: true,
+      content: {
+        embed: true,
+      },
     },
   });
 

--- a/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
+++ b/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
@@ -11,7 +11,9 @@ export function MarkdownFlavorsFixture({ flavor = "gfm" }: MarkdownFlavorsFixtur
   const editor = useVizelEditor({
     flavor,
     features: {
-      callout: true,
+      content: {
+        callout: true,
+      },
     },
   });
 

--- a/tests/ct/svelte/specs/DetailsFixture.svelte
+++ b/tests/ct/svelte/specs/DetailsFixture.svelte
@@ -14,7 +14,9 @@ const editor = createVizelEditor({
   placeholder: props.placeholder ?? "Type something...",
   initialContent: props.initialContent,
   features: {
-    details: true,
+    content: {
+      details: true,
+    },
   },
 });
 </script>

--- a/tests/ct/svelte/specs/DiagramFixture.svelte
+++ b/tests/ct/svelte/specs/DiagramFixture.svelte
@@ -13,7 +13,9 @@ const editor = createVizelEditor({
   placeholder: props.placeholder ?? "Type something...",
   initialContent: props.initialContent,
   features: {
-    diagram: true,
+    content: {
+      diagram: true,
+    },
   },
 });
 </script>

--- a/tests/ct/svelte/specs/EditorFixture.svelte
+++ b/tests/ct/svelte/specs/EditorFixture.svelte
@@ -13,7 +13,9 @@ const editor = createVizelEditor({
   placeholder: props.placeholder ?? "Type something...",
   initialContent: props.initialContent,
   features: {
-    mathematics: true,
+    content: {
+      mathematics: true,
+    },
   },
 });
 </script>

--- a/tests/ct/svelte/specs/EmbedFixture.svelte
+++ b/tests/ct/svelte/specs/EmbedFixture.svelte
@@ -14,7 +14,9 @@ const editor = createVizelEditor({
   placeholder: props.placeholder ?? "Type something...",
   initialContent: props.initialContent,
   features: {
-    embed: true,
+    content: {
+      embed: true,
+    },
   },
 });
 </script>

--- a/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
@@ -17,7 +17,9 @@ let markdownOutput = $state("");
 const editor = createVizelEditor({
   flavor: props.flavor ?? "gfm",
   features: {
-    callout: true,
+    content: {
+      callout: true,
+    },
   },
 });
 

--- a/tests/ct/vue/specs/DetailsFixture.vue
+++ b/tests/ct/vue/specs/DetailsFixture.vue
@@ -14,7 +14,9 @@ const editor = useVizelEditor({
   placeholder: props.placeholder,
   initialContent: props.initialContent,
   features: {
-    details: true,
+    content: {
+      details: true,
+    },
   },
 });
 </script>

--- a/tests/ct/vue/specs/DiagramFixture.vue
+++ b/tests/ct/vue/specs/DiagramFixture.vue
@@ -18,7 +18,9 @@ const editor = useVizelEditor({
   placeholder: props.placeholder,
   initialContent: props.initialContent,
   features: {
-    diagram: true,
+    content: {
+      diagram: true,
+    },
   },
 });
 </script>

--- a/tests/ct/vue/specs/EditorFixture.vue
+++ b/tests/ct/vue/specs/EditorFixture.vue
@@ -18,7 +18,9 @@ const editor = useVizelEditor({
   placeholder: props.placeholder,
   initialContent: props.initialContent,
   features: {
-    mathematics: true,
+    content: {
+      mathematics: true,
+    },
   },
 });
 </script>

--- a/tests/ct/vue/specs/EmbedFixture.vue
+++ b/tests/ct/vue/specs/EmbedFixture.vue
@@ -14,7 +14,9 @@ const editor = useVizelEditor({
   placeholder: props.placeholder,
   initialContent: props.initialContent,
   features: {
-    embed: true,
+    content: {
+      embed: true,
+    },
   },
 });
 </script>

--- a/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
+++ b/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
@@ -16,7 +16,9 @@ const markdownOutput = ref("");
 const editor = useVizelEditor({
   flavor: props.flavor,
   features: {
-    callout: true,
+    content: {
+      callout: true,
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- Restructure `VizelFeatureOptions` into a nested `{ content, interaction, collaboration }` shape per spec Section 8.
- Rename `features.slashCommand` to `features.interaction.slashMenu` and `features.comment` to `features.collaboration.comments` (breaking).
- Move `link`, `markdown`, and `codeBlock` out of `features` into the always-on core (breaking — these are no longer toggleable through `features`).
- Move `underline`, `superscript`, `subscript` out of the always-on base into `features.content.*` (default-on, but now opt-out-able).
- Update React / Vue / Svelte demos and Playwright CT fixtures to the new shape.

## Breaking Changes

- `features.slashCommand` → `features.interaction.slashMenu`
- `features.comment` → `features.collaboration.comments`
- `features.table` → `features.content.table`
- `features.image` → `features.content.image`
- `features.taskList` → `features.content.taskList`
- `features.textColor` → `features.content.textColor`
- `features.mathematics` → `features.content.mathematics`
- `features.embed` → `features.content.embed`
- `features.details` → `features.content.details`
- `features.callout` → `features.content.callout`
- `features.diagram` → `features.content.diagram`
- `features.wikiLink` → `features.content.wikiLink`
- `features.tableOfContents` → `features.content.tableOfContents`
- `features.superscript` → `features.content.superscript`
- `features.subscript` → `features.content.subscript`
- `features.dragHandle` → `features.interaction.dragHandle`
- `features.mention` → `features.interaction.mention`
- `features.characterCount` → `features.interaction.characterCount`
- `features.typography` → `features.interaction.typography`
- `features.collaboration: boolean` → `features.collaboration.provider: boolean` (8e replaces the boolean with a structured provider type)
- `features.link`, `features.markdown`, `features.codeBlock` — REMOVED (always-on)

Subsequent sub-PRs (8b–8f) introduce new fields under the same nested
shape — see `docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md`.

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm check:parity`
- [x] `pnpm test:ct:react` (chromium, 269 passed; webkit binary missing in local sandbox is unrelated to this PR)
- [ ] Manual: open each demo, verify slash menu / image / table / drag handle / mention still work.
