### PR TITLE
feat(core): add interaction features (placeholder, historyDepth, typography options)

### DIFF
--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -20,7 +20,6 @@ import Strike from "@tiptap/extension-strike";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import Text from "@tiptap/extension-text";
-import Typography from "@tiptap/extension-typography";
 import Underline from "@tiptap/extension-underline";
 import type { VizelLocale } from "../i18n/types.ts";
 import type { VizelFeatureOptions } from "../types.ts";
@@ -52,6 +51,7 @@ import { createVizelTableExtensions } from "./table.ts";
 import { createVizelTableOfContentsExtension } from "./table-of-contents.ts";
 import { createVizelTaskListExtensions } from "./task-list.ts";
 import { createVizelTextColorExtensions } from "./text-color.ts";
+import { createVizelTypographyExtension } from "./typography.ts";
 import { createVizelWikiLinkExtension } from "./wiki-link.ts";
 
 export interface VizelExtensionsOptions {
@@ -87,9 +87,13 @@ export interface VizelExtensionsOptions {
  * to support syntax highlighting when enabled.
  */
 function createBaseExtensions(
-  options: { headingLevels?: (1 | 2 | 3 | 4 | 5 | 6)[]; excludeHistory?: boolean } = {}
+  options: {
+    headingLevels?: (1 | 2 | 3 | 4 | 5 | 6)[];
+    excludeHistory?: boolean;
+    historyDepth?: number;
+  } = {}
 ): Extensions {
-  const { headingLevels = [1, 2, 3, 4, 5, 6], excludeHistory = false } = options;
+  const { headingLevels = [1, 2, 3, 4, 5, 6], excludeHistory = false, historyDepth } = options;
 
   const extensions: Extensions = [
     // Nodes
@@ -117,7 +121,9 @@ function createBaseExtensions(
 
   // History is excluded when collaboration is enabled (Yjs provides its own undo manager)
   if (!excludeHistory) {
-    extensions.push(History);
+    extensions.push(
+      historyDepth === undefined ? History : History.configure({ depth: historyDepth })
+    );
   }
 
   return extensions;
@@ -432,11 +438,17 @@ export async function createVizelExtensions(
 
   const flavorConfig = resolveVizelFlavorConfig(flavor);
   const excludeHistory = Boolean(features.collaboration?.provider);
+  const historyDepth = features.interaction?.historyDepth;
+  const placeholderText = features.interaction?.placeholder ?? placeholder;
 
   const extensions: Extensions = [
-    ...createBaseExtensions({ headingLevels, excludeHistory }),
+    ...createBaseExtensions({
+      headingLevels,
+      excludeHistory,
+      ...(historyDepth !== undefined && { historyDepth }),
+    }),
     Placeholder.configure({
-      placeholder,
+      placeholder: placeholderText,
       emptyEditorClass: "vizel-editor-empty",
       emptyNodeClass: "vizel-node-empty",
     }),
@@ -481,8 +493,10 @@ export async function createVizelExtensions(
   if (features.content?.subscript !== false) {
     extensions.push(Subscript);
   }
-  if (features.interaction?.typography !== false) {
-    extensions.push(Typography);
+  const typography = features.interaction?.typography;
+  if (typography !== false) {
+    const typographyOptions = typeof typography === "object" ? typography : {};
+    extensions.push(createVizelTypographyExtension(typographyOptions));
   }
 
   // CodeBlock (always-on, async — lowlight is loaded dynamically)

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -231,6 +231,12 @@ export {
   type VizelTextColorOptions,
 } from "./text-color.ts";
 
+// Typography
+export {
+  createVizelTypographyExtension,
+  type VizelTypographyOptions,
+} from "./typography.ts";
+
 // Wiki link
 export {
   createVizelWikiLinkExtension,

--- a/packages/core/src/extensions/typography.ts
+++ b/packages/core/src/extensions/typography.ts
@@ -1,0 +1,21 @@
+import type { TypographyOptions } from "@tiptap/extension-typography";
+import Typography from "@tiptap/extension-typography";
+
+/**
+ * Options for the typography extension.
+ *
+ * Re-exports the Tiptap `TypographyOptions` shape under a Vizel-branded
+ * name so consumers can configure smart quotes, em-dash conversion,
+ * ellipsis substitution, and other auto-correct replacements through
+ * `features.interaction.typography`.
+ */
+export type VizelTypographyOptions = TypographyOptions;
+
+/**
+ * Create the typography extension.
+ */
+export function createVizelTypographyExtension(
+  options: Partial<VizelTypographyOptions> = {}
+): typeof Typography {
+  return Typography.configure(options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,7 @@ export {
   // Task list
   createVizelTaskListExtensions,
   createVizelTextColorExtensions,
+  createVizelTypographyExtension,
   createVizelWikiLinkExtension,
   detectVizelEmbedProvider,
   filterVizelFilesByMimeType,
@@ -314,6 +315,7 @@ export {
   type VizelTaskListOptions,
   type VizelTextColorOptions,
   type VizelTOCHeading,
+  type VizelTypographyOptions,
   type VizelUploadImageFn,
   VizelWikiLink,
   type VizelWikiLinkOptions,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@ import type { VizelTableOptions } from "./extensions/table.ts";
 import type { VizelTableOfContentsOptions } from "./extensions/table-of-contents.ts";
 import type { VizelTaskListExtensionsOptions } from "./extensions/task-list.ts";
 import type { VizelTextColorOptions } from "./extensions/text-color.ts";
+import type { VizelTypographyOptions } from "./extensions/typography.ts";
 import type { VizelWikiLinkOptions } from "./extensions/wiki-link.ts";
 import type { VizelLocale } from "./i18n/types.ts";
 import type { VizelImageUploadPluginOptions } from "./plugins/image-upload.ts";
@@ -130,8 +131,24 @@ export interface VizelInteractionFeatureOptions {
   mention?: VizelMentionOptions | boolean;
   /** Character and word count tracking */
   characterCount?: VizelCharacterCountOptions | boolean;
-  /** Typography auto-conversion (smart quotes, em-dashes, ellipsis, etc.) */
-  typography?: boolean;
+  /**
+   * Typography auto-conversion (smart quotes, em-dashes, ellipsis, etc.).
+   * Pass an options object to override individual replacement characters.
+   */
+  typography?: VizelTypographyOptions | boolean;
+  /**
+   * Placeholder text shown when the editor is empty.
+   * Replaces the top-level `VizelEditorOptions.placeholder` option from
+   * v1.x. Default: "Type '/' for commands...".
+   */
+  placeholder?: string;
+  /**
+   * Maximum number of history entries (undo / redo depth).
+   * Forwarded to the Tiptap History extension. When `collaboration.provider`
+   * is set, the History extension is excluded and this value is ignored.
+   * @default 100
+   */
+  historyDepth?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Sub-PR 8c of Section 8 (`docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md`).
- Add three new entries to `VizelInteractionFeatureOptions`:
  - `placeholder?: string` — placeholder text. Takes precedence over the top-level `VizelExtensionsOptions.placeholder` when both are set.
  - `historyDepth?: number` — forwarded to the Tiptap History extension as the maximum undo/redo stack depth.
  - `typography?: VizelTypographyOptions | boolean` — boolean shape preserved; object form allows overriding individual smart-quote / em-dash / ellipsis characters.
- Add new `extensions/typography.ts` module exposing `createVizelTypographyExtension(options)` and `VizelTypographyOptions` (re-export of Tiptap's `TypographyOptions`).

## Behavior Changes

- When `features.interaction.placeholder` is set, it wins over the legacy top-level `placeholder` option (no behavior change when only one is set).
- `Typography` is now configured through the factory; previously the extension was imported and pushed as-is.

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm check:parity`
- [x] CI exercises all three browsers / frameworks.
