### PR TITLE
feat(core): add SSR factory guard, theme init script, and CI lint (Section 12a)

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -310,6 +310,54 @@ when the output differs from the input after whitespace
 normalization. Use it from a test runner; do not import it in
 production code.
 
+## SSR Safety
+
+Vizel is rendered into a contenteditable element in the browser, so
+the editor itself is client-only. The surrounding APIs are designed
+to remain callable on Node, edge runtimes, and the browser so that
+consumers can mix server and client without crashing at import time.
+
+### Layer-by-layer rules
+
+| Layer | Server-callable | DOM access |
+|-------|----------------|-----------|
+| `utils/` | Yes | Never at module scope |
+| `builders/` | Yes | Never |
+| `commands/` | Yes | Never |
+| `markdown/` | Yes | Never |
+| `controllers/` | Factory yes; `mount()` no | Inside `mount()` only, with an SSR guard |
+| `extensions/` | Factory yes; ProseMirror plugin no | Inside ProseMirror plugins only |
+| `utils/editorFactory.ts` | No — throws `VizelError("SSR_NOT_SUPPORTED")` | (Throws before reaching the DOM) |
+
+`pnpm check:ssr` runs `scripts/check-ssr-safety.ts`, which walks
+`utils/`, `builders/`, `commands/`, `markdown/`, plus `types.ts` and
+`index.ts`, and fails when it finds a `document.` or `window.`
+reference at the module's top scope. References inside function
+bodies are allowed because they execute lazily — the SSR-time import
+graph stays clean. Run it before opening a PR; CI gates merges on a
+green run.
+
+### Factory guard
+
+`createVizelEditorInstance` opens with `typeof document === "undefined"`
+and throws `VizelError("SSR_NOT_SUPPORTED")` when the check passes.
+Consumers that accidentally try to construct an editor in a server
+function get a typed error pointing at the right lifecycle hook
+(`useEffect`, `onMounted`, `onMount`) rather than a cryptic
+`document is not defined` ReferenceError from deep inside Tiptap.
+
+### Theme-flash mitigation
+
+`vizelThemeInitScript(options?)` returns a self-contained IIFE that
+reads `localStorage[storageKey]` (default `"vizel-theme"`), falls
+back to the supplied `defaultTheme` (`"system"` resolves via
+`matchMedia`), and writes `data-vizel-theme` on
+`document.documentElement` synchronously. The script body is built
+from typed options — never from consumer-supplied raw markup — so it
+carries no XSS surface. Embed the return value inline in the
+server-rendered `<head>` via the framework's idiomatic raw-script
+mechanism to eliminate the dark-mode flash on first paint.
+
 ## Dependencies
 
 ### Allowed

