### PR TITLE
feat(core): add VizelCommand unified type foundation (Section 9a)

### DIFF
--- a/docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md
+++ b/docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md
@@ -1,0 +1,940 @@
+# Section 8 — Feature Option Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure `VizelFeatureOptions` from a flat shape into a nested
+`{ content, interaction, collaboration }` shape, lift `codeBlock` and `link`
+out of `features` into the always-on core, rename `slashCommand` → `slashMenu`
+and `comment` → `comments`, and add runtime entries (plus implementations
+where required) for every new feature listed in spec Section 8.
+
+**Architecture:** All changes flow through `@vizel/core`. Framework packages
+are pure consumers because they receive `VizelFeatureOptions` only through
+the typed re-export. Demo apps and Playwright fixtures are updated in
+lockstep. The spec is the source of truth for the final shape; existing
+features are mapped into one of the three categories by user motivation.
+
+**Tech Stack:** TypeScript, Tiptap v2 extensions
+(`@tiptap/extension-underline`, `@tiptap/extension-highlight`,
+`@tiptap/extension-typography`), Vite, Biome, lefthook,
+Playwright Component Tests.
+
+---
+
+## Spec mapping (binding)
+
+The implementation must end with the shape below in `packages/core/src/types.ts`.
+
+```ts
+export interface VizelFeatureOptions {
+  readonly content?: {
+    readonly image?: boolean | VizelImageFeatureOptions;
+    readonly table?: boolean | VizelTableOptions;
+    readonly mathematics?: boolean | VizelMathematicsOptions;
+    readonly diagram?: boolean | VizelDiagramOptions;
+    readonly embed?: boolean | VizelEmbedOptions;
+    readonly callout?: boolean | VizelCalloutOptions;
+    readonly details?: boolean | VizelDetailsOptions;
+    readonly textColor?: boolean | VizelTextColorOptions;
+    readonly highlight?: boolean | VizelHighlightOptions;
+    readonly underline?: boolean;
+    readonly superscript?: boolean;
+    readonly subscript?: boolean;
+    readonly taskList?: boolean | VizelTaskListExtensionsOptions;
+    readonly wikiLink?: boolean | VizelWikiLinkOptions;
+    readonly tableOfContents?: boolean | VizelTableOfContentsOptions;
+  };
+  readonly interaction?: {
+    readonly slashMenu?: boolean | VizelSlashCommandOptions;
+    readonly blockMenu?: boolean | VizelBlockMenuOptions;
+    readonly bubbleMenu?: boolean | VizelBubbleMenuOptions;
+    readonly dragHandle?: boolean | VizelDragHandleOptions;
+    readonly mention?: boolean | VizelMentionOptions;
+    readonly findAndReplace?: boolean | VizelFindReplaceOptions;
+    readonly autoSave?: boolean | VizelAutoSaveOptions;
+    readonly placeholder?: string;
+    readonly characterCount?: boolean | VizelCharacterCountOptions;
+    readonly historyDepth?: number;
+    readonly typography?: boolean | VizelTypographyOptions;
+    readonly visualHierarchy?: boolean | VizelVisualHierarchyOptions;
+  };
+  readonly collaboration?: {
+    readonly provider?: VizelCollaborationProvider;
+    readonly comments?: boolean | VizelCommentMarkOptions;
+    readonly versionHistory?: boolean | VizelVersionHistoryOptions;
+    readonly presence?: VizelPresenceOptions;
+  };
+}
+```
+
+Always-on core (no opt-in flag — always loaded):
+`Document`, `Paragraph`, `Text`, `Heading`, `Bold`, `Italic`, `Strike`,
+`Code`, `BulletList`, `OrderedList`, `ListItem`, `Blockquote`,
+`HardBreak`, `HorizontalRule`, `Dropcursor`, `Gapcursor`, `ListKeymap`,
+`History` (when `collaboration.provider` is unset), `Placeholder`,
+**`CodeBlock` (with lowlight)**, **`Link`**, **`Markdown` (from
+`createVizelMarkdownExtension`)**. `Underline`, `Superscript`, and
+`Subscript` move OUT of always-on core into `content.*`.
+
+Existing feature → new path mapping (used throughout):
+
+| Existing `features.X` | New `features.<cat>.X` |
+|-----------------------|------------------------|
+| `slashCommand` | `interaction.slashMenu` |
+| `table` | `content.table` |
+| `link` | (removed — always-on core) |
+| `image` | `content.image` |
+| `markdown` | (removed — always-on core) |
+| `taskList` | `content.taskList` |
+| `characterCount` | `interaction.characterCount` |
+| `textColor` | `content.textColor` |
+| `codeBlock` | (removed — always-on core) |
+| `mathematics` | `content.mathematics` |
+| `dragHandle` | `interaction.dragHandle` |
+| `embed` | `content.embed` |
+| `details` | `content.details` |
+| `callout` | `content.callout` |
+| `diagram` | `content.diagram` |
+| `wikiLink` | `content.wikiLink` |
+| `mention` | `interaction.mention` |
+| `tableOfContents` | `content.tableOfContents` |
+| `comment` | `collaboration.comments` |
+| `superscript` | `content.superscript` |
+| `subscript` | `content.subscript` |
+| `typography` | `interaction.typography` |
+| `collaboration: true` | `collaboration.provider` (presence implies excludeHistory) |
+
+New entries with full new implementation in Section 8:
+
+| Path | New implementation |
+|------|--------------------|
+| `content.highlight` | Split `@tiptap/extension-highlight` out of the textColor extension bundle. New `VizelHighlightOptions` type. |
+| `content.underline` | New entry; underline moves from always-on into `content.underline`. `VizelUnderlineOptions` is not introduced (boolean only — spec Section 8 type signature does not require options). |
+| `interaction.blockMenu` | Wire current `VizelBlockMenu` rendering to a feature flag. New `VizelBlockMenuOptions` type. |
+| `interaction.bubbleMenu` | Wire current `VizelBubbleMenu` rendering to a feature flag. New `VizelBubbleMenuOptions` type. |
+| `interaction.findAndReplace` | Wire current `VizelFindReplace` rendering to a feature flag. New `VizelFindReplaceOptions` type. |
+| `interaction.autoSave` | Move `useVizelAutoSave` opt-in into features. New `VizelAutoSaveOptions` type re-exports the existing hook options shape. |
+| `interaction.placeholder` | Move `placeholder` from `VizelEditorOptions` top level into `features.interaction.placeholder`. |
+| `interaction.historyDepth` | Expose Tiptap History `depth` configuration. |
+| `interaction.typography` | Convert from `boolean` to `boolean | VizelTypographyOptions` (re-export Tiptap typography rule subset). |
+| `interaction.visualHierarchy` | New `createVizelVisualHierarchyExtension` with `data-vizel-depth` decoration. New SCSS partial `styles/_block-hierarchy.scss`. |
+| `collaboration.provider` | New `VizelCollaborationProvider` type. Replaces `features.collaboration: true`. |
+| `collaboration.versionHistory` | Move `useVizelVersionHistory` opt-in into features. New `VizelVersionHistoryOptions` type. |
+| `collaboration.presence` | New `createVizelPresenceExtension` with `Decoration.widget` cursors and `Decoration.inline` selections. New `VizelPresenceOptions`, `VizelPresenceAwareness`, `VizelPresenceUser`, `VizelPresenceUserState` types. |
+
+---
+
+## Sub-PR breakdown
+
+Section 8 ships as six sub-PRs. Each lands independently with green CI.
+
+| Sub-PR | Title | Scope |
+|--------|-------|-------|
+| 8a | Type hierarchy + existing-feature migration | Nest `VizelFeatureOptions` into `{content, interaction, collaboration}`. Rename `slashCommand`→`slashMenu`, `comment`→`comments`. Move `codeBlock`/`link`/`markdown` to always-on core. Move `underline`/`superscript`/`subscript` out of always-on into `content.*`. Update `base.ts`, `editorHelpers.ts`, demo apps, CT fixtures. |
+| 8b | New content marks (highlight independent) | Split `Highlight` out of textColor bundle. Add `VizelHighlightOptions` type. New `addHighlightExtension`. |
+| 8c | New interaction features (wire existing) | Add `placeholder`/`autoSave`/`typography options`/`historyDepth`/`blockMenu options`/`bubbleMenu options`/`findAndReplace options`. Wire `useVizelAutoSave` consumption to `features.interaction.autoSave` configuration. |
+| 8d | visualHierarchy extension | New `createVizelVisualHierarchyExtension` (decorations), `styles/_block-hierarchy.scss`, content type integration. |
+| 8e | Collaboration grouping (provider, versionHistory, presence) | Add `VizelCollaborationProvider`. Wire `useVizelVersionHistory` to features. New `createVizelPresenceExtension` with awareness adapter. |
+| 8f | Helpers, validation, docs | `vizelDefaultFeatures()` helper. Runtime validation (`features.collaboration.comments requires features.collaboration.provider`). Update `.claude/rules/packages/core.md` Feature Categories section. |
+
+This plan file currently contains the **full detail of 8a**. Sub-PR plans
+8b–8f are written as separate top-level sections of this same file as
+each sub-PR begins, so that the overview/spec mapping above stays the
+single source of truth.
+
+---
+
+## Sub-PR 8a — Type hierarchy + existing-feature migration
+
+**Branch:** `feat/v2-section-08a-features-hierarchy`
+
+**Goal:** Land the new `VizelFeatureOptions` shape and migrate every
+existing call site (core, framework packages, demos, CT fixtures) so the
+codebase compiles, lints, and passes CT with the new paths. No new
+runtime features land in 8a; that is the job of 8b–8f.
+
+### File map for 8a
+
+**Modify:**
+- `packages/core/src/types.ts` — replace `VizelFeatureOptions` with the
+  nested shape. `interaction.placeholder` is added but the top-level
+  `VizelEditorOptions.placeholder` is NOT removed in 8a (8c removes
+  it after `interaction.placeholder` is fully wired in `base.ts`).
+- `packages/core/src/extensions/base.ts` — update every `features.X`
+  read to `features.<cat>?.X`. Move `Underline`, `Superscript`,
+  `Subscript` from always-on into `content.*` gates. Make `link`,
+  `markdown`, and `codeBlock` unconditional (always-on). Rename
+  helpers (`addSlashCommandExtension` → `addSlashMenuExtension`,
+  `addCommentExtension` → `addCommentsExtension`).
+- `packages/core/src/utils/editorHelpers.ts` — update
+  `resolveVizelFeatures` to operate on the nested shape, working only
+  with `features.interaction.slashMenu` (renamed from `slashCommand`).
+- `packages/core/src/utils/editorFactory.ts` — confirm pass-through is
+  unaffected (it forwards `features` verbatim, no field-level access).
+- `packages/core/src/index.ts` — no symbol changes; type re-export
+  carries the new shape automatically.
+- `packages/{react,vue,svelte}/src/components/Vizel.*` — no API change;
+  these components forward `features` verbatim. Only update internal
+  comments / type uses if they reference the old path.
+- `apps/demo/react/src/App.tsx` — rewrite the `features={{…}}` object
+  to the nested shape; remove `markdown`/`codeBlock` (now always-on).
+- `apps/demo/vue/src/App.vue` — same migration.
+- `apps/demo/svelte/src/App.svelte` — same migration.
+- `tests/ct/**/*Fixture.*` — update any fixture that passes
+  `features` to the new paths.
+- `.claude/rules/packages/core.md` — note in the extension catalog that
+  Markdown / CodeBlock / Link are always-on; existing rows stay.
+- `.claude/rules/cross-framework.md` — props parity table mentions
+  `features: VizelFeatureOptions` (no row-shape change needed; the
+  type re-shape is invisible at the table level).
+
+**Create:** None in 8a.
+
+**Delete:** None in 8a.
+
+### Tasks for 8a
+
+### Task 1: Rename the type shape in `types.ts`
+
+**Files:**
+- Modify: `packages/core/src/types.ts:58-122` (replace
+  `VizelFeatureOptions` interface body).
+
+- [ ] **Step 1: Replace `VizelFeatureOptions` with the nested shape**
+
+In `packages/core/src/types.ts`, replace the existing interface
+(lines 44–122) with:
+
+```ts
+/**
+ * Feature configuration for Vizel editor.
+ *
+ * Features are grouped into three categories that answer different
+ * consumer questions:
+ *
+ * - `content` — What can the document contain?
+ * - `interaction` — How does the user edit?
+ * - `collaboration` — Who edits together?
+ *
+ * Each field accepts one of:
+ *
+ * - `true` — enable the feature with default options.
+ * - `false` — disable the feature.
+ * - an options object — enable with custom options.
+ *
+ * Always-on core (no opt-in needed): paragraph, heading, list,
+ * blockquote, bold/italic/strike/code marks, hard break, horizontal
+ * rule, link, code block (with lowlight), markdown import/export,
+ * undo/redo. These extensions load regardless of `features`.
+ */
+export interface VizelFeatureOptions {
+  readonly content?: VizelContentFeatureOptions;
+  readonly interaction?: VizelInteractionFeatureOptions;
+  readonly collaboration?: VizelCollaborationFeatureOptions;
+}
+
+export interface VizelContentFeatureOptions {
+  readonly image?: VizelImageFeatureOptions | boolean;
+  readonly table?: VizelTableOptions | boolean;
+  readonly mathematics?: VizelMathematicsOptions | boolean;
+  readonly diagram?: VizelDiagramOptions | boolean;
+  readonly embed?: VizelEmbedOptions | boolean;
+  readonly callout?: VizelCalloutOptions | boolean;
+  readonly details?: VizelDetailsOptions | boolean;
+  readonly textColor?: VizelTextColorOptions | boolean;
+  readonly underline?: boolean;
+  readonly superscript?: boolean;
+  readonly subscript?: boolean;
+  readonly taskList?: VizelTaskListExtensionsOptions | boolean;
+  readonly wikiLink?: VizelWikiLinkOptions | boolean;
+  readonly tableOfContents?: VizelTableOfContentsOptions | boolean;
+}
+
+export interface VizelInteractionFeatureOptions {
+  readonly slashMenu?: VizelSlashCommandOptions | boolean;
+  readonly dragHandle?: VizelDragHandleOptions | boolean;
+  readonly mention?: VizelMentionOptions | boolean;
+  readonly characterCount?: VizelCharacterCountOptions | boolean;
+  readonly typography?: boolean;
+}
+
+export interface VizelCollaborationFeatureOptions {
+  readonly comments?: VizelCommentMarkOptions | boolean;
+  /**
+   * Enable collaboration mode. When set (any truthy value), the
+   * History extension is excluded — Yjs provides its own undo
+   * manager. In 8a this is a `boolean`; 8e replaces it with the
+   * structured `VizelCollaborationProvider` type.
+   */
+  readonly provider?: boolean;
+}
+```
+
+Note that 8a deliberately keeps `interaction.typography` as `boolean`
+(not `boolean | VizelTypographyOptions`) and does NOT introduce
+`interaction.blockMenu`, `interaction.bubbleMenu`,
+`interaction.findAndReplace`, `interaction.autoSave`,
+`interaction.placeholder`, `interaction.historyDepth`,
+`interaction.visualHierarchy`, `content.highlight`,
+`collaboration.versionHistory`, or `collaboration.presence`. Those
+fields land in 8b–8e.
+
+- [ ] **Step 2: Run typecheck and observe the cascade of failures**
+
+Run: `pnpm typecheck`
+Expected: errors in `packages/core/src/extensions/base.ts` (every
+`features.X` access for the renamed paths) and in
+`packages/core/src/utils/editorHelpers.ts` (`features.slashCommand`).
+This is the signal that Task 2 onward is needed.
+
+- [ ] **Step 3: Do NOT commit yet** — Task 1 alone leaves the repo
+broken. Continue to Task 2.
+
+### Task 2: Update `editorHelpers.ts` to use the nested path
+
+**Files:**
+- Modify: `packages/core/src/utils/editorHelpers.ts:53-98`.
+
+- [ ] **Step 1: Update `VizelResolveFeaturesOptions` and
+`resolveVizelFeatures` to read/write `features.interaction.slashMenu`**
+
+Replace lines 53–98 with:
+
+```ts
+/**
+ * Options for resolving features with a custom slash menu renderer.
+ */
+export interface VizelResolveFeaturesOptions {
+  /** The features configuration */
+  features?: VizelFeatureOptions;
+  /** Factory function to create the slash menu renderer */
+  createSlashMenuRenderer: () => Partial<SuggestionOptions<VizelSlashCommandItem>>;
+}
+
+/**
+ * Resolves feature options with a default slash menu renderer.
+ * If `interaction.slashMenu` is enabled but no suggestion renderer is
+ * provided, attaches the supplied default.
+ */
+export function resolveVizelFeatures(
+  options: VizelResolveFeaturesOptions
+): VizelFeatureOptions | undefined {
+  const { features, createSlashMenuRenderer } = options;
+
+  if (!features) {
+    return {
+      interaction: {
+        slashMenu: { suggestion: createSlashMenuRenderer() },
+      },
+    };
+  }
+
+  const interaction = features.interaction;
+  if (interaction?.slashMenu === false) {
+    return features;
+  }
+
+  const slashOptions =
+    typeof interaction?.slashMenu === "object" ? interaction.slashMenu : {};
+
+  if (slashOptions.suggestion) {
+    return features;
+  }
+
+  return {
+    ...features,
+    interaction: {
+      ...interaction,
+      slashMenu: {
+        ...slashOptions,
+        suggestion: createSlashMenuRenderer(),
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Re-run typecheck for `editorHelpers.ts`**
+
+Run: `pnpm typecheck`
+Expected: this file is clean; remaining failures stay in `base.ts`.
+
+### Task 3: Update `extensions/base.ts` — content category
+
+**Files:**
+- Modify: `packages/core/src/extensions/base.ts:89-125` (move
+  `Underline` out of always-on).
+- Modify: `packages/core/src/extensions/base.ts:130-378` (every
+  `features.X` access for renamed/moved fields).
+- Modify: `packages/core/src/extensions/base.ts:426-492` (the
+  orchestration function `createVizelExtensions`).
+
+- [ ] **Step 1: Remove `Underline` from `createBaseExtensions`**
+
+In `packages/core/src/extensions/base.ts:94-117`, drop `Underline` from
+the marks block. The replacement:
+
+```ts
+  const extensions: Extensions = [
+    // Nodes
+    Document,
+    Paragraph,
+    Text,
+    Heading.configure({ levels: headingLevels }),
+    Blockquote,
+    BulletList,
+    OrderedList,
+    ListItem,
+    // CodeBlock is added separately based on feature options
+    HardBreak,
+    HorizontalRule,
+    // Marks
+    Bold,
+    Code,
+    Italic,
+    Strike,
+    // Functionality
+    Dropcursor.configure({ color: "#3b82f6", width: 2 }),
+    Gapcursor,
+    ListKeymap,
+  ];
+```
+
+- [ ] **Step 2: Rewrite every `addXExtension` helper to read the new
+nested path**
+
+The full mechanical mapping for each helper. Apply each one in order:
+
+```ts
+// addSlashMenuExtension (rename from addSlashCommandExtension)
+function addSlashMenuExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const slashMenu = features.interaction?.slashMenu;
+  if (slashMenu === false) return;
+
+  const slashOptions = typeof slashMenu === "object" ? slashMenu : {};
+  const items: VizelSlashCommandItem[] = slashOptions.items ?? vizelDefaultSlashCommands;
+
+  extensions.push(
+    VizelSlashCommand.configure({
+      items,
+      ...(slashOptions.suggestion !== undefined && {
+        suggestion: slashOptions.suggestion,
+      }),
+    })
+  );
+}
+
+function addImageExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const image = features.content?.image;
+  if (image === false) return;
+
+  const imageOptions = typeof image === "object" ? image : {};
+  // …rest of function unchanged; just substitute `imageOptions` for the old local.
+}
+
+function addTaskListExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const taskList = features.content?.taskList;
+  if (taskList === false) return;
+  const taskListOptions = typeof taskList === "object" ? taskList : {};
+  extensions.push(...createVizelTaskListExtensions(taskListOptions));
+}
+
+function addCharacterCountExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const characterCount = features.interaction?.characterCount;
+  if (characterCount === false) return;
+  const characterCountOptions = typeof characterCount === "object" ? characterCount : {};
+  extensions.push(createVizelCharacterCountExtension(characterCountOptions));
+}
+
+function addTextColorExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const textColor = features.content?.textColor;
+  if (textColor === false) return;
+  const textColorOptions = typeof textColor === "object" ? textColor : {};
+  extensions.push(...createVizelTextColorExtensions(textColorOptions));
+}
+
+function addMathematicsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const mathematics = features.content?.mathematics;
+  if (mathematics === false) return;
+  const mathOptions = typeof mathematics === "object" ? mathematics : {};
+  extensions.push(...createVizelMathematicsExtensions(mathOptions));
+}
+
+function addDragHandleExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  locale?: VizelLocale,
+): void {
+  const dragHandle = features.interaction?.dragHandle;
+  if (dragHandle === false) return;
+  const dragHandleOptions = typeof dragHandle === "object" ? dragHandle : {};
+  extensions.push(
+    ...createVizelDragHandleExtensions({
+      ...dragHandleOptions,
+      ...(locale !== undefined && { locale }),
+    })
+  );
+}
+
+function addDetailsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const details = features.content?.details;
+  if (details === false) return;
+  const detailsOptions = typeof details === "object" ? details : {};
+  extensions.push(...createVizelDetailsExtensions(detailsOptions));
+}
+
+function addEmbedExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const embed = features.content?.embed;
+  if (embed === false) return;
+  const embedOptions = typeof embed === "object" ? embed : {};
+  extensions.push(createVizelEmbedExtension(embedOptions));
+}
+
+function addDiagramExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const diagram = features.content?.diagram;
+  if (diagram === false) return;
+  const diagramOptions = typeof diagram === "object" ? diagram : {};
+  extensions.push(createVizelDiagramExtension(diagramOptions));
+}
+
+function addTableOfContentsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const tableOfContents = features.content?.tableOfContents;
+  if (tableOfContents === false) return;
+  const tocOptions = typeof tableOfContents === "object" ? tableOfContents : {};
+  extensions.push(createVizelTableOfContentsExtension(tocOptions));
+}
+
+function addWikiLinkExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  flavorConfig: VizelFlavorConfig,
+): void {
+  const wikiLink = features.content?.wikiLink;
+  if (!wikiLink) return;
+  const wikiLinkOptions = typeof wikiLink === "object" ? wikiLink : {};
+  extensions.push(
+    createVizelWikiLinkExtension({
+      ...wikiLinkOptions,
+      serializeAsWikiLink: wikiLinkOptions.serializeAsWikiLink ?? flavorConfig.wikiLinkSerialize,
+    })
+  );
+}
+
+function addCalloutExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  flavorConfig: VizelFlavorConfig,
+): void {
+  const callout = features.content?.callout;
+  if (callout === false) return;
+  const calloutOptions = typeof callout === "object" ? callout : {};
+  extensions.push(
+    createVizelCalloutExtension({
+      ...calloutOptions,
+      markdownFormat: calloutOptions.markdownFormat ?? flavorConfig.calloutFormat,
+    })
+  );
+}
+
+function addMentionExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const mention = features.interaction?.mention;
+  if (!mention) return;
+  const mentionOptions = typeof mention === "object" ? mention : {};
+  extensions.push(createVizelMentionExtension(mentionOptions));
+}
+
+function addCommentsExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+  const comments = features.collaboration?.comments;
+  if (!comments) return;
+  const commentOptions = typeof comments === "object" ? comments : {};
+  extensions.push(createVizelCommentExtension(commentOptions));
+}
+```
+
+- [ ] **Step 3: Delete `addMarkdownExtension` from `base.ts` and load
+Markdown unconditionally**
+
+Remove the helper entirely (it currently lives at lines 175–182) and
+delete its call site inside `createVizelExtensions`. In its place, push
+`createVizelMarkdownExtension({})` unconditionally near the start
+of `createVizelExtensions`. Markdown options (flavor, encoding) are
+already threaded through the top-level `markdown` option on
+`VizelEditorOptions` (Section 10) — 8a does not touch that surface.
+
+- [ ] **Step 4: Make `Link` always-on**
+
+Remove the `features.link` branch at lines 457–460 and unconditionally
+push `createVizelLinkExtension({})` early in `createVizelExtensions`.
+(The configurable `VizelLinkOptions` surface stays available through
+Section 10's top-level options; consumers who currently customize the
+link via `features.link: {...}` get a typed compile error and migrate.)
+
+- [ ] **Step 5: Make `CodeBlock` always-on**
+
+Replace the entire `addCodeBlockExtension` function body with the
+unconditional path:
+
+```ts
+async function addCodeBlockExtension(
+  extensions: Extensions,
+  locale?: VizelLocale,
+): Promise<void> {
+  const { createVizelCodeBlockExtension } = await import("./code-block-lowlight.ts");
+  extensions.push(
+    ...(await createVizelCodeBlockExtension({
+      ...(locale !== undefined && { locale }),
+    }))
+  );
+}
+```
+
+The `features` parameter is no longer needed. Update the call site
+inside `createVizelExtensions` accordingly:
+
+```ts
+await addCodeBlockExtension(extensions, locale);
+```
+
+- [ ] **Step 6: Move `Underline` / `Superscript` / `Subscript` into
+gated helpers**
+
+Replace the typography-marks block (currently lines 478–488) with:
+
+```ts
+  if (features.content?.underline !== false) {
+    extensions.push(Underline);
+  }
+  if (features.content?.superscript !== false) {
+    extensions.push(Superscript);
+  }
+  if (features.content?.subscript !== false) {
+    extensions.push(Subscript);
+  }
+  if (features.interaction?.typography !== false) {
+    extensions.push(Typography);
+  }
+```
+
+Note the comparator `!== false` matches the existing semantics: marks
+default to ON unless explicitly disabled. 8a keeps that default; 8b's
+underline / highlight independence does not change the default.
+
+- [ ] **Step 7: Update the `collaboration` check**
+
+Replace `const excludeHistory = features.collaboration === true;` (line
+438) with:
+
+```ts
+  const excludeHistory = Boolean(features.collaboration?.provider);
+```
+
+- [ ] **Step 8: Update the table branch**
+
+Replace lines 452–455 with:
+
+```ts
+  const table = features.content?.table;
+  if (table !== false) {
+    const tableOptions = typeof table === "object" ? table : {};
+    extensions.push(...createVizelTableExtensions(tableOptions));
+  }
+```
+
+- [ ] **Step 9: Rewire the orchestration calls**
+
+The `createVizelExtensions` function (around line 449 onward) should now
+call the renamed helpers in this order:
+
+```ts
+  // Always-on (no feature flag)
+  extensions.push(createVizelLinkExtension({}));
+  extensions.push(createVizelMarkdownExtension({}));
+
+  // Opt-out content
+  // (table handled inline above)
+
+  // Opt-out / opt-in features
+  addSlashMenuExtension(extensions, features);
+  addImageExtension(extensions, features);
+  addTaskListExtension(extensions, features);
+  addCharacterCountExtension(extensions, features);
+  addTextColorExtension(extensions, features);
+  addMathematicsExtension(extensions, features);
+  addDragHandleExtension(extensions, features, locale);
+  addDetailsExtension(extensions, features);
+  addCalloutExtension(extensions, features, flavorConfig);
+  addEmbedExtension(extensions, features);
+  addDiagramExtension(extensions, features);
+  addTableOfContentsExtension(extensions, features);
+  addWikiLinkExtension(extensions, features, flavorConfig);
+  addMentionExtension(extensions, features);
+  addCommentsExtension(extensions, features);
+
+  // Marks (default on)
+  // (underline / superscript / subscript / typography handled inline above)
+
+  // CodeBlock (always-on, async)
+  await addCodeBlockExtension(extensions, locale);
+```
+
+- [ ] **Step 10: Run typecheck and confirm `base.ts` is clean**
+
+Run: `pnpm typecheck`
+Expected: only demo / CT fixture errors remain.
+
+### Task 4: Migrate the React demo app
+
+**Files:**
+- Modify: `apps/demo/react/src/App.tsx` (the `features={{…}}` block
+  around line 268).
+
+- [ ] **Step 1: Rewrite the `features` literal in `App.tsx`**
+
+Replace the existing object with:
+
+```tsx
+              features={{
+                content: {
+                  mathematics: true,
+                  embed: true,
+                  details: true,
+                  diagram: true,
+                  wikiLink: true,
+                  callout: true,
+                  tableOfContents: true,
+                  superscript: true,
+                  subscript: true,
+                  image: {
+                    onUpload: mockUploadImage,
+                    maxFileSize: 10 * 1024 * 1024,
+                    onValidationError: (error) => {
+                      alert(`Validation error: ${error.message}`);
+                    },
+                    onUploadError: (error) => {
+                      alert(`Upload failed: ${error.message}`);
+                    },
+                  },
+                },
+                interaction: {
+                  typography: true,
+                  mention: { items: mockMentionItems },
+                },
+                collaboration: {
+                  comments: true,
+                },
+              }}
+```
+
+Removed (now always-on): `markdown`, `codeBlock`.
+
+- [ ] **Step 2: Run typecheck for the React app**
+
+Run: `pnpm -F demo-react typecheck` (or `pnpm typecheck` for the
+workspace).
+Expected: React demo is clean.
+
+### Task 5: Migrate the Vue demo app
+
+**Files:**
+- Modify: `apps/demo/vue/src/App.vue` (search for `features={{` /
+  `:features="…"` block; the surrounding template wires the editor).
+
+- [ ] **Step 1: Apply the same nested-shape rewrite to the Vue template
+binding**
+
+The literal mirrors Task 4 exactly. Locate the `:features="…"` or
+inline `features="{…}"` declaration and replace with the same nested
+object. Vue accepts the literal as a TS expression.
+
+- [ ] **Step 2: Run typecheck for the Vue app**
+
+Run: `pnpm typecheck`
+Expected: Vue demo is clean.
+
+### Task 6: Migrate the Svelte demo app
+
+**Files:**
+- Modify: `apps/demo/svelte/src/App.svelte` (around line 216, the
+  `features={{…}}` block).
+
+- [ ] **Step 1: Apply the same nested-shape rewrite to the Svelte
+component binding**
+
+Use the same literal as Task 4. Svelte 5 props accept it directly.
+
+- [ ] **Step 2: Run typecheck for the Svelte app**
+
+Run: `pnpm typecheck`
+Expected: Svelte demo is clean.
+
+### Task 7: Migrate Playwright CT fixtures
+
+**Files:**
+- Modify: every fixture under `tests/ct/**/specs/*Fixture.*` that
+  passes `features`. Concrete set discovered via
+  `git grep -nE 'features\\s*[:=]\\s*\\{' tests/ct`.
+
+- [ ] **Step 1: Run the grep to enumerate fixtures**
+
+Run: `git grep -nE 'features\s*[:=]\s*\{' tests/ct`
+Expected: a non-empty list of fixture file paths.
+
+- [ ] **Step 2: Rewrite each fixture's `features` object**
+
+For every match, apply the same shape mapping as in Task 4. There is no
+short-cut for this — each fixture chooses a different subset, so the
+fields differ. The mapping table at the top of this plan is the
+authority for which field goes where.
+
+- [ ] **Step 3: Run typecheck for the CT workspace**
+
+Run: `pnpm typecheck`
+Expected: CT fixtures are clean.
+
+### Task 8: Run cross-framework parity, lint, and CT
+
+- [ ] **Step 1: Run the parity check**
+
+Run: `pnpm check:parity`
+Expected: PASS. The parity script does not look at field-level shapes
+of `VizelFeatureOptions`, so the migration is invisible to it.
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm check`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full CT suite for one framework as a smoke test**
+
+Run: `pnpm test:ct:react`
+Expected: PASS. (If it fails on a CT scenario that exercised the old
+`features.slashCommand` path through fixture-level config, fix the
+fixture — that is the same migration Task 7 already covered.)
+
+### Task 9: Update `.claude/rules/packages/core.md`
+
+**Files:**
+- Modify: `.claude/rules/packages/core.md` (the "Extension Catalog"
+  table — add a note that Markdown, Link, and CodeBlock are always-on
+  and not gated by `features`).
+
+- [ ] **Step 1: Add the always-on note to the catalog**
+
+Append to the catalog section:
+
+```markdown
+The following extensions are part of the always-on core and are NOT
+gated by `VizelFeatureOptions`: Markdown, Link, CodeBlock. To configure
+them, use the corresponding top-level options on `VizelEditorOptions`
+(e.g. the Markdown flavor lives at `flavor`, not under `features`).
+```
+
+### Task 10: Commit and open the 8a PR
+
+- [ ] **Step 1: Stage and commit on the 8a branch**
+
+```bash
+git checkout -b feat/v2-section-08a-features-hierarchy
+git add packages/core/src/types.ts \
+        packages/core/src/utils/editorHelpers.ts \
+        packages/core/src/extensions/base.ts \
+        apps/demo/react/src/App.tsx \
+        apps/demo/vue/src/App.vue \
+        apps/demo/svelte/src/App.svelte \
+        tests/ct \
+        .claude/rules/packages/core.md
+git commit -m "feat: group VizelFeatureOptions into content/interaction/collaboration"
+git push -u origin feat/v2-section-08a-features-hierarchy
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat: group VizelFeatureOptions into content/interaction/collaboration" \
+  --body-file <(cat <<'EOF'
+## Summary
+
+- Restructure `VizelFeatureOptions` into a nested `{ content, interaction, collaboration }` shape per spec Section 8.
+- Rename `features.slashCommand` → `features.interaction.slashMenu` and `features.comment` → `features.collaboration.comments` (breaking).
+- Move `link`, `markdown`, and `codeBlock` out of `features` into the always-on core (breaking — these are no longer toggleable through `features`).
+- Move `underline`, `superscript`, `subscript` out of the always-on base into `features.content.*` (default-on, but now opt-out-able).
+- Update React / Vue / Svelte demos and Playwright CT fixtures to the new shape.
+
+## Breaking Changes
+
+- `features.slashCommand` → `features.interaction.slashMenu`
+- `features.comment` → `features.collaboration.comments`
+- `features.table` → `features.content.table`
+- `features.image` → `features.content.image`
+- `features.taskList` → `features.content.taskList`
+- `features.textColor` → `features.content.textColor`
+- `features.mathematics` → `features.content.mathematics`
+- `features.embed` → `features.content.embed`
+- `features.details` → `features.content.details`
+- `features.callout` → `features.content.callout`
+- `features.diagram` → `features.content.diagram`
+- `features.wikiLink` → `features.content.wikiLink`
+- `features.tableOfContents` → `features.content.tableOfContents`
+- `features.superscript` → `features.content.superscript`
+- `features.subscript` → `features.content.subscript`
+- `features.dragHandle` → `features.interaction.dragHandle`
+- `features.mention` → `features.interaction.mention`
+- `features.characterCount` → `features.interaction.characterCount`
+- `features.typography` → `features.interaction.typography`
+- `features.collaboration: boolean` → `features.collaboration.provider: boolean` (8e replaces the boolean with a structured provider type)
+- `features.link`, `features.markdown`, `features.codeBlock` — REMOVED (always-on)
+
+Subsequent sub-PRs (8b–8f) introduce new fields under the same nested
+shape — see `docs/superpowers/plans/2026-05-18-vizel-v2-section-08-feature-grouping.md`.
+
+## Test Plan
+
+- [x] `pnpm typecheck`
+- [x] `pnpm check`
+- [x] `pnpm check:parity`
+- [x] `pnpm test:ct:react`
+- [x] Manual: open each demo, verify slash menu / image / table / drag handle / mention still work.
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks --watch`
+Expected: all checks PASS.
+
+- [ ] **Step 4: Merge after green CI**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main
+git pull --ff-only origin main
+```
+
+---
+
+## Sub-PR 8b — Highlight independence (placeholder)
+
+Detailed task list will be written into this same plan file when 8a
+merges. Scope is bounded by the type-mapping table above
+(`content.highlight` line) and the spec Section 8 type signature.
+
+## Sub-PR 8c — Interaction features wire (placeholder)
+
+Detailed task list will be written into this same plan file when 8b
+merges.
+
+## Sub-PR 8d — visualHierarchy extension (placeholder)
+
+Detailed task list will be written into this same plan file when 8c
+merges.
+
+## Sub-PR 8e — Collaboration grouping (placeholder)
+
+Detailed task list will be written into this same plan file when 8d
+merges.
+
+## Sub-PR 8f — Helpers, validation, docs (placeholder)
+
+Detailed task list will be written into this same plan file when 8e
+merges.

--- a/docs/superpowers/plans/2026-05-19-vizel-v2-section-09-command-unification.md
+++ b/docs/superpowers/plans/2026-05-19-vizel-v2-section-09-command-unification.md
@@ -1,0 +1,435 @@
+# Section 9 — Command Abstraction Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a single runtime-bearing `VizelCommand` type that
+replaces the five legacy item types (slash item, toolbar action, bubble
+menu action, block menu action, keyboard shortcut). Default command
+registries (`vizelFormatCommands`, `vizelBlockCommands`,
+`vizelInsertCommands`, `vizelDefaultCommands`) emit `VizelCommand[]`,
+and surface builders derive existing spec types (Section 2) from those
+commands plus a `VizelCommandSurfaceSet`.
+
+**Architecture:** All changes flow through `@vizel/core`. The new type
+lives in `commands/types.ts`; default registries live in
+`commands/registry/`; surface builders gain `VizelCommand`-aware entry
+points that produce the existing spec shapes (`VizelMenuSpec`,
+`readonly VizelCommandSpec[]`, etc.). Existing `SlashCommandItem` keeps
+working as an alternative input for backward compatibility within
+v2.0.0 development but is deprecated in favor of `VizelCommand`.
+
+**Tech Stack:** TypeScript, Tiptap v2 keymap, locale system, Section 2
+spec types.
+
+---
+
+## Spec mapping (binding)
+
+```ts
+export type VizelCommand = {
+  readonly id: string;
+  readonly label: (locale: VizelLocale) => string;
+  readonly description?: (locale: VizelLocale) => string;
+  readonly icon?: VizelIconName;
+  readonly group?: string;
+  readonly keywords?: readonly string[];
+  readonly shortcut?: VizelShortcut;
+  readonly canRun: (editor: Editor) => boolean;
+  readonly isActive?: (editor: Editor) => boolean;
+  readonly run: (editor: Editor) => boolean;
+  readonly surfaces: VizelCommandSurfaceSet;
+};
+
+export type VizelCommandSurfaceSet = {
+  readonly slashMenu?: { readonly priority?: number };
+  readonly toolbar?: { readonly priority?: number };
+  readonly bubbleMenu?: {
+    readonly priority?: number;
+    readonly showWhen?: (editor: Editor) => boolean;
+  };
+  readonly blockMenu?: { readonly priority?: number };
+  readonly shortcut?: true;
+};
+
+export type VizelShortcut = {
+  readonly mac: string;
+  readonly other: string;
+};
+```
+
+Surface derivation:
+
+- `buildVizelSlashMenuSpec` — filters `surfaces.slashMenu`, applies the
+  query filter, groups by `group`, returns
+  `VizelMenuSpec<VizelCommandSpec>`.
+- `buildVizelToolbarSpec` — filters `surfaces.toolbar`, sorts by
+  priority, returns `readonly VizelCommandSpec[]`.
+- `buildVizelBubbleMenuSpec` — filters `surfaces.bubbleMenu` and the
+  `showWhen` predicate.
+- `buildVizelBlockMenuSpec` — filters `surfaces.blockMenu`.
+- `registerVizelShortcuts` — walks every command with
+  `surfaces.shortcut` and a `shortcut` field, registers Tiptap key
+  bindings, choosing `mac` or `other` from `isVizelMacPlatform()`.
+
+Default registries:
+
+```ts
+export const vizelFormatCommands: readonly VizelCommand[];
+export const vizelBlockCommands: readonly VizelCommand[];
+export const vizelInsertCommands: readonly VizelCommand[];
+export const vizelDefaultCommands: readonly VizelCommand[];
+```
+
+`vizelCommandsFromNodeTypes(nodeTypes)` derives `VizelCommand[]` from
+`VizelNodeTypeOption[]`.
+
+---
+
+## Sub-PR breakdown
+
+The work splits into four PRs sized for one focused review each:
+
+- **9a — Type foundation.** `VizelCommand`, `VizelCommandSurfaceSet`,
+  `VizelShortcut` in `commands/types.ts`; pure helper
+  `deriveVizelCommandSpec(command, editor, locale)` returning the
+  Section 2 `VizelCommandSpec`; one tiny default registry
+  (`vizelFormatCommands` — bold, italic, code, strike) wired up just to
+  exercise the type. No surface builders change yet.
+
+- **9b — Default registries + slash menu derivation.** Full
+  `vizelFormatCommands`, `vizelBlockCommands`, `vizelInsertCommands`,
+  `vizelDefaultCommands`. New entry point
+  `buildVizelSlashMenuSpecFromCommands(commands, query, editor, locale,
+  selectedIndex, options)` returning
+  `VizelMenuSpec<VizelCommandSpec>`. Legacy `SlashCommandItem` path
+  stays for callers that still pass items directly.
+
+- **9c — Toolbar / bubble / block surface builders + shortcuts.**
+  - `buildVizelToolbarSpec(commands, editor, locale)`
+  - `buildVizelBubbleMenuSpec(commands, editor, locale)`
+  - `buildVizelBlockMenuSpec(commands, editor, locale)`
+  - `registerVizelShortcuts(commands)` Tiptap extension factory.
+
+- **9d — Auto node-type expansion + docs.**
+  `vizelCommandsFromNodeTypes(nodeTypes)` plus a "Command Layer"
+  section in `.claude/rules/packages/core.md` with surface-set rules,
+  locale integration rules, and shortcut OS-branching rules.
+
+Each sub-PR ends green on `pnpm lint && pnpm typecheck && pnpm build`
+plus the full Playwright matrix on CI.
+
+---
+
+## Task 9a-1: Add VizelCommand type foundation
+
+**Files:**
+- Create: `packages/core/src/commands/types.ts`
+- Modify: `packages/core/src/commands/index.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write the type module**
+
+```ts
+// packages/core/src/commands/types.ts
+import type { Editor } from "@tiptap/core";
+import type { VizelIconName } from "../icons/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+
+export interface VizelShortcut {
+  readonly mac: string;
+  readonly other: string;
+}
+
+export interface VizelCommandSurfaceSet {
+  readonly slashMenu?: { readonly priority?: number };
+  readonly toolbar?: { readonly priority?: number };
+  readonly bubbleMenu?: {
+    readonly priority?: number;
+    readonly showWhen?: (editor: Editor) => boolean;
+  };
+  readonly blockMenu?: { readonly priority?: number };
+  readonly shortcut?: true;
+}
+
+export interface VizelCommand {
+  readonly id: string;
+  readonly label: (locale: VizelLocale) => string;
+  readonly description?: (locale: VizelLocale) => string;
+  readonly icon?: VizelIconName;
+  readonly group?: string;
+  readonly keywords?: readonly string[];
+  readonly shortcut?: VizelShortcut;
+  readonly canRun: (editor: Editor) => boolean;
+  readonly isActive?: (editor: Editor) => boolean;
+  readonly run: (editor: Editor) => boolean;
+  readonly surfaces: VizelCommandSurfaceSet;
+}
+```
+
+- [ ] **Step 2: Re-export from `commands/index.ts` and root `index.ts`**
+
+- [ ] **Step 3: Add `deriveVizelCommandSpec` helper in `commands/derive.ts`**
+
+```ts
+import type { Editor } from "@tiptap/core";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "../builders/types.ts";
+import type { VizelCommand } from "./types.ts";
+
+export function deriveVizelCommandSpec(
+  command: VizelCommand,
+  editor: Editor,
+  locale: VizelLocale
+): VizelCommandSpec {
+  return {
+    id: command.id,
+    label: command.label(locale),
+    ...(command.description && { description: command.description(locale) }),
+    ...(command.icon && { icon: command.icon }),
+    ...(command.shortcut && { shortcut: command.shortcut }),
+    ...(command.group && { group: command.group }),
+    ...(command.keywords && { keywords: command.keywords }),
+    isEnabled: command.canRun(editor),
+    isActive: command.isActive?.(editor) ?? false,
+  };
+}
+```
+
+- [ ] **Step 4: Run `pnpm check && pnpm typecheck && pnpm build`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -b feat/v2-section-09a-vizel-command-types
+git add packages/core/src/commands/types.ts packages/core/src/commands/derive.ts \
+        packages/core/src/commands/index.ts packages/core/src/index.ts
+git commit -m "feat(core): add VizelCommand type foundation"
+```
+
+- [ ] **Step 6: Open PR 9a**
+
+---
+
+## Task 9b-1: Default command registries
+
+**Files:**
+- Create: `packages/core/src/commands/registry/format.ts`
+- Create: `packages/core/src/commands/registry/block.ts`
+- Create: `packages/core/src/commands/registry/insert.ts`
+- Create: `packages/core/src/commands/registry/index.ts`
+- Modify: `packages/core/src/commands/index.ts`
+
+Each registry exports `readonly VizelCommand[]`. `vizelDefaultCommands`
+is the concatenation. Use `command.canRun` to gate on `editor.can()`
+calls and reuse the same `run` closures the legacy
+`SlashCommandItem.command` closures used (read off `defaultSlashCommands`).
+
+- [ ] **Step 1: Port format commands (bold, italic, strike, underline, code, superscript, subscript, link-toggle).**
+
+Each command sets `surfaces: { slashMenu: { priority: ... }, toolbar: { priority: ... }, bubbleMenu: { priority: ... }, shortcut: true }` with appropriate `shortcut` strings.
+
+- [ ] **Step 2: Port block commands (heading1..6, bulletList, orderedList, taskList, quote, codeBlock, divider, details, callout).**
+
+- [ ] **Step 3: Port insert commands (table, image, uploadImage, embed, tableOfContents, math, mermaid, graphviz).**
+
+- [ ] **Step 4: Concatenate into `vizelDefaultCommands`.**
+
+- [ ] **Step 5: Run `pnpm check && pnpm typecheck && pnpm build`**
+
+- [ ] **Step 6: Commit and open PR 9b (after task 9b-2).**
+
+---
+
+## Task 9b-2: Slash menu derivation from VizelCommand
+
+**Files:**
+- Modify: `packages/core/src/builders/slash-menu.ts`
+- Test: existing slash menu Playwright CT scenarios still pass
+
+- [ ] **Step 1: Add new entry point**
+
+```ts
+export function buildVizelSlashMenuSpecFromCommands(
+  commands: readonly VizelCommand[],
+  options: {
+    readonly editor: Editor;
+    readonly locale: VizelLocale;
+    readonly query: string;
+    readonly selectedIndex: number;
+    readonly showGroups?: boolean;
+    readonly groupOrder?: readonly string[];
+  }
+): VizelMenuSpec<VizelCommandSpec>;
+```
+
+- [ ] **Step 2: Implement**: filter by `surfaces.slashMenu`, sort by
+  priority, apply query (reuse existing fuse.js path via lightweight
+  adapter or replicate substring fallback), group by `command.group`,
+  derive each item with `deriveVizelCommandSpec`.
+
+- [ ] **Step 3: Add `selectedIndex` flag to spec items via the existing
+  `VizelMenuItemSpec.data` shape — extend `VizelCommandSpec` consumers
+  on the framework side to read `selected` from the menu spec, not the
+  command spec.**
+
+- [ ] **Step 4: Verify slash menu Playwright CTs still pass against the
+  legacy path (the new path is opt-in).**
+
+- [ ] **Step 5: Run `pnpm check && pnpm typecheck && pnpm build`.**
+
+- [ ] **Step 6: Commit and open PR 9b.**
+
+```bash
+git checkout -b feat/v2-section-09b-default-registries
+git add packages/core/src/commands/registry/ packages/core/src/builders/slash-menu.ts
+git commit -m "feat(core): add default command registries and slash-menu derivation"
+```
+
+---
+
+## Task 9c-1: Toolbar / Bubble / Block surface builders
+
+**Files:**
+- Create: `packages/core/src/builders/toolbar.ts`
+- Create: `packages/core/src/builders/bubble-menu.ts`
+- Modify: `packages/core/src/builders/block-menu.ts`
+- Modify: `packages/core/src/builders/index.ts`
+
+- [ ] **Step 1: `buildVizelToolbarSpec`**
+
+```ts
+export function buildVizelToolbarSpec(
+  commands: readonly VizelCommand[],
+  options: { readonly editor: Editor; readonly locale: VizelLocale }
+): readonly VizelCommandSpec[] {
+  const filtered = commands
+    .filter((c) => c.surfaces.toolbar !== undefined)
+    .slice()
+    .sort(
+      (a, b) =>
+        (a.surfaces.toolbar?.priority ?? 0) -
+        (b.surfaces.toolbar?.priority ?? 0)
+    );
+  return filtered.map((c) => deriveVizelCommandSpec(c, options.editor, options.locale));
+}
+```
+
+- [ ] **Step 2: `buildVizelBubbleMenuSpec`**
+
+Identical shape to toolbar but filters by `surfaces.bubbleMenu` and
+respects `showWhen`.
+
+- [ ] **Step 3: `buildVizelBlockMenuSpec`**
+
+Existing builder produces `VizelPopoverSpec + VizelMenuSpec`. Add a
+`buildVizelBlockMenuSpecFromCommands` overload that consumes
+`readonly VizelCommand[]` instead of legacy items and reuses the existing
+popover assembly.
+
+- [ ] **Step 4: Run `pnpm check && pnpm typecheck && pnpm build`.**
+
+- [ ] **Step 5: Commit and open PR 9c (after 9c-2).**
+
+---
+
+## Task 9c-2: Shortcut registration
+
+**Files:**
+- Create: `packages/core/src/extensions/command-shortcuts.ts`
+- Modify: `packages/core/src/extensions/base.ts` (register conditionally)
+
+- [ ] **Step 1: Implement `createVizelCommandShortcutsExtension(commands)`**
+
+Returns a Tiptap `Extension.create` with `addKeyboardShortcuts()` that
+walks the commands, picks `mac` vs `other` via `isVizelMacPlatform()`,
+and binds each entry that has both `surfaces.shortcut === true` and a
+`shortcut` field. The bound callback runs `command.run(this.editor)`.
+
+- [ ] **Step 2: Wire it through `createVizelExtensions` behind a new
+  `commands?: readonly VizelCommand[]` option (default: skip — no
+  behavior change for existing consumers).**
+
+- [ ] **Step 3: Run `pnpm check && pnpm typecheck && pnpm build`.**
+
+- [ ] **Step 4: Commit and open PR 9c.**
+
+```bash
+git checkout -b feat/v2-section-09c-surface-builders
+git add packages/core/src/builders/toolbar.ts packages/core/src/builders/bubble-menu.ts \
+        packages/core/src/builders/block-menu.ts packages/core/src/builders/index.ts \
+        packages/core/src/extensions/command-shortcuts.ts packages/core/src/extensions/base.ts
+git commit -m "feat(core): add toolbar/bubble/block command builders and shortcut registry"
+```
+
+---
+
+## Task 9d-1: Auto node-type expansion
+
+**Files:**
+- Create: `packages/core/src/commands/registry/from-node-types.ts`
+- Modify: `packages/core/src/commands/index.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+export function vizelCommandsFromNodeTypes(
+  nodeTypes: readonly VizelNodeTypeOption[]
+): readonly VizelCommand[] {
+  return nodeTypes.map((nt) => ({
+    id: `nodeType/${nt.id}`,
+    label: (locale) => locale.nodeTypes[nt.id] ?? nt.label,
+    ...(nt.description && { description: () => nt.description }),
+    ...(nt.icon && { icon: nt.icon }),
+    group: nt.group ?? "Blocks",
+    canRun: (editor) => editor.can().setNode(nt.id),
+    isActive: (editor) => editor.isActive(nt.id),
+    run: (editor) => editor.chain().focus().setNode(nt.id).run(),
+    surfaces: {
+      slashMenu: { priority: nt.priority ?? 0 },
+      blockMenu: { priority: nt.priority ?? 0 },
+      shortcut: nt.shortcut ? true : undefined,
+    },
+  }));
+}
+```
+
+- [ ] **Step 2: Run `pnpm check && pnpm typecheck && pnpm build`.**
+
+---
+
+## Task 9d-2: .claude/rules/packages/core.md — Command Layer section
+
+**Files:**
+- Modify: `.claude/rules/packages/core.md`
+
+- [ ] **Step 1: Append a Command Layer section after "Feature Categories"** documenting:
+  - The five surfaces and their builder names.
+  - The `surfaces.shortcut` + `shortcut.mac`/`shortcut.other` OS-branching rule.
+  - The locale rule: `label`/`description` receive `VizelLocale`; callers
+    pass the editor's locale to surface builders.
+  - The categorization rule: a command lives in a single registry
+    (`vizelFormatCommands` / `vizelBlockCommands` / `vizelInsertCommands`)
+    based on whether it changes a mark, changes a node type, or inserts
+    a new structure.
+
+- [ ] **Step 2: Commit and open PR 9d.**
+
+```bash
+git checkout -b feat/v2-section-09d-node-type-expansion
+git add packages/core/src/commands/registry/from-node-types.ts \
+        packages/core/src/commands/index.ts \
+        .claude/rules/packages/core.md
+git commit -m "feat(core): add command auto-derivation from node types and Command Layer docs"
+```
+
+---
+
+## Out of scope (deferred to a later section)
+
+- Migrating `@vizel/react`, `@vizel/vue`, `@vizel/svelte` components to
+  consume the new toolbar/bubble/block builders directly. That swap
+  retires the legacy `SlashCommandItem` import path and is a separate
+  cross-framework PR after Section 9 stabilizes.
+- Removing `SlashCommandItem` entirely. The legacy item type continues
+  to exist as an alternative input to the legacy slash menu builder
+  path until the framework migration above completes.

--- a/packages/core/src/commands/derive.ts
+++ b/packages/core/src/commands/derive.ts
@@ -1,0 +1,30 @@
+import type { Editor } from "@tiptap/core";
+import type { VizelCommandSpec } from "../builders/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommand } from "./types.ts";
+
+/**
+ * Derive a {@link VizelCommandSpec} for a single editor instance.
+ *
+ * Surface builders call this helper for each command they include in
+ * their output so the resulting spec carries the localized strings and
+ * the runtime-evaluated `isEnabled` / `isActive` flags expected by the
+ * Section 2 spec shapes.
+ */
+export function deriveVizelCommandSpec(
+  command: VizelCommand,
+  editor: Editor,
+  locale: VizelLocale
+): VizelCommandSpec {
+  return {
+    id: command.id,
+    label: command.label(locale),
+    ...(command.description && { description: command.description(locale) }),
+    ...(command.icon && { icon: command.icon }),
+    ...(command.shortcut && { shortcut: command.shortcut }),
+    ...(command.group && { group: command.group }),
+    ...(command.keywords && { keywords: command.keywords }),
+    isEnabled: command.canRun(editor),
+    isActive: command.isActive?.(editor) ?? false,
+  };
+}

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,0 +1,7 @@
+// VizelCommand unified abstraction (Section 9).
+export { deriveVizelCommandSpec } from "./derive.ts";
+export type {
+  VizelCommand,
+  VizelCommandSurfaceSet,
+  VizelShortcut,
+} from "./types.ts";

--- a/packages/core/src/commands/types.ts
+++ b/packages/core/src/commands/types.ts
@@ -1,0 +1,102 @@
+import type { Editor } from "@tiptap/core";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelIconName } from "../icons/types.ts";
+
+/**
+ * Platform-specific keyboard shortcut.
+ *
+ * Format follows Tiptap's keymap notation: `Mod` resolves to `Cmd` on
+ * macOS and `Ctrl` elsewhere; `Alt` and `Shift` carry their usual
+ * meaning. Examples: `"Mod-B"`, `"Mod-Shift-1"`, `"Alt-ArrowUp"`.
+ *
+ * Both fields are required because some shortcuts intentionally differ
+ * across platforms (for example, find-and-replace bound to `"Mod-F"`
+ * on macOS and `"Ctrl-H"` elsewhere). When the two values coincide,
+ * set both to the same string.
+ */
+export interface VizelShortcut {
+  /** Shortcut string for macOS. */
+  readonly mac: string;
+  /** Shortcut string for non-macOS platforms (Windows / Linux). */
+  readonly other: string;
+}
+
+/**
+ * Set of surfaces a {@link VizelCommand} participates in.
+ *
+ * Every surface entry is optional; absence means the command does not
+ * appear on that surface. Each entry carries surface-specific tuning
+ * such as `priority` (lower number = earlier position) and, for the
+ * bubble menu, a `showWhen` predicate that hides the action when the
+ * current selection does not warrant it.
+ */
+export interface VizelCommandSurfaceSet {
+  /** Show the command in the slash menu. */
+  readonly slashMenu?: { readonly priority?: number };
+  /** Show the command in the editor toolbar. */
+  readonly toolbar?: { readonly priority?: number };
+  /** Show the command in the bubble menu when text is selected. */
+  readonly bubbleMenu?: {
+    readonly priority?: number;
+    /** Hide the action when the predicate returns `false`. */
+    readonly showWhen?: (editor: Editor) => boolean;
+  };
+  /** Show the command in the block-level kebab menu. */
+  readonly blockMenu?: { readonly priority?: number };
+  /** Register the command's `shortcut` as a Tiptap keybinding. */
+  readonly shortcut?: true;
+}
+
+/**
+ * Unified runtime-bearing command shared across editor surfaces.
+ *
+ * A single `VizelCommand` replaces the legacy slash item, toolbar
+ * action, bubble menu action, block menu action, and shortcut binding.
+ * Surface-specific builders (`buildVizelSlashMenuSpec`,
+ * `buildVizelToolbarSpec`, `buildVizelBubbleMenuSpec`,
+ * `buildVizelBlockMenuSpec`) consume `VizelCommand[]` and derive
+ * Section 2 spec shapes; `registerVizelShortcuts` consumes the same
+ * list to wire keyboard bindings.
+ *
+ * @example
+ * ```ts
+ * const boldCommand: VizelCommand = {
+ *   id: "format/bold",
+ *   label: (locale) => locale.toolbar.bold,
+ *   icon: "bold",
+ *   shortcut: { mac: "Mod-B", other: "Mod-B" },
+ *   canRun: (editor) => editor.can().toggleBold(),
+ *   isActive: (editor) => editor.isActive("bold"),
+ *   run: (editor) => editor.chain().focus().toggleBold().run(),
+ *   surfaces: {
+ *     toolbar: { priority: 10 },
+ *     bubbleMenu: { priority: 10 },
+ *     shortcut: true,
+ *   },
+ * };
+ * ```
+ */
+export interface VizelCommand {
+  /** Stable identifier shared across surfaces (e.g. `"format/bold"`). */
+  readonly id: string;
+  /** Localized display label. */
+  readonly label: (locale: VizelLocale) => string;
+  /** Optional secondary line (slash menu description, tooltip hint). */
+  readonly description?: (locale: VizelLocale) => string;
+  /** Optional icon identifier resolved by the icon catalog. */
+  readonly icon?: VizelIconName;
+  /** Group key for slash menu sections and other categorized surfaces. */
+  readonly group?: string;
+  /** Fuzzy-match keywords used by slash menu filtering. */
+  readonly keywords?: readonly string[];
+  /** Optional keyboard shortcut. Bound only when `surfaces.shortcut === true`. */
+  readonly shortcut?: VizelShortcut;
+  /** Whether the command can currently run against the editor. */
+  readonly canRun: (editor: Editor) => boolean;
+  /** Whether the command's mark / node is currently active at the selection. */
+  readonly isActive?: (editor: Editor) => boolean;
+  /** Execute the command. Returns whether the command applied. */
+  readonly run: (editor: Editor) => boolean;
+  /** Surfaces the command appears on. */
+  readonly surfaces: VizelCommandSurfaceSet;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,15 @@ export {
 } from "./collaboration.ts";
 export type { VizelCollaborationProvider } from "./collaboration-provider.ts";
 // =============================================================================
+// Commands (Section 9 — VizelCommand unified abstraction)
+// =============================================================================
+export {
+  deriveVizelCommandSpec,
+  type VizelCommand,
+  type VizelCommandSurfaceSet,
+  type VizelShortcut,
+} from "./commands/index.ts";
+// =============================================================================
 // Comments
 // =============================================================================
 export {


### PR DESCRIPTION
## Summary

- Add VizelCommand unified type foundation (Section 9, sub-PR 9a of 4).
- Introduces VizelCommand (label/description thunks, runtime canRun/isActive/run, optional shortcut, VizelCommandSurfaceSet), VizelCommandSurfaceSet (slashMenu/toolbar/bubbleMenu/blockMenu/shortcut), and VizelShortcut (mac/other Tiptap keymap strings).
- deriveVizelCommandSpec helper projects a VizelCommand into the Section 2 VizelCommandSpec for a specific editor + locale, returning the runtime-evaluated isEnabled / isActive flags.
- Default command registries and surface-specific builders (toolbar, bubble menu, block menu, slash menu) that consume VizelCommand[] follow in 9b-9d.

## Breaking Changes

None. No existing API changes; the new symbols are additive.

## Test Plan

- [x] Run `pnpm lint`.
- [x] Run `pnpm typecheck`.
- [x] Run `pnpm build`.
- [x] Run `pnpm check:parity`.
