### PR TITLE
feat(core): add markdown option with flavor + encoding (Section 10c)

### DIFF
--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -22,7 +22,11 @@ import Superscript from "@tiptap/extension-superscript";
 import Text from "@tiptap/extension-text";
 import Underline from "@tiptap/extension-underline";
 import type { VizelLocale } from "../i18n/types.ts";
-import type { VizelMarkdownFlavor } from "../markdown/types.ts";
+import type {
+  VizelMarkdownEncodingOptions,
+  VizelMarkdownFlavor,
+  VizelMarkdownLossyEncodingMode,
+} from "../markdown/types.ts";
 import type { VizelFeatureOptions } from "../types.ts";
 import { resolveVizelFlavorConfig, type VizelFlavorConfig } from "../utils/markdown-flavors.ts";
 import { createVizelCalloutExtension } from "./callout.ts";
@@ -72,6 +76,12 @@ export interface VizelExtensionsOptions {
    * @default "gfm"
    */
   flavor?: VizelMarkdownFlavor;
+  /**
+   * Per-node encoding mode for nodes that have no canonical Markdown
+   * representation (`embed`, `mention`, `wikiLink`). See
+   * {@link VizelMarkdownEncodingOptions}.
+   */
+  encoding?: VizelMarkdownEncodingOptions;
   /**
    * Locale for editor UI strings.
    * If not provided, default English strings are used.
@@ -357,12 +367,21 @@ function addCalloutExtension(
 /**
  * Add Mention extension if enabled (disabled by default).
  */
-function addMentionExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+function addMentionExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  mentionEncoding: VizelMarkdownLossyEncodingMode | undefined
+): void {
   const mention = features.interaction?.mention;
   if (!mention) return;
 
   const mentionOptions = typeof mention === "object" ? mention : {};
-  extensions.push(createVizelMentionExtension(mentionOptions));
+  extensions.push(
+    createVizelMentionExtension({
+      ...mentionOptions,
+      ...(mentionEncoding !== undefined && { encoding: mentionEncoding }),
+    })
+  );
 }
 
 /**
@@ -461,6 +480,7 @@ export async function createVizelExtensions(
     headingLevels = [1, 2, 3, 4, 5, 6],
     features = {},
     flavor,
+    encoding,
     locale,
   } = options;
 
@@ -508,7 +528,7 @@ export async function createVizelExtensions(
   addDiagramExtension(extensions, features);
   addTableOfContentsExtension(extensions, features);
   addWikiLinkExtension(extensions, features, flavorConfig);
-  addMentionExtension(extensions, features);
+  addMentionExtension(extensions, features, encoding?.mention);
   addCommentsExtension(extensions, features);
   addVisualHierarchyExtension(extensions, features);
   addPresenceExtension(extensions, features);

--- a/packages/core/src/extensions/mention.ts
+++ b/packages/core/src/extensions/mention.ts
@@ -73,6 +73,19 @@ export interface VizelMentionOptions {
   deleteTriggerWithBackspace?: boolean;
 
   /**
+   * Markdown encoding mode (Section 10).
+   *
+   * - `"default"` emits the lossy form `@username`. The mention id is
+   *   lost on round-trip if the label and id differ.
+   * - `"metadata-comment"` emits the lossless form
+   *   `@username <!-- vizel:mention id="..." -->` so the id survives
+   *   round-trips through plain markdown.
+   *
+   * @default "default"
+   */
+  encoding?: import("../markdown/types.ts").VizelMarkdownLossyEncodingMode;
+
+  /**
    * Custom HTML attributes for the rendered mention element.
    */
   HTMLAttributes?: Record<string, string>;
