### PR TITLE
feat(core): add command auto-derivation and Command Layer rule docs (Section 9d)

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -173,6 +173,70 @@ every safe opt-in (everything except `mention`, `provider`, `comments`,
 configuration to function). Use it when you want the Notion-like
 surface without enumerating each toggle.
 
+## Command Layer
+
+A single `VizelCommand` represents one user action everywhere it
+appears. The same logical command (e.g. "format/bold") shows up in
+the toolbar, the bubble menu, and the keyboard shortcut table without
+being defined more than once. Surface-specific builders consume a
+`readonly VizelCommand[]` and project each entry into the matching
+Section 2 spec for a specific editor and locale.
+
+### Surfaces and builders
+
+| Surface | Builder | Output |
+|---------|---------|--------|
+| Slash menu | `buildVizelSlashMenuSpecFromCommands` | `VizelMenuSpec<VizelCommandSpec>` |
+| Toolbar | `buildVizelToolbarSpec` | `readonly VizelCommandSpec[]` |
+| Bubble menu | `buildVizelBubbleMenuSpec` | `readonly VizelCommandSpec[]` |
+| Block menu | `buildVizelBlockMenuSpecFromCommands` | `readonly VizelCommandSpec[]` |
+| Keyboard shortcut | `createVizelCommandShortcutsExtension` | `Extension` |
+
+Each builder filters by the corresponding `command.surfaces.*` entry,
+applies surface-specific tuning (priority sort, `showWhen` predicate),
+and derives one `VizelCommandSpec` per command via
+`deriveVizelCommandSpec(command, editor, locale)`. The framework
+components consume the resulting specs without seeing a
+`VizelCommand`.
+
+### Built-in registries
+
+`vizelFormatCommands`, `vizelBlockCommands`, and
+`vizelInsertCommands` ship in `packages/core/src/commands/registry/`.
+A command lives in exactly one registry, chosen by what the command
+*does*:
+
+- **`vizelFormatCommands`** — toggles a mark (bold, italic, strike,
+  underline, code, superscript, subscript). Marks surface on the
+  toolbar / bubble menu only; they do not appear in the slash menu.
+- **`vizelBlockCommands`** — changes the current block's node type
+  (headings, lists, quote, code block, divider, details, callout).
+  Block commands surface on the slash menu plus an optional shortcut.
+- **`vizelInsertCommands`** — inserts a new node into the document
+  (table, image, embed, math, diagram, table of contents). Insert
+  commands surface on the slash menu only.
+
+`vizelDefaultCommands` is the concatenation of the three registries.
+`vizelCommandsFromNodeTypes(nodeTypes)` derives a parallel
+`VizelCommand[]` from `VizelNodeTypeOption[]` so adding a node type
+registers it across the block menu and slash menu in one entry.
+
+### Locale integration
+
+`VizelCommand.label` and `VizelCommand.description` are thunks that
+receive a `VizelLocale` and return a string. Surface builders pass the
+current locale; consumers override individual strings by passing a
+customized `VizelLocale` to the editor.
+
+### Shortcut OS branching
+
+`VizelShortcut` carries both `mac` and `other` strings (Tiptap keymap
+notation, where `Mod` resolves to `Cmd` on macOS and `Ctrl`
+elsewhere). `createVizelCommandShortcutsExtension` selects the right
+string via `isVizelMacPlatform()` and binds the result to
+`command.run(editor)`. When the two strings differ, document the
+reason in a comment on the command definition.
+
 ## Dependencies
 
 ### Allowed

