### PR TITLE
feat(core): add command auto-derivation and Command Layer rule docs (Section 9d)

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -173,6 +173,70 @@ every safe opt-in (everything except `mention`, `provider`, `comments`,
 configuration to function). Use it when you want the Notion-like
 surface without enumerating each toggle.
 
+## Command Layer
+
+A single `VizelCommand` represents one user action everywhere it
+appears. The same logical command (e.g. "format/bold") shows up in
+the toolbar, the bubble menu, and the keyboard shortcut table without
+being defined more than once. Surface-specific builders consume a
+`readonly VizelCommand[]` and project each entry into the matching
+Section 2 spec for a specific editor and locale.
+
+### Surfaces and builders
+
+| Surface | Builder | Output |
+|---------|---------|--------|
+| Slash menu | `buildVizelSlashMenuSpecFromCommands` | `VizelMenuSpec<VizelCommandSpec>` |
+| Toolbar | `buildVizelToolbarSpec` | `readonly VizelCommandSpec[]` |
+| Bubble menu | `buildVizelBubbleMenuSpec` | `readonly VizelCommandSpec[]` |
+| Block menu | `buildVizelBlockMenuSpecFromCommands` | `readonly VizelCommandSpec[]` |
+| Keyboard shortcut | `createVizelCommandShortcutsExtension` | `Extension` |
+
+Each builder filters by the corresponding `command.surfaces.*` entry,
+applies surface-specific tuning (priority sort, `showWhen` predicate),
+and derives one `VizelCommandSpec` per command via
+`deriveVizelCommandSpec(command, editor, locale)`. The framework
+components consume the resulting specs without seeing a
+`VizelCommand`.
+
+### Built-in registries
+
+`vizelFormatCommands`, `vizelBlockCommands`, and
+`vizelInsertCommands` ship in `packages/core/src/commands/registry/`.
+A command lives in exactly one registry, chosen by what the command
+*does*:
+
+- **`vizelFormatCommands`** — toggles a mark (bold, italic, strike,
+  underline, code, superscript, subscript). Marks surface on the
+  toolbar / bubble menu only; they do not appear in the slash menu.
+- **`vizelBlockCommands`** — changes the current block's node type
+  (headings, lists, quote, code block, divider, details, callout).
+  Block commands surface on the slash menu plus an optional shortcut.
+- **`vizelInsertCommands`** — inserts a new node into the document
+  (table, image, embed, math, diagram, table of contents). Insert
+  commands surface on the slash menu only.
+
+`vizelDefaultCommands` is the concatenation of the three registries.
+`vizelCommandsFromNodeTypes(nodeTypes)` derives a parallel
+`VizelCommand[]` from `VizelNodeTypeOption[]` so adding a node type
+registers it across the block menu and slash menu in one entry.
+
+### Locale integration
+
+`VizelCommand.label` and `VizelCommand.description` are thunks that
+receive a `VizelLocale` and return a string. Surface builders pass the
+current locale; consumers override individual strings by passing a
+customized `VizelLocale` to the editor.
+
+### Shortcut OS branching
+
+`VizelShortcut` carries both `mac` and `other` strings (Tiptap keymap
+notation, where `Mod` resolves to `Cmd` on macOS and `Ctrl`
+elsewhere). `createVizelCommandShortcutsExtension` selects the right
+string via `isVizelMacPlatform()` and binds the result to
+`command.run(editor)`. When the two strings differ, document the
+reason in a comment on the command definition.
+
 ## Dependencies
 
 ### Allowed

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -2,6 +2,7 @@
 export { deriveVizelCommandSpec } from "./derive.ts";
 export {
   vizelBlockCommands,
+  vizelCommandsFromNodeTypes,
   vizelDefaultCommands,
   vizelFormatCommands,
   vizelInsertCommands,

--- a/packages/core/src/commands/registry/from-node-types.ts
+++ b/packages/core/src/commands/registry/from-node-types.ts
@@ -1,0 +1,38 @@
+import type { VizelNodeTypeOption } from "../../extensions/node-types.ts";
+import type { VizelCommand } from "../types.ts";
+
+/**
+ * Derive a {@link VizelCommand} array from a {@link VizelNodeTypeOption}
+ * array.
+ *
+ * Each node-type option becomes a slash-menu and block-menu entry that
+ * uses the option's `command` callback as `run` and its `isActive`
+ * callback as `isActive`. The derived `canRun` returns `true` — node
+ * types are expected to be applicable wherever the block menu is
+ * shown. Add a `canRun` predicate at the callsite when a node type
+ * needs finer gating.
+ *
+ * The derived `id` namespace is `nodeType/<option.name>` so the
+ * generated commands cannot collide with the hand-rolled registries.
+ * `label` uses the option's `label` directly; consumers that need
+ * locale-aware labels should pass `createVizelNodeTypes(locale)` here.
+ */
+export function vizelCommandsFromNodeTypes(
+  nodeTypes: readonly VizelNodeTypeOption[]
+): readonly VizelCommand[] {
+  return nodeTypes.map((option, index) => ({
+    id: `nodeType/${option.name}`,
+    label: () => option.label,
+    icon: option.icon,
+    canRun: () => true,
+    isActive: option.isActive,
+    run: (editor) => {
+      option.command(editor);
+      return true;
+    },
+    surfaces: {
+      slashMenu: { priority: 1000 + index },
+      blockMenu: { priority: 1000 + index },
+    },
+  }));
+}

--- a/packages/core/src/commands/registry/index.ts
+++ b/packages/core/src/commands/registry/index.ts
@@ -5,6 +5,7 @@ import { vizelInsertCommands } from "./insert.ts";
 
 export { vizelBlockCommands } from "./block.ts";
 export { vizelFormatCommands } from "./format.ts";
+export { vizelCommandsFromNodeTypes } from "./from-node-types.ts";
 export { vizelInsertCommands } from "./insert.ts";
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export {
   type VizelCommandSurfaceSet,
   type VizelShortcut,
   vizelBlockCommands,
+  vizelCommandsFromNodeTypes,
   vizelDefaultCommands,
   vizelFormatCommands,
   vizelInsertCommands,


### PR DESCRIPTION
## Summary

- Section 9 sub-PR 9d of 4 (final). Adds node-type auto-derivation and the Command Layer rule docs.
- `vizelCommandsFromNodeTypes(nodeTypes)` derives a parallel `VizelCommand[]` from `VizelNodeTypeOption[]`, registering each option in the slash menu and block menu under the `nodeType/<name>` id namespace. Adding a node type to `vizelDefaultNodeTypes` now exposes it across both surfaces in one entry.
- `.claude/rules/packages/core.md` gains a "Command Layer" section: maps the five surfaces to their builders, documents the three built-in registries (`vizelFormatCommands` / `vizelBlockCommands` / `vizelInsertCommands`) with the rule that places a command in exactly one of them, and explains the locale and shortcut-OS-branching contracts.

## Breaking Changes

None.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.

> Builds on the surface builders merged in #479 (Section 9c). Replaces the auto-closed #477.