@@ -134,6 +147,7 @@ export function createVizelMentionExtension(options: VizelMentionOptions = {}) {
     suggestion = {},
     deleteTriggerWithBackspace = false,
     HTMLAttributes = {},
+    encoding = "default",
   } = options;
 
   const VizelMention = Mention.extend({
@@ -142,7 +156,13 @@ export function createVizelMentionExtension(options: VizelMentionOptions = {}) {
         markdown: {
           serialize(state: MarkdownSerializerState, node: PMNode) {
             const label = String(node.attrs?.label ?? node.attrs?.id ?? "");
-            state.write(`@${label}`);
+            const id = String(node.attrs?.id ?? "");
+            if (encoding === "metadata-comment" && id) {
+              const escaped = id.replace(/"/g, "&quot;");
+              state.write(`@${label} <!-- vizel:mention id="${escaped}" -->`);
+            } else {
+              state.write(`@${label}`);
+            }
           },
           parse: {
             setup(md: MarkdownIt) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,7 +21,7 @@ import type { VizelTypographyOptions } from "./extensions/typography.ts";
 import type { VizelVisualHierarchyOptions } from "./extensions/visual-hierarchy.ts";
 import type { VizelWikiLinkOptions } from "./extensions/wiki-link.ts";
 import type { VizelLocale } from "./i18n/types.ts";
-import type { VizelMarkdownFlavor } from "./markdown/types.ts";
+import type { VizelMarkdownEncodingOptions, VizelMarkdownFlavor } from "./markdown/types.ts";
 import type { VizelImageUploadPluginOptions } from "./plugins/image-upload.ts";
 import type { VizelError } from "./utils/errorHandling.ts";
 import type { VizelVersionHistoryOptions } from "./version-history.ts";
@@ -206,18 +206,21 @@ export interface VizelEditorOptions {
    */
   locale?: VizelLocale;
   /**
-   * Markdown output flavor.
-   * Controls how Markdown is serialized when exporting content.
+   * Markdown pipeline configuration.
    *
-   * - `"commonmark"` — Standard CommonMark (callouts fall back to blockquotes)
-   * - `"gfm"` — GitHub Flavored Markdown with `> [!NOTE]` alerts (default)
-   * - `"obsidian"` — Obsidian-style `> [!note]` callouts and `[[wiki-links]]`
-   * - `"docusaurus"` — Docusaurus/VitePress `:::note` admonitions
-   *
-   * Input parsing is always tolerant: all callout formats are recognized regardless of flavor.
-   * @default "gfm"
+   * - `flavor` selects the Markdown output flavor. The parser remains
+   *   tolerant across formats; only serialization follows the selected
+   *   flavor. Defaults to {@link vizelGfmFlavor} when omitted.
+   * - `encoding` selects the per-node encoding mode for nodes that have
+   *   no canonical Markdown representation (`embed`, `mention`,
+   *   `wikiLink`). `"default"` chooses the lossy-but-portable
+   *   encoding; `"metadata-comment"` chooses the lossless-but-noisy
+   *   encoding that preserves identifiers via a trailing HTML comment.
    */
-  flavor?: VizelMarkdownFlavor;
+  markdown?: {
+    readonly flavor?: VizelMarkdownFlavor;
+    readonly encoding?: VizelMarkdownEncodingOptions;
+  };
   /**
    * Initial content in JSON format.
    *

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -126,7 +126,7 @@ export async function createVizelEditorInstance(
     editable = true,
     autofocus = false,
     features,
-    flavor,
+    markdown,
     locale,
     extensions: additionalExtensions = [],
     createSlashMenuRenderer,
@@ -137,6 +137,8 @@ export async function createVizelEditorInstance(
     onFocus,
     onBlur,
   } = options;
+  const flavor = markdown?.flavor;
+  const encoding = markdown?.encoding;
 
   if (initialContent !== undefined && initialMarkdown !== undefined) {
     // Programming error: the two options are mutually exclusive. Throwing
@@ -181,6 +183,7 @@ export async function createVizelEditorInstance(
     ...(placeholder !== undefined && { placeholder }),
     ...(resolvedFeatures !== undefined && { features: resolvedFeatures }),
     ...(flavor !== undefined && { flavor }),
+    ...(encoding !== undefined && { encoding }),
     ...(locale !== undefined && { locale }),
   });
 

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -212,7 +212,7 @@ export function Vizel({
     editable,
     autofocus,
     ...(features !== undefined && { features }),
-    ...(flavor !== undefined && { flavor }),
+    ...(flavor !== undefined && { markdown: { flavor } }),
     ...(locale !== undefined && { locale }),
     ...(extensions !== undefined && { extensions }),
     onUpdate: (e) => {

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -148,7 +148,9 @@ const editorState = createVizelEditor({
   editable: restProps.editable ?? true,
   autofocus: restProps.autofocus ?? false,
   ...(restProps.features !== undefined && { features: restProps.features }),
-  ...(restProps.flavor !== undefined && { flavor: restProps.flavor }),
+  ...(restProps.flavor !== undefined && {
+    markdown: { flavor: restProps.flavor },
+  }),
   ...(restProps.locale !== undefined && { locale: restProps.locale }),
   ...(restProps.extensions !== undefined && { extensions: restProps.extensions }),
   onUpdate: wrappedOnUpdate,

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -122,7 +122,9 @@ const editor = useVizelEditor({
   editable: props.editable,
   autofocus: props.autofocus,
   ...(props.features !== undefined && { features: props.features }),
-  ...(props.flavor !== undefined && { flavor: props.flavor }),
+  ...(props.flavor !== undefined && {
+    markdown: { flavor: props.flavor },
+  }),
   ...(props.locale !== undefined && { locale: props.locale }),
   ...(props.extensions !== undefined && { extensions: props.extensions }),
   onUpdate: (e) => {

--- a/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
+++ b/tests/ct/react/specs/MarkdownFlavorsFixture.tsx
@@ -25,7 +25,7 @@ export function MarkdownFlavorsFixture({ flavor = "gfm" }: MarkdownFlavorsFixtur
   const [markdownOutput, setMarkdownOutput] = useState("");
 
   const editor = useVizelEditor({
-    flavor: FLAVOR_BY_NAME[flavor] ?? vizelGfmFlavor,
+    markdown: { flavor: FLAVOR_BY_NAME[flavor] ?? vizelGfmFlavor },
     features: {
       content: {
         callout: true,

--- a/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
+++ b/tests/ct/svelte/specs/MarkdownFlavorsFixture.svelte
@@ -26,7 +26,7 @@ const FLAVOR_BY_NAME: Record<string, VizelMarkdownFlavor> = {
 let markdownOutput = $state("");
 
 const editor = createVizelEditor({
-  flavor: FLAVOR_BY_NAME[props.flavor ?? "gfm"] ?? vizelGfmFlavor,
+  markdown: { flavor: FLAVOR_BY_NAME[props.flavor ?? "gfm"] ?? vizelGfmFlavor },
   features: {
     content: {
       callout: true,

--- a/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
+++ b/tests/ct/vue/specs/MarkdownFlavorsFixture.vue
@@ -34,7 +34,7 @@ const resolvedFlavor = computed<VizelMarkdownFlavor>(
 const markdownOutput = ref("");
 
 const editor = useVizelEditor({
-  flavor: resolvedFlavor.value,
+  markdown: { flavor: resolvedFlavor.value },
   features: {
     content: {
       callout: true,


### PR DESCRIPTION
## Summary

Section 10 sub-PR 10c of 4 — introduce the nested `markdown` option on `VizelEditorOptions` and wire `encoding.mention` through to the mention extension.

- `types.ts`: replace top-level `flavor?: VizelMarkdownFlavor` with `markdown?: { flavor?, encoding? }`. Encoding is typed as `VizelMarkdownEncodingOptions` (per-node mode for `embed` / `mention` / `wikiLink`).
- `editorFactory.ts`: destructure `markdown.flavor` and `markdown.encoding` separately and forward both to `createVizelExtensions`.
- `extensions/base.ts`: `createVizelExtensions` accepts `encoding`; `addMentionExtension` forwards `encoding.mention` to the mention factory.
- `extensions/mention.ts`: `VizelMentionOptions` gains `encoding?: VizelMarkdownLossyEncodingMode`. The serializer branches on the mode: `"default"` emits `@username`; `"metadata-comment"` emits `@username <!-- vizel:mention id="..." -->` so the id round-trips through plain markdown consumers.
- Framework components (React/Vue/Svelte `Vizel`) forward the existing `flavor` prop as `markdown: { flavor }` so the framework-side prop surface stays unchanged.

## Breaking Changes

- `VizelEditorOptions.flavor` is removed. Use `VizelEditorOptions.markdown.flavor` instead. Framework `Vizel` components still accept `flavor` as a prop and translate it internally.

## Out of Scope (deferred to 10d)

- `encoding.embed` and `encoding.wikiLink` modes.
- `MARKDOWN_LOSSY` emit when a node cannot serialize.
- `assertMarkdownRoundtrip` helper and the "Markdown Pipeline" section in `.claude/rules/packages/core.md`.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
