### PR TITLE
refactor(core): remove host theme selectors (Section 13)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -66,7 +66,13 @@ These hold across every framework package:
   helpers).
 - **Style surface.** A single CSS entry per framework package (e.g.
   `@vizel/react/styles.css`). No hand-mounting of additional stylesheets is
-  required to make any built-in component render correctly.
+  required to make any built-in component render correctly. The CSS ships
+  the entire token catalog under exactly two selectors —
+  `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` —
+  plus the `(prefers-color-scheme: dark)` fallback for unset themes.
+  Vizel never writes host-environment selectors (`.dark`, `.light`,
+  `[data-theme="*"]`); host theming belongs to the host theme library
+  and stays decoupled from Vizel.
 - **Symmetric API.** Component props, hook / composable / rune names, return
   shapes, and event payloads mirror each other across the three frameworks,
   modulo idiomatic naming (`useFoo` in React and Vue, `createFoo` in Svelte).

--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -429,3 +429,55 @@ CSS lives in `src/styles/`.
 - Scope styles to Vizel components.
 - Use CSS custom properties for theming.
 - Document non-trivial style dependencies in comments.
+
+## CSS Variables and Theme
+
+Vizel is theme-neutral. The library writes only the
+`data-vizel-theme` attribute on the host element. It never touches
+host theme selectors (`.dark`, `.light`, `[data-theme="*"]`, etc.) —
+those belong to the host theme library (Tailwind, next-themes, ...).
+
+### Two-selector rule
+
+`packages/core/src/styles/_variables.scss` declares the entire token
+catalog exactly twice:
+
+- `:root, [data-vizel-theme="light"]` — light tokens.
+- `[data-vizel-theme="dark"]` — dark overrides.
+
+A system-preference fallback covers users that have not chosen a
+theme: `@media (prefers-color-scheme: dark)` applies the dark
+overrides when neither `[data-vizel-theme="light"]` nor any explicit
+`[data-vizel-theme]` value is set on `:root`.
+
+Do not introduce `.light`, `.dark`, or `[data-theme="*"]` selectors
+to any SCSS file. The single permitted theme selector inside Vizel
+styles is `[data-vizel-theme]`.
+
+### `applyVizelTheme`
+
+`applyVizelTheme(resolvedTheme, targetSelector?)` writes the
+`data-vizel-theme` attribute on the resolved target element (defaults
+to `document.documentElement`). It does nothing else — no class
+toggles, no host-environment side effects.
+
+### Style surface
+
+A single CSS entry per framework package
+(`@vizel/<framework>/styles.css`) makes every built-in component
+render correctly. Three import patterns are supported via the
+subpath exports landed in Section 6c:
+
+| Pattern | Import | Use case |
+|---------|--------|----------|
+| Full | `@vizel/core/styles.css` | Default. Vizel ships its own tokens. |
+| Variables only | `@vizel/core/styles/variables.css` | Consumer supplies their own component CSS. |
+| Components only | `@vizel/core/styles/components.css` | Consumer maps another design system to Vizel tokens. |
+
+### Documentation policy
+
+`docs/guide/theming.md` consolidates theme documentation. It
+describes override and synchronization patterns abstractly without
+naming a specific dark-mode library. Library-specific recipes belong
+to that library's own documentation and decay when the library
+changes its API.

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -28,8 +28,6 @@
 // ============================================
 
 :root,
-.light,
-[data-theme="light"],
 [data-vizel-theme="light"] {
   // Color Tokens
   @include output-vars($light-colors);
@@ -102,8 +100,6 @@
 // Dark Theme
 // ============================================
 
-.dark,
-[data-theme="dark"],
 [data-vizel-theme="dark"] {
   // Color Overrides
   @include output-vars($dark-colors);
@@ -125,7 +121,7 @@
 // ============================================
 
 @media (prefers-color-scheme: dark) {
-  :root:not(.light):not([data-theme="light"]):not([data-vizel-theme="light"]):not([data-vizel-theme]) {
+  :root:not([data-vizel-theme="light"]):not([data-vizel-theme]) {
     // Color Overrides
     @include output-vars($dark-colors);
 

--- a/packages/core/src/styles/code-block.scss
+++ b/packages/core/src/styles/code-block.scss
@@ -278,8 +278,8 @@
 }
 
 // Light Theme Override
-:root[data-theme="light"] .vizel-code-block,
-.vizel-code-block[data-theme="light"] {
+:root[data-vizel-theme="light"] .vizel-code-block,
+.vizel-code-block[data-vizel-theme="light"] {
   --vizel-code-block-bg: oklch(0.968 0 0);
   --vizel-code-block-toolbar-bg: oklch(0 0 0 / 0.03);
   --vizel-code-block-border: oklch(0 0 0 / 0.1);

--- a/packages/core/src/styles/diagram.scss
+++ b/packages/core/src/styles/diagram.scss
@@ -166,8 +166,6 @@
   }
 }
 
-.dark .vizel-diagram,
-[data-theme="dark"] .vizel-diagram,
 [data-vizel-theme="dark"] .vizel-diagram {
   --vizel-diagram-bg: v("background-secondary");
   --vizel-diagram-hover-bg: v("background-tertiary");


### PR DESCRIPTION
## Summary

Section 13 — make Vizel theme-neutral by collapsing every theme selector down to the `[data-vizel-theme]` attribute.

- `packages/core/src/styles/_variables.scss` now declares the token catalog under exactly two selectors: `:root, [data-vizel-theme="light"]` for light tokens and `[data-vizel-theme="dark"]` for dark overrides. The `prefers-color-scheme: dark` fallback drops its negation chain down to the single `[data-vizel-theme]` attribute. The legacy `.light`, `.dark`, `[data-theme="light"]`, and `[data-theme="dark"]` selectors are gone.
- `packages/core/src/styles/code-block.scss` and `diagram.scss` had their `[data-theme="*"]` / `.dark` references rewritten to use the canonical `[data-vizel-theme]` attribute.
- `.claude/rules/packages/core.md` gains a "CSS Variables and Theme" section documenting the two-selector rule, the no-host-touch policy, the three CSS import patterns, and the documentation policy of not naming specific theme libraries.
- `.claude/rules/architecture.md`'s Style surface bullet now spells out the two-selector contract and the host-environment ban.

`applyVizelTheme` already wrote only `data-vizel-theme`, so no runtime change is required.

## Breaking Changes

Consumers that relied on Vizel CSS to apply dark tokens when their host wrote `.dark` or `[data-theme="dark"]` on the document root must now synchronize their host's theme state to `data-vizel-theme` themselves (call `applyVizelTheme(theme)` from the host theme library's change callback).

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
- [x] `pnpm check:ssr`.
