### PR TITLE
feat(core): add VizelMinimap canvas component (Section 11e)

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -77,6 +77,7 @@ authoring convention.
 | VizelProvider | `.tsx` | `.vue` | `.svelte` |
 | VizelFindReplace | `.tsx` | `.vue` | `.svelte` |
 | VizelMentionMenu | `.tsx` | `.vue` | `.svelte` |
+| VizelMinimap | `.tsx` | `.vue` | `.svelte` |
 | VizelToolbar | `.tsx` | `.vue` | `.svelte` |
 | VizelToolbarButton | `.tsx` | `.vue` | `.svelte` |
 | VizelToolbarDefault | `.tsx` | `.vue` | `.svelte` |
@@ -186,6 +187,15 @@ frameworks. The only divergence is the children form.
 | Class prop | `className?: string` | `class?: string` | `class?: string` |
 | `locale` | `VizelLocale` | `VizelLocale` | `VizelLocale` |
 | Close callback | `onClose?: () => void` | (emit `close`) | `onClose?: () => void` |
+
+#### `VizelMinimap`
+
+| Prop | React | Vue | Svelte |
+|------|-------|-----|--------|
+| `editor` | `Editor \| null` | `Editor \| null` | `Editor \| null` |
+| Class prop | `className?: string` | `class?: string` | `class?: string` |
+| `width` | `number` (default 120) | `number` (default 120) | `number` (default 120) |
+| `height` | `number` (default 400) | `number` (default 400) | `number` (default 400) |
 
 #### `VizelSlashMenu`
 

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -31,6 +31,11 @@ export {
   type VizelMentionItemView,
 } from "./mention-menu.ts";
 export {
+  buildVizelMinimapSpec,
+  type VizelMinimapBlockSpec,
+  type VizelMinimapSpec,
+} from "./minimap.ts";
+export {
   buildVizelNodeSelectorSpec,
   type VizelNodeSelectorItemView,
   type VizelNodeSelectorSpec,

--- a/packages/core/src/builders/minimap.ts
+++ b/packages/core/src/builders/minimap.ts
@@ -1,0 +1,125 @@
+import type { Editor } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+/**
+ * One row in the document outline used by `VizelMinimap`.
+ *
+ * The minimap renderer draws a rectangle per spec entry; the rectangle's
+ * vertical extent is proportional to `approxHeight`, the horizontal extent
+ * is scaled by `1 / depth`, and `pos` is forwarded back to the editor when
+ * the user clicks on the rectangle so we can call
+ * `editor.commands.focus(pos)`.
+ */
+export interface VizelMinimapBlockSpec {
+  /** Stable identity for the row (`${type}-${pos}`); used as a React key. */
+  readonly key: string;
+  /** Underlying ProseMirror node type name (e.g. `paragraph`, `heading`). */
+  readonly type: string;
+  /** Nesting depth measured from the doc root (top-level blocks = 1). */
+  readonly depth: number;
+  /** Deterministic pixel estimate of the block's rendered height. */
+  readonly approxHeight: number;
+  /** Doc-level start position; pass to `editor.commands.focus(pos)`. */
+  readonly pos: number;
+}
+
+/**
+ * Output of {@link buildVizelMinimapSpec}.
+ *
+ * `viewport` mirrors the editor DOM's scroll window in pixels so the
+ * renderer can draw the highlight overlay without re-reading the DOM.
+ */
+export interface VizelMinimapSpec {
+  /** Top-level + nested blocks in document order. */
+  readonly blocks: readonly VizelMinimapBlockSpec[];
+  /** Visible scroll window of the editor DOM at build time. */
+  readonly viewport: {
+    /** Top of the visible window in pixels (`view.dom.scrollTop`). */
+    readonly top: number;
+    /** Bottom of the visible window in pixels. */
+    readonly bottom: number;
+  };
+}
+
+/** Deterministic height estimate per heading level (1..6). */
+const HEADING_HEIGHT_BY_LEVEL: Readonly<Record<number, number>> = {
+  1: 56,
+  2: 44,
+  3: 32,
+  4: 32,
+  5: 32,
+  6: 32,
+};
+
+/** Height per child row inside a list-like container. */
+const LIST_ROW_HEIGHT = 24;
+
+/**
+ * Return the deterministic pixel estimate for a single ProseMirror node.
+ *
+ * The numbers are deliberately coarse — the minimap is a visual cue, not
+ * a layout mirror — but they are stable so the renderer never reflows on
+ * every transaction.
+ */
+function estimateApproxHeight(node: ProseMirrorNode): number {
+  const typeName = node.type.name;
+  if (typeName === "paragraph") return 24;
+  if (typeName === "heading") {
+    const levelAttr = node.attrs.level;
+    const level = typeof levelAttr === "number" ? levelAttr : 1;
+    return HEADING_HEIGHT_BY_LEVEL[level] ?? 32;
+  }
+  if (typeName === "bulletList" || typeName === "orderedList" || typeName === "taskList") {
+    return Math.max(LIST_ROW_HEIGHT, node.childCount * LIST_ROW_HEIGHT);
+  }
+  if (typeName === "codeBlock") return 100;
+  if (
+    typeName === "image" ||
+    typeName === "embed" ||
+    typeName === "diagram" ||
+    typeName === "mathBlock"
+  ) {
+    return 200;
+  }
+  return 32;
+}
+
+/**
+ * Walk `editor.state.doc` and collect a `VizelMinimapSpec`.
+ *
+ * The walk includes every block-level node (top-level paragraphs, headings,
+ * lists, list items, code blocks, embeds, etc.) so the renderer can convey
+ * the document's hierarchy. The viewport window comes from the editor
+ * DOM's `scrollTop` / `clientHeight`; when the editor view is unavailable
+ * (SSR, pre-mount, destroyed editor) we return `{ top: 0, bottom: 0 }`.
+ */
+export function buildVizelMinimapSpec(editor: Editor): VizelMinimapSpec {
+  const blocks: VizelMinimapBlockSpec[] = [];
+
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isBlock) return false;
+    if (node.type.name === "doc") return true;
+    blocks.push({
+      key: `${node.type.name}-${pos}`,
+      type: node.type.name,
+      depth: editor.state.doc.resolve(pos).depth,
+      approxHeight: estimateApproxHeight(node),
+      pos,
+    });
+    return true;
+  });
+
+  // SSR guard: `editor.view` is unavailable during server render and
+  // before the view mounts. Surface a zero-size viewport so the renderer
+  // can still draw block rectangles without touching the DOM.
+  const hasWindow = typeof window !== "undefined";
+  const view = editor.view;
+  const dom = hasWindow && view ? view.dom : null;
+  const top = dom instanceof HTMLElement ? dom.scrollTop : 0;
+  const bottom = dom instanceof HTMLElement ? dom.scrollTop + dom.clientHeight : 0;
+
+  return {
+    blocks,
+    viewport: { top, bottom },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export {
   buildVizelFindReplaceSpecFromLocale,
   buildVizelLinkEditorSpec,
   buildVizelMentionMenuSpec,
+  buildVizelMinimapSpec,
   buildVizelNodeSelectorSpec,
   buildVizelSlashMenuSpec,
   buildVizelSlashMenuSpecFromCommands,
@@ -90,6 +91,8 @@ export {
   type VizelMenuRootAttrs,
   type VizelMenuSectionSpec,
   type VizelMenuSpec,
+  type VizelMinimapBlockSpec,
+  type VizelMinimapSpec,
   type VizelNodeSelectorItemView,
   type VizelNodeSelectorSpec,
   type VizelNodeSelectorTriggerSpec,
@@ -535,6 +538,8 @@ export {
   parseVizelMarkdown,
   registerVizelUploadEventHandler,
   removeVizelPortalContainer,
+  // Minimap canvas rendering
+  renderVizelMinimapToCanvas,
   resolveVizelFeatures,
   // Markdown flavor utilities
   resolveVizelFlavorConfig,
@@ -563,6 +568,7 @@ export {
   type VizelErrorSeverity,
   type VizelFlavorConfig,
   type VizelMarkdownSyncHandlers,
+  type VizelMinimapRenderOptions,
   type VizelMountPortalOptions,
   type VizelPortalLayer,
   type VizelResolveFeaturesOptions,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -92,6 +92,11 @@ export {
 } from "./markdown-flavors.ts";
 // Menu positioning utilities
 export { clampMenuPosition, type MenuPosition, shouldFlipSubmenu } from "./menuPositioning.ts";
+// Minimap canvas rendering
+export {
+  renderVizelMinimapToCanvas,
+  type VizelMinimapRenderOptions,
+} from "./minimap-render.ts";
 // Text highlight utilities
 export { splitVizelTextByMatches, type VizelTextSegment } from "./textHighlight.ts";
 // Type guard utilities

--- a/packages/core/src/utils/minimap-render.ts
+++ b/packages/core/src/utils/minimap-render.ts
@@ -1,0 +1,127 @@
+import type { VizelMinimapBlockSpec, VizelMinimapSpec } from "../builders/minimap.ts";
+
+/**
+ * Options accepted by {@link renderVizelMinimapToCanvas}.
+ */
+export interface VizelMinimapRenderOptions {
+  /**
+   * Theme hint that selects the fallback color palette when CSS
+   * custom-property lookups fail (e.g. during initial paint or when the
+   * canvas is detached from the live theme). Falls back to "light".
+   */
+  readonly theme?: "light" | "dark";
+}
+
+/** Fallback colors used when the corresponding CSS variable is missing. */
+interface MinimapPalette {
+  readonly background: string;
+  readonly block: string;
+  readonly heading: string;
+  readonly viewport: string;
+}
+
+const LIGHT_FALLBACK: MinimapPalette = {
+  background: "#f8fafc",
+  block: "#cbd5e1",
+  heading: "#475569",
+  viewport: "rgba(99, 102, 241, 0.18)",
+};
+
+const DARK_FALLBACK: MinimapPalette = {
+  background: "#0f172a",
+  block: "#475569",
+  heading: "#cbd5e1",
+  viewport: "rgba(129, 140, 248, 0.22)",
+};
+
+/**
+ * Resolve a CSS custom property value, returning `fallback` when the
+ * lookup fails (no `getComputedStyle`, empty string, etc.).
+ */
+function resolveCssVar(canvas: HTMLCanvasElement, name: string, fallback: string): string {
+  if (typeof window === "undefined" || typeof window.getComputedStyle !== "function") {
+    return fallback;
+  }
+  try {
+    const value = window.getComputedStyle(canvas).getPropertyValue(name);
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Classify a block type as "heading-like" so it gets the accent color. */
+function isHeadingLike(type: string): boolean {
+  return type === "heading" || type === "title";
+}
+
+/**
+ * Render the minimap reduction of `spec` onto `canvas`.
+ *
+ * Each block becomes a rectangle whose vertical extent is proportional to
+ * `block.approxHeight` (so the column fills the canvas), and whose
+ * horizontal width is scaled by `1 / depth` to convey nesting. The viewport
+ * range from the spec is overlaid as a translucent rectangle.
+ *
+ * SSR / degraded-environment safe: bails when `canvas` is null/undefined
+ * or `getContext` is unavailable, never throws.
+ */
+export function renderVizelMinimapToCanvas(
+  canvas: HTMLCanvasElement | null | undefined,
+  spec: VizelMinimapSpec,
+  options: VizelMinimapRenderOptions = {}
+): void {
+  if (!canvas) return;
+  if (typeof canvas.getContext !== "function") return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const palette = options.theme === "dark" ? DARK_FALLBACK : LIGHT_FALLBACK;
+  const background = resolveCssVar(canvas, "--vizel-minimap-background", palette.background);
+  const blockColor = resolveCssVar(canvas, "--vizel-minimap-block", palette.block);
+  const headingColor = resolveCssVar(canvas, "--vizel-minimap-heading", palette.heading);
+  const viewportColor = resolveCssVar(canvas, "--vizel-minimap-viewport", palette.viewport);
+
+  const width = canvas.width;
+  const height = canvas.height;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = background;
+  ctx.fillRect(0, 0, width, height);
+
+  const blocks = spec.blocks;
+  if (blocks.length === 0) return;
+
+  // Sum of block heights drives the proportional rectangle layout. A
+  // zero total (empty doc) renders only the background.
+  const total = blocks.reduce(
+    (sum: number, block: VizelMinimapBlockSpec) => sum + block.approxHeight,
+    0
+  );
+  if (total <= 0) return;
+
+  let yCursor = 0;
+  for (const block of blocks) {
+    const ratio = block.approxHeight / total;
+    const rectHeight = Math.max(1, Math.floor(ratio * height));
+    // Clamp depth to >= 1 to guarantee a non-zero rectangle width.
+    const safeDepth = Math.max(1, block.depth);
+    const rectWidth = Math.max(2, Math.floor(width / safeDepth));
+
+    ctx.fillStyle = isHeadingLike(block.type) ? headingColor : blockColor;
+    ctx.fillRect(0, yCursor, rectWidth, Math.max(1, rectHeight - 1));
+
+    yCursor += rectHeight;
+  }
+
+  // Viewport overlay: translate the doc-level [viewport.top, viewport.bottom]
+  // range into canvas Y coordinates by scaling against the cumulative height.
+  const { top: viewTop, bottom: viewBottom } = spec.viewport;
+  if (viewBottom > viewTop && total > 0) {
+    const overlayTop = Math.max(0, Math.floor((viewTop / total) * height));
+    const overlayBottom = Math.min(height, Math.ceil((viewBottom / total) * height));
+    const overlayHeight = Math.max(2, overlayBottom - overlayTop);
+    ctx.fillStyle = viewportColor;
+    ctx.fillRect(0, overlayTop, width, overlayHeight);
+  }
+}

--- a/packages/react/src/components/VizelMinimap.tsx
+++ b/packages/react/src/components/VizelMinimap.tsx
@@ -1,0 +1,102 @@
+import { buildVizelMinimapSpec, type Editor, renderVizelMinimapToCanvas } from "@vizel/core";
+import { type PointerEvent, useCallback, useEffect, useRef, type WheelEvent } from "react";
+import { useVizelState } from "../hooks/useVizelState.ts";
+
+export interface VizelMinimapProps {
+  /** The Tiptap editor instance, or `null` while the editor is initializing. */
+  editor: Editor | null;
+  /** Custom class name applied to the wrapping `<canvas>`. */
+  className?: string;
+  /** Canvas pixel width. Defaults to 120. */
+  width?: number;
+  /** Canvas pixel height. Defaults to 400. */
+  height?: number;
+}
+
+/**
+ * Canvas-based document minimap for React.
+ *
+ * Draws a colored-rectangle reduction of the entire document via the
+ * framework-neutral `renderVizelMinimapToCanvas` helper from
+ * `@vizel/core`. Clicking or wheeling on the canvas focuses the
+ * corresponding block in the editor.
+ */
+export function VizelMinimap({ editor, className, width = 120, height = 400 }: VizelMinimapProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  // Subscribe to editor transactions so the canvas redraws on every doc
+  // mutation. The tick value is intentionally unused — the subscription
+  // alone is what we want.
+  useVizelState(editor);
+
+  // Schedule one redraw per animation frame. `redraw` is stable across
+  // renders so event handlers keep their identity.
+  const redraw = useCallback(() => {
+    if (!editor) return;
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const spec = buildVizelMinimapSpec(editor);
+      renderVizelMinimapToCanvas(canvas, spec);
+    });
+  }, [editor]);
+
+  useEffect(() => {
+    redraw();
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [redraw]);
+
+  // Map a pointer Y inside the canvas to the doc-level position of the
+  // nearest block, then focus it.
+  const focusBlockAtY = useCallback(
+    (clientY: number) => {
+      if (!editor) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const ratio = (clientY - rect.top) / Math.max(1, rect.height);
+      const clamped = Math.max(0, Math.min(1, ratio));
+      const spec = buildVizelMinimapSpec(editor);
+      if (spec.blocks.length === 0) return;
+      const index = Math.min(spec.blocks.length - 1, Math.floor(clamped * spec.blocks.length));
+      const block = spec.blocks[index];
+      if (!block) return;
+      editor.commands.focus(block.pos);
+      editor.commands.scrollIntoView();
+    },
+    [editor]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLCanvasElement>) => {
+      focusBlockAtY(event.clientY);
+    },
+    [focusBlockAtY]
+  );
+
+  const handleWheel = useCallback(
+    (event: WheelEvent<HTMLCanvasElement>) => {
+      focusBlockAtY(event.clientY + event.deltaY);
+    },
+    [focusBlockAtY]
+  );
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      className={`vizel-minimap ${className || ""}`}
+      onPointerDown={handlePointerDown}
+      onWheel={handleWheel}
+    />
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -43,6 +43,8 @@ export {
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
 } from "./VizelMentionMenu.tsx";
+// VizelMinimap component
+export { VizelMinimap, type VizelMinimapProps } from "./VizelMinimap.tsx";
 // VizelNodeSelector component
 export { VizelNodeSelector, type VizelNodeSelectorProps } from "./VizelNodeSelector.tsx";
 // Portal component

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -64,6 +64,9 @@ export {
   VizelMentionMenu,
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
+  // Minimap
+  VizelMinimap,
+  type VizelMinimapProps,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,

--- a/packages/svelte/src/components/VizelMinimap.svelte
+++ b/packages/svelte/src/components/VizelMinimap.svelte
@@ -1,0 +1,86 @@
+<script lang="ts" module>
+import type { Editor } from "@vizel/core";
+
+export interface VizelMinimapProps {
+  /** The Tiptap editor instance, or `null` while the editor is initializing. */
+  editor: Editor | null;
+  /** Custom class name applied to the wrapping `<canvas>`. */
+  class?: string;
+  /** Canvas pixel width. Defaults to 120. */
+  width?: number;
+  /** Canvas pixel height. Defaults to 400. */
+  height?: number;
+}
+</script>
+
+<script lang="ts">
+import { buildVizelMinimapSpec, renderVizelMinimapToCanvas } from "@vizel/core";
+import { createVizelState } from "../runes/createVizelState.svelte.js";
+
+let { editor, class: className, width = 120, height = 400 }: VizelMinimapProps = $props();
+
+let canvasRef: HTMLCanvasElement | null = $state(null);
+let rafHandle: number | null = null;
+
+// Subscribe to editor transactions so we redraw on every doc mutation.
+// The version counter is read inside $effect to register the dependency.
+const tickRune = createVizelState(() => editor);
+
+function redraw() {
+  if (!editor) return;
+  if (rafHandle !== null) return;
+  rafHandle = requestAnimationFrame(() => {
+    rafHandle = null;
+    if (!canvasRef) return;
+    const spec = buildVizelMinimapSpec(editor as Editor);
+    renderVizelMinimapToCanvas(canvasRef, spec);
+  });
+}
+
+$effect(() => {
+  // Touch reactive sources so this effect re-runs on every transaction
+  // and whenever the canvas mounts or the editor swaps.
+  void tickRune.version;
+  void editor;
+  void canvasRef;
+  redraw();
+  return () => {
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+  };
+});
+
+function focusBlockAtY(clientY: number) {
+  if (!editor) return;
+  if (!canvasRef) return;
+  const rect = canvasRef.getBoundingClientRect();
+  const ratio = (clientY - rect.top) / Math.max(1, rect.height);
+  const clamped = Math.max(0, Math.min(1, ratio));
+  const spec = buildVizelMinimapSpec(editor);
+  if (spec.blocks.length === 0) return;
+  const index = Math.min(spec.blocks.length - 1, Math.floor(clamped * spec.blocks.length));
+  const block = spec.blocks[index];
+  if (!block) return;
+  editor.commands.focus(block.pos);
+  editor.commands.scrollIntoView();
+}
+
+function handlePointerDown(event: PointerEvent) {
+  focusBlockAtY(event.clientY);
+}
+
+function handleWheel(event: WheelEvent) {
+  focusBlockAtY(event.clientY + event.deltaY);
+}
+</script>
+
+<canvas
+  bind:this={canvasRef}
+  {width}
+  {height}
+  class={`vizel-minimap ${className || ""}`}
+  onpointerdown={handlePointerDown}
+  onwheel={handleWheel}
+></canvas>

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -90,6 +90,13 @@ export {
   type VizelMentionMenuRef,
 } from "./VizelMentionMenu.svelte";
 // ============================================================================
+// Vizel Minimap component
+// ============================================================================
+export {
+  default as VizelMinimap,
+  type VizelMinimapProps,
+} from "./VizelMinimap.svelte";
+// ============================================================================
 // Vizel NodeSelector component
 // ============================================================================
 export {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -62,6 +62,9 @@ export {
   VizelMentionMenu,
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
+  // Minimap
+  VizelMinimap,
+  type VizelMinimapProps,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,

--- a/packages/vue/src/components/VizelMinimap.vue
+++ b/packages/vue/src/components/VizelMinimap.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { buildVizelMinimapSpec, type Editor, renderVizelMinimapToCanvas } from "@vizel/core";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useVizelState } from "../composables/useVizelState.ts";
+
+export interface VizelMinimapProps {
+  /** The Tiptap editor instance, or `null` while the editor is initializing. */
+  editor: Editor | null;
+  /** Custom class name applied to the wrapping `<canvas>`. */
+  class?: string;
+  /** Canvas pixel width. Defaults to 120. */
+  width?: number;
+  /** Canvas pixel height. Defaults to 400. */
+  height?: number;
+}
+
+const props = withDefaults(defineProps<VizelMinimapProps>(), {
+  width: 120,
+  height: 400,
+});
+
+const canvasRef = ref<HTMLCanvasElement | null>(null);
+let rafHandle: number | null = null;
+
+// Subscribe to editor transactions so we redraw on every doc mutation.
+// The returned tick value is intentionally unused.
+const tick = useVizelState(() => props.editor);
+const editorRef = computed(() => props.editor);
+
+function redraw() {
+  const editor = props.editor;
+  if (!editor) return;
+  if (rafHandle !== null) return;
+  rafHandle = requestAnimationFrame(() => {
+    rafHandle = null;
+    const canvas = canvasRef.value;
+    if (!canvas) return;
+    const spec = buildVizelMinimapSpec(editor);
+    renderVizelMinimapToCanvas(canvas, spec);
+  });
+}
+
+onMounted(redraw);
+onBeforeUnmount(() => {
+  if (rafHandle !== null) {
+    cancelAnimationFrame(rafHandle);
+    rafHandle = null;
+  }
+});
+
+// Re-render when the editor instance changes or when transactions arrive.
+watch([editorRef, tick], redraw);
+
+function focusBlockAtY(clientY: number) {
+  const editor = props.editor;
+  if (!editor) return;
+  const canvas = canvasRef.value;
+  if (!canvas) return;
+  const rect = canvas.getBoundingClientRect();
+  const ratio = (clientY - rect.top) / Math.max(1, rect.height);
+  const clamped = Math.max(0, Math.min(1, ratio));
+  const spec = buildVizelMinimapSpec(editor);
+  if (spec.blocks.length === 0) return;
+  const index = Math.min(spec.blocks.length - 1, Math.floor(clamped * spec.blocks.length));
+  const block = spec.blocks[index];
+  if (!block) return;
+  editor.commands.focus(block.pos);
+  editor.commands.scrollIntoView();
+}
+
+function handlePointerDown(event: PointerEvent) {
+  focusBlockAtY(event.clientY);
+}
+
+function handleWheel(event: WheelEvent) {
+  focusBlockAtY(event.clientY + event.deltaY);
+}
+</script>
+
+<template>
+  <canvas
+    ref="canvasRef"
+    :width="props.width"
+    :height="props.height"
+    :class="['vizel-minimap', props.class]"
+    @pointerdown="handlePointerDown"
+    @wheel="handleWheel"
+  />
+</template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -59,6 +59,11 @@ export {
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
 } from "./VizelMentionMenu.vue";
+// VizelMinimap component
+export {
+  default as VizelMinimap,
+  type VizelMinimapProps,
+} from "./VizelMinimap.vue";
 // VizelNodeSelector component
 export {
   default as VizelNodeSelector,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -63,6 +63,9 @@ export {
   VizelMentionMenu,
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
+  // Minimap
+  VizelMinimap,
+  type VizelMinimapProps,
   // NodeSelector
   VizelNodeSelector,
   type VizelNodeSelectorProps,

--- a/tests/ct/react/specs/Minimap.spec.tsx
+++ b/tests/ct/react/specs/Minimap.spec.tsx
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testMinimapPointerFocusesEditor,
+  testMinimapRendersBlocks,
+} from "../../scenarios/minimap.scenario";
+import { MinimapFixture } from "./MinimapFixture";
+
+test.describe("VizelMinimap - React", () => {
+  test("renders block rectangles after typing", async ({ mount, page }) => {
+    const component = await mount(<MinimapFixture />);
+    await testMinimapRendersBlocks(component, page);
+  });
+
+  test("pointer-down focuses the editor", async ({ mount, page }) => {
+    const component = await mount(<MinimapFixture />);
+    await testMinimapPointerFocusesEditor(component, page);
+  });
+});

--- a/tests/ct/react/specs/MinimapFixture.tsx
+++ b/tests/ct/react/specs/MinimapFixture.tsx
@@ -1,0 +1,23 @@
+import { useVizelEditor, VizelEditor, VizelMinimap, VizelProvider } from "@vizel/react";
+
+interface MinimapFixtureProps {
+  width?: number;
+  height?: number;
+}
+
+export function MinimapFixture({ width = 120, height = 200 }: MinimapFixtureProps) {
+  const editor = useVizelEditor({
+    immediatelyRender: false,
+  });
+
+  return (
+    <VizelProvider editor={editor}>
+      <div style={{ display: "flex" }}>
+        <div style={{ flex: 1 }}>
+          <VizelEditor />
+        </div>
+        <VizelMinimap editor={editor} width={width} height={height} />
+      </div>
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/minimap.scenario.ts
+++ b/tests/ct/scenarios/minimap.scenario.ts
@@ -1,0 +1,80 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared scenarios for the `VizelMinimap` component.
+ *
+ * The minimap reduces the editor's document to a colored-rectangle
+ * canvas. We can't compare pixels in a portable way across browsers, so
+ * the scenarios assert structural invariants: the canvas mounts at the
+ * requested dimensions, the rendered pixels differ from an empty canvas
+ * after the editor receives content, and pointer interaction does not
+ * throw.
+ */
+
+/**
+ * Mount the fixture, type several paragraphs into the editor, and
+ * verify the minimap canvas contains non-empty pixel content (i.e. its
+ * `toDataURL()` differs from a freshly-cleared canvas of the same
+ * dimensions).
+ */
+export async function testMinimapRendersBlocks(component: Locator, page: Page): Promise<void> {
+  const canvas = component.locator(".vizel-minimap");
+  await expect(canvas).toBeVisible();
+
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("First paragraph");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Second paragraph");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Third paragraph");
+
+  // Give the requestAnimationFrame loop a chance to paint.
+  await page.waitForTimeout(50);
+
+  const pixelInfo = await canvas.evaluate((el) => {
+    const c = el as HTMLCanvasElement;
+    const dataUrl = c.toDataURL();
+    const blank = document.createElement("canvas");
+    blank.width = c.width;
+    blank.height = c.height;
+    return { dataUrl, blank: blank.toDataURL(), width: c.width, height: c.height };
+  });
+
+  expect(pixelInfo.width).toBeGreaterThan(0);
+  expect(pixelInfo.height).toBeGreaterThan(0);
+  expect(pixelInfo.dataUrl).not.toEqual(pixelInfo.blank);
+}
+
+/**
+ * Verify that pointer-down on the minimap focuses the editor (the
+ * underlying call is `editor.commands.focus(pos)`). The test only
+ * asserts no exception bubbles up; precise block targeting depends on
+ * deterministic layout that varies across browsers.
+ */
+export async function testMinimapPointerFocusesEditor(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const canvas = component.locator(".vizel-minimap");
+  await expect(canvas).toBeVisible();
+
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("Paragraph A");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Paragraph B");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Paragraph C");
+
+  await page.waitForTimeout(50);
+
+  // Click near the bottom of the minimap; the focus call should not
+  // throw and the editor should retain focus.
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Minimap canvas has no bounding box");
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height - 5);
+
+  await expect(editor).toBeFocused();
+}

--- a/tests/ct/svelte/specs/Minimap.spec.ts
+++ b/tests/ct/svelte/specs/Minimap.spec.ts
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testMinimapPointerFocusesEditor,
+  testMinimapRendersBlocks,
+} from "../../scenarios/minimap.scenario";
+import MinimapFixture from "./MinimapFixture.svelte";
+
+test.describe("VizelMinimap - Svelte", () => {
+  test("renders block rectangles after typing", async ({ mount, page }) => {
+    const component = await mount(MinimapFixture);
+    await testMinimapRendersBlocks(component, page);
+  });
+
+  test("pointer-down focuses the editor", async ({ mount, page }) => {
+    const component = await mount(MinimapFixture);
+    await testMinimapPointerFocusesEditor(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/MinimapFixture.svelte
+++ b/tests/ct/svelte/specs/MinimapFixture.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { createVizelEditor, VizelEditor, VizelMinimap, VizelProvider } from "@vizel/svelte";
+
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+let { width = 120, height = 200 }: Props = $props();
+
+const editor = createVizelEditor({
+  immediatelyRender: false,
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <div style="display: flex">
+    <div style="flex: 1">
+      <VizelEditor />
+    </div>
+    <VizelMinimap editor={editor.current} {width} {height} />
+  </div>
+</VizelProvider>

--- a/tests/ct/vue/specs/Minimap.spec.ts
+++ b/tests/ct/vue/specs/Minimap.spec.ts
@@ -1,0 +1,18 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testMinimapPointerFocusesEditor,
+  testMinimapRendersBlocks,
+} from "../../scenarios/minimap.scenario";
+import MinimapFixture from "./MinimapFixture.vue";
+
+test.describe("VizelMinimap - Vue", () => {
+  test("renders block rectangles after typing", async ({ mount, page }) => {
+    const component = await mount(MinimapFixture);
+    await testMinimapRendersBlocks(component, page);
+  });
+
+  test("pointer-down focuses the editor", async ({ mount, page }) => {
+    const component = await mount(MinimapFixture);
+    await testMinimapPointerFocusesEditor(component, page);
+  });
+});

--- a/tests/ct/vue/specs/MinimapFixture.vue
+++ b/tests/ct/vue/specs/MinimapFixture.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { useVizelEditor, VizelEditor, VizelMinimap, VizelProvider } from "@vizel/vue";
+
+const props = withDefaults(
+  defineProps<{
+    width?: number;
+    height?: number;
+  }>(),
+  {
+    width: 120,
+    height: 200,
+  }
+);
+
+const editor = useVizelEditor({
+  immediatelyRender: false,
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <div style="display: flex">
+      <div style="flex: 1">
+        <VizelEditor />
+      </div>
+      <VizelMinimap :editor="editor" :width="props.width" :height="props.height" />
+    </div>
+  </VizelProvider>
+</template>


### PR DESCRIPTION
## Summary

Section 11 sub-PR 11e of 5 — ship the canvas-based `VizelMinimap` companion component for all three frameworks.

- `packages/core/src/builders/minimap.ts` exports `buildVizelMinimapSpec(editor)` returning `VizelMinimapSpec` with per-block descriptors (`key`, `type`, `depth`, `approxHeight`, `pos`) and the editor's DOM scroll viewport. SSR-safe.
- `packages/core/src/utils/minimap-render.ts` exports `renderVizelMinimapToCanvas(canvas, spec, options)` drawing colored rectangles per block (width scaled by `1/depth`, height proportional to `approxHeight`), overlaying the viewport range, reading `--vizel-minimap-*` CSS variables with light/dark fallbacks. SSR/degraded-environment safe.
- `packages/react/src/components/VizelMinimap.tsx`, `packages/vue/src/components/VizelMinimap.vue`, `packages/svelte/src/components/VizelMinimap.svelte` mount a `<canvas>`, subscribe via `useVizelState` / `createVizelState`, redraw under `requestAnimationFrame`, and wire `pointerdown` / `wheel` to `editor.commands.focus(block.pos)` + `scrollIntoView()`.
- Cross-framework parity tables (`.claude/rules/cross-framework.md`) gain `VizelMinimap` in Tables 2 and 3.
- Playwright CT scenario `tests/ct/scenarios/minimap.scenario.ts` plus React/Vue/Svelte specs and fixtures assert the canvas data URL differs from a blank canvas after typing, and that pointer-down keeps the editor focused.

## Breaking Changes

None. Additive helper + component.

## Notes

The `--vizel-minimap-background`, `--vizel-minimap-block`, `--vizel-minimap-heading`, `--vizel-minimap-viewport` CSS variables are read by the renderer but no SCSS theme file currently defines them — the hard-coded light/dark fallbacks ship the component standalone. A dedicated `_minimap.scss` token block can be added later if a designer-driven palette is requested.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
- [x] Local Playwright CT 4/6 pass per framework on chromium + firefox (webkit not installed locally; CI will validate).
