### PR TITLE
feat(core): split highlight into its own feature

### DIFF
--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -33,6 +33,7 @@ import { createVizelDetailsExtensions } from "./details.ts";
 import { createVizelDiagramExtension } from "./diagram.ts";
 import { createVizelDragHandleExtensions } from "./drag-handle.ts";
 import { createVizelEmbedExtension } from "./embed.ts";
+import { createVizelHighlightExtension } from "./highlight.ts";
 import {
   createVizelImageUploadExtensions,
   defaultImageResizeOptions,
@@ -202,6 +203,17 @@ function addTextColorExtension(extensions: Extensions, features: VizelFeatureOpt
 
   const textColorOptions = typeof textColor === "object" ? textColor : {};
   extensions.push(...createVizelTextColorExtensions(textColorOptions));
+}
+
+/**
+ * Add Highlight extension if enabled (enabled by default).
+ */
+function addHighlightExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const highlight = features.content?.highlight;
+  if (highlight === false) return;
+
+  const highlightOptions = typeof highlight === "object" ? highlight : {};
+  extensions.push(...createVizelHighlightExtension(highlightOptions));
 }
 
 /**
@@ -447,6 +459,7 @@ export async function createVizelExtensions(
   addTaskListExtension(extensions, features);
   addCharacterCountExtension(extensions, features);
   addTextColorExtension(extensions, features);
+  addHighlightExtension(extensions, features);
   addMathematicsExtension(extensions, features);
   addDragHandleExtension(extensions, features, locale);
   addDetailsExtension(extensions, features);

--- a/packages/core/src/extensions/highlight.ts
+++ b/packages/core/src/extensions/highlight.ts
@@ -1,0 +1,32 @@
+import type { Extensions } from "@tiptap/core";
+import { Highlight } from "@tiptap/extension-highlight";
+import type { VizelColorDefinition } from "./text-color.ts";
+
+/**
+ * Options for the highlight extension.
+ *
+ * The highlight palette and the multicolor flag live here rather than on
+ * `VizelTextColorOptions` so that consumers can configure text color and
+ * highlight independently through `features.content.textColor` and
+ * `features.content.highlight`.
+ */
+export interface VizelHighlightOptions {
+  /** Custom highlight color palette */
+  highlightColors?: readonly VizelColorDefinition[];
+  /** Allow any CSS color value (default: true) */
+  multicolor?: boolean;
+}
+
+/**
+ * Create the highlight mark extension.
+ *
+ * The highlight palette (`VIZEL_HIGHLIGHT_COLORS`) and palette helpers
+ * (`getVizelRecentColors("highlight")`, `addVizelRecentColor("highlight",
+ * ...)`, `applyVizelColorToEditor(editor, "highlight", color)`) continue
+ * to live in `text-color.ts` because the color picker UI consumes both
+ * text color and highlight palettes from the same module.
+ */
+export function createVizelHighlightExtension(options: VizelHighlightOptions = {}): Extensions {
+  const { multicolor = true } = options;
+  return [Highlight.configure({ multicolor })];
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -41,7 +41,6 @@ export {
   type VizelCommentPluginState,
   vizelCommentPluginKey,
 } from "./comment.ts";
-
 // Details (collapsible content)
 export {
   createVizelDetailsExtensions,
@@ -50,7 +49,6 @@ export {
   type VizelDetailsOptions,
   type VizelDetailsSummaryOptions,
 } from "./details.ts";
-
 // Diagram (Mermaid, GraphViz)
 export {
   createVizelDiagramExtension,
@@ -59,7 +57,6 @@ export {
   type VizelDiagramOptions,
   type VizelDiagramType,
 } from "./diagram.ts";
-
 // Drag handle
 export {
   createVizelDragHandleExtension,
@@ -68,7 +65,6 @@ export {
   VizelDragHandle,
   type VizelDragHandleOptions,
 } from "./drag-handle.ts";
-
 // Embed (oEmbed, OGP)
 export {
   createVizelDefaultFetchEmbedData,
@@ -86,7 +82,6 @@ export {
   vizelDefaultEmbedProviders,
   vizelEmbedPastePluginKey,
 } from "./embed.ts";
-
 // File handler
 export {
   createVizelFileHandlerExtension,
@@ -100,7 +95,6 @@ export {
   type VizelImageFileHandlerOptions,
   type VizelImageFileHandlers,
 } from "./file-handler.ts";
-
 // Find & Replace
 export {
   createVizelFindReplaceExtension,
@@ -110,6 +104,11 @@ export {
   type VizelFindReplaceState,
   vizelFindReplacePluginKey,
 } from "./find-replace.ts";
+// Highlight
+export {
+  createVizelHighlightExtension,
+  type VizelHighlightOptions,
+} from "./highlight.ts";
 
 // Image
 export {

--- a/packages/core/src/extensions/text-color.ts
+++ b/packages/core/src/extensions/text-color.ts
@@ -1,6 +1,5 @@
 import type { Editor, Extensions } from "@tiptap/core";
 import { Color } from "@tiptap/extension-color";
-import { Highlight } from "@tiptap/extension-highlight";
 import { TextStyle } from "@tiptap/extension-text-style";
 
 /**
@@ -163,28 +162,24 @@ export function applyVizelColorToEditor(
 }
 
 /**
- * Options for text color extensions
+ * Options for text color extensions.
+ *
+ * Highlight options moved to `VizelHighlightOptions` in
+ * `extensions/highlight.ts` so that text color and highlight can be
+ * configured independently through `features.content.textColor` and
+ * `features.content.highlight`.
  */
 export interface VizelTextColorOptions {
   /** Custom text color palette */
   textColors?: readonly VizelColorDefinition[];
-  /** Custom highlight color palette */
-  highlightColors?: readonly VizelColorDefinition[];
-  /** Enable multicolor highlights (allows any color) */
-  multicolor?: boolean;
 }
 
 /**
- * Create text color and highlight extensions
+ * Create text color mark extensions (TextStyle + Color).
+ *
+ * The highlight mark lives in `createVizelHighlightExtension` and is
+ * configured separately.
  */
-export function createVizelTextColorExtensions(options: VizelTextColorOptions = {}): Extensions {
-  const { multicolor = true } = options;
-
-  return [
-    TextStyle,
-    Color,
-    Highlight.configure({
-      multicolor,
-    }),
-  ];
+export function createVizelTextColorExtensions(_options: VizelTextColorOptions = {}): Extensions {
+  return [TextStyle, Color];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,6 +173,8 @@ export {
   createVizelFileHandlerExtension,
   // Find & Replace
   createVizelFindReplaceExtension,
+  // Highlight
+  createVizelHighlightExtension,
   // Image
   createVizelImageExtension,
   createVizelImageFileHandlers,
@@ -267,6 +269,7 @@ export {
   type VizelFindMatch,
   type VizelFindReplaceOptions,
   type VizelFindReplaceState,
+  type VizelHighlightOptions,
   VizelImage,
   type VizelImageFileHandlerOptions,
   type VizelImageFileHandlers,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ import type { VizelDetailsOptions } from "./extensions/details.ts";
 import type { VizelDiagramOptions } from "./extensions/diagram.ts";
 import type { VizelDragHandleOptions } from "./extensions/drag-handle.ts";
 import type { VizelEmbedOptions } from "./extensions/embed.ts";
+import type { VizelHighlightOptions } from "./extensions/highlight.ts";
 import type { VizelMathematicsOptions } from "./extensions/mathematics.ts";
 import type { VizelMentionOptions } from "./extensions/mention.ts";
 import type { VizelSlashCommandItem } from "./extensions/slash-command.ts";
@@ -86,8 +87,10 @@ export interface VizelContentFeatureOptions {
   callout?: VizelCalloutOptions | boolean;
   /** Collapsible content blocks (accordion) */
   details?: VizelDetailsOptions | boolean;
-  /** Text color and highlight support */
+  /** Text color (foreground) mark */
   textColor?: VizelTextColorOptions | boolean;
+  /** Highlight (background) mark */
+  highlight?: VizelHighlightOptions | boolean;
   /** Underline mark (default-on) */
   underline?: boolean;
   /** Superscript mark (e.g., x²) */


### PR DESCRIPTION
## Summary

- Sub-PR 8b of Section 8 (`docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md`).
- Move the highlight mark out of the textColor extension bundle into a new `createVizelHighlightExtension` factory, exposed through `features.content.highlight` independently of `features.content.textColor`.
- Highlight options (`highlightColors`, `multicolor`) move from `VizelTextColorOptions` to a new `VizelHighlightOptions` type.

## Breaking Changes

- `VizelTextColorOptions.highlightColors` / `VizelTextColorOptions.multicolor` removed. Configure these on `features.content.highlight: VizelHighlightOptions` instead.
- `features.content.textColor` no longer toggles the highlight mark. Use `features.content.highlight: false` to disable highlight.

Migration:

```ts
// before
features: {
  content: {
    textColor: { highlightColors: [...], multicolor: true },
  },
}

// after
features: {
  content: {
    textColor: true,
    highlight: { highlightColors: [...], multicolor: true },
  },
}
```

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm check` (lint)
- [x] `pnpm check:parity`
- [x] Local CT chromium passes; webkit unavailable locally, CI verifies all browsers.
