### PR TITLE
feat(core): add block path API and VizelOutline component (Section 11d)

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -64,6 +64,7 @@ authoring convention.
 | VizelBubbleMenuColorPicker | `.tsx` | `.vue` | `.svelte` |
 | VizelLinkEditor | `.tsx` | `.vue` | `.svelte` |
 | VizelNodeSelector | `.tsx` | `.vue` | `.svelte` |
+| VizelOutline | `.tsx` | `.vue` | `.svelte` |
 | VizelSlashMenu | `.tsx` | `.vue` | `.svelte` |
 | VizelSlashMenuItem | `.tsx` | `.vue` | `.svelte` |
 | VizelSlashMenuEmpty | `.tsx` | `.vue` | `.svelte` |
@@ -196,6 +197,15 @@ frameworks. The only divergence is the children form.
 | Class prop | `className?: string` | `class?: string` | `class?: string` |
 | `width` | `number` (default 120) | `number` (default 120) | `number` (default 120) |
 | `height` | `number` (default 400) | `number` (default 400) | `number` (default 400) |
+
+#### `VizelOutline`
+
+| Prop | React | Vue | Svelte |
+|------|-------|-----|--------|
+| `editor` | `Editor \| null` | `Editor \| null` | `Editor \| null` |
+| Class prop | `className?: string` | `class?: string` | `class?: string` |
+| `currentPos` | `number \| null` | `number \| null` | `number \| null` |
+| `locale` | `VizelLocale` | `VizelLocale` | `VizelLocale` |
 
 #### `VizelSlashMenu`
 

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -42,6 +42,11 @@ export {
   type VizelNodeSelectorTriggerSpec,
 } from "./node-selector.ts";
 export {
+  buildVizelOutlineSpec,
+  type VizelOutlineItemSpec,
+  type VizelOutlineSpec,
+} from "./outline.ts";
+export {
   buildVizelSlashMenuSpec,
   buildVizelSlashMenuSpecFromCommands,
   getNextVizelSlashMenuGroupIndex,

--- a/packages/core/src/builders/outline.ts
+++ b/packages/core/src/builders/outline.ts
@@ -1,0 +1,125 @@
+import type { Editor } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { VizelLocale } from "../i18n/types.ts";
+
+/**
+ * One entry in a document outline tree.
+ *
+ * Each entry corresponds to a single `heading` node from the editor's
+ * document. Entries are nested by heading level: an `h2` becomes a child
+ * of the nearest preceding `h1`, an `h3` becomes a child of the nearest
+ * preceding `h2`, and so on. Entries at the highest level encountered in
+ * the document appear at the top of {@link VizelOutlineSpec.items}.
+ */
+export interface VizelOutlineItemSpec {
+  /** Stable identifier for keyed rendering (`heading-${pos}`). */
+  readonly key: string;
+  /** Heading level, 1-6, as stored in the node's `level` attribute. */
+  readonly level: number;
+  /** Plain-text label derived from the heading's text content. */
+  readonly label: string;
+  /** Document position of the heading node start. */
+  readonly pos: number;
+  /** Whether the current selection sits inside this heading's node range. */
+  readonly isCurrent: boolean;
+  /** Headings nested under this entry, in document order. */
+  readonly children: readonly VizelOutlineItemSpec[];
+}
+
+/**
+ * Framework-neutral spec for the `VizelOutline` component.
+ */
+export interface VizelOutlineSpec {
+  /** Root container ARIA wiring. */
+  readonly root: {
+    readonly role: "tree";
+    readonly "aria-label": string;
+  };
+  /** Top-level outline entries, in document order. */
+  readonly items: readonly VizelOutlineItemSpec[];
+}
+
+interface OutlineCollectorEntry {
+  readonly node: ProseMirrorNode;
+  readonly pos: number;
+  readonly endPos: number;
+}
+
+/**
+ * Build the outline spec from an editor's current document.
+ *
+ * Walks every node in `editor.state.doc`, collects each `heading`, and
+ * nests them by `level`. The active entry is the one whose document
+ * range contains `currentNodePos`; when `currentNodePos` is `null` or
+ * sits outside every heading, no entry is marked current.
+ */
+export function buildVizelOutlineSpec(
+  editor: Editor,
+  currentNodePos: number | null,
+  locale: VizelLocale
+): VizelOutlineSpec {
+  const collected: OutlineCollectorEntry[] = [];
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === "heading") {
+      collected.push({ node, pos, endPos: pos + node.nodeSize });
+    }
+    return node.type.name !== "heading";
+  });
+
+  const items = buildOutlineTree(collected, currentNodePos);
+
+  return {
+    root: {
+      role: "tree",
+      "aria-label": locale.outline.ariaLabel,
+    },
+    items,
+  };
+}
+
+function buildOutlineTree(
+  entries: readonly OutlineCollectorEntry[],
+  currentNodePos: number | null
+): readonly VizelOutlineItemSpec[] {
+  interface Frame {
+    readonly level: number;
+    readonly children: VizelOutlineItemSpec[];
+  }
+
+  const root: VizelOutlineItemSpec[] = [];
+  const stack: Frame[] = [{ level: 0, children: root }];
+
+  for (const entry of entries) {
+    const rawLevel = (entry.node.attrs as { level?: number }).level;
+    const level = typeof rawLevel === "number" ? rawLevel : 1;
+    const label = entry.node.textContent;
+    const isCurrent =
+      currentNodePos !== null && currentNodePos >= entry.pos && currentNodePos < entry.endPos;
+
+    // Pop frames whose level is at or above the new entry. The root
+    // frame at level 0 stays so we always have a parent to push into.
+    let top = stack.at(-1);
+    while (top !== undefined && stack.length > 1 && top.level >= level) {
+      stack.pop();
+      top = stack.at(-1);
+    }
+
+    const children: VizelOutlineItemSpec[] = [];
+    const item: VizelOutlineItemSpec = {
+      key: `heading-${entry.pos}`,
+      level,
+      label,
+      pos: entry.pos,
+      isCurrent,
+      children,
+    };
+
+    const parent = stack.at(-1);
+    if (parent !== undefined) {
+      parent.children.push(item);
+    }
+    stack.push({ level, children });
+  }
+
+  return root;
+}

