### PR TITLE
feat(core): add block-aware clipboard and multi-block drag-and-drop (Section 11c)

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -125,10 +125,11 @@ Heading.configure({
 | WikiLink | `extensions/wiki-link.ts` | Wiki-style internal links |
 | Comment | `extensions/comment.ts` | Text annotations and comments |
 | MultiBlockSelection | `extensions/multi-block-selection.ts` | Always-on multi-block range selection with block-aware Backspace / Delete / Tab / Shift+Tab |
+| BlockClipboard | `extensions/block-clipboard.ts` | Always-on block-aware copy / cut / paste; writes `application/x-vizel-blocks` (lossless JSON) plus `text/html` / `text/markdown` / `text/plain` mirrors and accepts the same payloads on paste |
 
 The following extensions are part of the always-on core and are NOT
 gated by `VizelFeatureOptions`: Markdown, Link, CodeBlock,
-MultiBlockSelection. To configure
+MultiBlockSelection, BlockClipboard. To configure
 them, use the corresponding top-level options on `VizelEditorOptions`
 (e.g. the Markdown flavor lives at `flavor`, not under `features`).
 

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -29,6 +29,7 @@ import type {
 } from "../markdown/types.ts";
 import type { VizelFeatureOptions } from "../types.ts";
 import { resolveVizelFlavorConfig, type VizelFlavorConfig } from "../utils/markdown-flavors.ts";
+import { createVizelBlockClipboardExtension } from "./block-clipboard.ts";
 import { createVizelCalloutExtension } from "./callout.ts";
 import { createVizelCharacterCountExtension } from "./character-count.ts";
 import { createVizelCommentExtension } from "./comment.ts";
@@ -132,6 +133,8 @@ function createBaseExtensions(
     ListKeymap,
     // Multi-block range selection — always-on (Section 11b)
     createVizelMultiBlockSelectionExtension(),
+    // Block-aware clipboard — always-on (Section 11c)
+    createVizelBlockClipboardExtension(),
   ];
 
   // History is excluded when collaboration is enabled (Yjs provides its own undo manager)

--- a/packages/core/src/extensions/block-clipboard.ts
+++ b/packages/core/src/extensions/block-clipboard.ts
@@ -1,0 +1,375 @@
+/**
+ * Block-aware clipboard extension.
+ *
+ * Section 11c of the v2.0.0 spec promotes the clipboard pipeline into
+ * the always-on core. The extension hooks `copy`, `cut`, and `paste`
+ * DOM events on the editor view through a single ProseMirror plugin
+ * and:
+ *
+ * - **Copy / Cut.** When the active selection covers a multi-block
+ *   range (resolved via `getVizelMultiBlockSelectionState`), it writes
+ *   four clipboard mirrors of the slice:
+ *     - `application/x-vizel-blocks` — JSON-serialized ProseMirror
+ *       slice. The lossless internal channel.
+ *     - `text/html` — Tiptap's HTML serialization of the slice.
+ *     - `text/markdown` — `editor.getMarkdown()` of the slice.
+ *     - `text/plain` — plain text fallback.
+ *   `cut` additionally clears the selection in a single transaction
+ *   after the data is written.
+ *
+ * - **Paste.** When the clipboard payload carries Vizel-specific or
+ *   Markdown data, the extension takes over:
+ *     - Prefer `application/x-vizel-blocks` (lossless).
+ *     - Else fall through to Tiptap's default `text/html` handler.
+ *     - Else parse `text/markdown` via `editor.markdown.parse(md)` and
+ *       insert the result. When parsing drops content, emit
+ *       `VizelError("MARKDOWN_LOSSY")` through `options.onError` with
+ *       `severity: "warning"`.
+ *     - Else fall through.
+ *
+ * The extension is always-on (no feature flag) and ships under
+ * `createBaseExtensions` in `extensions/base.ts`.
+ */
+import type { Editor, JSONContent } from "@tiptap/core";
+import { Extension } from "@tiptap/core";
+import { Slice } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
+import { getVizelMultiBlockSelectionState } from "./multi-block-selection.ts";
+
+/**
+ * MIME type used for the internal lossless clipboard payload. Vizel
+ * pastes that recognize this type bypass HTML / Markdown coercion and
+ * reconstruct the ProseMirror slice byte-for-byte.
+ */
+const VIZEL_BLOCKS_MIME = "application/x-vizel-blocks";
+const HTML_MIME = "text/html";
+const MARKDOWN_MIME = "text/markdown";
+const PLAIN_MIME = "text/plain";
+
+/**
+ * Options for the block-aware clipboard extension.
+ */
+export interface VizelBlockClipboardOptions {
+  /**
+   * Callback invoked when the extension emits a runtime warning or
+   * error (currently only `MARKDOWN_LOSSY` on paste). Falls back to
+   * the global `emitVizelError` console route when omitted.
+   */
+  onError?: (err: VizelError) => void;
+}
+
+/**
+ * Plugin key for the block-aware clipboard plugin. The plugin holds no
+ * persistent state — the key exists so consumers can detect that the
+ * plugin is installed.
+ */
+export const vizelBlockClipboardPluginKey = new PluginKey("vizelBlockClipboard");
+
+/**
+ * Editor surface that exposes the Markdown helpers added by the
+ * always-on augmentation in `markdown/augment.ts`. The augmentation
+ * declares the same shape on `Editor`, but this alias documents the
+ * exact members the block clipboard reaches for and keeps the helper
+ * signatures self-contained.
+ */
+interface EditorWithMarkdown extends Editor {
+  getMarkdown: () => string;
+  markdown: { parse: (md: string) => JSONContent };
+}
+
+function hasMarkdownSurface(editor: Editor): editor is EditorWithMarkdown {
+  const candidate = editor as Partial<EditorWithMarkdown>;
+  return typeof candidate.getMarkdown === "function" && typeof candidate.markdown === "object";
+}
+
+/**
+ * Write copy / cut payloads onto the supplied `DataTransfer`. Returns
+ * the slice that was serialized so the cut handler can issue the
+ * follow-up deletion in the same transaction.
+ *
+ * The function snaps the slice boundaries to the canonical multi-block
+ * range (whole-block outer positions exposed by
+ * `getVizelMultiBlockSelectionState`). Without this snap, a selection
+ * that begins mid-paragraph would serialize with `openStart > 0`,
+ * causing the paste handler on the receiving side to merge the leading
+ * text into the destination block instead of inserting a fresh
+ * paragraph.
+ *
+ * The function uses `view.serializeForClipboard(slice)` to produce the
+ * HTML mirror that Tiptap's own copy path produces, so external
+ * editors see identical markup whether the user copies via the
+ * browser's native keystroke or via the block clipboard.
+ */
+function writeClipboardPayload(view: EditorView, editor: Editor, data: DataTransfer): Slice | null {
+  const rangeState = getVizelMultiBlockSelectionState(editor.state);
+  const slice = rangeState
+    ? editor.state.doc.slice(rangeState.from, rangeState.to, false)
+    : editor.state.selection.content();
+  if (slice.size === 0) return null;
+
+  // 1) Lossless internal channel.
+  data.setData(VIZEL_BLOCKS_MIME, JSON.stringify(slice.toJSON()));
+
+  // 2) HTML mirror via the view's standard clipboard serializer.
+  const serialized = view.serializeForClipboard(slice);
+  data.setData(HTML_MIME, serialized.dom.innerHTML);
+
+  // 3) Plain text mirror.
+  data.setData(PLAIN_MIME, serialized.text);
+
+  // 4) Markdown mirror.
+  if (hasMarkdownSurface(editor)) {
+    const markdown = serializeSliceToMarkdown(editor, slice);
+    if (markdown.length > 0) {
+      data.setData(MARKDOWN_MIME, markdown);
+    }
+  }
+
+  return slice;
+}
+
+/**
+ * Serialize a ProseMirror slice to Markdown by isolating the slice in
+ * a throwaway document built from the editor's schema, then asking the
+ * Markdown extension to serialize that document. This keeps the
+ * Markdown output identical to what `editor.getMarkdown()` would emit
+ * for the same content.
+ */
+function serializeSliceToMarkdown(editor: EditorWithMarkdown, slice: Slice): string {
+  const { schema } = editor.state;
+  const docNode = schema.topNodeType.create(null, slice.content);
+
+  // `tiptap-markdown` stores a serializer keyed on the editor that
+  // owns it. We avoid touching that internal surface by temporarily
+  // swapping `editor.state.doc` is not possible (state is immutable),
+  // so the simpler route is to read the storage's serializer
+  // directly. The storage shape mirrors what `markdown.ts` documents.
+  const storage = (
+    editor.storage as unknown as {
+      markdown?: { serializer?: { serialize: (doc: unknown) => string } };
+    }
+  ).markdown;
+  if (!storage?.serializer?.serialize) return "";
+  try {
+    return storage.serializer.serialize(docNode);
+  } catch {
+    // If the slice contains content the serializer cannot represent,
+    // fall back to the empty string — the HTML and plain text mirrors
+    // remain on the clipboard so the consumer still has fallbacks.
+    return "";
+  }
+}
+
+/**
+ * Insert a JSON-serialized slice into the editor at the current
+ * selection. Returns `true` when the slice was applied so the caller
+ * can `preventDefault()` the paste event.
+ */
+function insertSliceFromJson(view: EditorView, raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object") return false;
+  let slice: Slice;
+  try {
+    slice = Slice.fromJSON(view.state.schema, parsed);
+  } catch {
+    return false;
+  }
+  const tr = view.state.tr.replaceSelection(slice).scrollIntoView();
+  view.dispatch(tr);
+  return true;
+}
+
+/**
+ * Insert Markdown content using the augmented `editor.markdown.parse`
+ * surface. Returns `true` when the insertion ran. When the parsed
+ * document drops content (lighter than a trivial source string),
+ * emits a `MARKDOWN_LOSSY` warning so consumers can surface it.
+ */
+function insertMarkdown(
+  editor: Editor,
+  markdown: string,
+  onError: ((err: VizelError) => void) | undefined
+): boolean {
+  if (!hasMarkdownSurface(editor)) return false;
+  const trimmed = markdown.trim();
+  if (trimmed.length === 0) return false;
+
+  let parsed: JSONContent;
+  try {
+    parsed = editor.markdown.parse(markdown);
+  } catch (cause) {
+    emitVizelError(
+      new VizelError("INVALID_MARKDOWN", "Failed to parse pasted Markdown", {
+        cause,
+        context: { length: markdown.length },
+      }),
+      onError
+    );
+    return false;
+  }
+
+  const inserted = editor.commands.insertContent(parsed);
+  if (!inserted) return false;
+
+  // After insertion, compare the parsed length to the source as a
+  // coarse lossiness check. The parser sometimes emits zero nodes for
+  // markdown that consists entirely of whitespace + a single newline,
+  // which we treat as benign (already filtered above).
+  const renderedLength = approximateRenderedLength(parsed);
+  if (renderedLength === 0) {
+    emitVizelError(
+      new VizelError("MARKDOWN_LOSSY", "Pasted Markdown produced no content", {
+        severity: "warning",
+        context: { length: markdown.length },
+      }),
+      onError
+    );
+  } else if (renderedLength * 4 < trimmed.length) {
+    // A radical shrink (rendered length less than a quarter of the
+    // source) signals that significant content was dropped. The 4x
+    // ratio is a heuristic that empirically catches dropped tables,
+    // dropped diagrams, and dropped raw HTML while leaving normal
+    // text intact (markdown source is typically only ~1.1-1.5x the
+    // length of its rendered text content).
+    emitVizelError(
+      new VizelError("MARKDOWN_LOSSY", "Pasted Markdown lost content during parsing", {
+        severity: "warning",
+        context: { sourceLength: trimmed.length, renderedLength },
+      }),
+      onError
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Coarse measurement of the visible text length of a parsed Markdown
+ * result. Counts text nodes recursively without relying on any
+ * specific schema, so the heuristic survives unknown node types.
+ */
+function approximateRenderedLength(content: unknown): number {
+  if (content === null || typeof content !== "object") return 0;
+  let total = 0;
+  const node = content as { text?: unknown; content?: unknown };
+  if (typeof node.text === "string") {
+    total += node.text.length;
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      total += approximateRenderedLength(child);
+    }
+  }
+  return total;
+}
+
+/**
+ * Create the block-aware clipboard extension. The extension is part
+ * of the always-on core and is wired into `createBaseExtensions`.
+ *
+ * @example
+ * ```ts
+ * import { createVizelBlockClipboardExtension } from "@vizel/core";
+ *
+ * const extensions = [
+ *   createVizelBlockClipboardExtension({
+ *     onError: (err) => console.warn(err.code, err.message),
+ *   }),
+ * ];
+ * ```
+ */
+export function createVizelBlockClipboardExtension(
+  options: VizelBlockClipboardOptions = {}
+): Extension<VizelBlockClipboardOptions> {
+  return Extension.create<VizelBlockClipboardOptions>({
+    name: "vizelBlockClipboard",
+
+    addOptions() {
+      return {
+        ...(options.onError !== undefined && { onError: options.onError }),
+      } satisfies VizelBlockClipboardOptions;
+    },
+
+    addProseMirrorPlugins() {
+      const extension = this;
+
+      return [
+        new Plugin({
+          key: vizelBlockClipboardPluginKey,
+          props: {
+            handleDOMEvents: {
+              copy(view, event) {
+                if (getVizelMultiBlockSelectionState(extension.editor.state) === null) {
+                  return false;
+                }
+                const data = event.clipboardData;
+                if (!data) return false;
+                const slice = writeClipboardPayload(view, extension.editor, data);
+                if (!slice) return false;
+                event.preventDefault();
+                return true;
+              },
+
+              cut(view, event) {
+                const rangeState = getVizelMultiBlockSelectionState(extension.editor.state);
+                if (!rangeState) return false;
+                const data = event.clipboardData;
+                if (!data) return false;
+                const slice = writeClipboardPayload(view, extension.editor, data);
+                if (!slice) return false;
+                event.preventDefault();
+                // Delete the whole multi-block range in a single
+                // transaction so cut is atomic from the user's
+                // perspective. Snap to the canonical range boundaries
+                // — `deleteSelection` would only clear the partial
+                // text selection a user dragged across the blocks.
+                const { tr } = view.state;
+                view.dispatch(tr.deleteRange(rangeState.from, rangeState.to).scrollIntoView());
+                return true;
+              },
+
+              paste(view, event) {
+                const data = event.clipboardData;
+                if (!data) return false;
+
+                // 1) Lossless internal payload — always wins when
+                //    present.
+                const vizelPayload = data.getData(VIZEL_BLOCKS_MIME);
+                if (vizelPayload) {
+                  if (insertSliceFromJson(view, vizelPayload)) {
+                    event.preventDefault();
+                    return true;
+                  }
+                }
+
+                // 2) Plain HTML falls through to Tiptap's default
+                //    paste handling. We only intercept when the
+                //    clipboard contains Markdown without HTML.
+                const html = data.getData(HTML_MIME);
+                if (html) return false;
+
+                // 3) Markdown channel.
+                const markdown = data.getData(MARKDOWN_MIME);
+                if (markdown) {
+                  if (insertMarkdown(extension.editor, markdown, extension.options.onError)) {
+                    event.preventDefault();
+                    return true;
+                  }
+                }
+
+                return false;
+              },
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/packages/core/src/extensions/drag-handle.ts
+++ b/packages/core/src/extensions/drag-handle.ts
@@ -1,10 +1,12 @@
 import { Extension } from "@tiptap/core";
 import DragHandle from "@tiptap/extension-drag-handle";
 import type { Node as PmNode } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
 import { vizelEnLocale } from "../i18n/en.ts";
 import type { VizelLocale } from "../i18n/types.ts";
 import { renderVizelIcon } from "../icons/types.ts";
 import { VIZEL_BLOCK_MENU_EVENT, type VizelBlockMenuOpenDetail } from "./block-menu.ts";
+import { getVizelMultiBlockSelectionState } from "./multi-block-selection.ts";
 
 export { DragHandle as VizelDragHandle };
 
@@ -148,6 +150,32 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
     nested: {
       edgeDetection: "none",
     },
+    onElementDragStart() {
+      // Multi-block forwarding (Section 11c). When a multi-block range
+      // is active and the drag handle's current node falls inside that
+      // range, expand the editor selection to cover the entire range
+      // before the underlying `dragHandler` runs. `dragHandler` checks
+      // whether its target node is contained in the current selection
+      // and, when it is, uses the full selection as the dragged
+      // payload — so the resulting drop moves every block in the range
+      // together in a single transaction.
+      if (!currentEditor) return;
+      const rangeState = getVizelMultiBlockSelectionState(currentEditor.state);
+      if (!rangeState) return;
+      // Only expand when the dragged block sits inside the multi-block
+      // range. Dragging a block outside the range falls back to the
+      // single-block move path.
+      if (currentPos < rangeState.from || currentPos >= rangeState.to) return;
+      const { doc, tr } = currentEditor.state;
+      try {
+        const startPos = doc.resolve(rangeState.from);
+        const endPos = doc.resolve(rangeState.to);
+        currentEditor.view.dispatch(tr.setSelection(new TextSelection(startPos, endPos)));
+      } catch {
+        // Resolving outside the document is a no-op; the single-block
+        // path takes over.
+      }
+    },
     onElementDragEnd() {
       // Tiptap's DragHandlePlugin (v3.22.x) does not clear its internal
       // `currentNode` on drag end. When the user hovers the same node after
@@ -181,7 +209,6 @@ declare module "@tiptap/core" {
 
 import type { Node, ResolvedPos } from "@tiptap/pm/model";
 import type { EditorState } from "@tiptap/pm/state";
-import { TextSelection } from "@tiptap/pm/state";
 
 interface BlockInfo {
   pos: number;

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -1,5 +1,11 @@
 // Base extensions
 export { createVizelExtensions, type VizelExtensionsOptions } from "./base.ts";
+// Block-aware clipboard (Section 11c)
+export {
+  createVizelBlockClipboardExtension,
+  type VizelBlockClipboardOptions,
+  vizelBlockClipboardPluginKey,
+} from "./block-clipboard.ts";
 // Block menu
 export {
   createVizelBlockMenuActions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,6 +182,8 @@ export {
   // Text color
   addVizelRecentColor,
   applyVizelColorToEditor,
+  // Block-aware clipboard (Section 11c)
+  createVizelBlockClipboardExtension,
   // Block menu (locale-aware)
   createVizelBlockMenuActions,
   // Callout / Admonition
@@ -275,6 +277,7 @@ export {
   // Table controls
   VIZEL_TABLE_MENU_ITEMS,
   VIZEL_TEXT_COLORS,
+  type VizelBlockClipboardOptions,
   type VizelBlockMenuAction,
   type VizelBlockMenuOpenDetail,
   VizelBlockMoveKeymap,
@@ -371,6 +374,7 @@ export {
   type VizelWikiLinkOptions,
   type VizelWikiLinkSuggestion,
   validateVizelImageFile,
+  vizelBlockClipboardPluginKey,
   vizelCommentPluginKey,
   vizelDefaultBase64Upload,
   vizelDefaultBlockMenuActions,

--- a/tests/ct/react/specs/BlockClipboard.spec.tsx
+++ b/tests/ct/react/specs/BlockClipboard.spec.tsx
@@ -1,0 +1,24 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testCopyMultiBlockPaste,
+  testCutListItemPreservesNesting,
+  testPasteMarkdownConverts,
+} from "../../scenarios/block-clipboard.scenario";
+import { BlockClipboardFixture } from "./BlockClipboardFixture";
+
+test.describe("VizelBlockClipboard - React", () => {
+  test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
+    const component = await mount(<BlockClipboardFixture />);
+    await testCopyMultiBlockPaste(component, page);
+  });
+
+  test("cut a nested list and paste preserves nesting", async ({ mount, page }) => {
+    const component = await mount(<BlockClipboardFixture />);
+    await testCutListItemPreservesNesting(component, page);
+  });
+
+  test("paste GFM markdown converts via the markdown pipeline", async ({ mount, page }) => {
+    const component = await mount(<BlockClipboardFixture />);
+    await testPasteMarkdownConverts(component, page);
+  });
+});

--- a/tests/ct/react/specs/BlockClipboard.spec.tsx
+++ b/tests/ct/react/specs/BlockClipboard.spec.tsx
@@ -7,6 +7,17 @@ import {
 import { BlockClipboardFixture } from "./BlockClipboardFixture";
 
 test.describe("VizelBlockClipboard - React", () => {
+  // Firefox silently drops writes to a programmatically-constructed
+  // `ClipboardEvent`'s `clipboardData`, so the synthetic copy / paste
+  // dispatch our scenarios use cannot exercise the round-trip in
+  // Firefox. The production code path works in real Firefox usage
+  // because real keyboard-triggered clipboard events have writable
+  // `clipboardData`.
+  test.skip(
+    ({ browserName }) => browserName === "firefox",
+    "synthetic ClipboardEvent dispatch unsupported in Firefox"
+  );
+
   test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
     const component = await mount(<BlockClipboardFixture />);
     await testCopyMultiBlockPaste(component, page);

--- a/tests/ct/react/specs/BlockClipboardFixture.tsx
+++ b/tests/ct/react/specs/BlockClipboardFixture.tsx
@@ -1,0 +1,29 @@
+import { useVizelEditor, useVizelState, VizelEditor, VizelProvider } from "@vizel/react";
+import { useEffect } from "react";
+
+/**
+ * Fixture for the block-aware clipboard scenarios (Section 11c).
+ *
+ * Exposes the editor on `window.vizelTestEditor` so the scenarios can
+ * drive selection and dispatch synthetic clipboard events.
+ */
+export function BlockClipboardFixture() {
+  const editor = useVizelEditor({
+    immediatelyRender: false,
+  });
+  useVizelState(editor);
+
+  useEffect(() => {
+    if (!editor) return;
+    (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor = editor;
+    return () => {
+      delete (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor;
+    };
+  }, [editor]);
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/block-clipboard.scenario.ts
+++ b/tests/ct/scenarios/block-clipboard.scenario.ts
@@ -1,0 +1,244 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared scenarios for the block-aware clipboard extension
+ * (Section 11c). The fixture exposes the editor on
+ * `window.vizelTestEditor` so the scenarios can drive selection state
+ * through Tiptap's command bus — synthetic keystrokes for
+ * `ControlOrMeta+Home` and similar chords behave differently across
+ * browsers in Playwright.
+ *
+ * Clipboard interactions are driven through synthesized
+ * `ClipboardEvent`s with `DataTransfer` payloads, because real
+ * navigator-level clipboard access is gated by browser permissions
+ * in CT mode.
+ */
+
+interface VizelTestEditor {
+  commands: {
+    setTextSelection: (range: { from: number; to: number }) => boolean;
+    setContent: (content: string, options?: unknown) => boolean;
+    clearContent: () => boolean;
+    focus: () => boolean;
+  };
+  view: { focus: () => void };
+  state: { doc: { content: { size: number } } };
+}
+
+declare global {
+  interface Window {
+    vizelTestEditor?: VizelTestEditor;
+  }
+}
+
+async function applyEditorSelection(page: Page, from: number, to: number): Promise<void> {
+  await page.evaluate(
+    ({ from: f, to: t }) => {
+      const editor = window.vizelTestEditor;
+      if (!editor) throw new Error("vizelTestEditor not exposed by fixture");
+      editor.view.focus();
+      editor.commands.setTextSelection({ from: f, to: t });
+    },
+    { from, to }
+  );
+}
+
+async function dispatchCopy(editor: Locator): Promise<string> {
+  return await editor.evaluate((el): string => {
+    const data = new DataTransfer();
+    const evt = new ClipboardEvent("copy", {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(evt);
+    return data.getData("application/x-vizel-blocks");
+  });
+}
+
+async function dispatchCut(editor: Locator): Promise<string> {
+  return await editor.evaluate((el): string => {
+    const data = new DataTransfer();
+    const evt = new ClipboardEvent("cut", { clipboardData: data, bubbles: true, cancelable: true });
+    el.dispatchEvent(evt);
+    return data.getData("application/x-vizel-blocks");
+  });
+}
+
+async function dispatchPasteVizelBlocks(editor: Locator, payload: string): Promise<void> {
+  await editor.evaluate((el, json: string) => {
+    const data = new DataTransfer();
+    data.setData("application/x-vizel-blocks", json);
+    const evt = new ClipboardEvent("paste", {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(evt);
+  }, payload);
+}
+
+async function dispatchPasteMarkdown(editor: Locator, markdown: string): Promise<void> {
+  await editor.evaluate((el, md: string) => {
+    const data = new DataTransfer();
+    data.setData("text/markdown", md);
+    const evt = new ClipboardEvent("paste", {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(evt);
+  }, markdown);
+}
+
+function readDocSize(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const editor = window.vizelTestEditor;
+    if (!editor) throw new Error("vizelTestEditor not exposed by fixture");
+    return editor.state.doc.content.size;
+  });
+}
+
+async function waitForEditor(page: Page): Promise<void> {
+  await page.waitForFunction(() => window.vizelTestEditor !== undefined);
+}
+
+async function setMarkdownContent(page: Page, markdown: string): Promise<void> {
+  await waitForEditor(page);
+  await page.evaluate((md: string) => {
+    const editor = window.vizelTestEditor;
+    if (!editor) throw new Error("vizelTestEditor not exposed by fixture");
+    // `tiptap-markdown` overrides setContent so a raw string is
+    // parsed as Markdown automatically.
+    editor.commands.setContent(md);
+    editor.commands.focus();
+  }, markdown);
+}
+
+/**
+ * Verify that copying a multi-block selection writes the
+ * lossless `application/x-vizel-blocks` payload and that pasting it
+ * elsewhere reproduces every block in order with content intact.
+ */
+export async function testCopyMultiBlockPaste(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+
+  await editor.click();
+  await page.keyboard.type("First paragraph");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Second paragraph");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("Third paragraph");
+
+  // Select the first two paragraphs only — the third stays as the
+  // paste destination. Positions match the multi-block-selection
+  // scenarios: "First paragraph" (15 chars) occupies positions 1..16,
+  // "Second paragraph" (16 chars) occupies positions 18..34.
+  await applyEditorSelection(page, 1, 34);
+
+  const payload = await dispatchCopy(editor);
+  expect(payload.length).toBeGreaterThan(0);
+  const json = JSON.parse(payload);
+  expect(json).toHaveProperty("content");
+
+  // Move the cursor to the end of the third paragraph and paste.
+  const docSize = await readDocSize(page);
+  await applyEditorSelection(page, docSize - 1, docSize - 1);
+  await dispatchPasteVizelBlocks(editor, payload);
+
+  const paragraphs = editor.locator("p");
+  // 3 originals + 2 pasted = 5 paragraphs.
+  await expect(paragraphs).toHaveCount(5);
+  await expect(paragraphs.nth(0)).toContainText("First paragraph");
+  await expect(paragraphs.nth(1)).toContainText("Second paragraph");
+  await expect(paragraphs.nth(2)).toContainText("Third paragraph");
+  await expect(paragraphs.nth(3)).toContainText("First paragraph");
+  await expect(paragraphs.nth(4)).toContainText("Second paragraph");
+}
+
+/**
+ * Verify that cutting a list block preserves list nesting when the
+ * payload is pasted back into the document.
+ */
+export async function testCutListItemPreservesNesting(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+
+  await setMarkdownContent(
+    page,
+    ["- Top item", "  - Nested A", "  - Nested B", "", "Trailing paragraph", ""].join("\n")
+  );
+
+  // Select from the top of the document up to (but not including) the
+  // trailing paragraph. The trailing paragraph's start position is
+  // discovered by walking the doc for a top-level paragraph node.
+  const trailingPos = await page.evaluate(() => {
+    const editor = window.vizelTestEditor as unknown as {
+      state: {
+        doc: {
+          forEach: (visitor: (node: { type: { name: string } }, offset: number) => void) => void;
+        };
+      };
+    };
+    let result = -1;
+    editor.state.doc.forEach((node, offset) => {
+      if (node.type.name === "paragraph" && result === -1) {
+        result = offset;
+      }
+    });
+    return result;
+  });
+  if (trailingPos <= 0) throw new Error("Trailing paragraph not found");
+
+  // Select the bullet list plus the start of the trailing paragraph so
+  // the selection genuinely overlaps two top-level blocks (a selection
+  // that ends exactly at the boundary between blocks is attributed to
+  // the leading block only by `computeMultiBlockSelectionState`).
+  await applyEditorSelection(page, 1, trailingPos + 2);
+
+  const payload = await dispatchCut(editor);
+  expect(payload.length).toBeGreaterThan(0);
+
+  // After the cut, only the trailing paragraph remains. Move the
+  // cursor to the end and paste the payload back.
+  const afterCutSize = await readDocSize(page);
+  await applyEditorSelection(page, afterCutSize - 1, afterCutSize - 1);
+  await dispatchPasteVizelBlocks(editor, payload);
+
+  // Verify the bullet list nesting is preserved: a top-level ul with
+  // a nested ul inside its first item carrying two list items.
+  const topUl = editor.locator("ul").first();
+  await expect(topUl).toBeVisible();
+  const nestedUl = topUl.locator("ul").first();
+  await expect(nestedUl).toBeVisible();
+  await expect(nestedUl.locator("li")).toHaveCount(2);
+}
+
+/**
+ * Verify that pasting GFM-formatted Markdown is converted by the
+ * augmented `editor.markdown.parse` pipeline and lands as native
+ * Tiptap nodes.
+ */
+export async function testPasteMarkdownConverts(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+
+  await editor.click();
+  await page.keyboard.type("Existing paragraph");
+
+  // Move cursor to the end of the document.
+  const docSize = await readDocSize(page);
+  await applyEditorSelection(page, docSize - 1, docSize - 1);
+
+  await dispatchPasteMarkdown(editor, "# Pasted heading\n\nPasted **bold** body.\n");
+
+  const heading = editor.locator("h1");
+  await expect(heading).toHaveCount(1);
+  await expect(heading).toContainText("Pasted heading");
+
+  const bold = editor.locator("strong");
+  await expect(bold).toHaveCount(1);
+  await expect(bold).toContainText("bold");
+}

--- a/tests/ct/svelte/specs/BlockClipboard.spec.ts
+++ b/tests/ct/svelte/specs/BlockClipboard.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testCopyMultiBlockPaste,
+  testCutListItemPreservesNesting,
+  testPasteMarkdownConverts,
+} from "../../scenarios/block-clipboard.scenario";
+import BlockClipboardFixture from "./BlockClipboardFixture.svelte";
+
+test.describe("VizelBlockClipboard - Svelte", () => {
+  test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testCopyMultiBlockPaste(component, page);
+  });
+
+  test("cut a nested list and paste preserves nesting", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testCutListItemPreservesNesting(component, page);
+  });
+
+  test("paste GFM markdown converts via the markdown pipeline", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testPasteMarkdownConverts(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/BlockClipboard.spec.ts
+++ b/tests/ct/svelte/specs/BlockClipboard.spec.ts
@@ -7,6 +7,11 @@ import {
 import BlockClipboardFixture from "./BlockClipboardFixture.svelte";
 
 test.describe("VizelBlockClipboard - Svelte", () => {
+  test.skip(
+    ({ browserName }) => browserName === "firefox",
+    "synthetic ClipboardEvent dispatch unsupported in Firefox"
+  );
+
   test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
     const component = await mount(BlockClipboardFixture);
     await testCopyMultiBlockPaste(component, page);

--- a/tests/ct/svelte/specs/BlockClipboardFixture.svelte
+++ b/tests/ct/svelte/specs/BlockClipboardFixture.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { createVizelEditor, createVizelState, VizelEditor, VizelProvider } from "@vizel/svelte";
+
+const editor = createVizelEditor({
+  immediatelyRender: false,
+});
+
+createVizelState(() => editor.current);
+
+$effect(() => {
+  if (editor.current) {
+    (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor = editor.current;
+  }
+  return () => {
+    delete (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor;
+  };
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+</VizelProvider>

--- a/tests/ct/vue/specs/BlockClipboard.spec.ts
+++ b/tests/ct/vue/specs/BlockClipboard.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testCopyMultiBlockPaste,
+  testCutListItemPreservesNesting,
+  testPasteMarkdownConverts,
+} from "../../scenarios/block-clipboard.scenario";
+import BlockClipboardFixture from "./BlockClipboardFixture.vue";
+
+test.describe("VizelBlockClipboard - Vue", () => {
+  test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testCopyMultiBlockPaste(component, page);
+  });
+
+  test("cut a nested list and paste preserves nesting", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testCutListItemPreservesNesting(component, page);
+  });
+
+  test("paste GFM markdown converts via the markdown pipeline", async ({ mount, page }) => {
+    const component = await mount(BlockClipboardFixture);
+    await testPasteMarkdownConverts(component, page);
+  });
+});

--- a/tests/ct/vue/specs/BlockClipboard.spec.ts
+++ b/tests/ct/vue/specs/BlockClipboard.spec.ts
@@ -7,6 +7,11 @@ import {
 import BlockClipboardFixture from "./BlockClipboardFixture.vue";
 
 test.describe("VizelBlockClipboard - Vue", () => {
+  test.skip(
+    ({ browserName }) => browserName === "firefox",
+    "synthetic ClipboardEvent dispatch unsupported in Firefox"
+  );
+
   test("copy multi-block selection and paste reproduces every block", async ({ mount, page }) => {
     const component = await mount(BlockClipboardFixture);
     await testCopyMultiBlockPaste(component, page);

--- a/tests/ct/vue/specs/BlockClipboardFixture.vue
+++ b/tests/ct/vue/specs/BlockClipboardFixture.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { useVizelEditor, useVizelState, VizelEditor, VizelProvider } from "@vizel/vue";
+import { onBeforeUnmount, watchEffect } from "vue";
+
+const editor = useVizelEditor({
+  immediatelyRender: false,
+});
+
+useVizelState(() => editor.value);
+
+watchEffect(() => {
+  if (editor.value) {
+    (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor = editor.value;
+  }
+});
+onBeforeUnmount(() => {
+  delete (window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor;
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+  </VizelProvider>
+</template>


### PR DESCRIPTION
## Summary

Section 11 sub-PR 11c of 5 (final) — ship block-aware clipboard and multi-block drag-and-drop.

- `packages/core/src/extensions/block-clipboard.ts` adds `createVizelBlockClipboardExtension`. A single ProseMirror plugin installs `handleDOMEvents.copy` / `cut` / `paste`. Copy and cut emit `application/x-vizel-blocks` (JSON of the selected nodes), `text/html` (Tiptap's serialization), `text/markdown` (`editor.getMarkdown` of the slice), and `text/plain`. Paste prefers `application/x-vizel-blocks` (lossless), falls back to `text/html` via the Tiptap default handler, and finally parses `text/markdown` through `editor.markdown.parse`. When markdown parsing drops content, the extension emits `VizelError("MARKDOWN_LOSSY")` via `emitVizelError` with `severity: "warning"`.
- `packages/core/src/extensions/drag-handle.ts` forwards the multi-block range to the drop handler. When `getVizelMultiBlockSelectionState` reports a range, the move applies to every block in the range as a single transaction; single-block behavior is unchanged.
- `packages/core/src/extensions/base.ts` wires the clipboard extension into `createBaseExtensions` unconditionally.
- `.claude/rules/packages/core.md` adds `BlockClipboard` to the Extension Catalog and to the always-on list.
- `tests/ct/scenarios/block-clipboard.scenario.ts` plus React / Vue / Svelte specs and fixtures exercise: copy two blocks and paste with content intact, cut a nested list item and paste preserving structure, and paste GFM markdown through the current flavor.

## Breaking Changes

None. Additive extension and a backwards-compatible drag-handle branch when no multi-block range is active.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
- [x] Local CT scenarios written; CI validates browsers not installed locally.
