### PR TITLE
feat(core): add assertMarkdownRoundtrip helper and Markdown Pipeline docs (Section 10d)

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -237,6 +237,76 @@ string via `isVizelMacPlatform()` and binds the result to
 `command.run(editor)`. When the two strings differ, document the
 reason in a comment on the command definition.
 
+## Markdown Pipeline
+
+The Markdown extension is part of the always-on core (Section 8) — it
+loads without an opt-in flag, and consumer Markdown output is governed
+by the `markdown` option on `VizelEditorOptions`:
+
+```ts
+useVizelEditor({
+  markdown: {
+    flavor: vizelGfmFlavor,
+    encoding: {
+      mention: "metadata-comment",
+    },
+  },
+});
+```
+
+### Library and library swap
+
+Vizel uses `tiptap-markdown` (markdown-it base). The marked-based
+`@tiptap/markdown` is no longer a dependency. Extensions register
+parser hooks through `addStorage().markdown.parse.setup(md)` and
+serialize hooks through `addStorage().markdown.serialize(state, node,
+parent, index)` using `prosemirror-markdown`'s `MarkdownSerializerState`
+API. Never reintroduce the legacy `parseMarkdown(token, helpers)` /
+`renderMarkdown(node, helpers)` shape — it does not exist on the
+current library.
+
+### `VizelMarkdownFlavor` as plugin type
+
+A flavor is a `{ name, markdownItPlugins?, nodeSerializers?,
+markSerializers?, config? }` object. The five built-ins are
+`vizelCommonMarkFlavor`, `vizelGfmFlavor`, `vizelObsidianFlavor`,
+`vizelDocusaurusFlavor`, and `vizelPandocFlavor`. Compose them with
+`composeVizelMarkdownFlavors(flavors, name?)` — later flavors override
+earlier ones in `nodeSerializers` / `markSerializers` and shallow-merge
+`config`.
+
+### Parse tolerantly, serialize strictly
+
+The parser registers markdown-it plugins from every built-in flavor
+plus the user's selected flavor, so input remains tolerant across
+formats (every callout shape, every wiki-link shape, etc. is
+recognized). The serializer uses only the selected flavor's hooks, so
+output follows that flavor strictly. When a node has no
+representation under the chosen flavor, the extension emits
+`VizelError("MARKDOWN_LOSSY")` via `emitVizelError(err, options.onError)`.
+
+### Encoding modes for lossy nodes
+
+The `markdown.encoding` field selects per-node encoding for nodes
+without a canonical Markdown representation:
+
+| Node | `"default"` | `"metadata-comment"` |
+|------|-------------|---------------------|
+| `embed` | `[Title](url)` | `[Title](url)<!-- vizel:embed type="..." id="..." -->` |
+| `mention` | `@username` | `@username <!-- vizel:mention id="..." -->` |
+| `wikiLink` | flavor-dependent (`[[page]]` for Obsidian; `[page](page)` elsewhere) | flavor-dependent + comment |
+
+`"default"` is portable; `"metadata-comment"` is lossless.
+
+### Round-trip helper
+
+Flavor authors validate their custom flavors with
+`assertMarkdownRoundtrip(flavor, samples)`. The helper parses each
+sample, re-serializes it, and throws `VizelError("MARKDOWN_LOSSY")`
+when the output differs from the input after whitespace
+normalization. Use it from a test runner; do not import it in
+production code.
+
 ## Dependencies
 
 ### Allowed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -413,6 +413,7 @@ export {
 // Markdown flavor plugin types (Section 10)
 // =============================================================================
 export {
+  assertMarkdownRoundtrip,
   composeVizelMarkdownFlavors,
   type VizelMarkdownEncodingOptions,
   type VizelMarkdownFlavor,
@@ -420,6 +421,7 @@ export {
   type VizelMarkdownLossyEncodingMode,
   type VizelMarkSerializer,
   type VizelNodeSerializer,
+  type VizelRoundtripSample,
 } from "./markdown/index.ts";
 // =============================================================================
 // Plugin System

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -7,6 +7,10 @@ export {
   vizelObsidianFlavor,
   vizelPandocFlavor,
 } from "./flavors/index.ts";
+export {
+  assertMarkdownRoundtrip,
+  type VizelRoundtripSample,
+} from "./roundtrip.ts";
 export type {
   VizelMarkdownEncodingOptions,
   VizelMarkdownFlavor,

--- a/packages/core/src/markdown/roundtrip.ts
+++ b/packages/core/src/markdown/roundtrip.ts
@@ -1,0 +1,75 @@
+import { Editor } from "@tiptap/core";
+import { createVizelExtensions } from "../extensions/base.ts";
+import { createVizelError } from "../utils/errorHandling.ts";
+import { getVizelMarkdown, setVizelMarkdown } from "../utils/markdown.ts";
+import type { VizelMarkdownFlavor } from "./types.ts";
+
+/**
+ * A single Markdown round-trip sample.
+ */
+export interface VizelRoundtripSample {
+  /** Stable identifier (surfaced in error messages). */
+  readonly name: string;
+  /** Source Markdown text that must round-trip losslessly. */
+  readonly input: string;
+}
+
+/**
+ * Assert that every sample round-trips losslessly through the given
+ * flavor.
+ *
+ * Each sample is parsed into the editor with the flavor's parser and
+ * then re-serialized; if the output differs (after `.trim()`-equivalent
+ * whitespace normalisation), the helper throws a typed
+ * {@link VizelError} with code `"MARKDOWN_LOSSY"` carrying the sample
+ * name and flavor in the error context.
+ *
+ * Flavor authors call this helper from their own tests to verify that
+ * a custom flavor preserves its inputs.
+ *
+ * @example
+ * ```ts
+ * import { assertMarkdownRoundtrip, vizelGfmFlavor } from "@vizel/core";
+ *
+ * await assertMarkdownRoundtrip(vizelGfmFlavor, [
+ *   { name: "heading", input: "# Hello" },
+ *   { name: "list", input: "- a\n- b\n" },
+ * ]);
+ * ```
+ */
+export async function assertMarkdownRoundtrip(
+  flavor: VizelMarkdownFlavor,
+  samples: readonly VizelRoundtripSample[]
+): Promise<void> {
+  const extensions = await createVizelExtensions({ flavor });
+  const editor = new Editor({ extensions });
+  try {
+    for (const sample of samples) {
+      setVizelMarkdown(editor, sample.input);
+      const serialized = getVizelMarkdown(editor);
+      if (normalize(serialized) !== normalize(sample.input)) {
+        throw createVizelError(
+          "MARKDOWN_LOSSY",
+          `Round-trip mismatch in sample "${sample.name}" for flavor "${flavor.name}".`,
+          {
+            context: {
+              flavor: flavor.name,
+              sample: sample.name,
+              expected: sample.input,
+              received: serialized,
+            },
+          }
+        );
+      }
+    }
+  } finally {
+    editor.destroy();
+  }
+}
+
+function normalize(markdown: string): string {
+  return markdown
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .trim();
+}


### PR DESCRIPTION
## Summary

Section 10 sub-PR 10d of 4 (final) — close out Section 10 with the round-trip helper that flavor authors use to validate their work plus the Markdown Pipeline rule documenting the new architecture.

- `packages/core/src/markdown/roundtrip.ts` ships `assertMarkdownRoundtrip(flavor, samples)`. The helper boots an isolated Tiptap editor configured with the supplied flavor, parses each sample via `setVizelMarkdown`, re-serializes via `getVizelMarkdown`, and throws `VizelError("MARKDOWN_LOSSY")` with `flavor`/`sample` context when whitespace-normalized output diverges.
- `markdown/index.ts` and the root `packages/core/src/index.ts` re-export `assertMarkdownRoundtrip` and `VizelRoundtripSample`.
- `.claude/rules/packages/core.md` gains a "Markdown Pipeline" section documenting the library swap (tiptap-markdown / markdown-it), `VizelMarkdownFlavor` as a plugin type, the parse-tolerant / serialize-strict policy, the encoding-mode table for lossy nodes, and the round-trip helper.

## Out of Scope (deferred)

- `encoding.embed` and `encoding.wikiLink` implementations — the embed extension has no markdown serializer yet, and the wikiLink extension's encoding is currently flavor-driven only. These can land later without breaking the API.
- `MARKDOWN_LOSSY` emit at the extension level for nodes that cannot serialize — the error code, helper, and docs are in place; per-extension emit calls land alongside their encoding implementations.
- The 100+ sample × 5 flavor round-trip suite belongs under Section 14 (Playwright CT audit). This plan only ships the helper so flavor authors can validate their own work today.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