--- a/packages/core/src/i18n/en.ts
+++ b/packages/core/src/i18n/en.ts
@@ -145,6 +145,10 @@ export const vizelEnLocale = {
     currentBlockType: "Current block type: {type}",
   },
 
+  outline: {
+    ariaLabel: "Document outline",
+  },
+
   relativeTime: {
     justNow: "Just now",
     secondsAgo: "{n}s ago",

--- a/packages/core/src/i18n/types.ts
+++ b/packages/core/src/i18n/types.ts
@@ -172,6 +172,12 @@ export interface VizelLocale {
     currentBlockType: string;
   };
 
+  /** Outline (document heading navigation) */
+  outline: {
+    /** Aria label for the outline tree container */
+    ariaLabel: string;
+  };
+
   /**
    * Relative time strings.
    * Use `{n}` as placeholder for the numeric value.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export {
   buildVizelMentionMenuSpec,
   buildVizelMinimapSpec,
   buildVizelNodeSelectorSpec,
+  buildVizelOutlineSpec,
   buildVizelSlashMenuSpec,
   buildVizelSlashMenuSpecFromCommands,
   buildVizelToolbarDropdownSpec,
@@ -96,6 +97,8 @@ export {
   type VizelNodeSelectorItemView,
   type VizelNodeSelectorSpec,
   type VizelNodeSelectorTriggerSpec,
+  type VizelOutlineItemSpec,
+  type VizelOutlineSpec,
   type VizelPopoverBodySpec,
   type VizelPopoverSpec,
   type VizelPopoverTriggerSpec,
@@ -514,6 +517,8 @@ export {
   // Keyboard shortcut utilities
   formatVizelShortcut,
   formatVizelTooltip,
+  // Block path utility
+  getVizelBlockPath,
   getVizelEditorState,
   getVizelMarkdown,
   getVizelPortalContainer,
@@ -558,6 +563,7 @@ export {
   VIZEL_PORTAL_Z_INDEX,
   VIZEL_SUGGESTION_Z_INDEX,
   VIZEL_UPLOAD_IMAGE_EVENT,
+  type VizelBlockPathSegment,
   type VizelCalloutMarkdownFormat,
   type VizelContentNode,
   type VizelCreateUploadEventHandlerOptions,

--- a/packages/core/src/utils/block-path.ts
+++ b/packages/core/src/utils/block-path.ts
@@ -1,0 +1,71 @@
+import type { Editor } from "@tiptap/core";
+
+/**
+ * A single segment of a block path produced by {@link getVizelBlockPath}.
+ *
+ * Each segment describes one ancestor node between the document root and
+ * the cursor block, recorded in walk order (root first, current block
+ * last). The segment is intentionally lightweight: callers that need the
+ * underlying ProseMirror node can re-resolve from `editor.state.doc` at
+ * `pos`.
+ */
+export interface VizelBlockPathSegment {
+  /** ProseMirror node-type name (e.g. `"doc"`, `"bulletList"`, `"paragraph"`). */
+  readonly nodeType: string;
+  /** Document position where the node starts (`$from.start(depth)`-style). */
+  readonly pos: number;
+  /**
+   * Frozen shallow copy of the node's attrs, or `undefined` when the node
+   * carries no attributes. The object is `Object.freeze`d to discourage
+   * mutation; ProseMirror's own attrs are never mutated through this path.
+   */
+  readonly attrs?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Walk from the document root to the cursor block and return the path.
+ *
+ * The path's first segment is always the document root (`doc`) at position
+ * `0`; subsequent segments descend through each container until they reach
+ * the block that contains the cursor. The last segment corresponds to
+ * `editor.state.selection.$from` at the resolved position's deepest level.
+ *
+ * The function is pure: it reads `editor.state.selection.$from` and the
+ * underlying document, and never mutates editor state.
+ *
+ * @example
+ * ```ts
+ * const path = getVizelBlockPath(editor);
+ * for (const segment of path) {
+ *   console.log(segment.nodeType, "@", segment.pos);
+ * }
+ * ```
+ */
+export function getVizelBlockPath(editor: Editor): readonly VizelBlockPathSegment[] {
+  const { $from } = editor.state.selection;
+  const segments: VizelBlockPathSegment[] = [];
+
+  // Walk every ancestor from depth 0 (the doc) down to the current depth.
+  // `$from.node(depth)` returns the node at that level; `$from.before(depth)`
+  // returns the document position immediately before that node. For depth 0
+  // the doc has no `before` position, so use `0` instead.
+  for (let depth = 0; depth <= $from.depth; depth++) {
+    const node = $from.node(depth);
+    const pos = depth === 0 ? 0 : $from.before(depth);
+    const rawAttrs = node.attrs as Record<string, unknown> | undefined;
+    const hasAttrs = rawAttrs !== undefined && Object.keys(rawAttrs).length > 0;
+    const segment: VizelBlockPathSegment = hasAttrs
+      ? {
+          nodeType: node.type.name,
+          pos,
+          attrs: Object.freeze({ ...rawAttrs }),
+        }
+      : {
+          nodeType: node.type.name,
+          pos,
+        };
+    segments.push(segment);
+  }
+
+  return segments;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -21,6 +21,8 @@ export {
   type VizelDOMRectGetter,
   type VizelSuggestionContainer,
 } from "../controllers/suggestionContainer.ts";
+// Block path utilities
+export { getVizelBlockPath, type VizelBlockPathSegment } from "./block-path.ts";
 // Color utilities
 export { isVizelValidHexColor, normalizeVizelHexColor } from "./colorUtils.ts";
 // Curated default feature set

--- a/packages/react/src/components/VizelOutline.tsx
+++ b/packages/react/src/components/VizelOutline.tsx
@@ -1,0 +1,92 @@
+import {
+  buildVizelOutlineSpec,
+  type Editor,
+  type VizelLocale,
+  type VizelOutlineItemSpec,
+  vizelEnLocale,
+} from "@vizel/core";
+import { useVizelState } from "../hooks/useVizelState.ts";
+import { useVizelContextSafe } from "./VizelContext.tsx";
+
+export interface VizelOutlineProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Additional CSS class name */
+  className?: string;
+  /**
+   * Override for the current document position used to highlight the
+   * active heading. Defaults to `editor.state.selection.from`.
+   */
+  currentPos?: number | null;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
+}
+
+/**
+ * Sidebar-style outline view of every heading in the editor's document.
+ */
+export function VizelOutline({
+  editor: editorProp,
+  className,
+  currentPos,
+  locale,
+}: VizelOutlineProps) {
+  const contextEditor = useVizelContextSafe();
+  const editor = editorProp ?? contextEditor;
+  // Subscribe to editor transactions so the outline re-renders on doc /
+  // selection changes. The numeric tick itself is intentionally unused.
+  useVizelState(editor);
+
+  if (!editor) return null;
+
+  const resolvedLocale = locale ?? vizelEnLocale;
+  const resolvedPos = currentPos === undefined ? editor.state.selection.from : currentPos;
+  const spec = buildVizelOutlineSpec(editor, resolvedPos, resolvedLocale);
+
+  return (
+    <nav
+      className={`vizel-outline ${className ?? ""}`}
+      role={spec.root.role}
+      aria-label={spec.root["aria-label"]}
+      data-vizel-outline=""
+    >
+      {spec.items.length > 0 ? renderItems(spec.items, editor) : null}
+    </nav>
+  );
+}
+
+function renderItems(items: readonly VizelOutlineItemSpec[], editor: Editor) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: WAI-ARIA tree pattern requires role="group" on nested lists inside role="tree".
+    <ul className="vizel-outline-list" role="group">
+      {items.map((item) => (
+        <li
+          key={item.key}
+          role="treeitem"
+          tabIndex={-1}
+          aria-level={item.level}
+          aria-selected={item.isCurrent}
+          {...(item.isCurrent && { "aria-current": "true" as const })}
+          className={`vizel-outline-item vizel-outline-item--level-${item.level}${
+            item.isCurrent ? " vizel-outline-item--current" : ""
+          }`}
+        >
+          <button
+            type="button"
+            className="vizel-outline-link"
+            onClick={() => {
+              editor
+                .chain()
+                .focus()
+                .setTextSelection(item.pos + 1)
+                .run();
+            }}
+          >
+            {item.label}
+          </button>
+          {item.children.length > 0 ? renderItems(item.children, editor) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -47,6 +47,8 @@ export {
 export { VizelMinimap, type VizelMinimapProps } from "./VizelMinimap.tsx";
 // VizelNodeSelector component
 export { VizelNodeSelector, type VizelNodeSelectorProps } from "./VizelNodeSelector.tsx";
+// VizelOutline component
+export { VizelOutline, type VizelOutlineProps } from "./VizelOutline.tsx";
 // Portal component
 export { VizelPortal, type VizelPortalProps } from "./VizelPortal.tsx";
 export { VizelProvider, type VizelProviderProps } from "./VizelProvider.tsx";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -70,6 +70,9 @@ export {
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
+  // Outline
+  VizelOutline,
+  type VizelOutlineProps,
   // Portal
   VizelPortal,
   type VizelPortalProps,

--- a/packages/svelte/src/components/VizelOutline.svelte
+++ b/packages/svelte/src/components/VizelOutline.svelte
@@ -1,0 +1,57 @@
+<script lang="ts" module>
+import type { Editor, VizelLocale } from "@vizel/core";
+
+export interface VizelOutlineProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Custom class name */
+  class?: string;
+  /**
+   * Override for the current document position used to highlight the
+   * active heading. Defaults to `editor.state.selection.from`.
+   */
+  currentPos?: number | null;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
+}
+</script>
+
+<script lang="ts">
+import { buildVizelOutlineSpec, vizelEnLocale } from "@vizel/core";
+import { createVizelState } from "../runes/createVizelState.svelte.js";
+import { getVizelContextSafe } from "./VizelContext.js";
+import VizelOutlineItems from "./VizelOutlineItems.svelte";
+
+let {
+  editor: editorProp,
+  class: className,
+  currentPos,
+  locale,
+}: VizelOutlineProps = $props();
+
+const contextEditor = getVizelContextSafe();
+const editor = $derived(editorProp ?? contextEditor?.current ?? null);
+
+const stateRune = createVizelState(() => editor);
+
+const spec = $derived.by(() => {
+  void stateRune.version;
+  const e = editor;
+  if (!e) return null;
+  const resolvedPos = currentPos === undefined ? e.state.selection.from : currentPos;
+  return buildVizelOutlineSpec(e, resolvedPos, locale ?? vizelEnLocale);
+});
+</script>
+
+{#if editor && spec}
+  <nav
+    class="vizel-outline {className ?? ''}"
+    role={spec.root.role}
+    aria-label={spec.root["aria-label"]}
+    data-vizel-outline=""
+  >
+    {#if spec.items.length > 0}
+      <VizelOutlineItems items={spec.items} {editor} />
+    {/if}
+  </nav>
+{/if}

--- a/packages/svelte/src/components/VizelOutlineItems.svelte
+++ b/packages/svelte/src/components/VizelOutlineItems.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+import type { Editor, VizelOutlineItemSpec } from "@vizel/core";
+
+export interface VizelOutlineItemsProps {
+  items: readonly VizelOutlineItemSpec[];
+  editor: Editor;
+}
+</script>
+
+<script lang="ts">
+import Self from "./VizelOutlineItems.svelte";
+
+let { items, editor }: VizelOutlineItemsProps = $props();
+
+const onItemClick = (pos: number) => {
+  editor
+    .chain()
+    .focus()
+    .setTextSelection(pos + 1)
+    .run();
+};
+</script>
+
+<!-- biome-ignore lint/a11y/useSemanticElements: WAI-ARIA tree pattern requires role="group" on nested lists inside role="tree". -->
+<ul class="vizel-outline-list" role="group">
+  {#each items as item (item.key)}
+    <li
+      role="treeitem"
+      tabindex={-1}
+      aria-level={item.level}
+      aria-selected={item.isCurrent}
+      aria-current={item.isCurrent ? "true" : undefined}
+      class="vizel-outline-item vizel-outline-item--level-{item.level} {item.isCurrent
+        ? 'vizel-outline-item--current'
+        : ''}"
+    >
+      <button type="button" class="vizel-outline-link" onclick={() => onItemClick(item.pos)}>
+        {item.label}
+      </button>
+      {#if item.children.length > 0}
+        <Self items={item.children} {editor} />
+      {/if}
+    </li>
+  {/each}
+</ul>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -104,6 +104,13 @@ export {
   type VizelNodeSelectorProps,
 } from "./VizelNodeSelector.svelte";
 // ============================================================================
+// Vizel Outline component
+// ============================================================================
+export {
+  default as VizelOutline,
+  type VizelOutlineProps,
+} from "./VizelOutline.svelte";
+// ============================================================================
 // Vizel Portal component
 // ============================================================================
 export {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -68,6 +68,9 @@ export {
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
+  // Outline
+  VizelOutline,
+  type VizelOutlineProps,
   // Portal
   VizelPortal,
   type VizelPortalProps,

--- a/packages/vue/src/components/VizelOutline.vue
+++ b/packages/vue/src/components/VizelOutline.vue
@@ -1,0 +1,53 @@
+<script lang="ts">
+import type { Editor, VizelLocale } from "@vizel/core";
+
+export interface VizelOutlineProps {
+  /** Editor instance. Falls back to context if not provided. */
+  editor?: Editor | null;
+  /** Custom class name */
+  class?: string;
+  /**
+   * Override for the current document position used to highlight the
+   * active heading. Defaults to `editor.state.selection.from`.
+   */
+  currentPos?: number | null;
+  /** Locale for translated UI strings */
+  locale?: VizelLocale;
+}
+</script>
+
+<script setup lang="ts">
+import { buildVizelOutlineSpec, vizelEnLocale } from "@vizel/core";
+import { computed } from "vue";
+import { useVizelState } from "../composables/useVizelState.ts";
+import { useVizelContextSafe } from "./VizelContext.ts";
+import VizelOutlineItems from "./VizelOutlineItems.vue";
+
+const props = defineProps<VizelOutlineProps>();
+
+const contextEditor = useVizelContextSafe();
+const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
+
+const updateCount = useVizelState(() => editor.value);
+
+const resolvedLocale = computed(() => props.locale ?? vizelEnLocale);
+const spec = computed(() => {
+  void updateCount.value;
+  const e = editor.value;
+  if (!e) return null;
+  const resolvedPos = props.currentPos === undefined ? e.state.selection.from : props.currentPos;
+  return buildVizelOutlineSpec(e, resolvedPos, resolvedLocale.value);
+});
+</script>
+
+<template>
+  <nav
+    v-if="editor && spec"
+    :class="['vizel-outline', props.class]"
+    :role="spec.root.role"
+    :aria-label="spec.root['aria-label']"
+    data-vizel-outline=""
+  >
+    <VizelOutlineItems v-if="spec.items.length > 0" :items="spec.items" :editor="editor" />
+  </nav>
+</template>

--- a/packages/vue/src/components/VizelOutlineItems.vue
+++ b/packages/vue/src/components/VizelOutlineItems.vue
@@ -1,0 +1,49 @@
+<script lang="ts">
+import type { Editor, VizelOutlineItemSpec } from "@vizel/core";
+
+export interface VizelOutlineItemsProps {
+  items: readonly VizelOutlineItemSpec[];
+  editor: Editor;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<VizelOutlineItemsProps>();
+
+const onItemClick = (pos: number) => {
+  props.editor
+    .chain()
+    .focus()
+    .setTextSelection(pos + 1)
+    .run();
+};
+</script>
+
+<template>
+  <!-- biome-ignore lint/a11y/useSemanticElements: WAI-ARIA tree pattern requires role="group" on nested lists inside role="tree". -->
+  <ul class="vizel-outline-list" role="group">
+    <li
+      v-for="item in props.items"
+      :key="item.key"
+      role="treeitem"
+      :tabindex="-1"
+      :aria-level="item.level"
+      :aria-selected="item.isCurrent"
+      :aria-current="item.isCurrent ? 'true' : undefined"
+      :class="[
+        'vizel-outline-item',
+        `vizel-outline-item--level-${item.level}`,
+        item.isCurrent ? 'vizel-outline-item--current' : '',
+      ]"
+    >
+      <button type="button" class="vizel-outline-link" @click="onItemClick(item.pos)">
+        {{ item.label }}
+      </button>
+      <VizelOutlineItems
+        v-if="item.children.length > 0"
+        :items="item.children"
+        :editor="props.editor"
+      />
+    </li>
+  </ul>
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -69,6 +69,11 @@ export {
   default as VizelNodeSelector,
   type VizelNodeSelectorProps,
 } from "./VizelNodeSelector.vue";
+// VizelOutline component
+export {
+  default as VizelOutline,
+  type VizelOutlineProps,
+} from "./VizelOutline.vue";
 // VizelPortal component
 export { default as VizelPortal, type VizelPortalProps } from "./VizelPortal.vue";
 export { default as VizelProvider, type VizelProviderProps } from "./VizelProvider.vue";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -69,6 +69,9 @@ export {
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,
+  // Outline
+  VizelOutline,
+  type VizelOutlineProps,
   // Portal
   VizelPortal,
   type VizelPortalProps,

--- a/tests/ct/react/specs/Outline.spec.tsx
+++ b/tests/ct/react/specs/Outline.spec.tsx
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testOutlineClickMovesSelection,
+  testOutlineRendersHeadings,
+} from "../../scenarios/outline.scenario";
+import { OutlineFixture } from "./OutlineFixture";
+
+test.describe("VizelOutline - React", () => {
+  test("renders one entry per heading", async ({ mount, page }) => {
+    const component = await mount(<OutlineFixture />);
+    await testOutlineRendersHeadings(component, page);
+  });
+
+  test("clicking an entry moves the selection", async ({ mount, page }) => {
+    const component = await mount(<OutlineFixture />);
+    await testOutlineClickMovesSelection(component, page);
+  });
+});

--- a/tests/ct/react/specs/OutlineFixture.tsx
+++ b/tests/ct/react/specs/OutlineFixture.tsx
@@ -1,0 +1,24 @@
+import {
+  useVizelEditor,
+  useVizelState,
+  VizelEditor,
+  VizelOutline,
+  VizelProvider,
+} from "@vizel/react";
+
+export function OutlineFixture() {
+  const editor = useVizelEditor({
+    immediatelyRender: false,
+  });
+  useVizelState(editor);
+
+  const cursorPos = editor ? editor.state.selection.from : 0;
+
+  return (
+    <VizelProvider editor={editor}>
+      <div data-testid="cursor-pos">{cursorPos}</div>
+      <VizelOutline />
+      <VizelEditor />
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/outline.scenario.ts
+++ b/tests/ct/scenarios/outline.scenario.ts
@@ -8,7 +8,10 @@ export async function testOutlineRendersHeadings(component: Locator, page: Page)
   const editor = component.locator(".vizel-editor [contenteditable]");
   const outline = component.locator("[data-vizel-outline]");
 
-  await expect(outline).toBeVisible();
+  // Outline `<nav>` mounts as empty; check the structural attribute
+  // before any content is typed. `toBeVisible` is deferred until the
+  // outline actually has children — an empty `<nav>` collapses to
+  // zero height which Playwright reports as "hidden".
   await expect(outline).toHaveAttribute("role", "tree");
 
   // Type the three headings.
@@ -20,6 +23,7 @@ export async function testOutlineRendersHeadings(component: Locator, page: Page)
   await page.keyboard.type("## C");
 
   // Three outline entries become visible.
+  await expect(outline).toBeVisible();
   const items = outline.getByRole("treeitem");
   await expect(items).toHaveCount(3);
   await expect(items.nth(0)).toContainText("A");

--- a/tests/ct/scenarios/outline.scenario.ts
+++ b/tests/ct/scenarios/outline.scenario.ts
@@ -5,7 +5,7 @@ import { expect } from "@playwright/test";
  * Test that the outline renders one entry per heading in the document.
  */
 export async function testOutlineRendersHeadings(component: Locator, page: Page): Promise<void> {
-  const editor = component.locator(".vizel-editor [contenteditable]");
+  const editor = component.locator(".vizel-editor");
   const outline = component.locator("[data-vizel-outline]");
 
   // Outline `<nav>` mounts as empty; check the structural attribute
@@ -38,7 +38,7 @@ export async function testOutlineClickMovesSelection(
   component: Locator,
   page: Page
 ): Promise<void> {
-  const editor = component.locator(".vizel-editor [contenteditable]");
+  const editor = component.locator(".vizel-editor");
   const outline = component.locator("[data-vizel-outline]");
   const cursorPos = component.locator("[data-testid='cursor-pos']");
 

--- a/tests/ct/scenarios/outline.scenario.ts
+++ b/tests/ct/scenarios/outline.scenario.ts
@@ -1,0 +1,58 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Test that the outline renders one entry per heading in the document.
+ */
+export async function testOutlineRendersHeadings(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor [contenteditable]");
+  const outline = component.locator("[data-vizel-outline]");
+
+  await expect(outline).toBeVisible();
+  await expect(outline).toHaveAttribute("role", "tree");
+
+  // Type the three headings.
+  await editor.click();
+  await page.keyboard.type("# A");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("## B");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("## C");
+
+  // Three outline entries become visible.
+  const items = outline.getByRole("treeitem");
+  await expect(items).toHaveCount(3);
+  await expect(items.nth(0)).toContainText("A");
+  await expect(items.nth(1)).toContainText("B");
+  await expect(items.nth(2)).toContainText("C");
+}
+
+/**
+ * Test that clicking an outline entry moves the editor selection to that heading.
+ */
+export async function testOutlineClickMovesSelection(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor [contenteditable]");
+  const outline = component.locator("[data-vizel-outline]");
+  const cursorPos = component.locator("[data-testid='cursor-pos']");
+
+  await editor.click();
+  await page.keyboard.type("# A");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("## B");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("## C");
+
+  // Move the cursor back to the start.
+  await page.keyboard.press("ControlOrMeta+Home");
+
+  const initial = await cursorPos.textContent();
+
+  // Click the "C" entry.
+  await outline.getByRole("treeitem").nth(2).locator("button").click();
+
+  // Selection moved past the initial position.
+  await expect(cursorPos).not.toHaveText(initial ?? "");
+}

--- a/tests/ct/svelte/specs/Outline.spec.ts
+++ b/tests/ct/svelte/specs/Outline.spec.ts
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testOutlineClickMovesSelection,
+  testOutlineRendersHeadings,
+} from "../../scenarios/outline.scenario";
+import OutlineFixture from "./OutlineFixture.svelte";
+
+test.describe("VizelOutline - Svelte", () => {
+  test("renders one entry per heading", async ({ mount, page }) => {
+    const component = await mount(OutlineFixture);
+    await testOutlineRendersHeadings(component, page);
+  });
+
+  test("clicking an entry moves the selection", async ({ mount, page }) => {
+    const component = await mount(OutlineFixture);
+    await testOutlineClickMovesSelection(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/OutlineFixture.svelte
+++ b/tests/ct/svelte/specs/OutlineFixture.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import {
+  createVizelEditor,
+  createVizelState,
+  VizelEditor,
+  VizelOutline,
+  VizelProvider,
+} from "@vizel/svelte";
+
+const editor = createVizelEditor({
+  immediatelyRender: false,
+});
+
+const stateRune = createVizelState(() => editor.current);
+
+const cursorPos = $derived.by(() => {
+  void stateRune.version;
+  return editor.current ? editor.current.state.selection.from : 0;
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <div data-testid="cursor-pos">{cursorPos}</div>
+  <VizelOutline />
+  <VizelEditor />
+</VizelProvider>

--- a/tests/ct/vue/specs/Outline.spec.ts
+++ b/tests/ct/vue/specs/Outline.spec.ts
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testOutlineClickMovesSelection,
+  testOutlineRendersHeadings,
+} from "../../scenarios/outline.scenario";
+import OutlineFixture from "./OutlineFixture.vue";
+
+test.describe("VizelOutline - Vue", () => {
+  test("renders one entry per heading", async ({ mount, page }) => {
+    const component = await mount(OutlineFixture);
+    await testOutlineRendersHeadings(component, page);
+  });
+
+  test("clicking an entry moves the selection", async ({ mount, page }) => {
+    const component = await mount(OutlineFixture);
+    await testOutlineClickMovesSelection(component, page);
+  });
+});

--- a/tests/ct/vue/specs/OutlineFixture.vue
+++ b/tests/ct/vue/specs/OutlineFixture.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import {
+  useVizelEditor,
+  useVizelState,
+  VizelEditor,
+  VizelOutline,
+  VizelProvider,
+} from "@vizel/vue";
+import { computed } from "vue";
+
+const editor = useVizelEditor({
+  immediatelyRender: false,
+});
+
+const updateCount = useVizelState(() => editor.value);
+
+const cursorPos = computed(() => {
+  void updateCount.value;
+  return editor.value ? editor.value.state.selection.from : 0;
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <div data-testid="cursor-pos">{{ cursorPos }}</div>
+    <VizelOutline />
+    <VizelEditor />
+  </VizelProvider>
+</template>


### PR DESCRIPTION
## Summary

Section 11 sub-PR 11d of 5 — ship the block path helper plus the `VizelOutline` companion component for all three frameworks.

- `utils/block-path.ts` exports `getVizelBlockPath(editor)`, returning the path from doc root to the cursor block as a frozen array of `VizelBlockPathSegment` values (`nodeType`, `pos`, `attrs`).
- `builders/outline.ts` exports `buildVizelOutlineSpec(editor, currentNodePos, locale)` returning a `VizelOutlineSpec`. The builder walks `editor.state.doc.descendants` collecting heading nodes and nests them by level; `isCurrent` tracks the active heading via the current node position.
- `i18n/types.ts` and `i18n/en.ts` gain `locale.outline.ariaLabel` which the builder embeds in the spec root attributes.
- `packages/react/src/components/VizelOutline.tsx`, `packages/vue/src/components/{VizelOutline,VizelOutlineItems}.vue`, `packages/svelte/src/components/{VizelOutline,VizelOutlineItems}.svelte` iterate the spec recursively as `role="tree"` / `role="treeitem"` with `aria-current="true"` on the active node. Click handlers focus the editor at the heading's `pos`.
- Cross-framework parity tables (`.claude/rules/cross-framework.md`) gain `VizelOutline` in Tables 2 and 3.
- Playwright CT scenario `tests/ct/scenarios/outline.scenario.ts` plus React/Vue/Svelte specs and fixtures exercise: mount, type three headings, click an entry, expect the editor selection to move.

## Breaking Changes

None. Additive helper + component; no existing API surface changes.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