--- a/docs/superpowers/plans/2026-05-21-vizel-v2-section-12-ssr.md
+++ b/docs/superpowers/plans/2026-05-21-vizel-v2-section-12-ssr.md
@@ -1,0 +1,277 @@
+# Section 12 — SSR / Static Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Vizel's three SSR modes — `VizelStaticView` (read-only full SSR), `Vizel` with progressive enhancement, and `Vizel` with client-only mount — plus the supporting Core helpers (`generateVizelStaticHtml`, `vizelThemeInitScript`), an `SSR_NOT_SUPPORTED` guard at the editor factory, and a `scripts/check-ssr-safety.ts` lint script.
+
+**Architecture:** All server-callable code lives in `@vizel/core` and never touches `document` / `window` at module-top scope. The editor factory throws when called on the server. Framework packages add a thin `VizelStaticView` component plus rendering guidance. CI enforces SSR safety via a new script.
+
+**Tech Stack:** Tiptap v3, prosemirror-markdown, framework-agnostic HTML serialization, ES modules. The static-view HTML is sanitized through DOMPurify (already a `@vizel/core` dependency) before it reaches a framework renderer.
+
+---
+
+## Already-shipped infrastructure
+
+- `SSR_NOT_SUPPORTED` is already in the `VizelErrorCode` union (Section 7).
+- `controllers/` and `extensions/` already follow SSR-safe rules per Section 1.
+- `tiptap-markdown` (Section 10b) provides the markdown -> JSON path used by `generateVizelStaticHtml`.
+
+---
+
+## Sub-PR breakdown
+
+The work splits into two PRs:
+
+- **12a — Core SSR helpers + factory guard + CI script.** Ship
+  `generateVizelStaticHtml`, `vizelThemeInitScript`, the
+  `createVizelEditorInstance` SSR guard, and
+  `scripts/check-ssr-safety.ts`. Append an "SSR Safety" section to
+  `.claude/rules/packages/core.md`.
+
+- **12b — `VizelStaticView` x 3 framework + per-framework SSR
+  guidance.** Ship the React / Vue / Svelte `VizelStaticView`
+  components, update cross-framework parity tables, and add SSR
+  pattern sections to
+  `.claude/rules/packages/{react,vue,svelte}.md`.
+
+---
+
+## Spec mapping (binding)
+
+```ts
+export interface VizelStaticHtmlOptions {
+  readonly flavor?: VizelMarkdownFlavor;
+  readonly theme?: "light" | "dark";
+  readonly className?: string;
+}
+
+export interface VizelStaticHtmlInput {
+  /** Pre-parsed Tiptap JSON content. Mutually exclusive with `markdown`. */
+  readonly content?: JSONContent;
+  /** Source markdown text. Mutually exclusive with `content`. */
+  readonly markdown?: string;
+}
+
+export function generateVizelStaticHtml(
+  input: VizelStaticHtmlInput,
+  options?: VizelStaticHtmlOptions
+): string;
+
+export interface VizelThemeInitScriptOptions {
+  readonly defaultTheme?: "light" | "dark" | "system";
+  readonly storageKey?: string;
+}
+
+export function vizelThemeInitScript(options?: VizelThemeInitScriptOptions): string;
+```
+
+`createVizelEditorInstance` throws when `typeof document === "undefined"`:
+
+```ts
+if (typeof document === "undefined") {
+  throw new VizelError(
+    "SSR_NOT_SUPPORTED",
+    "createVizelEditorInstance cannot be called during SSR. " +
+      "Defer creation to a client lifecycle hook."
+  );
+}
+```
+
+`VizelStaticView` (all three frameworks):
+
+```tsx
+<VizelStaticView markdown={mdString} flavor={vizelGfmFlavor} theme="dark" />
+<VizelStaticView content={jsonContent} className="prose" />
+```
+
+---
+
+## Task 12a-1: `generateVizelStaticHtml`
+
+**Files:**
+- Create: `packages/core/src/utils/ssr.ts`
+- Modify: `packages/core/src/utils/index.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1:** Implement the helper. Approach:
+  - When `input.markdown` is supplied, parse it via the Tiptap schema.
+  - When `input.content` is supplied, use it directly.
+  - Walk the resulting node tree producing an HTML string. Use
+    `getHTMLFromFragment` (from `@tiptap/core`) over a `Schema` built
+    from `createBaseExtensions()` for the schema surface.
+  - Sanitize the HTML through DOMPurify before returning so that
+    consumer-supplied markdown cannot inject unsafe markup into the
+    rendered output.
+  - Wrap the sanitized HTML in
+    `<div class="vizel-root vizel-static-view${className ? ` ${className}` : ""}" data-vizel-root data-vizel-static-view${theme ? ` data-vizel-theme="${theme}"` : ""}>...</div>`.
+  - For diagram nodes (Mermaid, GraphViz), emit a `<pre><code
+    class="language-mermaid|graphviz">{source}</code></pre>` fallback so the
+    server output stays JavaScript-free; client hydration upgrades these.
+
+- [ ] **Step 2:** SSR-safe — must never touch `document` / `window`.
+  Build the schema with no DOM dependencies. Avoid extensions that
+  require browser globals (drag handle, image upload, etc.) — only
+  load schema-defining nodes/marks.
+
+- [ ] **Step 3:** Verify with a unit-style test harness (TS run
+  via `tsx` from `scripts/`) — emit HTML for a few representative
+  markdown samples and assert structure.
+
+## Task 12a-2: `vizelThemeInitScript`
+
+**Files:**
+- Modify: `packages/core/src/utils/ssr.ts` (add the helper)
+- Modify: `packages/core/src/utils/index.ts` (export)
+- Modify: `packages/core/src/index.ts` (export)
+
+- [ ] **Step 1:** Return a string containing:
+
+```js
+(function(){
+  var key = "<storageKey>";
+  var preferred = window.localStorage.getItem(key) || "<defaultTheme>";
+  var theme = preferred;
+  if (theme === "system") {
+    theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  document.documentElement.setAttribute("data-vizel-theme", theme);
+})();
+```
+
+Templated with the consumer's `defaultTheme` / `storageKey`. Consumers
+embed via `<script>{vizelThemeInitScript()}</script>` in their `<head>`.
+
+- [ ] **Step 2:** Document that the script runs synchronously to avoid
+  the dark-mode flash; it sets the attribute on `document.documentElement`
+  intentionally (matches Section 13's policy: the theme attribute lives
+  on the root element so descendants inherit it via CSS).
+
+## Task 12a-3: `createVizelEditorInstance` SSR guard
+
+**Files:**
+- Modify: `packages/core/src/utils/editorFactory.ts`
+
+- [ ] **Step 1:** At the top of `createVizelEditorInstance`, before any
+  option destructuring, add:
+
+```ts
+if (typeof document === "undefined") {
+  throw createVizelError(
+    "SSR_NOT_SUPPORTED",
+    "createVizelEditorInstance cannot be called during SSR. " +
+      "Defer creation to a client lifecycle hook."
+  );
+}
+```
+
+- [ ] **Step 2:** Verify the throw path with a quick `tsx` script that
+  imports the factory inside a `typeof document === "undefined"`
+  context and asserts the throw.
+
+## Task 12a-4: `scripts/check-ssr-safety.ts`
+
+**Files:**
+- Create: `scripts/check-ssr-safety.ts`
+- Modify: `package.json` (add `check:ssr` npm script)
+
+- [ ] **Step 1:** Walk `packages/core/src/{utils,builders,commands}/`
+  looking for top-level (module-scope) `document.` or `window.`
+  references. Allow references inside function bodies that begin with
+  an SSR guard (`typeof document === "undefined"` early-return).
+  Report any violation with file + line and exit non-zero.
+
+- [ ] **Step 2:** Wire it into `pnpm` scripts as
+  `"check:ssr": "tsx scripts/check-ssr-safety.ts"`.
+
+- [ ] **Step 3:** Run it locally — if existing code violates the rule,
+  fix the violations in this same PR (they should be rare; Sections 1
+  and 7 already enforce most of the surface).
+
+## Task 12a-5: `.claude/rules/packages/core.md` SSR Safety section
+
+**Files:**
+- Modify: `.claude/rules/packages/core.md`
+
+- [ ] **Step 1:** Append an "SSR Safety" section. Document:
+  - The "Layer-by-layer SSR safety" table from the spec.
+  - The `SSR_NOT_SUPPORTED` throw at the factory.
+  - The `generateVizelStaticHtml` helper for server rendering.
+  - The `vizelThemeInitScript` helper for pre-hydration theme.
+  - The CI script `pnpm check:ssr` that flags violations.
+  - The DOMPurify sanitization step the helper applies.
+
+## Task 12a-6: Verification
+
+- [ ] `pnpm exec biome check --write` — auto-fix
+- [ ] `pnpm typecheck` — clean
+- [ ] `pnpm build` — clean
+- [ ] `pnpm check:parity` — passes
+- [ ] `pnpm check:ssr` — passes
+- [ ] Commit and open PR 12a.
+
+---
+
+## Task 12b: `VizelStaticView` x 3 framework
+
+**Files (all new):**
+- `packages/react/src/components/VizelStaticView.tsx`
+- `packages/vue/src/components/VizelStaticView.vue`
+- `packages/svelte/src/components/VizelStaticView.svelte`
+- Re-export from each framework's `src/components/index.ts` and `src/index.ts`
+- Modify: `.claude/rules/cross-framework.md` Tables 2 and 3
+- Modify: `.claude/rules/packages/{react,vue,svelte}.md` SSR pattern sections
+- Tests: `tests/ct/scenarios/static-view.scenario.ts` + per-framework specs
+
+### Component shape
+
+```tsx
+export interface VizelStaticViewProps {
+  /** Source markdown text. Mutually exclusive with `content`. */
+  readonly markdown?: string;
+  /** Pre-parsed JSON content. Mutually exclusive with `markdown`. */
+  readonly content?: JSONContent;
+  /** Markdown flavor used to parse `markdown`. Defaults to `vizelGfmFlavor`. */
+  readonly flavor?: VizelMarkdownFlavor;
+  /** Locks the rendered theme; defaults to inheriting the host theme. */
+  readonly theme?: "light" | "dark";
+  /** Additional class name appended to `.vizel-static-view`. */
+  readonly className?: string; // `class` in Vue / Svelte
+}
+```
+
+The component calls `generateVizelStaticHtml(input, options)` which
+already returns sanitized HTML. The framework then injects that HTML
+via the framework's native raw-html escape hatch (React
+`dangerouslySetInnerHTML`, Vue `v-html`, Svelte `{@html}`). Because
+the string the consumer sees has already been routed through DOMPurify
+inside Core, the framework layer never accepts arbitrary HTML directly.
+Output is read-only — no editor instance, no contenteditable.
+
+### Tests
+
+`tests/ct/scenarios/static-view.scenario.ts`:
+
+- Mount with `markdown="# Hello\n\nWorld"` — assert the heading and
+  paragraph render with the right tags and classes.
+- Mount with `theme="dark"` — assert `data-vizel-theme="dark"`
+  appears on the wrapper.
+- Mount with `content={...JSON...}` — assert the JSON content renders.
+- Mount with `markdown="<script>alert(1)</script>"` — assert no
+  script tag survives (regression test for the sanitization step).
+
+### Verification
+
+- [ ] `pnpm exec biome check --write && pnpm typecheck && pnpm build && pnpm check:parity && pnpm check:ssr`
+- [ ] Cross-framework parity tables updated
+- [ ] Per-framework rule docs updated
+- [ ] Commit and open PR 12b
+
+---
+
+## Out of scope (deferred)
+
+- The Mermaid/GraphViz hydration upgrade path (client-side rewrite of
+  the server fallback `<pre><code>` into rendered diagrams) belongs to
+  a follow-up under Section 16 (demo overhaul) since it touches demo
+  app integration.
+- Per-Next/Nuxt/SvelteKit example apps live under Section 16.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
+    "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "prepare": "lefthook install",
     "deps:check": "pnpm dlx taze major -r",
     "deps:update": "pnpm dlx taze major -r -w && pnpm install"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -590,6 +590,8 @@ export {
   type VizelResolveFeaturesOptions,
   type VizelSuggestionContainer,
   type VizelTextSegment,
+  // SSR utilities (Section 12)
+  type VizelThemeInitScriptOptions,
   vizelCommonMarkFlavor,
   vizelDefaultEditorProps,
   vizelDefaultFeatures,
@@ -597,6 +599,7 @@ export {
   vizelGfmFlavor,
   vizelObsidianFlavor,
   vizelPandocFlavor,
+  vizelThemeInitScript,
   type WrapAsVizelErrorOptions,
   wrapAsVizelError,
 } from "./utils/index.ts";

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -118,6 +118,19 @@ export interface CreateVizelEditorInstanceResult {
 export async function createVizelEditorInstance(
   options: CreateVizelEditorInstanceOptions
 ): Promise<CreateVizelEditorInstanceResult> {
+  // Refuse to construct an editor on the server. Tiptap mounts to a
+  // contenteditable element that only exists in the browser, so
+  // calling this factory from a Node / edge runtime is a programming
+  // error. Section 12 of the v2.0 design surfaces this as the
+  // `SSR_NOT_SUPPORTED` typed error so consumers can distinguish it
+  // from runtime failures.
+  if (typeof document === "undefined") {
+    throw createVizelError(
+      "SSR_NOT_SUPPORTED",
+      "createVizelEditorInstance cannot be called during SSR. Defer creation to a client lifecycle hook (useEffect, onMounted, onMount)."
+    );
+  }
+
   const {
     initialContent,
     initialMarkdown,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -99,6 +99,11 @@ export {
   renderVizelMinimapToCanvas,
   type VizelMinimapRenderOptions,
 } from "./minimap-render.ts";
+// SSR utilities (Section 12)
+export {
+  type VizelThemeInitScriptOptions,
+  vizelThemeInitScript,
+} from "./ssr.ts";
 // Text highlight utilities
 export { splitVizelTextByMatches, type VizelTextSegment } from "./textHighlight.ts";
 // Type guard utilities

--- a/packages/core/src/utils/ssr.ts
+++ b/packages/core/src/utils/ssr.ts
@@ -1,0 +1,54 @@
+/**
+ * Server-side rendering utilities.
+ *
+ * The helpers in this module are intentionally DOM-free so they remain
+ * callable on Node, edge runtimes, and the browser alike. Anything
+ * that depends on `document` / `window` lives in `controllers/` or the
+ * framework packages, never here.
+ */
+
+/**
+ * Options for {@link vizelThemeInitScript}.
+ */
+export interface VizelThemeInitScriptOptions {
+  /**
+   * Theme to fall back to when nothing is stored.
+   * `"system"` resolves to `prefers-color-scheme: dark` at runtime.
+   * @default "system"
+   */
+  readonly defaultTheme?: "light" | "dark" | "system";
+  /**
+   * `localStorage` key holding the persisted theme value.
+   * @default "vizel-theme"
+   */
+  readonly storageKey?: string;
+}
+
+/**
+ * Build a synchronous theme-initialization script for embedding in
+ * the document `<head>`.
+ *
+ * The script reads the stored theme (falling back to the configured
+ * default) and sets `data-vizel-theme` on `document.documentElement`
+ * before the page paints. Inserting the result inline in a
+ * server-rendered `<head>` eliminates the dark-mode flash that
+ * otherwise appears on the first paint when the client mounts with
+ * the wrong theme.
+ *
+ * The script touches only `document.documentElement` — Vizel's other
+ * code stays scoped to the editor wrapper, per the theme policy in
+ * Section 13 of the v2.0 design. The output is a self-contained IIFE
+ * that the framework adapter places inside a `<script>` tag using
+ * the framework's idiomatic inline-script mechanism.
+ *
+ * The script body is fully synthesized from typed options inside this
+ * helper and never embeds consumer-supplied raw markup, so it carries
+ * no XSS surface.
+ */
+export function vizelThemeInitScript(options: VizelThemeInitScriptOptions = {}): string {
+  const defaultTheme = options.defaultTheme ?? "system";
+  const storageKey = options.storageKey ?? "vizel-theme";
+  const safeKey = JSON.stringify(storageKey);
+  const safeDefault = JSON.stringify(defaultTheme);
+  return `(function(){try{var k=${safeKey};var d=${safeDefault};var s=window.localStorage&&window.localStorage.getItem(k);var t=s||d;if(t==='system'){t=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.setAttribute('data-vizel-theme',t);}catch(e){}})();`;
+}

--- a/scripts/check-ssr-safety.ts
+++ b/scripts/check-ssr-safety.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env tsx
+/**
+ * SSR safety lint — scans the server-callable layers of
+ * `@vizel/core` for top-level (module-scope) `document.` or `window.`
+ * references that would crash at import time on the server.
+ *
+ * Permitted layers:
+ *
+ * - `packages/core/src/utils/`
+ * - `packages/core/src/builders/`
+ * - `packages/core/src/commands/`
+ * - `packages/core/src/markdown/`
+ * - `packages/core/src/types.ts`
+ * - `packages/core/src/index.ts`
+ *
+ * References INSIDE function bodies are allowed (the browser-only
+ * surface is exercised lazily). The script flags references at the
+ * file's module scope and exits non-zero if any are found.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleFile = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(moduleFile), "..");
+const CORE_SRC = join(REPO_ROOT, "packages", "core", "src");
+
+const SCANNED_DIRS = ["utils", "builders", "commands", "markdown"];
+const SCANNED_ROOT_FILES = ["types.ts", "index.ts"];
+
+const BANNED_PATTERNS: readonly { pattern: RegExp; label: string }[] = [
+  { pattern: /\bdocument\s*\./, label: "document." },
+  { pattern: /\bwindow\s*\./, label: "window." },
+];
+
+interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly snippet: string;
+  readonly label: string;
+}
+
+function collectFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      collectFiles(full, out);
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Walk the source and count braces to track scope depth.
+ * Depth 0 is module scope; any positive depth is inside a function /
+ * class / block. References at depth > 0 are permitted.
+ */
+function findModuleScopeViolations(file: string, source: string): Violation[] {
+  const lines = source.split("\n");
+  const violations: Violation[] = [];
+  let depth = 0;
+  let inBlockComment = false;
+  let inLineComment = false;
+  let inString: '"' | "'" | "`" | null = null;
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx] ?? "";
+    inLineComment = false;
+    for (let col = 0; col < line.length; col++) {
+      const ch = line[col];
+      const next = line[col + 1];
+      if (inLineComment) break;
+      if (inBlockComment) {
+        if (ch === "*" && next === "/") {
+          inBlockComment = false;
+          col++;
+        }
+        continue;
+      }
+      if (inString) {
+        if (ch === "\\") {
+          col++;
+          continue;
+        }
+        if (ch === inString) {
+          inString = null;
+        }
+        continue;
+      }
+      if (ch === "/" && next === "/") {
+        inLineComment = true;
+        break;
+      }
+      if (ch === "/" && next === "*") {
+        inBlockComment = true;
+        col++;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") {
+        inString = ch;
+        continue;
+      }
+      if (ch === "{") depth++;
+      else if (ch === "}") depth = Math.max(0, depth - 1);
+    }
+    if (depth !== 0 || inBlockComment) continue;
+    for (const { pattern, label } of BANNED_PATTERNS) {
+      const match = pattern.exec(line);
+      if (!match) continue;
+      const column = (match.index ?? 0) + 1;
+      violations.push({
+        file,
+        line: lineIdx + 1,
+        column,
+        snippet: line.trim(),
+        label,
+      });
+    }
+  }
+  return violations;
+}
+
+function main(): void {
+  const files: string[] = [];
+  for (const dir of SCANNED_DIRS) {
+    collectFiles(join(CORE_SRC, dir), files);
+  }
+  for (const name of SCANNED_ROOT_FILES) {
+    files.push(join(CORE_SRC, name));
+  }
+
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    violations.push(...findModuleScopeViolations(file, source));
+  }
+
+  if (violations.length === 0) {
+    process.stdout.write("SSR safety check passed.\n");
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `SSR safety check failed (${violations.length} violation${violations.length === 1 ? "" : "s"}):\n`
+  );
+  for (const v of violations) {
+    const rel = relative(REPO_ROOT, v.file);
+    process.stderr.write(`  ${rel}:${v.line}:${v.column}: ${v.label} at module scope\n`);
+    process.stderr.write(`    ${v.snippet}\n`);
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Section 12 sub-PR 12a of 2 — establish the SSR-safety surface for v2.0.

- `utils/ssr.ts` exports `vizelThemeInitScript({ defaultTheme, storageKey })` returning a self-contained IIFE that reads the stored theme (falling back to `defaultTheme`; `"system"` resolves via `matchMedia`) and sets `data-vizel-theme` on `document.documentElement` before the page paints. The body is templated from typed options only — no consumer-supplied raw markup — so it carries no XSS surface.
- `utils/editorFactory.ts` opens with `typeof document === "undefined"` and throws `VizelError("SSR_NOT_SUPPORTED")` with a message pointing at the right client lifecycle hook. Consumers that accidentally call the factory in a server function get a typed error instead of a deep "document is not defined" ReferenceError.
- `scripts/check-ssr-safety.ts` walks `utils/`, `builders/`, `commands/`, `markdown/`, plus `types.ts` and `index.ts` and fails when it finds a `document.` or `window.` reference at module top scope. The walker tracks brace depth, comments, and string literals so function-body references stay allowed. Wired into `pnpm` scripts as `check:ssr`.
- `.claude/rules/packages/core.md` gains an "SSR Safety" section documenting the layer-by-layer table, the factory guard, the `check:ssr` lint, and the theme-init helper.

## Out of Scope

`generateVizelStaticHtml` and the framework `VizelStaticView` components are deferred to a follow-up sub-PR that picks a server DOM shim (jsdom / linkedom) — Tiptap's `getHTMLFromFragment` depends on a real DOM and adding the shim warrants its own review pass.

## Breaking Changes

Calling `createVizelEditorInstance` in a Node / edge runtime now throws `VizelError("SSR_NOT_SUPPORTED")`. Previously it crashed with a `ReferenceError: document is not defined` deep inside Tiptap. The throw is fail-fast and message-rich, making the misuse easier to fix.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
- [x] `pnpm check:ssr` — passes (no module-scope DOM access in server-callable layers).
