### PR TITLE
fix(docs): exclude superpowers planning docs from VitePress build

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,13 @@ export default withMermaid({
   base: "/vizel/",
   lang: "en-US",
 
+  // Internal planning and spec documents live under docs/superpowers/.
+  // Exclude them from the published site so VitePress does not try to
+  // parse the embedded Tiptap / Vue / TypeScript code blocks (their
+  // `{{ ... }}` interpolation patterns crash the Vue compiler when it
+  // walks markdown files).
+  srcExclude: ["superpowers/**"],
+
   head: [
     ["link", { rel: "icon", type: "image/svg+xml", href: "/vizel/logo.svg" }],
     ["meta", { name: "theme-color", content: "#6366F1" }],


### PR DESCRIPTION
## Summary

Fix the failing `Deploy VitePress site to Pages` workflow on `main`.

- The plan and spec files under `docs/superpowers/` contain code blocks with Vue interpolation patterns (`{{ ... }}`) that crash the `@vitepress/markdown-it -> @vue/compiler-core` pipeline when it walks every `.md` file.
- Add a `srcExclude: ["superpowers/**"]` rule to `docs/.vitepress/config.mts` so VitePress ignores the planning documents — they are internal collaboration artifacts, not parts of the public docs site.

## Test Plan

- [x] `pnpm exec vitepress build docs` — passes locally.