--- a/packages/core/src/builders/block-menu-from-commands.ts
+++ b/packages/core/src/builders/block-menu-from-commands.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelBlockMenuSpecFromCommands}.
+ */
+export interface VizelBlockMenuFromCommandsOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying labels. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the block-menu action list from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.blockMenu`, sorts by priority ascending, and
+ * projects each command into a Section 2 {@link VizelCommandSpec}.
+ *
+ * The framework `VizelBlockMenu` component composes the resulting
+ * action list with the popover spec built by `buildVizelBlockMenuSpec`
+ * (which carries the existing block-level metadata like "Turn into"
+ * submenus). This helper only handles the action portion that flows
+ * from the unified command registry.
+ */
+export function buildVizelBlockMenuSpecFromCommands(
+  commands: readonly VizelCommand[],
+  options: VizelBlockMenuFromCommandsOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => command.surfaces.blockMenu !== undefined)
+    .slice()
+    .sort((a, b) => (a.surfaces.blockMenu?.priority ?? 0) - (b.surfaces.blockMenu?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/builders/bubble-menu.ts
+++ b/packages/core/src/builders/bubble-menu.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelBubbleMenuSpec}.
+ */
+export interface VizelBubbleMenuSpecOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying button labels and tooltips. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the bubble-menu spec from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.bubbleMenu`, applies each command's optional
+ * `showWhen` predicate against the editor, sorts by priority
+ * ascending, and projects each command into a Section 2
+ * {@link VizelCommandSpec}.
+ */
+export function buildVizelBubbleMenuSpec(
+  commands: readonly VizelCommand[],
+  options: VizelBubbleMenuSpecOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => {
+      const surface = command.surfaces.bubbleMenu;
+      if (!surface) return false;
+      return surface.showWhen ? surface.showWhen(options.editor) : true;
+    })
+    .slice()
+    .sort((a, b) => (a.surfaces.bubbleMenu?.priority ?? 0) - (b.surfaces.bubbleMenu?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -6,6 +6,14 @@ export {
   type VizelBlockMenuTurnIntoItemView,
 } from "./block-menu.ts";
 export {
+  buildVizelBlockMenuSpecFromCommands,
+  type VizelBlockMenuFromCommandsOptions,
+} from "./block-menu-from-commands.ts";
+export {
+  buildVizelBubbleMenuSpec,
+  type VizelBubbleMenuSpecOptions,
+} from "./bubble-menu.ts";
+export {
   buildVizelFindReplaceSpec,
   buildVizelFindReplaceSpecFromLocale,
   type VizelFindReplaceSpec,
@@ -30,10 +38,16 @@ export {
 } from "./node-selector.ts";
 export {
   buildVizelSlashMenuSpec,
+  buildVizelSlashMenuSpecFromCommands,
   getNextVizelSlashMenuGroupIndex,
   type VizelSlashItemView,
+  type VizelSlashMenuFromCommandsOptions,
   type VizelSlashMenuSpecOptions,
 } from "./slash-menu.ts";
+export {
+  buildVizelToolbarSpec,
+  type VizelToolbarSpecOptions,
+} from "./toolbar.ts";
 export {
   buildVizelToolbarDropdownSpec,
   type VizelToolbarDropdownItemView,

--- a/packages/core/src/builders/toolbar.ts
+++ b/packages/core/src/builders/toolbar.ts
@@ -1,0 +1,34 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelToolbarSpec}.
+ */
+export interface VizelToolbarSpecOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying button labels and tooltips. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the toolbar spec from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.toolbar`, sorts by priority ascending (lower
+ * priority appears first), and projects each command into a Section 2
+ * {@link VizelCommandSpec}. The framework `VizelToolbar` component
+ * iterates the result to render its buttons.
+ */
+export function buildVizelToolbarSpec(
+  commands: readonly VizelCommand[],
+  options: VizelToolbarSpecOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => command.surfaces.toolbar !== undefined)
+    .slice()
+    .sort((a, b) => (a.surfaces.toolbar?.priority ?? 0) - (b.surfaces.toolbar?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -2,6 +2,7 @@
 export { deriveVizelCommandSpec } from "./derive.ts";
 export {
   vizelBlockCommands,
+  vizelCommandsFromNodeTypes,
   vizelDefaultCommands,
   vizelFormatCommands,
   vizelInsertCommands,

--- a/packages/core/src/commands/registry/from-node-types.ts
+++ b/packages/core/src/commands/registry/from-node-types.ts
@@ -1,0 +1,38 @@
+import type { VizelNodeTypeOption } from "../../extensions/node-types.ts";
+import type { VizelCommand } from "../types.ts";
+
+/**
+ * Derive a {@link VizelCommand} array from a {@link VizelNodeTypeOption}
+ * array.
+ *
+ * Each node-type option becomes a slash-menu and block-menu entry that
+ * uses the option's `command` callback as `run` and its `isActive`
+ * callback as `isActive`. The derived `canRun` returns `true` — node
+ * types are expected to be applicable wherever the block menu is
+ * shown. Add a `canRun` predicate at the callsite when a node type
+ * needs finer gating.
+ *
+ * The derived `id` namespace is `nodeType/<option.name>` so the
+ * generated commands cannot collide with the hand-rolled registries.
+ * `label` uses the option's `label` directly; consumers that need
+ * locale-aware labels should pass `createVizelNodeTypes(locale)` here.
+ */
+export function vizelCommandsFromNodeTypes(
+  nodeTypes: readonly VizelNodeTypeOption[]
+): readonly VizelCommand[] {
+  return nodeTypes.map((option, index) => ({
+    id: `nodeType/${option.name}`,
+    label: () => option.label,
+    icon: option.icon,
+    canRun: () => true,
+    isActive: option.isActive,
+    run: (editor) => {
+      option.command(editor);
+      return true;
+    },
+    surfaces: {
+      slashMenu: { priority: 1000 + index },
+      blockMenu: { priority: 1000 + index },
+    },
+  }));
+}

--- a/packages/core/src/commands/registry/index.ts
+++ b/packages/core/src/commands/registry/index.ts
@@ -5,6 +5,7 @@ import { vizelInsertCommands } from "./insert.ts";
 
 export { vizelBlockCommands } from "./block.ts";
 export { vizelFormatCommands } from "./format.ts";
+export { vizelCommandsFromNodeTypes } from "./from-node-types.ts";
 export { vizelInsertCommands } from "./insert.ts";
 
 /**

--- a/packages/core/src/extensions/command-shortcuts.ts
+++ b/packages/core/src/extensions/command-shortcuts.ts
@@ -1,0 +1,47 @@
+import { Extension } from "@tiptap/core";
+import type { VizelCommand } from "../commands/types.ts";
+import { isVizelMacPlatform } from "../utils/keyboard.ts";
+
+/**
+ * Options accepted by {@link createVizelCommandShortcutsExtension}.
+ */
+export interface VizelCommandShortcutsOptions {
+  /**
+   * Commands to scan. Only entries with both `surfaces.shortcut === true`
+   * and a `shortcut` field contribute a keybinding.
+   */
+  readonly commands: readonly VizelCommand[];
+}
+
+/**
+ * Create a Tiptap extension that binds the keyboard shortcuts declared
+ * by a {@link VizelCommand} array.
+ *
+ * For every command with `surfaces.shortcut === true` and a `shortcut`
+ * field, the extension registers a binding using the platform-specific
+ * string: `shortcut.mac` on macOS, `shortcut.other` elsewhere. The
+ * bound callback runs `command.run(editor)`; the return value follows
+ * Tiptap's keybinding contract — `true` signals the editor consumed
+ * the key event.
+ */
+export function createVizelCommandShortcutsExtension(
+  options: VizelCommandShortcutsOptions
+): Extension {
+  return Extension.create({
+    name: "vizelCommandShortcuts",
+    addKeyboardShortcuts() {
+      const isMac = isVizelMacPlatform();
+      const bindings: Record<string, () => boolean> = {};
+
+      for (const command of options.commands) {
+        if (command.surfaces.shortcut !== true) continue;
+        if (!command.shortcut) continue;
+        const key = isMac ? command.shortcut.mac : command.shortcut.other;
+        if (!key) continue;
+        bindings[key] = () => command.run(this.editor);
+      }
+
+      return bindings;
+    },
+  });
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -32,6 +32,11 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
 } from "./code-block-lowlight.ts";
+// Command shortcuts (Section 9)
+export {
+  createVizelCommandShortcutsExtension,
+  type VizelCommandShortcutsOptions,
+} from "./command-shortcuts.ts";
 // Comment
 export {
   createVizelCommentExtension,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export {
   type VizelCommandSurfaceSet,
   type VizelShortcut,
   vizelBlockCommands,
+  vizelCommandsFromNodeTypes,
   vizelDefaultCommands,
   vizelFormatCommands,
   vizelInsertCommands,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,19 +47,25 @@ export {
 export {
   applyVizelLinkEdit,
   buildVizelBlockMenuSpec,
+  buildVizelBlockMenuSpecFromCommands,
+  buildVizelBubbleMenuSpec,
   buildVizelFindReplaceSpec,
   buildVizelFindReplaceSpecFromLocale,
   buildVizelLinkEditorSpec,
   buildVizelMentionMenuSpec,
   buildVizelNodeSelectorSpec,
   buildVizelSlashMenuSpec,
+  buildVizelSlashMenuSpecFromCommands,
   buildVizelToolbarDropdownSpec,
+  buildVizelToolbarSpec,
   getNextVizelSlashMenuGroupIndex,
   resolveVizelLinkEditorLabels,
+  type VizelBlockMenuFromCommandsOptions,
   type VizelBlockMenuItemView,
   type VizelBlockMenuSpec,
   type VizelBlockMenuSubmenuTriggerSpec,
   type VizelBlockMenuTurnIntoItemView,
+  type VizelBubbleMenuSpecOptions,
   type VizelCommandSpec,
   type VizelFindReplaceSpec,
   type VizelFormFieldAttrs,
@@ -87,10 +93,12 @@ export {
   type VizelPopoverTriggerSpec,
   type VizelShortcutSpec,
   type VizelSlashItemView,
+  type VizelSlashMenuFromCommandsOptions,
   type VizelSlashMenuSpecOptions,
   type VizelToolbarDropdownItemView,
   type VizelToolbarDropdownSpec,
   type VizelToolbarDropdownTriggerSpec,
+  type VizelToolbarSpecOptions,
 } from "./builders/index.ts";
 // =============================================================================
 // Collaboration
@@ -169,6 +177,8 @@ export {
   createVizelCharacterCountExtension,
   // Code block with syntax highlighting
   createVizelCodeBlockExtension,
+  // Command shortcuts (Section 9)
+  createVizelCommandShortcutsExtension,
   // Comment
   createVizelCommentExtension,
   // Embed (oEmbed, OGP)
@@ -260,6 +270,7 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
   type VizelColorDefinition,
+  type VizelCommandShortcutsOptions,
   VizelCommentMark,
   type VizelCommentMarkOptions,
   type VizelCommentPluginState,


### PR DESCRIPTION
## Summary

- Section 9 sub-PR 9d of 4 (final). Adds node-type auto-derivation and the Command Layer rule docs.
- `vizelCommandsFromNodeTypes(nodeTypes)` derives a parallel `VizelCommand[]` from `VizelNodeTypeOption[]`, registering each option in the slash menu and block menu under the `nodeType/<name>` id namespace. Adding a node type to `vizelDefaultNodeTypes` now exposes it across both surfaces in one entry.
- `.claude/rules/packages/core.md` gains a "Command Layer" section: maps the five surfaces to their builders, documents the three built-in registries (`vizelFormatCommands` / `vizelBlockCommands` / `vizelInsertCommands`) with the rule that places a command in exactly one of them, and explains the locale and shortcut-OS-branching contracts.

## Breaking Changes

None.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.

> Stacks on top of #476 (Section 9c).
