### PR TITLE
feat(core): add toolbar/bubble/block builders and shortcut registry (Section 9c)

### DIFF
--- a/packages/core/src/builders/block-menu-from-commands.ts
+++ b/packages/core/src/builders/block-menu-from-commands.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelBlockMenuSpecFromCommands}.
+ */
+export interface VizelBlockMenuFromCommandsOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying labels. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the block-menu action list from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.blockMenu`, sorts by priority ascending, and
+ * projects each command into a Section 2 {@link VizelCommandSpec}.
+ *
+ * The framework `VizelBlockMenu` component composes the resulting
+ * action list with the popover spec built by `buildVizelBlockMenuSpec`
+ * (which carries the existing block-level metadata like "Turn into"
+ * submenus). This helper only handles the action portion that flows
+ * from the unified command registry.
+ */
+export function buildVizelBlockMenuSpecFromCommands(
+  commands: readonly VizelCommand[],
+  options: VizelBlockMenuFromCommandsOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => command.surfaces.blockMenu !== undefined)
+    .slice()
+    .sort((a, b) => (a.surfaces.blockMenu?.priority ?? 0) - (b.surfaces.blockMenu?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/builders/bubble-menu.ts
+++ b/packages/core/src/builders/bubble-menu.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelBubbleMenuSpec}.
+ */
+export interface VizelBubbleMenuSpecOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying button labels and tooltips. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the bubble-menu spec from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.bubbleMenu`, applies each command's optional
+ * `showWhen` predicate against the editor, sorts by priority
+ * ascending, and projects each command into a Section 2
+ * {@link VizelCommandSpec}.
+ */
+export function buildVizelBubbleMenuSpec(
+  commands: readonly VizelCommand[],
+  options: VizelBubbleMenuSpecOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => {
+      const surface = command.surfaces.bubbleMenu;
+      if (!surface) return false;
+      return surface.showWhen ? surface.showWhen(options.editor) : true;
+    })
+    .slice()
+    .sort((a, b) => (a.surfaces.bubbleMenu?.priority ?? 0) - (b.surfaces.bubbleMenu?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -6,6 +6,14 @@ export {
   type VizelBlockMenuTurnIntoItemView,
 } from "./block-menu.ts";
 export {
+  buildVizelBlockMenuSpecFromCommands,
+  type VizelBlockMenuFromCommandsOptions,
+} from "./block-menu-from-commands.ts";
+export {
+  buildVizelBubbleMenuSpec,
+  type VizelBubbleMenuSpecOptions,
+} from "./bubble-menu.ts";
+export {
   buildVizelFindReplaceSpec,
   buildVizelFindReplaceSpecFromLocale,
   type VizelFindReplaceSpec,
@@ -30,10 +38,16 @@ export {
 } from "./node-selector.ts";
 export {
   buildVizelSlashMenuSpec,
+  buildVizelSlashMenuSpecFromCommands,
   getNextVizelSlashMenuGroupIndex,
   type VizelSlashItemView,
+  type VizelSlashMenuFromCommandsOptions,
   type VizelSlashMenuSpecOptions,
 } from "./slash-menu.ts";
+export {
+  buildVizelToolbarSpec,
+  type VizelToolbarSpecOptions,
+} from "./toolbar.ts";
 export {
   buildVizelToolbarDropdownSpec,
   type VizelToolbarDropdownItemView,

--- a/packages/core/src/builders/toolbar.ts
+++ b/packages/core/src/builders/toolbar.ts
@@ -1,0 +1,34 @@
+import type { Editor } from "@tiptap/core";
+import { deriveVizelCommandSpec } from "../commands/derive.ts";
+import type { VizelCommand } from "../commands/types.ts";
+import type { VizelLocale } from "../i18n/types.ts";
+import type { VizelCommandSpec } from "./types.ts";
+
+/**
+ * Options accepted by {@link buildVizelToolbarSpec}.
+ */
+export interface VizelToolbarSpecOptions {
+  /** Editor instance used for `canRun` / `isActive` resolution. */
+  readonly editor: Editor;
+  /** Locale supplying button labels and tooltips. */
+  readonly locale: VizelLocale;
+}
+
+/**
+ * Build the toolbar spec from a {@link VizelCommand} array.
+ *
+ * Filters by `surfaces.toolbar`, sorts by priority ascending (lower
+ * priority appears first), and projects each command into a Section 2
+ * {@link VizelCommandSpec}. The framework `VizelToolbar` component
+ * iterates the result to render its buttons.
+ */
+export function buildVizelToolbarSpec(
+  commands: readonly VizelCommand[],
+  options: VizelToolbarSpecOptions
+): readonly VizelCommandSpec[] {
+  return commands
+    .filter((command) => command.surfaces.toolbar !== undefined)
+    .slice()
+    .sort((a, b) => (a.surfaces.toolbar?.priority ?? 0) - (b.surfaces.toolbar?.priority ?? 0))
+    .map((command) => deriveVizelCommandSpec(command, options.editor, options.locale));
+}

--- a/packages/core/src/extensions/command-shortcuts.ts
+++ b/packages/core/src/extensions/command-shortcuts.ts
@@ -1,0 +1,47 @@
+import { Extension } from "@tiptap/core";
+import type { VizelCommand } from "../commands/types.ts";
+import { isVizelMacPlatform } from "../utils/keyboard.ts";
+
+/**
+ * Options accepted by {@link createVizelCommandShortcutsExtension}.
+ */
+export interface VizelCommandShortcutsOptions {
+  /**
+   * Commands to scan. Only entries with both `surfaces.shortcut === true`
+   * and a `shortcut` field contribute a keybinding.
+   */
+  readonly commands: readonly VizelCommand[];
+}
+
+/**
+ * Create a Tiptap extension that binds the keyboard shortcuts declared
+ * by a {@link VizelCommand} array.
+ *
+ * For every command with `surfaces.shortcut === true` and a `shortcut`
+ * field, the extension registers a binding using the platform-specific
+ * string: `shortcut.mac` on macOS, `shortcut.other` elsewhere. The
+ * bound callback runs `command.run(editor)`; the return value follows
+ * Tiptap's keybinding contract — `true` signals the editor consumed
+ * the key event.
+ */
+export function createVizelCommandShortcutsExtension(
+  options: VizelCommandShortcutsOptions
+): Extension {
+  return Extension.create({
+    name: "vizelCommandShortcuts",
+    addKeyboardShortcuts() {
+      const isMac = isVizelMacPlatform();
+      const bindings: Record<string, () => boolean> = {};
+
+      for (const command of options.commands) {
+        if (command.surfaces.shortcut !== true) continue;
+        if (!command.shortcut) continue;
+        const key = isMac ? command.shortcut.mac : command.shortcut.other;
+        if (!key) continue;
+        bindings[key] = () => command.run(this.editor);
+      }
+
+      return bindings;
+    },
+  });
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -32,6 +32,11 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
 } from "./code-block-lowlight.ts";
+// Command shortcuts (Section 9)
+export {
+  createVizelCommandShortcutsExtension,
+  type VizelCommandShortcutsOptions,
+} from "./command-shortcuts.ts";
 // Comment
 export {
   createVizelCommentExtension,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,19 +47,25 @@ export {
 export {
   applyVizelLinkEdit,
   buildVizelBlockMenuSpec,
+  buildVizelBlockMenuSpecFromCommands,
+  buildVizelBubbleMenuSpec,
   buildVizelFindReplaceSpec,
   buildVizelFindReplaceSpecFromLocale,
   buildVizelLinkEditorSpec,
   buildVizelMentionMenuSpec,
   buildVizelNodeSelectorSpec,
   buildVizelSlashMenuSpec,
+  buildVizelSlashMenuSpecFromCommands,
   buildVizelToolbarDropdownSpec,
+  buildVizelToolbarSpec,
   getNextVizelSlashMenuGroupIndex,
   resolveVizelLinkEditorLabels,
+  type VizelBlockMenuFromCommandsOptions,
   type VizelBlockMenuItemView,
   type VizelBlockMenuSpec,
   type VizelBlockMenuSubmenuTriggerSpec,
   type VizelBlockMenuTurnIntoItemView,
+  type VizelBubbleMenuSpecOptions,
   type VizelCommandSpec,
   type VizelFindReplaceSpec,
   type VizelFormFieldAttrs,
@@ -87,10 +93,12 @@ export {
   type VizelPopoverTriggerSpec,
   type VizelShortcutSpec,
   type VizelSlashItemView,
+  type VizelSlashMenuFromCommandsOptions,
   type VizelSlashMenuSpecOptions,
   type VizelToolbarDropdownItemView,
   type VizelToolbarDropdownSpec,
   type VizelToolbarDropdownTriggerSpec,
+  type VizelToolbarSpecOptions,
 } from "./builders/index.ts";
 // =============================================================================
 // Collaboration
@@ -169,6 +177,8 @@ export {
   createVizelCharacterCountExtension,
   // Code block with syntax highlighting
   createVizelCodeBlockExtension,
+  // Command shortcuts (Section 9)
+  createVizelCommandShortcutsExtension,
   // Comment
   createVizelCommentExtension,
   // Embed (oEmbed, OGP)
@@ -260,6 +270,7 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
   type VizelColorDefinition,
+  type VizelCommandShortcutsOptions,
   VizelCommentMark,
   type VizelCommentMarkOptions,
   type VizelCommentPluginState,


### PR DESCRIPTION
## Summary

- Section 9 sub-PR 9c of 4. Adds remaining surface builders and the shortcut-registry extension.
- `buildVizelToolbarSpec(commands, { editor, locale })` — filters `surfaces.toolbar`, sorts ascending by priority, derives `readonly VizelCommandSpec[]`.
- `buildVizelBubbleMenuSpec(commands, { editor, locale })` — same shape, additionally honors each command's optional `surfaces.bubbleMenu.showWhen` predicate.
- `buildVizelBlockMenuSpecFromCommands(commands, { editor, locale })` — derives the action portion of the block menu from a `VizelCommand[]`; framework components compose the result with the existing popover spec.
- `createVizelCommandShortcutsExtension({ commands })` — Tiptap Extension whose `addKeyboardShortcuts` binds `shortcut.mac`/`other` (selected via `isVizelMacPlatform()`) to `command.run(editor)`. Only commands with both `surfaces.shortcut === true` and a `shortcut` field contribute a binding.

## Breaking Changes

None.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.

> Builds on the default registries merged in #478 (Section 9b). Replaces the auto-closed #476.
