### PR TITLE
feat(core): add vizelDefaultFeatures helper and dependency validation

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -130,6 +130,49 @@ gated by `VizelFeatureOptions`: Markdown, Link, CodeBlock. To configure
 them, use the corresponding top-level options on `VizelEditorOptions`
 (e.g. the Markdown flavor lives at `flavor`, not under `features`).
 
+## Feature Categories
+
+`VizelFeatureOptions` groups every opt-in into three categories that
+answer different consumer questions. Adding a new feature requires
+placing it in one of these three categories.
+
+| Category | Consumer question | Examples |
+|----------|--------------------|----------|
+| `content` | What can the document contain? | `image`, `table`, `mathematics`, `diagram`, `embed`, `callout`, `details`, `textColor`, `highlight`, `underline`, `superscript`, `subscript`, `taskList`, `wikiLink`, `tableOfContents` |
+| `interaction` | How does the user edit? | `slashMenu`, `dragHandle`, `mention`, `characterCount`, `typography`, `placeholder`, `historyDepth`, `visualHierarchy` |
+| `collaboration` | Who edits together? | `comments`, `provider`, `versionHistory`, `presence` |
+
+### Categorization rule
+
+When adding a new feature, ask: *what is the user's main motivation to
+turn this on?* That motivation determines the category. `mention` lives
+under `interaction` because users turn it on for the completion
+experience, not for the inline node it produces. `comments` lives under
+`collaboration` because the annotation flow only matters when other
+collaborators can read it.
+
+### Dependency validation
+
+`createVizelEditorInstance` validates feature dependencies at
+construction time and throws `VizelError("INVALID_CONFIG", ...)` when a
+required dependency is missing. The current rules:
+
+- `features.collaboration.comments` requires `features.collaboration.provider`.
+- `features.collaboration.presence` requires `features.collaboration.provider`.
+
+Add new dependency rules to `packages/core/src/utils/editorFactory.ts`
+alongside the existing checks. Each rule must throw a typed
+`VizelError` with a stable `code` (`INVALID_CONFIG`) and a `context`
+carrying the offending feature name.
+
+### Curated defaults
+
+`vizelDefaultFeatures()` returns a curated feature object that enables
+every safe opt-in (everything except `mention`, `provider`, `comments`,
+`versionHistory`, `presence` — features that need consumer-supplied
+configuration to function). Use it when you want the Notion-like
+surface without enumerating each toggle.
+
 ## Dependencies
 
 ### Allowed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -525,6 +525,7 @@ export {
   type VizelSuggestionContainer,
   type VizelTextSegment,
   vizelDefaultEditorProps,
+  vizelDefaultFeatures,
   type WrapAsVizelErrorOptions,
   wrapAsVizelError,
 } from "./utils/index.ts";

--- a/packages/core/src/utils/default-features.ts
+++ b/packages/core/src/utils/default-features.ts
@@ -1,0 +1,48 @@
+import type { VizelFeatureOptions } from "../types.ts";
+
+/**
+ * Curated `VizelFeatureOptions` value that enables every opt-in feature
+ * Vizel ships with reasonable defaults. Use this when you want the full
+ * Notion-like surface without enumerating each toggle yourself.
+ *
+ * Features that require consumer-supplied configuration to be useful
+ * (`interaction.mention`, `collaboration.provider`, `collaboration.comments`,
+ * `collaboration.presence`, `collaboration.versionHistory`) are deliberately
+ * NOT enabled here — turning them on without their dependencies would
+ * throw at editor-construction time.
+ *
+ * @example
+ * ```ts
+ * const editor = useVizelEditor({
+ *   features: vizelDefaultFeatures(),
+ * });
+ * ```
+ */
+export function vizelDefaultFeatures(): VizelFeatureOptions {
+  return {
+    content: {
+      image: true,
+      table: true,
+      mathematics: true,
+      diagram: true,
+      embed: true,
+      callout: true,
+      details: true,
+      textColor: true,
+      highlight: true,
+      underline: true,
+      superscript: true,
+      subscript: true,
+      taskList: true,
+      wikiLink: true,
+      tableOfContents: true,
+    },
+    interaction: {
+      slashMenu: true,
+      dragHandle: true,
+      characterCount: true,
+      typography: true,
+      visualHierarchy: true,
+    },
+  };
+}

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -14,6 +14,33 @@ import { initializeVizelMarkdownContent } from "./markdown.ts";
  * which we have to undo for cases where the consumer asked for "start", "all",
  * a numeric position, or no focus at all.
  */
+/**
+ * Validate collaboration-feature dependencies. Both `comments` and
+ * `presence` lose meaning without an underlying provider distributing
+ * their state; the editor refuses to construct rather than render
+ * silently broken UI.
+ */
+function validateVizelCollaborationFeatures(features: VizelEditorOptions["features"]): void {
+  const collaboration = features?.collaboration;
+  if (!collaboration) return;
+  const provider = collaboration.provider;
+
+  if (collaboration.comments && !provider) {
+    throw createVizelError(
+      "INVALID_CONFIG",
+      "features.collaboration.comments requires features.collaboration.provider to be set.",
+      { context: { feature: "comments" } }
+    );
+  }
+  if (collaboration.presence && !provider) {
+    throw createVizelError(
+      "INVALID_CONFIG",
+      "features.collaboration.presence requires features.collaboration.provider to be set.",
+      { context: { feature: "presence" } }
+    );
+  }
+}
+
 function applyInitialSelection(editor: Editor, autofocus: VizelEditorOptions["autofocus"]): void {
   const docSize = editor.state.doc.content.size;
   if (autofocus === false || autofocus === undefined) {
@@ -121,6 +148,8 @@ export async function createVizelEditorInstance(
       "Cannot supply both `initialContent` and `initialMarkdown` to the editor. Pick one."
     );
   }
+
+  validateVizelCollaborationFeatures(features);
 
   // Resolve features with slash menu renderer
   const resolvedFeatures = resolveVizelFeatures({

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -23,6 +23,8 @@ export {
 } from "../controllers/suggestionContainer.ts";
 // Color utilities
 export { isVizelValidHexColor, normalizeVizelHexColor } from "./colorUtils.ts";
+// Curated default feature set
+export { vizelDefaultFeatures } from "./default-features.ts";
 // Editor factory
 export {
   type CreateVizelEditorInstanceOptions,


### PR DESCRIPTION
## Summary

- Sub-PR 8f (final) of Section 8 (`docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md`).
- Add `vizelDefaultFeatures()` returning a curated `VizelFeatureOptions` value (everything safe-on except features needing consumer-supplied configuration: `mention`, `provider`, `comments`, `versionHistory`, `presence`).
- `createVizelEditorInstance` now validates collaboration-feature dependencies at construction time and throws `VizelError("INVALID_CONFIG")`:
  - `features.collaboration.comments` requires `features.collaboration.provider`
  - `features.collaboration.presence` requires `features.collaboration.provider`
- `.claude/rules/packages/core.md` gains a **Feature Categories** section documenting the three categories, the motivation rule for classifying new features, the dependency-validation pattern, and the curated default helper.

Section 8 now ships in full across PR #468 (8a), #469 (8b), #470 (8c), #471 (8d), #472 (8e), and this PR (8f).

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm check:parity`
- [x] CI exercises all three browsers / frameworks.
