### PR TITLE
refactor: eliminate let in favor of immutable patterns (Batch H)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -100,6 +100,62 @@ if (isAction(data)) {
 }
 ```
 
+## Immutability
+
+The project's TypeScript surface is immutability-first. `let` declarations
+are banned outside Svelte components and runes — every reassignable
+counter, accumulator, or timer handle lives in a typed state object so the
+file scope never needs `let`.
+
+### Why
+
+- Loops with mutable accumulators obscure data flow. The functional
+  equivalents (`.reduce`, `.flatMap`, ternary, recursion) localize the
+  computation and read top-to-bottom.
+- A closure-shared `const state = { ... }` object is type-checkable,
+  refactor-safe, and survives a `Find Usages` query that a `let`
+  binding inside a function does not.
+- Forbidding `let` removes an entire class of `let-vs-const` review
+  comments and keeps the codebase consistent across thousands of files.
+
+### Scope
+
+| In scope | Excluded |
+|----------|----------|
+| `packages/core/src/**/*.ts` | `packages/svelte/src/**/*.{svelte,svelte.ts}` |
+| `packages/react/src/**/*.{ts,tsx}` | `apps/demo/svelte/src/**/*.svelte` |
+| `packages/vue/src/**/*.{ts,vue}` (`<script setup>` blocks) | `tests/ct/svelte/specs/**/*.svelte` |
+| `scripts/**/*.ts` | Any `*.svelte.ts` rune file |
+| `tests/ct/scenarios/**/*.ts` | Any `*.d.ts` |
+| `tests/ct/react/specs/**/*.{ts,tsx}` | `node_modules/`, `dist/`, `.svelte-kit/`, `.vite/`, `.cache/` |
+| `tests/ct/vue/specs/**/*.{ts,vue}` (script blocks only) | |
+| `apps/demo/{react,vue}/src/**/*.{ts,tsx,vue}` (script blocks only) | |
+
+Svelte is excluded because Svelte 5's reactivity model treats top-level
+`let` (and runes like `$state(...)`) as the canonical reactivity primitive.
+
+### Escape hatch
+
+When a third-party API (typically a Tiptap / ProseMirror plugin's
+`addProseMirrorPlugins` closure that captures mutable state across
+transactions) genuinely requires a mutable binding, opt out with a
+required-reason ignore comment on the preceding line or the same line:
+
+```ts
+// biome-ignore lint/style/noLet: ProseMirror plugin state must be mutable.
+let decoSet = currentSet.map(tr.mapping, tr.doc);
+```
+
+The `<reason>` text is mandatory and is surfaced in code review.
+
+### Enforcement
+
+`pnpm check:nolet` (`scripts/check-no-let.ts`) walks the in-scope
+directories listed above, skips Svelte files and build artifacts, and
+exits non-zero on any unguarded `let` binding. Lefthook runs the same
+check on `pre-push`, and CI gates merges on a green run. Run it locally
+before opening a PR.
+
 ## Error Handling
 
 Vizel uses a single error model rooted at `VizelError`. Errors fall

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -54,3 +54,6 @@ pre-push:
 
     ssr:
       run: pnpm check:ssr
+
+    nolet:
+      run: pnpm check:nolet

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
+    "check:nolet": "tsx scripts/check-no-let.ts",
     "prepare": "lefthook install",
     "deps:check": "pnpm dlx taze major -r",
     "deps:update": "pnpm dlx taze major -r -w && pnpm install"

--- a/packages/core/src/auto-save.ts
+++ b/packages/core/src/auto-save.ts
@@ -64,24 +64,24 @@ function debounce<T extends (...args: Parameters<T>) => void>(
   fn: T,
   ms: number
 ): { (...args: Parameters<T>): void; cancel: () => void } {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const state: { timeoutId: ReturnType<typeof setTimeout> | null } = { timeoutId: null };
+
+  const cancel = (): void => {
+    if (state.timeoutId) {
+      clearTimeout(state.timeoutId);
+      state.timeoutId = null;
+    }
+  };
 
   const debounced = (...args: Parameters<T>) => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
+    cancel();
+    state.timeoutId = setTimeout(() => {
       fn(...args);
-      timeoutId = null;
+      state.timeoutId = null;
     }, ms);
   };
 
-  debounced.cancel = () => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-  };
+  debounced.cancel = cancel;
 
   return debounced;
 }
@@ -317,18 +317,18 @@ export function createVizelRelativeTimeTicker(
     onTick(date ? formatVizelRelativeTime(date, getLocale?.()) : "");
   };
 
-  let intervalId: ReturnType<typeof setInterval> | null = null;
+  const state: { intervalId: ReturnType<typeof setInterval> | null } = { intervalId: null };
 
   return {
     mount: (): void => {
-      if (intervalId !== null) return;
+      if (state.intervalId !== null) return;
       emit();
-      intervalId = setInterval(emit, intervalMs);
+      state.intervalId = setInterval(emit, intervalMs);
     },
     unmount: (): void => {
-      if (intervalId === null) return;
-      clearInterval(intervalId);
-      intervalId = null;
+      if (state.intervalId === null) return;
+      clearInterval(state.intervalId);
+      state.intervalId = null;
     },
   };
 }

--- a/packages/core/src/builders/block-menu.ts
+++ b/packages/core/src/builders/block-menu.ts
@@ -93,13 +93,19 @@ export function buildVizelBlockMenuSpec(
   const turnIntoLabel = locale?.blockMenu.turnInto ?? "Turn into";
 
   const groups = groupVizelBlockMenuActions(actions);
-  let globalIndex = 0;
+  const groupOffsets = groups.reduce<number[]>(
+    (acc, group) => {
+      acc.push((acc.at(-1) ?? 0) + group.length);
+      return acc;
+    },
+    [0]
+  );
   const sections: VizelMenuSectionSpec<VizelBlockMenuItemView>[] = groups.map(
     (group, groupIndex) => ({
       key: `group-${groupIndex}`,
-      items: group.map((action) => ({
+      items: group.map((action, indexInGroup) => ({
         key: action.id,
-        index: globalIndex++,
+        index: (groupOffsets[groupIndex] ?? 0) + indexInGroup,
         data: { action, isDestructive: action.id === "delete" },
         attrs: { role: "menuitem" satisfies "menuitem" } as VizelMenuItemAttrs,
       })),

--- a/packages/core/src/builders/outline.ts
+++ b/packages/core/src/builders/outline.ts
@@ -98,10 +98,8 @@ function buildOutlineTree(
 
     // Pop frames whose level is at or above the new entry. The root
     // frame at level 0 stays so we always have a parent to push into.
-    let top = stack.at(-1);
-    while (top !== undefined && stack.length > 1 && top.level >= level) {
+    while (stack.length > 1 && (stack.at(-1)?.level ?? 0) >= level) {
       stack.pop();
-      top = stack.at(-1);
     }
 
     const children: VizelOutlineItemSpec[] = [];

--- a/packages/core/src/builders/slash-menu.ts
+++ b/packages/core/src/builders/slash-menu.ts
@@ -69,10 +69,17 @@ export function buildVizelSlashMenuSpec(
       ? [{ name: "", items: [...items] }]
       : groupVizelSlashCommands([...items], groupOrder);
 
-  let globalIndex = 0;
+  const groupOffsets = groups.reduce<number[]>(
+    (acc, group) => {
+      acc.push((acc.at(-1) ?? 0) + group.items.length);
+      return acc;
+    },
+    [0]
+  );
   const sections = groups.map((group, gIndex) => {
-    const sectionItems = group.items.map((item) => {
-      const index = globalIndex++;
+    const baseOffset = groupOffsets[gIndex] ?? 0;
+    const sectionItems = group.items.map((item, indexInGroup) => {
+      const index = baseOffset + indexInGroup;
       return {
         key: item.id,
         index,
@@ -197,11 +204,18 @@ export function buildVizelSlashMenuSpecFromCommands(
         ...[...groupedMap.keys()].filter((name) => !order.includes(name)),
       ];
 
-  let globalIndex = 0;
+  const groupOffsets = orderedGroupNames.reduce<number[]>(
+    (acc, groupName) => {
+      acc.push((acc.at(-1) ?? 0) + (groupedMap.get(groupName)?.length ?? 0));
+      return acc;
+    },
+    [0]
+  );
   const sections = orderedGroupNames.map((groupName, gIndex) => {
     const groupCommands = groupedMap.get(groupName) ?? [];
-    const sectionItems = groupCommands.map((command) => {
-      const index = globalIndex++;
+    const baseOffset = groupOffsets[gIndex] ?? 0;
+    const sectionItems = groupCommands.map((command, indexInGroup) => {
+      const index = baseOffset + indexInGroup;
       return {
         key: command.id,
         index,

--- a/packages/core/src/commands/slash-items.ts
+++ b/packages/core/src/commands/slash-items.ts
@@ -489,31 +489,35 @@ export function createVizelSlashCommands(locale: VizelLocale): SlashCommandItem[
     const groupKey = item.group ? groupToLocaleKey[item.group] : undefined;
     const localizedGroup = groupKey ? t.groups[groupKey] : item.group;
 
-    // For items with window.prompt, wrap the command to use locale strings
-    let { command } = item;
-    if (item.icon === "image") {
-      command = ({ editor, range }) => {
-        const url = window.prompt(t.enterImageUrl);
-        if (url) {
-          editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
-        }
-      };
-    } else if (item.icon === "embed") {
-      command = ({ editor, range }) => {
-        const hasEmbedExtension = typeof editor.commands.setEmbed === "function";
-        if (!hasEmbedExtension) {
-          const url = window.prompt(t.enterUrl);
+    // For items with window.prompt, wrap the command to use locale strings.
+    const wrapPromptCommand = (): SlashCommandItem["command"] => {
+      if (item.icon === "image") {
+        return ({ editor, range }) => {
+          const url = window.prompt(t.enterImageUrl);
           if (url) {
-            editor.chain().focus().deleteRange(range).setLink({ href: url }).run();
+            editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
           }
-          return;
-        }
-        const url = window.prompt(t.enterEmbedUrl);
-        if (url) {
-          editor.chain().focus().deleteRange(range).setEmbed({ url }).run();
-        }
-      };
-    }
+        };
+      }
+      if (item.icon === "embed") {
+        return ({ editor, range }) => {
+          const hasEmbedExtension = typeof editor.commands.setEmbed === "function";
+          if (!hasEmbedExtension) {
+            const url = window.prompt(t.enterUrl);
+            if (url) {
+              editor.chain().focus().deleteRange(range).setLink({ href: url }).run();
+            }
+            return;
+          }
+          const url = window.prompt(t.enterEmbedUrl);
+          if (url) {
+            editor.chain().focus().deleteRange(range).setEmbed({ url }).run();
+          }
+        };
+      }
+      return item.command;
+    };
+    const command = wrapPromptCommand();
 
     return {
       ...item,
@@ -567,16 +571,18 @@ interface FuseSearchable {
  * Factory function for creating Fuse instances.
  * Populated when fuse.js is dynamically loaded; null if unavailable.
  */
-let createFuseInstance:
-  | ((items: SlashCommandItem[], options: IFuseOptions<SlashCommandItem>) => FuseSearchable)
-  | null = null;
+const fuseFactory: {
+  create:
+    | ((items: SlashCommandItem[], options: IFuseOptions<SlashCommandItem>) => FuseSearchable)
+    | null;
+} = { create: null };
 
 // fuse.js is an optional peerDependency — preload eagerly via dynamic import
 // so it's ready by the time the user opens the slash menu.
 void import("fuse.js").then(
   (mod) => {
     const Fuse = mod.default;
-    createFuseInstance = (items, options) => new Fuse(items, options);
+    fuseFactory.create = (items, options) => new Fuse(items, options);
   },
   () => {
     // fuse.js not installed — fuzzy search unavailable, simple filtering used
@@ -593,12 +599,12 @@ const fuseCache = new WeakMap<SlashCommandItem[], FuseSearchable>();
  * Returns null if fuse.js is not installed.
  */
 function getFuseInstance(items: SlashCommandItem[]): FuseSearchable | null {
-  if (!createFuseInstance) return null;
-  let fuse = fuseCache.get(items);
-  if (!fuse) {
-    fuse = createFuseInstance(items, fuseOptions);
-    fuseCache.set(items, fuse);
-  }
+  const create = fuseFactory.create;
+  if (!create) return null;
+  const cached = fuseCache.get(items);
+  if (cached) return cached;
+  const fuse = create(items, fuseOptions);
+  fuseCache.set(items, fuse);
   return fuse;
 }
 

--- a/packages/core/src/comment.ts
+++ b/packages/core/src/comment.ts
@@ -217,20 +217,20 @@ export function createVizelCommentHandlers(
   const opts = { ...VIZEL_DEFAULT_COMMENT_OPTIONS, ...options };
   const storageBackend = getVizelCommentStorageBackend(opts.storage, opts.key);
 
-  let cachedComments: VizelComment[] = [];
+  const cache: { comments: VizelComment[] } = { comments: [] };
 
   const loadComments = async (): Promise<VizelComment[]> => {
     try {
       onStateChange({ isLoading: true });
       const comments = await storageBackend.load();
-      cachedComments = comments;
+      cache.comments = comments;
       onStateChange({ comments, isLoading: false, error: null });
       return comments;
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
       onStateChange({ isLoading: false, error });
       opts.onError?.(error);
-      return cachedComments;
+      return cache.comments;
     }
   };
 
@@ -253,9 +253,9 @@ export function createVizelCommentHandlers(
 
       editor.commands.addCommentMark(comment.id);
 
-      const updated = [comment, ...cachedComments];
+      const updated = [comment, ...cache.comments];
       await storageBackend.save(updated);
-      cachedComments = updated;
+      cache.comments = updated;
       onStateChange({ comments: updated, activeCommentId: comment.id, error: null });
 
       opts.onAdd?.(comment);
@@ -276,9 +276,9 @@ export function createVizelCommentHandlers(
         editor.commands.removeCommentMark(commentId);
       }
 
-      const updated = cachedComments.filter((c) => c.id !== commentId);
+      const updated = cache.comments.filter((c) => c.id !== commentId);
       await storageBackend.save(updated);
-      cachedComments = updated;
+      cache.comments = updated;
       onStateChange({ comments: updated, activeCommentId: null, error: null });
 
       opts.onRemove?.(commentId);
@@ -291,13 +291,13 @@ export function createVizelCommentHandlers(
 
   const resolveComment = async (commentId: string): Promise<boolean> => {
     try {
-      const comment = cachedComments.find((c) => c.id === commentId);
+      const comment = cache.comments.find((c) => c.id === commentId);
       if (!comment) return false;
 
       const updatedComment = { ...comment, resolved: true };
-      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      const updated = cache.comments.map((c) => (c.id === commentId ? updatedComment : c));
       await storageBackend.save(updated);
-      cachedComments = updated;
+      cache.comments = updated;
       onStateChange({ comments: updated, error: null });
 
       opts.onResolve?.(updatedComment);
@@ -312,13 +312,13 @@ export function createVizelCommentHandlers(
 
   const reopenComment = async (commentId: string): Promise<boolean> => {
     try {
-      const comment = cachedComments.find((c) => c.id === commentId);
+      const comment = cache.comments.find((c) => c.id === commentId);
       if (!comment) return false;
 
       const updatedComment = { ...comment, resolved: false };
-      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      const updated = cache.comments.map((c) => (c.id === commentId ? updatedComment : c));
       await storageBackend.save(updated);
-      cachedComments = updated;
+      cache.comments = updated;
       onStateChange({ comments: updated, error: null });
 
       opts.onReopen?.(updatedComment);
@@ -337,7 +337,7 @@ export function createVizelCommentHandlers(
     author?: string
   ): Promise<VizelCommentReply | null> => {
     try {
-      const comment = cachedComments.find((c) => c.id === commentId);
+      const comment = cache.comments.find((c) => c.id === commentId);
       if (!comment) return null;
 
       const reply: VizelCommentReply = {
@@ -348,9 +348,9 @@ export function createVizelCommentHandlers(
       };
 
       const updatedComment = { ...comment, replies: [...comment.replies, reply] };
-      const updated = cachedComments.map((c) => (c.id === commentId ? updatedComment : c));
+      const updated = cache.comments.map((c) => (c.id === commentId ? updatedComment : c));
       await storageBackend.save(updated);
-      cachedComments = updated;
+      cache.comments = updated;
       onStateChange({ comments: updated, error: null });
 
       return reply;
@@ -371,7 +371,7 @@ export function createVizelCommentHandlers(
   };
 
   const getCommentById = (commentId: string): VizelComment | undefined => {
-    return cachedComments.find((c) => c.id === commentId);
+    return cache.comments.find((c) => c.id === commentId);
   };
 
   return {

--- a/packages/core/src/controllers/dismissibleController.ts
+++ b/packages/core/src/controllers/dismissibleController.ts
@@ -75,27 +75,27 @@ export function createVizelDismissibleController(
     }
   };
 
-  let isMounted = false;
+  const state = { isMounted: false };
 
   return {
     mount: (): void => {
       // SSR guard: skip DOM work when `document` is unavailable.
       if (typeof document === "undefined") return;
-      if (isMounted) return;
+      if (state.isMounted) return;
       document.addEventListener("mousedown", handleMouseDown);
       if (dismissOnEscape) {
         document.addEventListener("keydown", handleKeyDown);
       }
-      isMounted = true;
+      state.isMounted = true;
     },
     unmount: (): void => {
       if (typeof document === "undefined") return;
-      if (!isMounted) return;
+      if (!state.isMounted) return;
       document.removeEventListener("mousedown", handleMouseDown);
       if (dismissOnEscape) {
         document.removeEventListener("keydown", handleKeyDown);
       }
-      isMounted = false;
+      state.isMounted = false;
     },
   };
 }

--- a/packages/core/src/controllers/gridController.ts
+++ b/packages/core/src/controllers/gridController.ts
@@ -66,17 +66,16 @@ export function createVizelGridController(
     itemSelector = "[role=gridcell]",
   } = options;
 
-  let selectedIndex = initialIndex;
-  let isMounted = false;
+  const state = { selectedIndex: initialIndex, isMounted: false };
 
   const handleKey = (event: KeyboardEvent): boolean => {
     const root = getRoot();
     if (!root) return false;
     const items = root.querySelectorAll(itemSelector);
-    const next = resolveVizelGridNavigation(event.key, selectedIndex, items.length, columns);
+    const next = resolveVizelGridNavigation(event.key, state.selectedIndex, items.length, columns);
     if (next === null) return false;
-    selectedIndex = next;
-    onChange(selectedIndex);
+    state.selectedIndex = next;
+    onChange(state.selectedIndex);
     return true;
   };
 
@@ -90,22 +89,22 @@ export function createVizelGridController(
   return {
     mount: (): void => {
       if (typeof document === "undefined") return;
-      if (isMounted) return;
+      if (state.isMounted) return;
       const root = getRoot();
       if (!root) return;
       root.addEventListener("keydown", handleKeyDown);
-      isMounted = true;
+      state.isMounted = true;
     },
     unmount: (): void => {
       if (typeof document === "undefined") return;
-      if (!isMounted) return;
+      if (!state.isMounted) return;
       getRoot()?.removeEventListener("keydown", handleKeyDown);
-      isMounted = false;
+      state.isMounted = false;
     },
     handleKey,
-    getSelectedIndex: () => selectedIndex,
+    getSelectedIndex: () => state.selectedIndex,
     setSelectedIndex: (index: number) => {
-      selectedIndex = index;
+      state.selectedIndex = index;
     },
   };
 }

--- a/packages/core/src/controllers/listboxController.ts
+++ b/packages/core/src/controllers/listboxController.ts
@@ -76,17 +76,16 @@ export function createVizelListboxController(
 ): VizelListboxController {
   const { getRoot, initialIndex = 0, onChange, itemSelector = "[role=option]" } = options;
 
-  let selectedIndex = initialIndex;
-  let isMounted = false;
+  const state = { selectedIndex: initialIndex, isMounted: false };
 
   const handleKey = (event: KeyboardEvent): boolean => {
     const root = getRoot();
     if (!root) return false;
     const items = root.querySelectorAll(itemSelector);
-    const next = resolveVizelListNavigation(event.key, selectedIndex, items.length);
+    const next = resolveVizelListNavigation(event.key, state.selectedIndex, items.length);
     if (next === null) return false;
-    selectedIndex = next;
-    onChange(selectedIndex);
+    state.selectedIndex = next;
+    onChange(state.selectedIndex);
     return true;
   };
 
@@ -100,22 +99,22 @@ export function createVizelListboxController(
   return {
     mount: (): void => {
       if (typeof document === "undefined") return;
-      if (isMounted) return;
+      if (state.isMounted) return;
       const root = getRoot();
       if (!root) return;
       root.addEventListener("keydown", handleKeyDown);
-      isMounted = true;
+      state.isMounted = true;
     },
     unmount: (): void => {
       if (typeof document === "undefined") return;
-      if (!isMounted) return;
+      if (!state.isMounted) return;
       getRoot()?.removeEventListener("keydown", handleKeyDown);
-      isMounted = false;
+      state.isMounted = false;
     },
     handleKey,
-    getSelectedIndex: () => selectedIndex,
+    getSelectedIndex: () => state.selectedIndex,
     setSelectedIndex: (index: number) => {
-      selectedIndex = index;
+      state.selectedIndex = index;
     },
   };
 }

--- a/packages/core/src/controllers/popoverController.ts
+++ b/packages/core/src/controllers/popoverController.ts
@@ -95,6 +95,69 @@ export function createVizelPopoverController(
     dismissOnEscape,
   });
 
+  const computeRawPosition = (
+    placementValue: VizelPopoverPlacement,
+    anchorRect: DOMRect,
+    bodyRect: DOMRect,
+    viewport: { width: number; height: number }
+  ): { top: number; left: number } => {
+    switch (placementValue) {
+      case "bottom-start": {
+        const top = anchorRect.bottom + offset;
+        return {
+          top:
+            top + bodyRect.height > viewport.height
+              ? anchorRect.top - bodyRect.height - offset
+              : top,
+          left: anchorRect.left,
+        };
+      }
+      case "bottom-end": {
+        const top = anchorRect.bottom + offset;
+        return {
+          top:
+            top + bodyRect.height > viewport.height
+              ? anchorRect.top - bodyRect.height - offset
+              : top,
+          left: anchorRect.right - bodyRect.width,
+        };
+      }
+      case "top-start": {
+        const top = anchorRect.top - bodyRect.height - offset;
+        return {
+          top: top < 0 ? anchorRect.bottom + offset : top,
+          left: anchorRect.left,
+        };
+      }
+      case "top-end": {
+        const top = anchorRect.top - bodyRect.height - offset;
+        return {
+          top: top < 0 ? anchorRect.bottom + offset : top,
+          left: anchorRect.right - bodyRect.width,
+        };
+      }
+      case "right-start": {
+        const left = anchorRect.right + offset;
+        return {
+          top: anchorRect.top,
+          left:
+            left + bodyRect.width > viewport.width
+              ? anchorRect.left - bodyRect.width - offset
+              : left,
+        };
+      }
+      case "left-start": {
+        const left = anchorRect.left - bodyRect.width - offset;
+        return {
+          top: anchorRect.top,
+          left: left < 0 ? anchorRect.right + offset : left,
+        };
+      }
+      default:
+        return { top: anchorRect.bottom + offset, left: anchorRect.left };
+    }
+  };
+
   const updatePosition = (): void => {
     if (typeof window === "undefined") return;
     const anchor = getAnchor();
@@ -105,56 +168,9 @@ export function createVizelPopoverController(
     const bodyRect = body.getBoundingClientRect();
     const viewport = { width: window.innerWidth, height: window.innerHeight };
 
-    let top = 0;
-    let left = 0;
-
-    switch (placement) {
-      case "bottom-start":
-        top = anchorRect.bottom + offset;
-        left = anchorRect.left;
-        if (top + bodyRect.height > viewport.height) {
-          top = anchorRect.top - bodyRect.height - offset;
-        }
-        break;
-      case "bottom-end":
-        top = anchorRect.bottom + offset;
-        left = anchorRect.right - bodyRect.width;
-        if (top + bodyRect.height > viewport.height) {
-          top = anchorRect.top - bodyRect.height - offset;
-        }
-        break;
-      case "top-start":
-        top = anchorRect.top - bodyRect.height - offset;
-        left = anchorRect.left;
-        if (top < 0) {
-          top = anchorRect.bottom + offset;
-        }
-        break;
-      case "top-end":
-        top = anchorRect.top - bodyRect.height - offset;
-        left = anchorRect.right - bodyRect.width;
-        if (top < 0) {
-          top = anchorRect.bottom + offset;
-        }
-        break;
-      case "right-start":
-        top = anchorRect.top;
-        left = anchorRect.right + offset;
-        if (left + bodyRect.width > viewport.width) {
-          left = anchorRect.left - bodyRect.width - offset;
-        }
-        break;
-      case "left-start":
-        top = anchorRect.top;
-        left = anchorRect.left - bodyRect.width - offset;
-        if (left < 0) {
-          left = anchorRect.right + offset;
-        }
-        break;
-    }
-
+    const { top, left: rawLeft } = computeRawPosition(placement, anchorRect, bodyRect, viewport);
     // Clamp horizontally inside the viewport (vertical handled above).
-    left = Math.max(0, Math.min(left, viewport.width - bodyRect.width));
+    const left = Math.max(0, Math.min(rawLeft, viewport.width - bodyRect.width));
 
     body.style.position = "fixed";
     body.style.top = `${top}px`;
@@ -165,29 +181,29 @@ export function createVizelPopoverController(
     updatePosition();
   };
 
-  let isMounted = false;
+  const state = { isMounted: false };
 
   return {
     mount: (): void => {
       if (typeof document === "undefined") return;
-      if (isMounted) return;
+      if (state.isMounted) return;
       dismissible.mount();
       updatePosition();
       if (repositionOnWindowEvents) {
         window.addEventListener("resize", handleReposition);
         window.addEventListener("scroll", handleReposition, true);
       }
-      isMounted = true;
+      state.isMounted = true;
     },
     unmount: (): void => {
       if (typeof document === "undefined") return;
-      if (!isMounted) return;
+      if (!state.isMounted) return;
       dismissible.unmount();
       if (repositionOnWindowEvents) {
         window.removeEventListener("resize", handleReposition);
         window.removeEventListener("scroll", handleReposition, true);
       }
-      isMounted = false;
+      state.isMounted = false;
     },
     updatePosition,
   };

--- a/packages/core/src/controllers/portal.ts
+++ b/packages/core/src/controllers/portal.ts
@@ -36,15 +36,13 @@ export type VizelPortalLayer = keyof typeof VIZEL_PORTAL_Z_INDEX;
  * ```
  */
 export function getVizelPortalContainer(): HTMLElement {
-  let container = document.getElementById(VIZEL_PORTAL_ID);
+  const existing = document.getElementById(VIZEL_PORTAL_ID);
+  if (existing) return existing;
 
-  if (!container) {
-    container = document.createElement("div");
-    container.id = VIZEL_PORTAL_ID;
-    container.setAttribute("data-vizel-portal", "");
-    document.body.appendChild(container);
-  }
-
+  const container = document.createElement("div");
+  container.id = VIZEL_PORTAL_ID;
+  container.setAttribute("data-vizel-portal", "");
+  document.body.appendChild(container);
   return container;
 }
 

--- a/packages/core/src/controllers/transactionStore.ts
+++ b/packages/core/src/controllers/transactionStore.ts
@@ -43,7 +43,7 @@ export interface VizelEditorTransactionStore {
 export function createVizelEditorTransactionStore(
   getEditor: () => Editor | null | undefined
 ): VizelEditorTransactionStore {
-  let version = 0;
+  const state = { version: 0 };
 
   return {
     subscribe(onChange) {
@@ -54,7 +54,7 @@ export function createVizelEditorTransactionStore(
         };
       }
       const handler = () => {
-        version = (version + 1) | 0;
+        state.version = (state.version + 1) | 0;
         onChange();
       };
       editor.on("transaction", handler);
@@ -63,7 +63,7 @@ export function createVizelEditorTransactionStore(
       };
     },
     getVersion() {
-      return version;
+      return state.version;
     },
   };
 }

--- a/packages/core/src/extensions/block-clipboard.ts
+++ b/packages/core/src/extensions/block-clipboard.ts
@@ -168,22 +168,29 @@ function serializeSliceToMarkdown(editor: EditorWithMarkdown, slice: Slice): str
  * can `preventDefault()` the paste event.
  */
 function insertSliceFromJson(view: EditorView, raw: string): boolean {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return false;
-  }
+  const parsed = tryParseJson(raw);
   if (parsed === null || typeof parsed !== "object") return false;
-  let slice: Slice;
-  try {
-    slice = Slice.fromJSON(view.state.schema, parsed);
-  } catch {
-    return false;
-  }
+  const slice = tryBuildSlice(view.state.schema, parsed);
+  if (!slice) return false;
   const tr = view.state.tr.replaceSelection(slice).scrollIntoView();
   view.dispatch(tr);
   return true;
+}
+
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function tryBuildSlice(schema: EditorView["state"]["schema"], parsed: unknown): Slice | null {
+  try {
+    return Slice.fromJSON(schema, parsed);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -192,6 +199,25 @@ function insertSliceFromJson(view: EditorView, raw: string): boolean {
  * document drops content (lighter than a trivial source string),
  * emits a `MARKDOWN_LOSSY` warning so consumers can surface it.
  */
+function tryParseMarkdown(
+  editor: EditorWithMarkdown,
+  markdown: string,
+  onError: ((err: VizelError) => void) | undefined
+): JSONContent | null {
+  try {
+    return editor.markdown.parse(markdown);
+  } catch (cause) {
+    emitVizelError(
+      new VizelError("INVALID_MARKDOWN", "Failed to parse pasted Markdown", {
+        cause,
+        context: { length: markdown.length },
+      }),
+      onError
+    );
+    return null;
+  }
+}
+
 function insertMarkdown(
   editor: Editor,
   markdown: string,
@@ -201,19 +227,8 @@ function insertMarkdown(
   const trimmed = markdown.trim();
   if (trimmed.length === 0) return false;
 
-  let parsed: JSONContent;
-  try {
-    parsed = editor.markdown.parse(markdown);
-  } catch (cause) {
-    emitVizelError(
-      new VizelError("INVALID_MARKDOWN", "Failed to parse pasted Markdown", {
-        cause,
-        context: { length: markdown.length },
-      }),
-      onError
-    );
-    return false;
-  }
+  const parsed = tryParseMarkdown(editor, markdown, onError);
+  if (parsed === null) return false;
 
   const inserted = editor.commands.insertContent(parsed);
   if (!inserted) return false;
@@ -257,17 +272,12 @@ function insertMarkdown(
  */
 function approximateRenderedLength(content: unknown): number {
   if (content === null || typeof content !== "object") return 0;
-  let total = 0;
   const node = content as { text?: unknown; content?: unknown };
-  if (typeof node.text === "string") {
-    total += node.text.length;
-  }
-  if (Array.isArray(node.content)) {
-    for (const child of node.content) {
-      total += approximateRenderedLength(child);
-    }
-  }
-  return total;
+  const textLength = typeof node.text === "string" ? node.text.length : 0;
+  const childrenLength = Array.isArray(node.content)
+    ? node.content.reduce<number>((sum, child) => sum + approximateRenderedLength(child), 0)
+    : 0;
+  return textLength + childrenLength;
 }
 
 /**

--- a/packages/core/src/extensions/callout.ts
+++ b/packages/core/src/extensions/callout.ts
@@ -130,21 +130,21 @@ function tryParseDirectiveCallout(
   const match = /^:::(\w+)\s*$/.exec(firstLine);
   if (!match) return null;
   const type = parseCalloutType(match[1] ?? "info");
-  let nextLine = startLine + 1;
-  let closingLine = -1;
-  while (nextLine < endLine) {
-    if (readLine(state, nextLine) === ":::") {
-      closingLine = nextLine;
-      break;
-    }
-    nextLine++;
-  }
+  const closingLine = findClosingDirectiveLine(state, startLine + 1, endLine);
   if (closingLine === -1) return false;
   if (silent) return true;
   const innerSrc = state.getLines(startLine + 1, closingLine, state.tShift[startLine] ?? 0, false);
   emitCalloutTokens(state, md, type, innerSrc, startLine, closingLine);
   state.line = closingLine + 1;
   return true;
+}
+
+function findClosingDirectiveLine(state: StateBlock, fromLine: number, endLine: number): number {
+  const candidate = Array.from(
+    { length: Math.max(0, endLine - fromLine) },
+    (_, i) => fromLine + i
+  ).find((line) => readLine(state, line) === ":::");
+  return candidate ?? -1;
 }
 
 function tryParseAlertCallout(
@@ -158,19 +158,27 @@ function tryParseAlertCallout(
   const match = /^>\s*\[!(\w+)\]\s*$/.exec(firstLine);
   if (!match) return null;
   const type = parseCalloutType(match[1] ?? "info");
-  let nextLine = startLine + 1;
-  const contentLines: string[] = [];
-  while (nextLine < endLine) {
-    const lineText = readLine(state, nextLine);
-    if (!/^>/.test(lineText)) break;
-    contentLines.push(lineText.replace(/^>\s?/, ""));
-    nextLine++;
-  }
+  const { contentLines, nextLine } = collectAlertCalloutLines(state, startLine + 1, endLine);
   if (silent) return true;
   const innerSrc = contentLines.join("\n");
   emitCalloutTokens(state, md, type, innerSrc, startLine, nextLine - 1);
   state.line = nextLine;
   return true;
+}
+
+function collectAlertCalloutLines(
+  state: StateBlock,
+  fromLine: number,
+  endLine: number
+): { contentLines: string[]; nextLine: number } {
+  const maxCount = Math.max(0, endLine - fromLine);
+  const candidates = Array.from({ length: maxCount }, (_, i) => readLine(state, fromLine + i));
+  const stopOffset = candidates.findIndex((line) => !/^>/.test(line));
+  const consumedCount = stopOffset === -1 ? candidates.length : stopOffset;
+  return {
+    contentLines: candidates.slice(0, consumedCount).map((line) => line.replace(/^>\s?/, "")),
+    nextLine: fromLine + consumedCount,
+  };
 }
 
 function registerCalloutRule(md: MarkdownIt): void {

--- a/packages/core/src/extensions/code-block-lowlight.ts
+++ b/packages/core/src/extensions/code-block-lowlight.ts
@@ -61,16 +61,18 @@ export interface VizelCodeBlockOptions {
  * Module-level cached lowlight instance.
  * Set when the extension is created, used by utility functions.
  */
-let activeLowlightInstance: ReturnType<typeof import("lowlight").createLowlight> | null = null;
+const lowlightRef: {
+  instance: ReturnType<typeof import("lowlight").createLowlight> | null;
+} = { instance: null };
 
 /**
  * Get the list of all registered languages (sorted alphabetically).
  * Returns an empty array if the code block extension has not been initialized yet.
  */
 export function getVizelRegisteredLanguages(): VizelCodeBlockLanguage[] {
-  if (!activeLowlightInstance) return [];
+  if (!lowlightRef.instance) return [];
 
-  const registeredNames = activeLowlightInstance.listLanguages();
+  const registeredNames = lowlightRef.instance.listLanguages();
 
   return registeredNames
     .sort((a, b) => a.localeCompare(b))
@@ -172,7 +174,7 @@ export async function createVizelCodeBlockExtension(
   const lowlight = customLowlight ?? (await loadLowlightInstance(languages));
 
   // Cache the instance for utility functions
-  activeLowlightInstance = lowlight;
+  lowlightRef.instance = lowlight;
 
   // Pre-resolve locale labels to keep addNodeView closure complexity low
   const codeBlockLabels = {
@@ -303,7 +305,7 @@ export async function createVizelCodeBlockExtension(
         setIconContent(copyBtn, "copy");
         copyBtn.title = codeBlockLabels.copyCode;
 
-        let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+        const copyTimerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
 
         copyBtn.addEventListener("click", (e) => {
           e.preventDefault();
@@ -313,12 +315,12 @@ export async function createVizelCodeBlockExtension(
             copyBtn.classList.add("copied");
             setIconContent(copyBtn, "checkSmall");
             copyBtn.title = codeBlockLabels.copied;
-            if (copyTimeout) clearTimeout(copyTimeout);
-            copyTimeout = setTimeout(() => {
+            if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+            copyTimerRef.current = setTimeout(() => {
               copyBtn.classList.remove("copied");
               setIconContent(copyBtn, "copy");
               copyBtn.title = codeBlockLabels.copyCode;
-              copyTimeout = null;
+              copyTimerRef.current = null;
             }, 2000);
           });
         });
@@ -361,13 +363,13 @@ export async function createVizelCodeBlockExtension(
             text.endsWith("\n") && lines.length > 1 ? lines.length - 1 : Math.max(1, lines.length);
 
           if (gutter.children.length !== lineCount) {
-            gutter.replaceChildren();
-            for (let i = 1; i <= lineCount; i++) {
+            const lineNums = Array.from({ length: lineCount }, (_, i) => {
               const lineNum = document.createElement("div");
               lineNum.classList.add("vizel-code-block-line-number");
-              lineNum.textContent = String(i);
-              gutter.appendChild(lineNum);
-            }
+              lineNum.textContent = String(i + 1);
+              return lineNum;
+            });
+            gutter.replaceChildren(...lineNums);
           }
         };
 
@@ -378,8 +380,10 @@ export async function createVizelCodeBlockExtension(
         }
 
         // Track current state
-        let currentLanguage = node.attrs.language;
-        let currentLineNumbers = node.attrs.lineNumbers;
+        const nodeViewState: { currentLanguage: string; currentLineNumbers: boolean } = {
+          currentLanguage: node.attrs.language,
+          currentLineNumbers: node.attrs.lineNumbers,
+        };
 
         // Add click handler for line numbers toggle (using currentLineNumbers)
         lineNumbersBtn.addEventListener("click", (e) => {
@@ -392,20 +396,20 @@ export async function createVizelCodeBlockExtension(
           if (!nodeAtPos) return;
           tr.setNodeMarkup(pos, undefined, {
             ...nodeAtPos.attrs,
-            lineNumbers: !currentLineNumbers,
+            lineNumbers: !nodeViewState.currentLineNumbers,
           });
           editor.view.dispatch(tr);
         });
 
         // Helper functions for update
         const syncLanguage = (newLang: string) => {
-          currentLanguage = newLang;
+          nodeViewState.currentLanguage = newLang;
           languageInput.value = newLang || defaultLanguage;
           code.className = `language-${newLang || defaultLanguage}`;
         };
 
         const syncLineNumbers = (enabled: boolean) => {
-          currentLineNumbers = enabled;
+          nodeViewState.currentLineNumbers = enabled;
           dom.classList.toggle("vizel-code-block-line-numbers", enabled);
           lineNumbersBtn.classList.toggle("active", enabled);
           lineNumbersBtn.title = enabled
@@ -423,17 +427,17 @@ export async function createVizelCodeBlockExtension(
             }
 
             // Sync language if changed
-            if (updatedNode.attrs.language !== currentLanguage) {
+            if (updatedNode.attrs.language !== nodeViewState.currentLanguage) {
               syncLanguage(updatedNode.attrs.language);
             }
 
             // Sync line numbers if changed
-            if (updatedNode.attrs.lineNumbers !== currentLineNumbers) {
+            if (updatedNode.attrs.lineNumbers !== nodeViewState.currentLineNumbers) {
               syncLineNumbers(updatedNode.attrs.lineNumbers);
             }
 
             // Update gutter if line numbers enabled
-            if (currentLineNumbers) {
+            if (nodeViewState.currentLineNumbers) {
               setTimeout(updateLineNumbers, 0);
             }
 
@@ -446,7 +450,7 @@ export async function createVizelCodeBlockExtension(
           },
 
           destroy() {
-            if (copyTimeout) clearTimeout(copyTimeout);
+            if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
           },
         };
       };

--- a/packages/core/src/extensions/comment.ts
+++ b/packages/core/src/extensions/comment.ts
@@ -139,13 +139,12 @@ export const VizelCommentMark = Mark.create<VizelCommentMarkOptions>({
           const positions = findCommentMarkPositions(state, commentId, markType);
           if (positions.length === 0) return false;
 
-          let tr = state.tr;
-          for (let i = positions.length - 1; i >= 0; i -= 1) {
-            const pos = positions[i];
-            if (pos) {
-              tr = tr.removeMark(pos.from, pos.to, markType.create({ commentId }));
-            }
-          }
+          const tr = [...positions]
+            .reverse()
+            .reduce(
+              (acc, pos) => acc.removeMark(pos.from, pos.to, markType.create({ commentId })),
+              state.tr
+            );
 
           dispatch(tr);
           return true;

--- a/packages/core/src/extensions/diagram.ts
+++ b/packages/core/src/extensions/diagram.ts
@@ -106,13 +106,14 @@ declare module "@tiptap/core" {
 /**
  * Unique counter for generating diagram IDs
  */
-let diagramIdCounter = 0;
+const diagramIdState = { counter: 0 };
 
 /**
  * Generate a unique ID for diagram rendering
  */
 function generateDiagramId(): string {
-  return `vizel-diagram-${Date.now()}-${++diagramIdCounter}`;
+  diagramIdState.counter += 1;
+  return `vizel-diagram-${Date.now()}-${diagramIdState.counter}`;
 }
 
 /**
@@ -187,24 +188,27 @@ async function initializeMermaid(
  * GraphViz WASM initialization is expensive, so the instance is shared across
  * all editor instances at the module level.
  */
-let graphvizInstance: GraphvizType | null = null;
-let graphvizInitPromise: Promise<GraphvizType> | null = null;
+const graphvizState: {
+  instance: GraphvizType | null;
+  initPromise: Promise<GraphvizType> | null;
+} = { instance: null, initPromise: null };
 
 /**
  * Initialize GraphViz WASM (shared singleton)
  */
 function initializeGraphviz(): Promise<GraphvizType> {
-  if (graphvizInstance) return Promise.resolve(graphvizInstance);
-  if (graphvizInitPromise) return graphvizInitPromise;
+  if (graphvizState.instance) return Promise.resolve(graphvizState.instance);
+  if (graphvizState.initPromise) return graphvizState.initPromise;
 
-  graphvizInitPromise = (async () => {
+  const promise = (async () => {
     const GraphvizClass = await loadGraphvizModule();
     const instance = await GraphvizClass.load();
-    graphvizInstance = instance;
+    graphvizState.instance = instance;
     return instance;
   })();
+  graphvizState.initPromise = promise;
 
-  return graphvizInitPromise;
+  return promise;
 }
 
 /**
@@ -428,9 +432,15 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
 
       dom.appendChild(editContainer);
 
-      let isEditing = false;
-      let currentCode = node.attrs.code;
-      let currentType: VizelDiagramType = node.attrs.type;
+      const viewState: {
+        isEditing: boolean;
+        currentCode: string;
+        currentType: VizelDiagramType;
+      } = {
+        isEditing: false,
+        currentCode: node.attrs.code,
+        currentType: node.attrs.type,
+      };
 
       const renderDiagram = async (
         code: string,
@@ -445,14 +455,13 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
           return;
         }
 
-        let result: { svg: string; error: string | null };
-
-        if (type === "graphviz") {
-          result = await renderGraphviz(code, this.options.graphvizEngine);
-        } else {
-          await initializeMermaid(mermaidConfig, diagramStorage);
-          result = await renderMermaid(code);
-        }
+        const result: { svg: string; error: string | null } =
+          type === "graphviz"
+            ? await renderGraphviz(code, this.options.graphvizEngine)
+            : await (async () => {
+                await initializeMermaid(mermaidConfig, diagramStorage);
+                return renderMermaid(code);
+              })();
 
         if (result.error) {
           container.textContent = "";
@@ -513,19 +522,19 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
 
       const startEditing = () => {
         if (!editor.isEditable) return;
-        isEditing = true;
+        viewState.isEditing = true;
         dom.classList.add("vizel-diagram-editing");
         renderContainer.style.display = "none";
         typeIndicator.style.display = "none";
         editContainer.style.display = "";
-        editTextarea.value = currentCode;
-        void renderDiagram(currentCode, currentType, previewContainer);
+        editTextarea.value = viewState.currentCode;
+        void renderDiagram(viewState.currentCode, viewState.currentType, previewContainer);
         editTextarea.focus();
       };
 
       const stopEditing = () => {
-        if (!isEditing) return;
-        isEditing = false;
+        if (!viewState.isEditing) return;
+        viewState.isEditing = false;
         dom.classList.remove("vizel-diagram-editing");
         renderContainer.style.display = "";
         typeIndicator.style.display = "";
@@ -535,15 +544,15 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
         const pos = typeof getPos === "function" ? getPos() : null;
 
         if (pos !== null && pos !== undefined) {
-          if (newCode === "" && currentCode !== "") {
+          if (newCode === "" && viewState.currentCode !== "") {
             // If user clears the code, delete the node
             editor
               .chain()
               .focus()
               .deleteRange({ from: pos, to: pos + node.nodeSize })
               .run();
-          } else if (newCode !== currentCode) {
-            currentCode = newCode;
+          } else if (newCode !== viewState.currentCode) {
+            viewState.currentCode = newCode;
             editor.chain().focus().updateAttributes("diagram", { code: newCode }).run();
           }
         }
@@ -551,7 +560,7 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
 
       // Event listeners
       const handleDomClick = (e: MouseEvent) => {
-        if (!isEditing && e.target === dom) {
+        if (!viewState.isEditing && e.target === dom) {
           e.preventDefault();
           e.stopPropagation();
           startEditing();
@@ -576,7 +585,7 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
       const handleTextareaKeydown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
           e.preventDefault();
-          editTextarea.value = currentCode;
+          editTextarea.value = viewState.currentCode;
           stopEditing();
         }
         // Allow Ctrl/Cmd + Enter to save
@@ -587,13 +596,15 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
       };
 
       // Debounce preview updates
-      let previewTimeout: ReturnType<typeof setTimeout> | null = null;
+      const debounceState: { previewTimeout: ReturnType<typeof setTimeout> | null } = {
+        previewTimeout: null,
+      };
       const handleTextareaInput = () => {
-        if (previewTimeout) {
-          clearTimeout(previewTimeout);
+        if (debounceState.previewTimeout) {
+          clearTimeout(debounceState.previewTimeout);
         }
-        previewTimeout = setTimeout(() => {
-          void renderDiagram(editTextarea.value, currentType, previewContainer);
+        debounceState.previewTimeout = setTimeout(() => {
+          void renderDiagram(editTextarea.value, viewState.currentType, previewContainer);
         }, 300);
       };
 
@@ -604,7 +615,7 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
       editTextarea.addEventListener("input", handleTextareaInput);
 
       // Initial render
-      void renderDiagram(currentCode, currentType, renderContainer);
+      void renderDiagram(viewState.currentCode, viewState.currentType, renderContainer);
 
       return {
         dom,
@@ -612,17 +623,17 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
           if (updatedNode.type.name !== "diagram") {
             return false;
           }
-          const typeChanged = updatedNode.attrs.type !== currentType;
-          const codeChanged = updatedNode.attrs.code !== currentCode;
+          const typeChanged = updatedNode.attrs.type !== viewState.currentType;
+          const codeChanged = updatedNode.attrs.code !== viewState.currentCode;
 
           if (typeChanged) {
-            currentType = updatedNode.attrs.type;
-            typeIndicator.textContent = getDiagramTypeName(currentType);
+            viewState.currentType = updatedNode.attrs.type;
+            typeIndicator.textContent = getDiagramTypeName(viewState.currentType);
           }
 
-          if (!isEditing && (codeChanged || typeChanged)) {
-            currentCode = updatedNode.attrs.code;
-            void renderDiagram(currentCode, currentType, renderContainer);
+          if (!viewState.isEditing && (codeChanged || typeChanged)) {
+            viewState.currentCode = updatedNode.attrs.code;
+            void renderDiagram(viewState.currentCode, viewState.currentType, renderContainer);
           }
 
           return true;
@@ -634,8 +645,8 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
           dom.classList.remove("vizel-diagram-selected");
         },
         destroy() {
-          if (previewTimeout) {
-            clearTimeout(previewTimeout);
+          if (debounceState.previewTimeout) {
+            clearTimeout(debounceState.previewTimeout);
           }
           dom.removeEventListener("click", handleDomClick);
           renderContainer.removeEventListener("click", handleRenderClick);

--- a/packages/core/src/extensions/drag-handle.ts
+++ b/packages/core/src/extensions/drag-handle.ts
@@ -45,10 +45,17 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
   }
 
   // Store references for onNodeChange and click handler
-  let dragHandleElement: HTMLElement | null = null;
-  let currentNode: PmNode | null = null;
-  let currentPos = 0;
-  let currentEditor: import("@tiptap/core").Editor | null = null;
+  const handleState: {
+    dragHandleElement: HTMLElement | null;
+    currentNode: PmNode | null;
+    currentPos: number;
+    currentEditor: import("@tiptap/core").Editor | null;
+  } = {
+    dragHandleElement: null,
+    currentNode: null,
+    currentPos: 0,
+    currentEditor: null,
+  };
 
   return DragHandle.configure({
     render() {
@@ -71,66 +78,75 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
       grip.appendChild(template.content);
       element.appendChild(grip);
 
-      // Click vs drag detection
-      let startX = 0;
-      let startY = 0;
-      let isDrag = false;
+      // Click vs drag detection (mutable across listener invocations).
+      const clickDetect = { startX: 0, startY: 0, isDrag: false };
 
       element.addEventListener("mousedown", (e: MouseEvent) => {
-        startX = e.clientX;
-        startY = e.clientY;
-        isDrag = false;
+        clickDetect.startX = e.clientX;
+        clickDetect.startY = e.clientY;
+        clickDetect.isDrag = false;
       });
 
       element.addEventListener("mousemove", (e: MouseEvent) => {
-        if (Math.abs(e.clientX - startX) + Math.abs(e.clientY - startY) > CLICK_DRAG_THRESHOLD) {
-          isDrag = true;
+        if (
+          Math.abs(e.clientX - clickDetect.startX) + Math.abs(e.clientY - clickDetect.startY) >
+          CLICK_DRAG_THRESHOLD
+        ) {
+          clickDetect.isDrag = true;
         }
       });
 
       element.addEventListener("mouseup", () => {
-        if (!isDrag && currentNode && currentEditor && dragHandleElement) {
-          const handleRect = dragHandleElement.getBoundingClientRect();
+        if (
+          !clickDetect.isDrag &&
+          handleState.currentNode &&
+          handleState.currentEditor &&
+          handleState.dragHandleElement
+        ) {
+          const handleRect = handleState.dragHandleElement.getBoundingClientRect();
           const detail: VizelBlockMenuOpenDetail = {
-            editor: currentEditor,
-            pos: currentPos,
-            node: currentNode,
+            editor: handleState.currentEditor,
+            pos: handleState.currentPos,
+            node: handleState.currentNode,
             handleRect,
           };
           document.dispatchEvent(new CustomEvent(VIZEL_BLOCK_MENU_EVENT, { detail }));
         }
       });
 
-      dragHandleElement = element;
+      handleState.dragHandleElement = element;
 
       return element;
     },
     onNodeChange({ node, editor, ...rest }) {
-      currentNode = node ?? null;
+      handleState.currentNode = node ?? null;
       // The drag-handle plugin passes pos at runtime but the public type omits it
-      currentPos = (rest as { pos?: number }).pos ?? 0;
-      currentEditor = editor;
+      handleState.currentPos = (rest as { pos?: number }).pos ?? 0;
+      handleState.currentEditor = editor;
 
       // Toggle visibility class based on whether a node is being targeted
-      if (dragHandleElement) {
+      if (handleState.dragHandleElement) {
         if (node) {
-          dragHandleElement.classList.add("is-visible");
+          handleState.dragHandleElement.classList.add("is-visible");
 
           // Add list-specific class for styling adjustments
           const isListContainer = LIST_CONTAINER_NODE_TYPES.has(node.type.name);
           const isListItem = LIST_ITEM_NODE_TYPES.has(node.type.name);
-          dragHandleElement.classList.toggle("is-list-target", isListContainer || isListItem);
+          handleState.dragHandleElement.classList.toggle(
+            "is-list-target",
+            isListContainer || isListItem
+          );
           // Bullet and ordered list items render their marker in the parent
           // list's padding area, which the default left placement of the
           // handle overlaps. Mark these items so CSS can shift the handle
           // further left past the marker. Task items render their checkbox
           // inside the li content and do not need the shift.
-          dragHandleElement.classList.toggle(
+          handleState.dragHandleElement.classList.toggle(
             "is-marker-list-target",
             node.type.name === "listItem"
           );
         } else {
-          dragHandleElement.classList.remove(
+          handleState.dragHandleElement.classList.remove(
             "is-visible",
             "is-list-target",
             "is-marker-list-target"
@@ -159,18 +175,21 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
       // and, when it is, uses the full selection as the dragged
       // payload — so the resulting drop moves every block in the range
       // together in a single transaction.
-      if (!currentEditor) return;
-      const rangeState = getVizelMultiBlockSelectionState(currentEditor.state);
+      if (!handleState.currentEditor) return;
+      const rangeState = getVizelMultiBlockSelectionState(handleState.currentEditor.state);
       if (!rangeState) return;
       // Only expand when the dragged block sits inside the multi-block
       // range. Dragging a block outside the range falls back to the
       // single-block move path.
-      if (currentPos < rangeState.from || currentPos >= rangeState.to) return;
-      const { doc, tr } = currentEditor.state;
+      if (handleState.currentPos < rangeState.from || handleState.currentPos >= rangeState.to)
+        return;
+      const { doc, tr } = handleState.currentEditor.state;
       try {
         const startPos = doc.resolve(rangeState.from);
         const endPos = doc.resolve(rangeState.to);
-        currentEditor.view.dispatch(tr.setSelection(new TextSelection(startPos, endPos)));
+        handleState.currentEditor.view.dispatch(
+          tr.setSelection(new TextSelection(startPos, endPos))
+        );
       } catch {
         // Resolving outside the document is a no-op; the single-block
         // path takes over.
@@ -185,7 +204,7 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
       // to a different node. Dispatch a synthetic mouseleave on the editor
       // view to force the plugin to reset `currentNode` so the next hover
       // re-triggers detection.
-      const view = currentEditor?.view;
+      const view = handleState.currentEditor?.view;
       if (!view) return;
       view.dom.dispatchEvent(new MouseEvent("mouseleave", { bubbles: false, cancelable: true }));
     },
@@ -265,27 +284,20 @@ function findPreviousSiblingInfo(
   const parentStart = resolvedPos.start(parentDepth);
   const parent = resolvedPos.parent;
 
-  // Find current node index by iterating through parent's children
-  let currentOffset = parentStart;
-  let currentIndex = -1;
+  // Compute cumulative offsets for each child index so we can find the
+  // matching index without mutable accumulators.
+  const childOffsets = Array.from({ length: parent.childCount + 1 }, (_, i) =>
+    Array.from({ length: i }, (_, j) => parent.child(j).nodeSize).reduce(
+      (sum, size) => sum + size,
+      parentStart
+    )
+  );
+  const currentIndex = childOffsets.indexOf(blockInfo.pos);
 
-  for (let i = 0; i < parent.childCount; i++) {
-    if (currentOffset === blockInfo.pos) {
-      currentIndex = i;
-      break;
-    }
-    currentOffset += parent.child(i).nodeSize;
-  }
-
-  // If current node is first child, no previous sibling
+  // If current node is first child or not found, no previous sibling
   if (currentIndex <= 0) return null;
 
-  // Calculate the position of the previous sibling
-  let prevPos = parentStart;
-  for (let i = 0; i < currentIndex - 1; i++) {
-    prevPos += parent.child(i).nodeSize;
-  }
-
+  const prevPos = childOffsets[currentIndex - 1] ?? parentStart;
   return { pos: prevPos, node: parent.child(currentIndex - 1) };
 }
 

--- a/packages/core/src/extensions/find-replace.ts
+++ b/packages/core/src/extensions/find-replace.ts
@@ -62,6 +62,18 @@ function isFindReplaceMeta(value: unknown): value is VizelFindReplaceMeta {
   return typeof value === "object" && value !== null && "type" in value;
 }
 
+function findAllOccurrences(haystack: string, needle: string): number[] {
+  if (!needle) return [];
+  const step = Math.max(needle.length, 1);
+  const collect = (cursor: number, acc: readonly number[]): readonly number[] => {
+    if (cursor > haystack.length - needle.length) return acc;
+    const found = haystack.indexOf(needle, cursor);
+    if (found === -1) return acc;
+    return collect(found + step, [...acc, found]);
+  };
+  return [...collect(0, [])];
+}
+
 function buildMatches(
   doc: ProseMirrorNode,
   query: string,
@@ -76,18 +88,11 @@ function buildMatches(
 
     const text = node.text ?? "";
     const haystack = caseSensitive ? text : text.toLowerCase();
-    let index = 0;
-
-    while (index <= haystack.length - needle.length) {
-      const found = haystack.indexOf(needle, index);
-      if (found === -1) break;
-
+    for (const found of findAllOccurrences(haystack, needle)) {
       matches.push({
         from: pos + found,
         to: pos + found + needle.length,
       });
-
-      index = found + Math.max(needle.length, 1);
     }
 
     return true;
@@ -99,6 +104,46 @@ function buildMatches(
 function clampActiveIndex(activeIndex: number, matches: VizelFindMatch[]): number {
   if (matches.length === 0) return -1;
   return Math.min(Math.max(activeIndex, 0), matches.length - 1);
+}
+
+function applyFindReplaceMeta(
+  tr: import("@tiptap/pm/state").Transaction,
+  value: VizelFindReplaceState,
+  meta: VizelFindReplaceMeta
+): VizelFindReplaceState {
+  switch (meta.type) {
+    case "setQuery": {
+      const matches = buildMatches(tr.doc, meta.query, value.caseSensitive);
+      return {
+        ...value,
+        query: meta.query,
+        matches,
+        activeIndex: matches.length > 0 ? 0 : -1,
+      };
+    }
+    case "setActiveIndex":
+      return {
+        ...value,
+        activeIndex: clampActiveIndex(meta.index, value.matches),
+      };
+    case "setCaseSensitive": {
+      const matches = buildMatches(tr.doc, value.query, meta.caseSensitive);
+      return {
+        ...value,
+        caseSensitive: meta.caseSensitive,
+        matches,
+        activeIndex: clampActiveIndex(value.activeIndex, matches),
+      };
+    }
+    case "setOpen":
+      return { ...value, isOpen: true, mode: meta.mode };
+    case "setClosed":
+      return { ...value, isOpen: false };
+    case "clear":
+      return createEmptyState(value.caseSensitive);
+    default:
+      return value;
+  }
 }
 
 /**
@@ -232,13 +277,9 @@ export function createVizelFindReplaceExtension(options: VizelFindReplaceOptions
             if (!pluginState || pluginState.matches.length === 0) return false;
 
             // Replace from back to front to preserve positions
-            let tr = state.tr;
-            for (let i = pluginState.matches.length - 1; i >= 0; i -= 1) {
-              const match = pluginState.matches[i];
-              if (match) {
-                tr = tr.insertText(text, match.from, match.to);
-              }
-            }
+            const tr = [...pluginState.matches]
+              .reverse()
+              .reduce((acc, match) => acc.insertText(text, match.from, match.to), state.tr);
 
             if (dispatch) dispatch(tr.scrollIntoView());
             return true;
@@ -275,62 +316,21 @@ export function createVizelFindReplaceExtension(options: VizelFindReplaceOptions
             init: () => createEmptyState(initialCaseSensitive),
             apply: (tr, value) => {
               const metaRaw = tr.getMeta(vizelFindReplacePluginKey);
-              let next = value;
-
-              if (isFindReplaceMeta(metaRaw)) {
-                switch (metaRaw.type) {
-                  case "setQuery": {
-                    const matches = buildMatches(tr.doc, metaRaw.query, next.caseSensitive);
-                    next = {
-                      ...next,
-                      query: metaRaw.query,
-                      matches,
-                      activeIndex: matches.length > 0 ? 0 : -1,
-                    };
-                    break;
-                  }
-                  case "setActiveIndex":
-                    next = {
-                      ...next,
-                      activeIndex: clampActiveIndex(metaRaw.index, next.matches),
-                    };
-                    break;
-                  case "setCaseSensitive": {
-                    const matches = buildMatches(tr.doc, next.query, metaRaw.caseSensitive);
-                    next = {
-                      ...next,
-                      caseSensitive: metaRaw.caseSensitive,
-                      matches,
-                      activeIndex: clampActiveIndex(next.activeIndex, matches),
-                    };
-                    break;
-                  }
-                  case "setOpen":
-                    next = { ...next, isOpen: true, mode: metaRaw.mode };
-                    break;
-                  case "setClosed":
-                    next = { ...next, isOpen: false };
-                    break;
-                  case "clear":
-                    next = createEmptyState(next.caseSensitive);
-                    break;
-                  default:
-                    // All cases are handled; this satisfies the linter
-                    break;
-                }
-              }
+              const afterMeta = isFindReplaceMeta(metaRaw)
+                ? applyFindReplaceMeta(tr, value, metaRaw)
+                : value;
 
               // Rebuild matches if document changed and we have a query
-              if (tr.docChanged && next.query) {
-                const matches = buildMatches(tr.doc, next.query, next.caseSensitive);
-                next = {
-                  ...next,
+              if (tr.docChanged && afterMeta.query) {
+                const matches = buildMatches(tr.doc, afterMeta.query, afterMeta.caseSensitive);
+                return {
+                  ...afterMeta,
                   matches,
-                  activeIndex: clampActiveIndex(next.activeIndex, matches),
+                  activeIndex: clampActiveIndex(afterMeta.activeIndex, matches),
                 };
               }
 
-              return next;
+              return afterMeta;
             },
           },
 
@@ -354,7 +354,7 @@ export function createVizelFindReplaceExtension(options: VizelFindReplaceOptions
           },
 
           view: () => {
-            let prev = { total: 0, current: 0 };
+            const ref = { prev: { total: 0, current: 0 } };
             return {
               update: (view) => {
                 const pluginState = vizelFindReplacePluginKey.getState(view.state);
@@ -365,9 +365,9 @@ export function createVizelFindReplaceExtension(options: VizelFindReplaceOptions
                   current: pluginState.activeIndex >= 0 ? pluginState.activeIndex + 1 : 0,
                 };
 
-                if (next.total !== prev.total || next.current !== prev.current) {
+                if (next.total !== ref.prev.total || next.current !== ref.prev.current) {
                   extensionOptions.onResultsChange?.(next);
-                  prev = next;
+                  ref.prev = next;
                 }
               },
             };

--- a/packages/core/src/extensions/image-resize.ts
+++ b/packages/core/src/extensions/image-resize.ts
@@ -118,11 +118,19 @@ export const VizelResizableImage = Image.extend<VizelResizableImageOptions>({
       wrapper.appendChild(rightHandle);
       wrapper.appendChild(tooltip);
 
-      // Handle resize
-      let startX = 0;
-      let startWidth = 0;
-      let isResizing = false;
-      let resizeDirection: "left" | "right" = "right";
+      // Handle resize - drag state lives in a closure-shared ref so handlers
+      // can read and clear it without mutable let bindings.
+      const dragState: {
+        startX: number;
+        startWidth: number;
+        isResizing: boolean;
+        resizeDirection: "left" | "right";
+      } = {
+        startX: 0,
+        startWidth: 0,
+        isResizing: false,
+        resizeDirection: "right",
+      };
 
       const updateTooltip = (width: number, height: number) => {
         tooltip.textContent = `${Math.round(width)} × ${Math.round(height)}`;
@@ -143,10 +151,10 @@ export const VizelResizableImage = Image.extend<VizelResizableImageOptions>({
 
         if (!editor.isEditable) return;
 
-        isResizing = true;
-        resizeDirection = direction;
-        startX = e.clientX;
-        startWidth = img.offsetWidth;
+        dragState.isResizing = true;
+        dragState.resizeDirection = direction;
+        dragState.startX = e.clientX;
+        dragState.startWidth = img.offsetWidth;
 
         showTooltip();
 
@@ -157,16 +165,22 @@ export const VizelResizableImage = Image.extend<VizelResizableImageOptions>({
       };
 
       const onMouseMove = (e: MouseEvent) => {
-        if (!isResizing) return;
+        if (!dragState.isResizing) return;
 
-        const diff = resizeDirection === "right" ? e.clientX - startX : startX - e.clientX;
+        const diff =
+          dragState.resizeDirection === "right"
+            ? e.clientX - dragState.startX
+            : dragState.startX - e.clientX;
 
         // Calculate effective maxWidth: use option if set, otherwise use container width
         const containerWidth = wrapper.parentElement?.clientWidth ?? Number.POSITIVE_INFINITY;
         const effectiveMaxWidth = maxWidth ?? containerWidth;
 
         // Clamp width between min and max
-        const newWidth = Math.min(effectiveMaxWidth, Math.max(minWidth, startWidth + diff));
+        const newWidth = Math.min(
+          effectiveMaxWidth,
+          Math.max(minWidth, dragState.startWidth + diff)
+        );
 
         // Only set width - height will auto-adjust to maintain aspect ratio
         img.style.width = `${newWidth}px`;
@@ -177,9 +191,9 @@ export const VizelResizableImage = Image.extend<VizelResizableImageOptions>({
       };
 
       const onMouseUp = () => {
-        if (!isResizing) return;
+        if (!dragState.isResizing) return;
 
-        isResizing = false;
+        dragState.isResizing = false;
         hideTooltip();
         document.removeEventListener("mousemove", onMouseMove);
         document.removeEventListener("mouseup", onMouseUp);
@@ -237,8 +251,8 @@ export const VizelResizableImage = Image.extend<VizelResizableImageOptions>({
           // Restore body styles if the node view is destroyed mid-drag, so
           // the document does not stay stuck with a resize cursor and
           // disabled text selection.
-          if (isResizing) {
-            isResizing = false;
+          if (dragState.isResizing) {
+            dragState.isResizing = false;
             document.body.style.cursor = "";
             document.body.style.userSelect = "";
           }

--- a/packages/core/src/extensions/mathematics.ts
+++ b/packages/core/src/extensions/mathematics.ts
@@ -169,14 +169,12 @@ function readMathLine(state: StateBlock, lineIndex: number): string {
 }
 
 function findMathBlockClose(state: StateBlock, startLine: number, endLine: number): number {
-  let nextLine = startLine + 1;
-  while (nextLine < endLine) {
-    if (readMathLine(state, nextLine).trim() === "$$") {
-      return nextLine;
-    }
-    nextLine++;
-  }
-  return -1;
+  const fromLine = startLine + 1;
+  const candidate = Array.from(
+    { length: Math.max(0, endLine - fromLine) },
+    (_, i) => fromLine + i
+  ).find((line) => readMathLine(state, line).trim() === "$$");
+  return candidate ?? -1;
 }
 
 function registerMathBlockRule(md: MarkdownIt): void {
@@ -295,7 +293,7 @@ export const VizelMathInline = Node.create<VizelMathematicsOptions>({
       editInput.style.display = "none";
       dom.appendChild(editInput);
 
-      let isEditing = false;
+      const viewState = { isEditing: false };
       const katexOptions = this.options.katexOptions;
 
       const renderMath = (latex: string) => {
@@ -307,7 +305,7 @@ export const VizelMathInline = Node.create<VizelMathematicsOptions>({
 
       const startEditing = () => {
         if (!editor.isEditable) return;
-        isEditing = true;
+        viewState.isEditing = true;
         dom.classList.add("vizel-math-editing");
         renderContainer.style.display = "none";
         editInput.style.display = "inline";
@@ -317,8 +315,8 @@ export const VizelMathInline = Node.create<VizelMathematicsOptions>({
       };
 
       const stopEditing = () => {
-        if (!isEditing) return;
-        isEditing = false;
+        if (!viewState.isEditing) return;
+        viewState.isEditing = false;
         dom.classList.remove("vizel-math-editing");
         renderContainer.style.display = "";
         editInput.style.display = "none";
@@ -342,7 +340,7 @@ export const VizelMathInline = Node.create<VizelMathematicsOptions>({
 
       // Event listeners - store references for proper cleanup
       const handleDomClick = (e: MouseEvent) => {
-        if (!isEditing) {
+        if (!viewState.isEditing) {
           e.preventDefault();
           e.stopPropagation();
           startEditing();
@@ -375,7 +373,7 @@ export const VizelMathInline = Node.create<VizelMathematicsOptions>({
           if (updatedNode.type.name !== "mathInline") {
             return false;
           }
-          if (!isEditing) {
+          if (!viewState.isEditing) {
             renderMath(updatedNode.attrs.latex);
           }
           return true;
@@ -517,7 +515,7 @@ export const VizelMathBlock = Node.create<VizelMathematicsOptions>({
 
       dom.appendChild(editContainer);
 
-      let isEditing = false;
+      const viewState = { isEditing: false };
       const katexBlockOptions = this.options.katexOptions;
 
       const renderMath = (latex: string) => {
@@ -536,7 +534,7 @@ export const VizelMathBlock = Node.create<VizelMathematicsOptions>({
 
       const startEditing = () => {
         if (!editor.isEditable) return;
-        isEditing = true;
+        viewState.isEditing = true;
         dom.classList.add("vizel-math-editing");
         renderContainer.style.display = "none";
         editContainer.style.display = "";
@@ -546,8 +544,8 @@ export const VizelMathBlock = Node.create<VizelMathematicsOptions>({
       };
 
       const stopEditing = () => {
-        if (!isEditing) return;
-        isEditing = false;
+        if (!viewState.isEditing) return;
+        viewState.isEditing = false;
         dom.classList.remove("vizel-math-editing");
         renderContainer.style.display = "";
         editContainer.style.display = "none";
@@ -571,7 +569,7 @@ export const VizelMathBlock = Node.create<VizelMathematicsOptions>({
 
       // Event listeners (named handlers for proper cleanup in destroy())
       const handleDomClick = (e: MouseEvent) => {
-        if (!isEditing && e.target === dom) {
+        if (!viewState.isEditing && e.target === dom) {
           e.preventDefault();
           e.stopPropagation();
           startEditing();
@@ -625,7 +623,7 @@ export const VizelMathBlock = Node.create<VizelMathematicsOptions>({
           if (updatedNode.type.name !== "mathBlock") {
             return false;
           }
-          if (!isEditing) {
+          if (!viewState.isEditing) {
             renderMath(updatedNode.attrs.latex);
           }
           return true;

--- a/packages/core/src/extensions/multi-block-selection.ts
+++ b/packages/core/src/extensions/multi-block-selection.ts
@@ -82,9 +82,7 @@ function computeMultiBlockSelectionState(
   // Walk the doc's top-level children and collect blocks that overlap
   // the selection range. Top-level blocks live at depth 1 in the
   // ProseMirror tree (the doc node itself is depth 0).
-  const blockPositions: number[] = [];
-  let rangeFrom = -1;
-  let rangeTo = -1;
+  const overlappingBlocks: Array<{ start: number; end: number }> = [];
 
   doc.forEach((child, offset) => {
     if (!child.isBlock) return;
@@ -99,13 +97,15 @@ function computeMultiBlockSelectionState(
     const overlaps = blockStart < to && blockEnd > from;
     if (!overlaps) return;
 
-    blockPositions.push(blockStart);
-    if (rangeFrom === -1) rangeFrom = blockStart;
-    rangeTo = blockEnd;
+    overlappingBlocks.push({ start: blockStart, end: blockEnd });
   });
 
-  if (blockPositions.length < 2) return null;
-  return { from: rangeFrom, to: rangeTo, blockPositions };
+  if (overlappingBlocks.length < 2) return null;
+  const blockPositions = overlappingBlocks.map((b) => b.start);
+  const first = overlappingBlocks[0];
+  const last = overlappingBlocks.at(-1);
+  if (!(first && last)) return null;
+  return { from: first.start, to: last.end, blockPositions };
 }
 
 /**
@@ -186,16 +186,15 @@ function applyListIndentToRange(
   direction: "sink" | "lift"
 ): boolean {
   const positions = [...rangeState.blockPositions].reverse();
-  let applied = false;
 
-  for (const pos of positions) {
+  return positions.reduce<boolean>((applied, pos) => {
     const node = editor.state.doc.nodeAt(pos);
-    if (!node) continue;
+    if (!node) return applied;
     // Only act on list-item-like nodes — Tab on a paragraph does
     // nothing in Tiptap defaults, so we should not invent behavior for
     // those cases.
     const typeName = node.type.name;
-    if (typeName !== "listItem" && typeName !== "taskItem") continue;
+    if (typeName !== "listItem" && typeName !== "taskItem") return applied;
 
     // Select the list item by its node position so the Tiptap command
     // operates against exactly that block.
@@ -203,10 +202,8 @@ function applyListIndentToRange(
       .chain()
       .setNodeSelection(pos)
       [direction === "sink" ? "sinkListItem" : "liftListItem"](typeName);
-    if (chain.run()) applied = true;
-  }
-
-  return applied;
+    return chain.run() || applied;
+  }, false);
 }
 
 /**

--- a/packages/core/src/extensions/table-controls.ts
+++ b/packages/core/src/extensions/table-controls.ts
@@ -150,23 +150,16 @@ function findColumnBoundary(
   const firstBoundary = boundaries[0];
   if (!firstBoundary) return null;
 
-  let closest = firstBoundary;
-  let minDistance = Math.abs(relativeX - closest.position);
-
-  for (const boundary of boundaries) {
-    const distance = Math.abs(relativeX - boundary.position);
-    if (distance < minDistance) {
-      minDistance = distance;
-      closest = boundary;
-    }
-  }
+  const { closest, minDistance } = boundaries.reduce(
+    (acc, boundary) => {
+      const distance = Math.abs(relativeX - boundary.position);
+      return distance < acc.minDistance ? { closest: boundary, minDistance: distance } : acc;
+    },
+    { closest: firstBoundary, minDistance: Math.abs(relativeX - firstBoundary.position) }
+  );
 
   // Only return if within threshold
-  if (minDistance <= BOUNDARY_THRESHOLD_PX) {
-    return closest;
-  }
-
-  return null;
+  return minDistance <= BOUNDARY_THRESHOLD_PX ? closest : null;
 }
 
 /**
@@ -199,23 +192,16 @@ function findRowBoundary(
   const firstBoundary = boundaries[0];
   if (!firstBoundary) return null;
 
-  let closest = firstBoundary;
-  let minDistance = Math.abs(relativeY - closest.position);
-
-  for (const boundary of boundaries) {
-    const distance = Math.abs(relativeY - boundary.position);
-    if (distance < minDistance) {
-      minDistance = distance;
-      closest = boundary;
-    }
-  }
+  const { closest, minDistance } = boundaries.reduce(
+    (acc, boundary) => {
+      const distance = Math.abs(relativeY - boundary.position);
+      return distance < acc.minDistance ? { closest: boundary, minDistance: distance } : acc;
+    },
+    { closest: firstBoundary, minDistance: Math.abs(relativeY - firstBoundary.position) }
+  );
 
   // Only return if within threshold
-  if (minDistance <= BOUNDARY_THRESHOLD_PX) {
-    return closest;
-  }
-
-  return null;
+  return minDistance <= BOUNDARY_THRESHOLD_PX ? closest : null;
 }
 
 /**
@@ -274,21 +260,20 @@ function selectCellInRow(editor: Editor, tablePos: number, rowIndex: number): vo
   const table = state.doc.nodeAt(tablePos);
   if (!table) return;
 
-  let pos = tablePos + 1; // Skip table node start
-  for (let i = 0; i < table.childCount; i++) {
-    const row = table.child(i);
-    if (i === rowIndex) {
-      // Select first cell in this row
-      const cellPos = pos + 1; // Skip row node start
-      editor
-        .chain()
-        .focus()
-        .setTextSelection(cellPos + 1)
-        .run();
-      return;
-    }
-    pos += row.nodeSize;
-  }
+  // Sum sizes of preceding rows to locate the requested row's start position.
+  const startOffset = Array.from({ length: rowIndex }, (_, i) => table.child(i).nodeSize).reduce(
+    (sum, size) => sum + size,
+    0
+  );
+  if (rowIndex >= table.childCount) return;
+  const rowStartPos = tablePos + 1 + startOffset;
+  // Skip row node start then enter the first cell.
+  const cellPos = rowStartPos + 1;
+  editor
+    .chain()
+    .focus()
+    .setTextSelection(cellPos + 1)
+    .run();
 }
 
 /**
@@ -300,25 +285,29 @@ function selectCellInColumn(editor: Editor, tablePos: number, colIndex: number):
   if (!table || table.childCount === 0) return;
 
   const firstRow = table.child(0);
-  let pos = tablePos + 2; // Skip table node start and row node start
-
-  for (let i = 0; i < firstRow.childCount; i++) {
-    if (i === colIndex || (colIndex > firstRow.childCount && i === firstRow.childCount - 1)) {
-      editor
-        .chain()
-        .focus()
-        .setTextSelection(pos + 1)
-        .run();
-      return;
+  const targetIndex = colIndex > firstRow.childCount ? firstRow.childCount - 1 : colIndex;
+  if (targetIndex < 0 || targetIndex >= firstRow.childCount) {
+    // If colIndex is 0 (and clamping kept us here), select first cell.
+    if (colIndex === 0 && firstRow.childCount > 0) {
+      const firstCellPos = tablePos + 3;
+      editor.chain().focus().setTextSelection(firstCellPos).run();
     }
-    pos += firstRow.child(i).nodeSize;
+    return;
   }
 
-  // If colIndex is 0, select first cell
-  if (colIndex === 0 && firstRow.childCount > 0) {
-    const firstCellPos = tablePos + 3;
-    editor.chain().focus().setTextSelection(firstCellPos).run();
-  }
+  // Sum sizes of preceding cells to locate the target cell's start position.
+  const cellOffset = Array.from(
+    { length: targetIndex },
+    (_, i) => firstRow.child(i).nodeSize
+  ).reduce((sum, size) => sum + size, 0);
+
+  // Skip table node start and row node start, then accumulate cell sizes.
+  const pos = tablePos + 2 + cellOffset;
+  editor
+    .chain()
+    .focus()
+    .setTextSelection(pos + 1)
+    .run();
 }
 
 /**
@@ -348,11 +337,8 @@ function getTablePosition(
   getPos: (() => number | undefined) | boolean,
   editor: Editor
 ): number | undefined {
-  let pos = typeof getPos === "function" ? getPos() : undefined;
-  if (pos === undefined) {
-    pos = findTablePositionFromSelection(editor);
-  }
-  return pos;
+  const fromGetPos = typeof getPos === "function" ? getPos() : undefined;
+  return fromGetPos ?? findTablePositionFromSelection(editor);
 }
 
 /**
@@ -369,29 +355,32 @@ function setColumnAlignment(
   if (!table) return;
 
   const { tr } = state;
-  let pos = tablePos + 1; // Skip table node start
 
-  // Iterate through all rows
-  for (let rowIdx = 0; rowIdx < table.childCount; rowIdx++) {
-    const row = table.child(rowIdx);
-    let cellPos = pos + 1; // Skip row node start
+  // Compute cumulative row offsets so each row's start position is derived
+  // without a running accumulator.
+  const rowOffsets = Array.from({ length: table.childCount }, (_, idx) =>
+    Array.from({ length: idx }, (_, j) => table.child(j).nodeSize).reduce(
+      (sum, size) => sum + size,
+      0
+    )
+  );
 
-    // Find the cell at colIndex
-    for (let cellIdx = 0; cellIdx < row.childCount; cellIdx++) {
-      const cell = row.child(cellIdx);
-      if (cellIdx === colIndex) {
-        // Set textAlign attribute on this cell
-        tr.setNodeMarkup(cellPos, undefined, {
-          ...cell.attrs,
-          textAlign: alignment,
-        });
-        break;
-      }
-      cellPos += cell.nodeSize;
-    }
-
-    pos += row.nodeSize;
-  }
+  // Mutate `tr` in place. `setNodeMarkup` returns the same transaction; we
+  // forEach over rows and stage one mark per row.
+  table.forEach((row, _, rowIdx) => {
+    const rowStartPos = tablePos + 1 + (rowOffsets[rowIdx] ?? 0);
+    const cellOffset = Array.from({ length: colIndex }, (_, j) => row.child(j).nodeSize).reduce(
+      (sum, size) => sum + size,
+      0
+    );
+    if (colIndex < 0 || colIndex >= row.childCount) return;
+    const cellPos = rowStartPos + 1 + cellOffset;
+    const cell = row.child(colIndex);
+    tr.setNodeMarkup(cellPos, undefined, {
+      ...cell.attrs,
+      textAlign: alignment,
+    });
+  });
 
   view.dispatch(tr);
 }
@@ -570,17 +559,26 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
       columnHandle.style.left = "64px";
       columnHandle.style.top = "0px";
 
-      // Menu state
-      let activeMenu: HTMLElement | null = null;
-      let currentColumnBoundary: { index: number; position: number } | null = null;
-      let currentRowBoundary: { index: number; position: number } | null = null;
-      let currentHoveredRow: { index: number; element: HTMLTableRowElement } | null = null;
-      let currentHoveredColumn: { index: number; centerX: number } | null = null;
+      // Menu / pointer-tracking state (held in a single closure-shared object
+      // so multiple handlers can read and write without mutable bindings).
+      const controlState: {
+        activeMenu: HTMLElement | null;
+        currentColumnBoundary: { index: number; position: number } | null;
+        currentRowBoundary: { index: number; position: number } | null;
+        currentHoveredRow: { index: number; element: HTMLTableRowElement } | null;
+        currentHoveredColumn: { index: number; centerX: number } | null;
+      } = {
+        activeMenu: null,
+        currentColumnBoundary: null,
+        currentRowBoundary: null,
+        currentHoveredRow: null,
+        currentHoveredColumn: null,
+      };
 
       const closeMenu = () => {
-        if (activeMenu) {
-          activeMenu.remove();
-          activeMenu = null;
+        if (controlState.activeMenu) {
+          controlState.activeMenu.remove();
+          controlState.activeMenu = null;
         }
       };
 
@@ -589,14 +587,14 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         e.preventDefault();
         e.stopPropagation();
 
-        if (!editor.isEditable || currentColumnBoundary == null) return;
+        if (!editor.isEditable || controlState.currentColumnBoundary == null) return;
 
         const pos = getTablePosition(getPos, editor);
         if (pos == null) return;
 
-        selectCellInColumn(editor, pos, Math.max(0, currentColumnBoundary.index - 1));
+        selectCellInColumn(editor, pos, Math.max(0, controlState.currentColumnBoundary.index - 1));
 
-        if (currentColumnBoundary.index === 0) {
+        if (controlState.currentColumnBoundary.index === 0) {
           editor.chain().focus().addColumnBefore().run();
         } else {
           editor.chain().focus().addColumnAfter().run();
@@ -610,14 +608,14 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         e.preventDefault();
         e.stopPropagation();
 
-        if (!editor.isEditable || currentRowBoundary == null) return;
+        if (!editor.isEditable || controlState.currentRowBoundary == null) return;
 
         const pos = getTablePosition(getPos, editor);
         if (pos == null) return;
 
-        selectCellInRow(editor, pos, Math.max(0, currentRowBoundary.index - 1));
+        selectCellInRow(editor, pos, Math.max(0, controlState.currentRowBoundary.index - 1));
 
-        if (currentRowBoundary.index === 0) {
+        if (controlState.currentRowBoundary.index === 0) {
           editor.chain().focus().addRowBefore().run();
         } else {
           editor.chain().focus().addRowAfter().run();
@@ -631,7 +629,7 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         e.preventDefault();
         e.stopPropagation();
 
-        const hoveredRow = currentHoveredRow;
+        const hoveredRow = controlState.currentHoveredRow;
         if (!editor.isEditable || hoveredRow == null) return;
 
         const pos = getTablePosition(getPos, editor);
@@ -647,14 +645,14 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         menu.style.top = `${handleRect.top}px`;
 
         document.body.appendChild(menu);
-        activeMenu = menu;
+        controlState.activeMenu = menu;
       };
 
       // Use both mousedown and click for cross-browser compatibility
       // Store click handler references for proper cleanup
       const handleRowClick = (e: MouseEvent) => {
         // Prevent duplicate handling if mousedown already succeeded
-        if (activeMenu) {
+        if (controlState.activeMenu) {
           e.preventDefault();
           e.stopPropagation();
         }
@@ -668,7 +666,7 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         e.preventDefault();
         e.stopPropagation();
 
-        const hoveredColumn = currentHoveredColumn;
+        const hoveredColumn = controlState.currentHoveredColumn;
         if (!editor.isEditable || hoveredColumn == null) return;
 
         const pos = getTablePosition(getPos, editor);
@@ -685,14 +683,14 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         menu.style.top = `${handleRect.bottom + 4}px`;
 
         document.body.appendChild(menu);
-        activeMenu = menu;
+        controlState.activeMenu = menu;
       };
 
       // Use both mousedown and click for cross-browser compatibility
       // Store click handler references for proper cleanup
       const handleColumnClick = (e: MouseEvent) => {
         // Prevent duplicate handling if mousedown already succeeded
-        if (activeMenu) {
+        if (controlState.activeMenu) {
           e.preventDefault();
           e.stopPropagation();
         }
@@ -705,18 +703,18 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
       // Note: We process synchronously instead of using RAF because React may re-render
       // and replace the DOM elements before RAF callbacks execute. This ensures the
       // button visibility is updated immediately when the mouse moves.
-      let lastMoveTime = 0;
+      const throttleState = { lastMoveTime: 0 };
       const THROTTLE_MS = 16; // ~60fps throttle
 
       // Helper to update column insert button position
       const updateColumnInsertPosition = (mouseX: number, tableRect: DOMRect) => {
         const boundary = findColumnBoundary(table, mouseX, tableRect);
         if (boundary) {
-          currentColumnBoundary = boundary;
+          controlState.currentColumnBoundary = boundary;
           columnInsertBtn.style.left = `${boundary.position + PADDING_LEFT_PX}px`;
           columnInsertBtn.style.top = "0px";
-        } else if (!currentColumnBoundary) {
-          currentColumnBoundary = { index: 0, position: 0 };
+        } else if (!controlState.currentColumnBoundary) {
+          controlState.currentColumnBoundary = { index: 0, position: 0 };
         }
       };
 
@@ -724,11 +722,11 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
       const updateRowInsertPosition = (mouseY: number, tableRect: DOMRect) => {
         const boundary = findRowBoundary(table, mouseY, tableRect);
         if (boundary) {
-          currentRowBoundary = boundary;
+          controlState.currentRowBoundary = boundary;
           rowInsertBtn.style.left = "0px";
           rowInsertBtn.style.top = `${boundary.position + PADDING_TOP_PX}px`;
-        } else if (!currentRowBoundary) {
-          currentRowBoundary = { index: 0, position: 0 };
+        } else if (!controlState.currentRowBoundary) {
+          controlState.currentRowBoundary = { index: 0, position: 0 };
         }
       };
 
@@ -736,7 +734,7 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
       const updateRowHandlePosition = (mouseY: number, tableRect: DOMRect) => {
         const hoveredRow = findHoveredRow(table, mouseY);
         if (hoveredRow) {
-          currentHoveredRow = hoveredRow;
+          controlState.currentHoveredRow = hoveredRow;
           const rowRect = hoveredRow.element.getBoundingClientRect();
           rowHandle.style.left = "2px";
           rowHandle.style.top = `${rowRect.top - tableRect.top + PADDING_TOP_PX + (rowRect.height - 20) / 2}px`;
@@ -747,7 +745,7 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
       const updateColumnHandlePosition = (mouseX: number, tableRect: DOMRect) => {
         const hoveredColumn = findHoveredColumn(table, mouseX, tableRect);
         if (hoveredColumn) {
-          currentHoveredColumn = hoveredColumn;
+          controlState.currentHoveredColumn = hoveredColumn;
           columnHandle.style.left = `${hoveredColumn.centerX + PADDING_LEFT_PX}px`;
           columnHandle.style.top = "0px";
         }
@@ -757,8 +755,8 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         if (!editor.isEditable) return;
 
         const now = Date.now();
-        if (now - lastMoveTime < THROTTLE_MS) return;
-        lastMoveTime = now;
+        if (now - throttleState.lastMoveTime < THROTTLE_MS) return;
+        throttleState.lastMoveTime = now;
 
         const tableRect = table.getBoundingClientRect();
         const isInTable =
@@ -780,11 +778,11 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         // CSS controls visibility via :hover, so we just reset state variables
         // Delay to allow clicking on buttons that might extend outside wrapper
         setTimeout(() => {
-          if (!(wrapper.matches(":hover") || activeMenu)) {
-            currentColumnBoundary = null;
-            currentRowBoundary = null;
-            currentHoveredRow = null;
-            currentHoveredColumn = null;
+          if (!(wrapper.matches(":hover") || controlState.activeMenu)) {
+            controlState.currentColumnBoundary = null;
+            controlState.currentRowBoundary = null;
+            controlState.currentHoveredRow = null;
+            controlState.currentHoveredColumn = null;
           }
         }, 100);
       };
@@ -826,7 +824,7 @@ export const VizelTableWithControls = VizelTable.extend<VizelTableControlsOption
         menu.style.top = `${e.clientY}px`;
 
         document.body.appendChild(menu);
-        activeMenu = menu;
+        controlState.activeMenu = menu;
       };
 
       table.addEventListener("contextmenu", handleContextMenu);

--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -315,7 +315,7 @@ export type VizelIconRendererWithOptions = (
 ) => string;
 
 // Global icon renderer, injected by framework packages
-let iconRenderer: VizelIconRendererWithOptions | null = null;
+const iconRendererRef: { current: VizelIconRendererWithOptions | null } = { current: null };
 
 /**
  * Set the icon renderer function.
@@ -339,7 +339,7 @@ let iconRenderer: VizelIconRendererWithOptions | null = null;
  * ```
  */
 export function setVizelIconRenderer(renderer: VizelIconRendererWithOptions): void {
-  iconRenderer = renderer;
+  iconRendererRef.current = renderer;
 }
 
 /**
@@ -354,7 +354,8 @@ export function renderVizelIcon(
   name: VizelInternalIconName,
   options?: VizelIconRendererOptions
 ): string {
-  if (!iconRenderer) {
+  const renderer = iconRendererRef.current;
+  if (!renderer) {
     // Emit as warning so production stays silent under the default
     // `emitVizelError` fallback (warnings with no `onError` are silent),
     // while consumers wiring `onError` still surface the misconfiguration.
@@ -370,7 +371,7 @@ export function renderVizelIcon(
     );
     return "";
   }
-  return iconRenderer(name, options);
+  return renderer(name, options);
 }
 
 /**

--- a/packages/core/src/plugins/image-upload.ts
+++ b/packages/core/src/plugins/image-upload.ts
@@ -107,7 +107,7 @@ export function createVizelImageUploadPlugin(options: VizelImageUploadPluginOpti
       },
       apply(tr, currentSet: DecorationSet): DecorationSet {
         // Map decorations through document changes
-        let decoSet = currentSet.map(tr.mapping, tr.doc);
+        const mapped = currentSet.map(tr.mapping, tr.doc);
 
         const meta = tr.getMeta(imageUploadKey);
         const action = isImageUploadAction(meta) ? meta : undefined;
@@ -130,14 +130,13 @@ export function createVizelImageUploadPlugin(options: VizelImageUploadPluginOpti
           placeholder.appendChild(spinner);
 
           const deco = Decoration.widget(pos, placeholder, { id });
-          decoSet = decoSet.add(tr.doc, [deco]);
-        } else if (action?.type === "remove") {
-          decoSet = decoSet.remove(
-            decoSet.find(undefined, undefined, (spec) => spec.id === action.id)
-          );
+          return mapped.add(tr.doc, [deco]);
+        }
+        if (action?.type === "remove") {
+          return mapped.remove(mapped.find(undefined, undefined, (spec) => spec.id === action.id));
         }
 
-        return decoSet;
+        return mapped;
       },
     },
     props: {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -190,23 +190,26 @@ export function createVizelSystemThemeListener(
     callback(event.matches ? "dark" : "light");
   };
 
-  let mediaQuery: MediaQueryList | null = null;
-  let isMounted = false;
+  const state: { mediaQuery: MediaQueryList | null; isMounted: boolean } = {
+    mediaQuery: null,
+    isMounted: false,
+  };
 
   return {
     mount: (): void => {
       if (typeof window === "undefined") return;
-      if (isMounted) return;
-      mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      if (state.isMounted) return;
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
       mediaQuery.addEventListener("change", handleChange);
-      isMounted = true;
+      state.mediaQuery = mediaQuery;
+      state.isMounted = true;
     },
     unmount: (): void => {
       if (typeof window === "undefined") return;
-      if (!(isMounted && mediaQuery)) return;
-      mediaQuery.removeEventListener("change", handleChange);
-      mediaQuery = null;
-      isMounted = false;
+      if (!(state.isMounted && state.mediaQuery)) return;
+      state.mediaQuery.removeEventListener("change", handleChange);
+      state.mediaQuery = null;
+      state.isMounted = false;
     },
   };
 }

--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -234,22 +234,20 @@ export function getVizelEditorState(editor: Editor | null | undefined): VizelEdi
     };
   }
 
-  let characterCount = 0;
-  let wordCount = 0;
-
   const storage: unknown = editor.storage;
-  if (hasVizelCharacterCountStorage(storage)) {
-    characterCount = storage.characterCount.characters();
-    wordCount = storage.characterCount.words();
-  }
+  const counts = hasVizelCharacterCountStorage(storage)
+    ? {
+        characterCount: storage.characterCount.characters(),
+        wordCount: storage.characterCount.words(),
+      }
+    : { characterCount: 0, wordCount: 0 };
 
   return {
     isFocused: editor.isFocused,
     isEmpty: editor.isEmpty,
     canUndo: editor.can().undo(),
     canRedo: editor.can().redo(),
-    characterCount,
-    wordCount,
+    ...counts,
   };
 }
 
@@ -356,17 +354,10 @@ export function convertVizelCodeBlocksToDiagrams(editor: Editor): void {
   if (replacements.length === 0) return;
 
   // Apply replacements in reverse order to preserve positions
-  let { tr } = editor.state;
-  for (let i = replacements.length - 1; i >= 0; i--) {
-    const replacement = replacements[i];
-    if (!replacement) continue;
-    const { from, to, code, type } = replacement;
-    const diagramNode = diagramType.create({
-      code,
-      type,
-    });
-    tr = tr.replaceWith(from, to, diagramNode);
-  }
+  const tr = [...replacements].reverse().reduce((acc, { from, to, code, type }) => {
+    const diagramNode = diagramType.create({ code, type });
+    return acc.replaceWith(from, to, diagramNode);
+  }, editor.state.tr);
 
   editor.view.dispatch(tr);
 }

--- a/packages/core/src/utils/groupByField.ts
+++ b/packages/core/src/utils/groupByField.ts
@@ -20,24 +20,13 @@
  * ```
  */
 export function groupByConsecutiveField<T>(items: readonly T[], field: keyof T & string): T[][] {
-  const groups: T[][] = [];
-  let currentValue: unknown = Symbol("initial");
-  let currentGroup: T[] = [];
-
-  for (const item of items) {
-    if (item[field] !== currentValue) {
-      if (currentGroup.length > 0) {
-        groups.push(currentGroup);
-      }
-      currentValue = item[field];
-      currentGroup = [];
+  return items.reduce<T[][]>((groups, item) => {
+    const lastGroup = groups.at(-1);
+    if (lastGroup && lastGroup[0]?.[field] === item[field]) {
+      lastGroup.push(item);
+    } else {
+      groups.push([item]);
     }
-    currentGroup.push(item);
-  }
-
-  if (currentGroup.length > 0) {
-    groups.push(currentGroup);
-  }
-
-  return groups;
+    return groups;
+  }, []);
 }

--- a/packages/core/src/utils/keyboard.ts
+++ b/packages/core/src/utils/keyboard.ts
@@ -48,33 +48,23 @@ export function formatVizelShortcut(shortcut: string): string {
 
   if (isMac) {
     // macOS: use symbols, modifiers first in standard Apple order (⌃⌥⇧⌘)
-    const modifiers: string[] = [];
-    let key = "";
-
-    for (const part of parts) {
-      switch (part) {
-        case "Mod":
-          modifiers.push("⌘");
-          break;
-        case "Shift":
-          modifiers.push("⇧");
-          break;
-        case "Alt":
-          modifiers.push("⌥");
-          break;
-        case "Ctrl":
-          modifiers.push("⌃");
-          break;
-        default:
-          key = part;
-      }
-    }
+    const modifierSymbols: Record<string, string> = {
+      Mod: "⌘",
+      Shift: "⇧",
+      Alt: "⌥",
+      Ctrl: "⌃",
+    };
+    const modifierSet = new Set(Object.keys(modifierSymbols));
+    const modifiers = parts
+      .filter((part) => modifierSet.has(part))
+      .map((part) => modifierSymbols[part] ?? part);
+    const key = parts.findLast((part) => !modifierSet.has(part)) ?? "";
 
     // Apple standard modifier order: ⌃ ⌥ ⇧ ⌘
     const order = ["⌃", "⌥", "⇧", "⌘"];
-    modifiers.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+    const orderedModifiers = [...modifiers].sort((a, b) => order.indexOf(a) - order.indexOf(b));
 
-    return modifiers.join("") + key;
+    return orderedModifiers.join("") + key;
   }
 
   // Windows/Linux: use text labels with + separator

--- a/packages/core/src/utils/lazy-import.ts
+++ b/packages/core/src/utils/lazy-import.ts
@@ -29,21 +29,23 @@ export function createLazyLoader<T>(
   moduleName: string,
   importFn: () => Promise<T>
 ): () => Promise<T> {
-  let cached: T | null = null;
-  let loading: Promise<T> | null = null;
+  const state: { cached: T | null; loading: Promise<T> | null } = {
+    cached: null,
+    loading: null,
+  };
 
   return () => {
-    if (cached) return Promise.resolve(cached);
-    if (loading) return loading;
+    if (state.cached) return Promise.resolve(state.cached);
+    if (state.loading) return state.loading;
 
-    loading = importFn().then(
+    const promise = importFn().then(
       (mod) => {
-        cached = mod;
-        loading = null;
+        state.cached = mod;
+        state.loading = null;
         return mod;
       },
       (error) => {
-        loading = null;
+        state.loading = null;
         throw new Error(
           `[Vizel] Failed to load "${moduleName}". ` +
             `Please install it: npm install ${moduleName}\n` +
@@ -51,7 +53,8 @@ export function createLazyLoader<T>(
         );
       }
     );
+    state.loading = promise;
 
-    return loading;
+    return promise;
   };
 }

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -162,17 +162,27 @@ export function createVizelMarkdownSyncHandlers(
 ): VizelMarkdownSyncHandlers {
   const { debounceMs = VIZEL_DEFAULT_MARKDOWN_DEBOUNCE_MS, transformDiagrams = true } = options;
 
-  let currentMarkdown = "";
-  let pending = false;
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const state: {
+    currentMarkdown: string;
+    pending: boolean;
+    timeoutId: ReturnType<typeof setTimeout> | null;
+  } = {
+    currentMarkdown: "",
+    pending: false,
+    timeoutId: null,
+  };
+
+  const clearTimer = (): void => {
+    if (state.timeoutId) {
+      clearTimeout(state.timeoutId);
+      state.timeoutId = null;
+    }
+  };
 
   const flush = (editor: Editor): void => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-    currentMarkdown = getVizelMarkdown(editor);
-    pending = false;
+    clearTimer();
+    state.currentMarkdown = getVizelMarkdown(editor);
+    state.pending = false;
   };
 
   const handleUpdate = (editor: Editor): void => {
@@ -181,54 +191,40 @@ export function createVizelMarkdownSyncHandlers(
       // after a subsequent `debounceMs === 0` call. The previous shape left
       // a stale `setTimeout` running, which made `isPending()` lie about
       // the export status.
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      pending = false;
-      currentMarkdown = getVizelMarkdown(editor);
+      clearTimer();
+      state.pending = false;
+      state.currentMarkdown = getVizelMarkdown(editor);
       return;
     }
 
-    pending = true;
+    state.pending = true;
+    clearTimer();
 
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-
-    timeoutId = setTimeout(() => {
-      currentMarkdown = getVizelMarkdown(editor);
-      pending = false;
-      timeoutId = null;
+    state.timeoutId = setTimeout(() => {
+      state.currentMarkdown = getVizelMarkdown(editor);
+      state.pending = false;
+      state.timeoutId = null;
     }, debounceMs);
   };
 
   const setMarkdownFn = (editor: Editor, markdown: string): void => {
     // Cancel any pending export
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-    pending = false;
+    clearTimer();
+    state.pending = false;
 
     // Set the markdown content
     setVizelMarkdown(editor, markdown, { transformDiagrams });
 
     // Update current markdown
-    currentMarkdown = markdown;
+    state.currentMarkdown = markdown;
   };
 
   return {
     handleUpdate,
-    getMarkdown: () => currentMarkdown,
+    getMarkdown: () => state.currentMarkdown,
     setMarkdown: setMarkdownFn,
-    isPending: () => pending,
+    isPending: () => state.pending,
     flush,
-    destroy: () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-    },
+    destroy: clearTimer,
   };
 }

--- a/packages/core/src/utils/menuPositioning.ts
+++ b/packages/core/src/utils/menuPositioning.ts
@@ -39,26 +39,16 @@ export function clampMenuPosition(
   const vw = window.innerWidth;
   const vh = window.innerHeight;
 
-  let x = anchorRect.left;
-  let y = anchorRect.bottom + gap;
+  const rawX = anchorRect.left;
+  const rawY = anchorRect.bottom + gap;
 
-  // Clamp horizontal: prevent overflow on right edge
-  if (x + menuWidth > vw - padding) {
-    x = vw - menuWidth - padding;
-  }
-  // Clamp horizontal: prevent overflow on left edge
-  if (x < padding) {
-    x = padding;
-  }
+  // Clamp horizontal: prevent overflow on right edge first, then left edge
+  const clampedRight = rawX + menuWidth > vw - padding ? vw - menuWidth - padding : rawX;
+  const x = clampedRight < padding ? padding : clampedRight;
 
-  // Clamp vertical: if menu overflows bottom, flip above anchor
-  if (y + menuHeight > vh - padding) {
-    y = anchorRect.top - menuHeight - gap;
-  }
-  // Clamp vertical: prevent overflow on top edge
-  if (y < padding) {
-    y = padding;
-  }
+  // Clamp vertical: flip above anchor if overflow, then clamp top edge
+  const flippedY = rawY + menuHeight > vh - padding ? anchorRect.top - menuHeight - gap : rawY;
+  const y = flippedY < padding ? padding : flippedY;
 
   return { x, y };
 }

--- a/packages/core/src/utils/minimap-render.ts
+++ b/packages/core/src/utils/minimap-render.ts
@@ -100,8 +100,7 @@ export function renderVizelMinimapToCanvas(
   );
   if (total <= 0) return;
 
-  let yCursor = 0;
-  for (const block of blocks) {
+  blocks.reduce((yCursor, block) => {
     const ratio = block.approxHeight / total;
     const rectHeight = Math.max(1, Math.floor(ratio * height));
     // Clamp depth to >= 1 to guarantee a non-zero rectangle width.
@@ -111,8 +110,8 @@ export function renderVizelMinimapToCanvas(
     ctx.fillStyle = isHeadingLike(block.type) ? headingColor : blockColor;
     ctx.fillRect(0, yCursor, rectWidth, Math.max(1, rectHeight - 1));
 
-    yCursor += rectHeight;
-  }
+    return yCursor + rectHeight;
+  }, 0);
 
   // Viewport overlay: translate the doc-level [viewport.top, viewport.bottom]
   // range into canvas Y coordinates by scaling against the cumulative height.

--- a/packages/core/src/utils/textHighlight.ts
+++ b/packages/core/src/utils/textHighlight.ts
@@ -42,23 +42,23 @@ export function splitVizelTextByMatches(
     return [{ text, highlight: false }];
   }
 
-  const result: VizelTextSegment[] = [];
-  let lastIndex = 0;
+  const result = matches.reduce<{
+    segments: VizelTextSegment[];
+    cursor: number;
+  }>(
+    (acc, [start, end]) => {
+      if (start > acc.cursor) {
+        acc.segments.push({ text: text.slice(acc.cursor, start), highlight: false });
+      }
+      acc.segments.push({ text: text.slice(start, end + 1), highlight: true });
+      acc.cursor = end + 1;
+      return acc;
+    },
+    { segments: [], cursor: 0 }
+  );
 
-  for (const [start, end] of matches) {
-    // Add text before match
-    if (start > lastIndex) {
-      result.push({ text: text.slice(lastIndex, start), highlight: false });
-    }
-    // Add highlighted match
-    result.push({ text: text.slice(start, end + 1), highlight: true });
-    lastIndex = end + 1;
+  if (result.cursor < text.length) {
+    result.segments.push({ text: text.slice(result.cursor), highlight: false });
   }
-
-  // Add remaining text
-  if (lastIndex < text.length) {
-    result.push({ text: text.slice(lastIndex), highlight: false });
-  }
-
-  return result;
+  return result.segments;
 }

--- a/packages/core/src/version-history.ts
+++ b/packages/core/src/version-history.ts
@@ -187,20 +187,20 @@ export function createVizelVersionHistoryHandlers(
   const opts = { ...VIZEL_DEFAULT_VERSION_HISTORY_OPTIONS, ...options };
   const storageBackend = getVizelVersionStorageBackend(opts.storage, opts.key);
 
-  let cachedSnapshots: VizelVersionSnapshot[] = [];
+  const cache: { snapshots: VizelVersionSnapshot[] } = { snapshots: [] };
 
   const loadVersions = async (): Promise<VizelVersionSnapshot[]> => {
     try {
       onStateChange({ isLoading: true });
       const snapshots = await storageBackend.load();
-      cachedSnapshots = snapshots;
+      cache.snapshots = snapshots;
       onStateChange({ snapshots, isLoading: false, error: null });
       return snapshots;
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
       onStateChange({ isLoading: false, error });
       opts.onError?.(error);
-      return cachedSnapshots;
+      return cache.snapshots;
     }
   };
 
@@ -225,7 +225,7 @@ export function createVizelVersionHistoryHandlers(
       const updated = [snapshot, ...existing].slice(0, opts.maxVersions);
 
       await storageBackend.save(updated);
-      cachedSnapshots = updated;
+      cache.snapshots = updated;
       onStateChange({ snapshots: updated, error: null });
 
       opts.onSave?.(snapshot);
@@ -243,7 +243,7 @@ export function createVizelVersionHistoryHandlers(
     if (!editor) return false;
 
     try {
-      const snapshots = cachedSnapshots.length > 0 ? cachedSnapshots : await storageBackend.load();
+      const snapshots = cache.snapshots.length > 0 ? cache.snapshots : await storageBackend.load();
       const snapshot = snapshots.find((s) => s.id === versionId);
       if (!snapshot) return false;
 
@@ -260,10 +260,10 @@ export function createVizelVersionHistoryHandlers(
 
   const deleteVersion = async (versionId: string): Promise<void> => {
     try {
-      const snapshots = cachedSnapshots.length > 0 ? cachedSnapshots : await storageBackend.load();
+      const snapshots = cache.snapshots.length > 0 ? cache.snapshots : await storageBackend.load();
       const updated = snapshots.filter((s) => s.id !== versionId);
       await storageBackend.save(updated);
-      cachedSnapshots = updated;
+      cache.snapshots = updated;
       onStateChange({ snapshots: updated, error: null });
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
@@ -275,7 +275,7 @@ export function createVizelVersionHistoryHandlers(
   const clearVersions = async (): Promise<void> => {
     try {
       await storageBackend.save([]);
-      cachedSnapshots = [];
+      cache.snapshots = [];
       onStateChange({ snapshots: [], error: null });
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));

--- a/packages/react/src/components/VizelColorPicker.tsx
+++ b/packages/react/src/components/VizelColorPicker.tsx
@@ -117,48 +117,35 @@ export function VizelColorPicker({
       const totalColors = allColors.length;
       if (totalColors === 0) return;
 
-      let newIndex = currentIndex;
-      let handled = false;
-
-      switch (e.key) {
-        case "ArrowRight":
-          newIndex = (currentIndex + 1) % totalColors;
-          handled = true;
-          break;
-        case "ArrowLeft":
-          newIndex = (currentIndex - 1 + totalColors) % totalColors;
-          handled = true;
-          break;
-        case "ArrowDown":
-          newIndex = Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
-          handled = true;
-          break;
-        case "ArrowUp":
-          newIndex = Math.max(currentIndex - GRID_COLUMNS, 0);
-          handled = true;
-          break;
-        case "Home":
-          newIndex = 0;
-          handled = true;
-          break;
-        case "End":
-          newIndex = totalColors - 1;
-          handled = true;
-          break;
-        case "Enter":
-        case " ": {
-          e.preventDefault();
-          const selectedColor = allColors[currentIndex];
-          if (selectedColor) {
-            handleSelect(selectedColor);
-          }
-          return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        const selectedColor = allColors[currentIndex];
+        if (selectedColor) {
+          handleSelect(selectedColor);
         }
-        default:
-          break;
+        return;
       }
 
-      if (handled) {
+      const newIndex = ((): number | null => {
+        switch (e.key) {
+          case "ArrowRight":
+            return (currentIndex + 1) % totalColors;
+          case "ArrowLeft":
+            return (currentIndex - 1 + totalColors) % totalColors;
+          case "ArrowDown":
+            return Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
+          case "ArrowUp":
+            return Math.max(currentIndex - GRID_COLUMNS, 0);
+          case "Home":
+            return 0;
+          case "End":
+            return totalColors - 1;
+          default:
+            return null;
+        }
+      })();
+
+      if (newIndex !== null) {
         e.preventDefault();
         setFocusedIndex(newIndex);
         swatchRefs.current[newIndex]?.focus();

--- a/packages/react/src/components/VizelSlashMenuItem.tsx
+++ b/packages/react/src/components/VizelSlashMenuItem.tsx
@@ -15,11 +15,12 @@ export interface VizelSlashMenuItemProps {
  */
 const renderHighlightedText = (text: string, matches?: [number, number][]): React.ReactNode => {
   const segments = splitVizelTextByMatches(text, matches);
-  // Use fragment with cumulative character position as unique key
-  let charPos = 0;
-  return segments.map((segment) => {
+  // Use fragment with cumulative character position as unique key. The
+  // cumulative offset is derived from a running prefix-sum over preceding
+  // segment lengths so the implementation stays free of mutable counters.
+  return segments.map((segment, i) => {
+    const charPos = segments.slice(0, i).reduce((sum, s) => sum + s.text.length, 0);
     const key = `${charPos}-${segment.highlight}`;
-    charPos += segment.text.length;
     return segment.highlight ? (
       <mark key={key} className="vizel-slash-menu-highlight">
         {segment.text}

--- a/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelMentionMenuRenderer.ts
@@ -35,17 +35,25 @@ export function createVizelMentionMenuRenderer(
 ): Partial<SuggestionOptions<VizelMentionItem>> {
   return {
     render: () => {
-      let root: Root | null = null;
-      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
-      let items: VizelMentionItem[] = [];
-      let commandFn: ((item: VizelMentionItem) => void) | null = null;
+      const rendererState: {
+        root: Root | null;
+        suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null;
+        items: VizelMentionItem[];
+        commandFn: ((item: VizelMentionItem) => void) | null;
+      } = {
+        root: null,
+        suggestionContainer: null,
+        items: [],
+        commandFn: null,
+      };
       const menuRef: RefObject<VizelMentionMenuRef | null> = { current: null };
 
       const renderMenu = () => {
+        const { root, commandFn } = rendererState;
         if (!(root && commandFn)) return;
         root.render(
           createElement(VizelMentionMenu, {
-            items,
+            items: rendererState.items,
             onSelect: commandFn,
             ...(options.className !== undefined && { className: options.className }),
             ref: menuRef,
@@ -55,20 +63,21 @@ export function createVizelMentionMenuRenderer(
 
       return {
         onStart: (props: SuggestionProps<VizelMentionItem>) => {
-          items = props.items;
-          commandFn = props.command;
+          rendererState.items = props.items;
+          rendererState.commandFn = props.command;
 
-          suggestionContainer = createVizelSuggestionContainer();
-          root = createRoot(suggestionContainer.menuContainer);
+          const suggestionContainer = createVizelSuggestionContainer();
+          rendererState.suggestionContainer = suggestionContainer;
+          rendererState.root = createRoot(suggestionContainer.menuContainer);
           renderMenu();
           suggestionContainer.updatePosition(props.clientRect);
         },
 
         onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
-          items = props.items;
-          commandFn = props.command;
+          rendererState.items = props.items;
+          rendererState.commandFn = props.command;
           renderMenu();
-          suggestionContainer?.updatePosition(props.clientRect);
+          rendererState.suggestionContainer?.updatePosition(props.clientRect);
         },
 
         onKeyDown: (props: { event: KeyboardEvent }) => {
@@ -79,10 +88,10 @@ export function createVizelMentionMenuRenderer(
         },
 
         onExit: () => {
-          root?.unmount();
-          suggestionContainer?.destroy();
-          root = null;
-          suggestionContainer = null;
+          rendererState.root?.unmount();
+          rendererState.suggestionContainer?.destroy();
+          rendererState.root = null;
+          rendererState.suggestionContainer = null;
         },
       };
     },

--- a/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
+++ b/packages/react/src/hooks/createVizelSlashMenuRenderer.ts
@@ -35,17 +35,25 @@ export function createVizelSlashMenuRenderer(
 ): Partial<SuggestionOptions<VizelSlashCommandItem>> {
   return {
     render: () => {
-      let root: Root | null = null;
-      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
-      let items: VizelSlashCommandItem[] = [];
-      let commandFn: ((item: VizelSlashCommandItem) => void) | null = null;
+      const rendererState: {
+        root: Root | null;
+        suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null;
+        items: VizelSlashCommandItem[];
+        commandFn: ((item: VizelSlashCommandItem) => void) | null;
+      } = {
+        root: null,
+        suggestionContainer: null,
+        items: [],
+        commandFn: null,
+      };
       const menuRef: RefObject<VizelSlashMenuRef | null> = { current: null };
 
       const renderMenu = () => {
+        const { root, commandFn } = rendererState;
         if (!(root && commandFn)) return;
         root.render(
           createElement(VizelSlashMenu, {
-            items,
+            items: rendererState.items,
             onSelect: commandFn,
             ...(options.className !== undefined && { className: options.className }),
             ref: menuRef,
@@ -55,20 +63,21 @@ export function createVizelSlashMenuRenderer(
 
       return {
         onStart: (props: SuggestionProps<VizelSlashCommandItem>) => {
-          items = props.items;
-          commandFn = props.command;
+          rendererState.items = props.items;
+          rendererState.commandFn = props.command;
 
-          suggestionContainer = createVizelSuggestionContainer();
-          root = createRoot(suggestionContainer.menuContainer);
+          const suggestionContainer = createVizelSuggestionContainer();
+          rendererState.suggestionContainer = suggestionContainer;
+          rendererState.root = createRoot(suggestionContainer.menuContainer);
           renderMenu();
           suggestionContainer.updatePosition(props.clientRect);
         },
 
         onUpdate: (props: SuggestionProps<VizelSlashCommandItem>) => {
-          items = props.items;
-          commandFn = props.command;
+          rendererState.items = props.items;
+          rendererState.commandFn = props.command;
           renderMenu();
-          suggestionContainer?.updatePosition(props.clientRect);
+          rendererState.suggestionContainer?.updatePosition(props.clientRect);
         },
 
         onKeyDown: (props: { event: KeyboardEvent }) => {
@@ -79,10 +88,10 @@ export function createVizelSlashMenuRenderer(
         },
 
         onExit: () => {
-          root?.unmount();
-          suggestionContainer?.destroy();
-          root = null;
-          suggestionContainer = null;
+          rendererState.root?.unmount();
+          rendererState.suggestionContainer?.destroy();
+          rendererState.root = null;
+          rendererState.suggestionContainer = null;
         },
       };
     },

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -73,8 +73,13 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
   // Create editor on mount (async - optional dependencies are loaded dynamically)
   useEffect(() => {
     const opts = optionsRef.current;
-    let isMounted = true;
-    let editorInstance: Editor | null = null;
+    // Mount / instance state held in a closure-shared object so the async
+    // initializer and the cleanup function can both observe the latest values
+    // without mutable let bindings.
+    const lifecycle: { isMounted: boolean; editorInstance: Editor | null } = {
+      isMounted: true,
+      editorInstance: null,
+    };
 
     void (async () => {
       try {
@@ -85,12 +90,12 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
           createSlashMenuRenderer: createVizelSlashMenuRenderer,
         });
 
-        if (!isMounted) {
+        if (!lifecycle.isMounted) {
           result.editor.destroy();
           return;
         }
 
-        editorInstance = result.editor;
+        lifecycle.editorInstance = result.editor;
         setEditor(result.editor);
       } catch (error) {
         const vizelError = wrapAsVizelError(error, {
@@ -112,8 +117,8 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
     })();
 
     return () => {
-      isMounted = false;
-      editorInstance?.destroy();
+      lifecycle.isMounted = false;
+      lifecycle.editorInstance?.destroy();
     };
   }, []);
 

--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -120,26 +120,26 @@ export function useVizelMarkdown(
     const handlers = handlersRef.current;
     if (!handlers) return;
 
-    let rafId: number | null = null;
+    const rafState: { id: number | null } = { id: null };
 
     const handleUpdate = () => {
       handlers.handleUpdate(editor);
       setIsPending(handlers.isPending());
 
       // Cancel any pending rAF before scheduling a new one
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      if (rafState.id !== null) cancelAnimationFrame(rafState.id);
 
       // Schedule state update after debounce
       const checkPending = () => {
         if (handlers.isPending()) {
-          rafId = requestAnimationFrame(checkPending);
+          rafState.id = requestAnimationFrame(checkPending);
         } else {
-          rafId = null;
+          rafState.id = null;
           setMarkdownState(handlers.getMarkdown());
           setIsPending(false);
         }
       };
-      rafId = requestAnimationFrame(checkPending);
+      rafState.id = requestAnimationFrame(checkPending);
     };
 
     editor.on("update", handleUpdate);
@@ -153,7 +153,7 @@ export function useVizelMarkdown(
         setIsPending(false);
       }
       editor.off("update", handleUpdate);
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      if (rafState.id !== null) cancelAnimationFrame(rafState.id);
     };
   }, [editor]);
 

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -111,8 +111,10 @@ const markdown = defineModel<string>("markdown");
 
 const slots = useSlots();
 
-// Track whether we're currently updating from external markdown change
-let isUpdatingFromMarkdown = false;
+// Track whether we're currently updating from external markdown change.
+// A closure-shared ref lets the update callback and the markdown watcher
+// flip the guard without resorting to a mutable `let` binding.
+const markdownSyncFlag = { isUpdatingFromMarkdown: false };
 
 const editor = useVizelEditor({
   ...(props.initialContent !== undefined && { initialContent: props.initialContent }),
@@ -130,7 +132,7 @@ const editor = useVizelEditor({
   onUpdate: (e) => {
     emit("update", e);
     // Update markdown model if not updating from external change
-    if (!isUpdatingFromMarkdown && markdown.value !== undefined) {
+    if (!markdownSyncFlag.isUpdatingFromMarkdown && markdown.value !== undefined) {
       markdown.value = getVizelMarkdown(e.editor);
     }
   },
@@ -151,11 +153,11 @@ watch(markdown, (newMarkdown) => {
   if (newMarkdown === currentMarkdown) return;
 
   // Set flag to prevent emitting update:markdown during this update
-  isUpdatingFromMarkdown = true;
+  markdownSyncFlag.isUpdatingFromMarkdown = true;
   setVizelMarkdown(editor.value, newMarkdown, {
     transformDiagrams: props.transformDiagramsOnImport,
   });
-  isUpdatingFromMarkdown = false;
+  markdownSyncFlag.isUpdatingFromMarkdown = false;
 });
 
 // Expose editor instance for advanced use cases.

--- a/packages/vue/src/components/VizelColorPicker.vue
+++ b/packages/vue/src/components/VizelColorPicker.vue
@@ -123,48 +123,35 @@ function handleKeyDown(e: KeyboardEvent, currentIndex: number) {
   const totalColors = allColors.value.length;
   if (totalColors === 0) return;
 
-  let newIndex = currentIndex;
-  let handled = false;
-
-  switch (e.key) {
-    case "ArrowRight":
-      newIndex = (currentIndex + 1) % totalColors;
-      handled = true;
-      break;
-    case "ArrowLeft":
-      newIndex = (currentIndex - 1 + totalColors) % totalColors;
-      handled = true;
-      break;
-    case "ArrowDown":
-      newIndex = Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
-      handled = true;
-      break;
-    case "ArrowUp":
-      newIndex = Math.max(currentIndex - GRID_COLUMNS, 0);
-      handled = true;
-      break;
-    case "Home":
-      newIndex = 0;
-      handled = true;
-      break;
-    case "End":
-      newIndex = totalColors - 1;
-      handled = true;
-      break;
-    case "Enter":
-    case " ": {
-      e.preventDefault();
-      const selectedColor = allColors.value[currentIndex];
-      if (selectedColor) {
-        handleSelect(selectedColor);
-      }
-      return;
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    const selectedColor = allColors.value[currentIndex];
+    if (selectedColor) {
+      handleSelect(selectedColor);
     }
-    default:
-      break;
+    return;
   }
 
-  if (handled) {
+  const newIndex = ((): number | null => {
+    switch (e.key) {
+      case "ArrowRight":
+        return (currentIndex + 1) % totalColors;
+      case "ArrowLeft":
+        return (currentIndex - 1 + totalColors) % totalColors;
+      case "ArrowDown":
+        return Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
+      case "ArrowUp":
+        return Math.max(currentIndex - GRID_COLUMNS, 0);
+      case "Home":
+        return 0;
+      case "End":
+        return totalColors - 1;
+      default:
+        return null;
+    }
+  })();
+
+  if (newIndex !== null) {
     e.preventDefault();
     focusedIndex.value = newIndex;
     swatchRefs.value[newIndex]?.focus();

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -28,23 +28,23 @@ defineExpose<VizelExposed>({
   },
 });
 
-let dispose: (() => void) | null = null;
+const mountState: { dispose: (() => void) | null } = { dispose: null };
 
 watch(
   () => [resolvedEditor.value, containerRef.value] as const,
   ([editorValue, container]) => {
-    dispose?.();
-    dispose = null;
+    mountState.dispose?.();
+    mountState.dispose = null;
     if (editorValue && container) {
-      dispose = mountVizelEditorView(editorValue, container);
+      mountState.dispose = mountVizelEditorView(editorValue, container);
     }
   },
   { immediate: true }
 );
 
 onBeforeUnmount(() => {
-  dispose?.();
-  dispose = null;
+  mountState.dispose?.();
+  mountState.dispose = null;
 });
 </script>
 

--- a/packages/vue/src/components/VizelMinimap.vue
+++ b/packages/vue/src/components/VizelMinimap.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<VizelMinimapProps>(), {
 });
 
 const canvasRef = ref<HTMLCanvasElement | null>(null);
-let rafHandle: number | null = null;
+const rafState: { handle: number | null } = { handle: null };
 
 // Subscribe to editor transactions so we redraw on every doc mutation.
 // The returned tick value is intentionally unused.
@@ -30,9 +30,9 @@ const editorRef = computed(() => props.editor);
 function redraw() {
   const editor = props.editor;
   if (!editor) return;
-  if (rafHandle !== null) return;
-  rafHandle = requestAnimationFrame(() => {
-    rafHandle = null;
+  if (rafState.handle !== null) return;
+  rafState.handle = requestAnimationFrame(() => {
+    rafState.handle = null;
     const canvas = canvasRef.value;
     if (!canvas) return;
     const spec = buildVizelMinimapSpec(editor);
@@ -42,9 +42,9 @@ function redraw() {
 
 onMounted(redraw);
 onBeforeUnmount(() => {
-  if (rafHandle !== null) {
-    cancelAnimationFrame(rafHandle);
-    rafHandle = null;
+  if (rafState.handle !== null) {
+    cancelAnimationFrame(rafState.handle);
+    rafState.handle = null;
   }
 });
 

--- a/packages/vue/src/components/VizelSaveIndicator.vue
+++ b/packages/vue/src/components/VizelSaveIndicator.vue
@@ -26,22 +26,25 @@ const props = withDefaults(defineProps<VizelSaveIndicatorProps>(), {
 });
 
 const relativeTime = ref("");
-let ticker: ReturnType<typeof createVizelRelativeTimeTicker> | null = null;
+const tickerState: { instance: ReturnType<typeof createVizelRelativeTimeTicker> | null } = {
+  instance: null,
+};
 
 onMounted(() => {
-  ticker = createVizelRelativeTimeTicker({
+  const instance = createVizelRelativeTimeTicker({
     getDate: () => props.lastSaved,
     getLocale: () => props.locale,
     onTick: (text) => {
       relativeTime.value = text;
     },
   });
-  ticker.mount();
+  tickerState.instance = instance;
+  instance.mount();
 });
 
 onBeforeUnmount(() => {
-  ticker?.unmount();
-  ticker = null;
+  tickerState.instance?.unmount();
+  tickerState.instance = null;
 });
 
 const view = computed(() =>

--- a/packages/vue/src/components/VizelThemeProvider.vue
+++ b/packages/vue/src/components/VizelThemeProvider.vue
@@ -49,17 +49,20 @@ const themeState: VizelThemeState = {
 
 provide(VIZEL_THEME_CONTEXT_KEY, themeState);
 
-let themeListener: ReturnType<typeof createVizelSystemThemeListener> | null = null;
+const listenerState: { instance: ReturnType<typeof createVizelSystemThemeListener> | null } = {
+  instance: null,
+};
 
 onMounted(() => {
   // Apply initial theme
   applyVizelTheme(resolvedTheme.value, props.targetSelector, props.disableTransitionOnChange);
 
   // Listen for system theme changes
-  themeListener = createVizelSystemThemeListener((newSystemTheme) => {
+  const instance = createVizelSystemThemeListener((newSystemTheme) => {
     systemTheme.value = newSystemTheme;
   });
-  themeListener.mount();
+  listenerState.instance = instance;
+  instance.mount();
 });
 
 // Re-apply the theme whenever ANY input changes: the resolved theme,
@@ -75,8 +78,8 @@ watch(
 );
 
 onBeforeUnmount(() => {
-  themeListener?.unmount();
-  themeListener = null;
+  listenerState.instance?.unmount();
+  listenerState.instance = null;
 });
 </script>
 

--- a/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelMentionMenuRenderer.ts
@@ -38,8 +38,10 @@ export function createVizelMentionMenuRenderer(
 ): Partial<SuggestionOptions<VizelMentionItem>> {
   return {
     render: () => {
-      let app: App | null = null;
-      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
+      const renderState: {
+        app: App | null;
+        suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null;
+      } = { app: null, suggestionContainer: null };
       const componentRef = ref<VizelMentionMenuRef | null>(null);
       const items = ref<VizelMentionItem[]>([]);
       const commandFn = ref<((item: VizelMentionItem) => void) | null>(null);
@@ -49,9 +51,10 @@ export function createVizelMentionMenuRenderer(
           items.value = props.items;
           commandFn.value = props.command;
 
-          suggestionContainer = createVizelSuggestionContainer();
+          const suggestionContainer = createVizelSuggestionContainer();
+          renderState.suggestionContainer = suggestionContainer;
 
-          app = createApp({
+          const app = createApp({
             setup() {
               return () =>
                 h(VizelMentionMenu, {
@@ -64,6 +67,7 @@ export function createVizelMentionMenuRenderer(
                 });
             },
           });
+          renderState.app = app;
 
           app.mount(suggestionContainer.menuContainer);
           suggestionContainer.updatePosition(props.clientRect);
@@ -72,7 +76,7 @@ export function createVizelMentionMenuRenderer(
         onUpdate: (props: SuggestionProps<VizelMentionItem>) => {
           items.value = props.items;
           commandFn.value = props.command;
-          suggestionContainer?.updatePosition(props.clientRect);
+          renderState.suggestionContainer?.updatePosition(props.clientRect);
         },
 
         onKeyDown: (props: { event: KeyboardEvent }) => {
@@ -83,10 +87,10 @@ export function createVizelMentionMenuRenderer(
         },
 
         onExit: () => {
-          app?.unmount();
-          suggestionContainer?.destroy();
-          app = null;
-          suggestionContainer = null;
+          renderState.app?.unmount();
+          renderState.suggestionContainer?.destroy();
+          renderState.app = null;
+          renderState.suggestionContainer = null;
         },
       };
     },

--- a/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
+++ b/packages/vue/src/composables/createVizelSlashMenuRenderer.ts
@@ -38,8 +38,10 @@ export function createVizelSlashMenuRenderer(
 ): Partial<SuggestionOptions<VizelSlashCommandItem>> {
   return {
     render: () => {
-      let app: App | null = null;
-      let suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null = null;
+      const renderState: {
+        app: App | null;
+        suggestionContainer: ReturnType<typeof createVizelSuggestionContainer> | null;
+      } = { app: null, suggestionContainer: null };
       const componentRef = ref<VizelSlashMenuRef | null>(null);
       const items = ref<VizelSlashCommandItem[]>([]);
       const commandFn = ref<((item: VizelSlashCommandItem) => void) | null>(null);
@@ -49,9 +51,10 @@ export function createVizelSlashMenuRenderer(
           items.value = props.items;
           commandFn.value = props.command;
 
-          suggestionContainer = createVizelSuggestionContainer();
+          const suggestionContainer = createVizelSuggestionContainer();
+          renderState.suggestionContainer = suggestionContainer;
 
-          app = createApp({
+          const app = createApp({
             setup() {
               return () =>
                 h(VizelSlashMenu, {
@@ -64,6 +67,7 @@ export function createVizelSlashMenuRenderer(
                 });
             },
           });
+          renderState.app = app;
 
           app.mount(suggestionContainer.menuContainer);
           suggestionContainer.updatePosition(props.clientRect);
@@ -72,7 +76,7 @@ export function createVizelSlashMenuRenderer(
         onUpdate: (props: SuggestionProps<VizelSlashCommandItem>) => {
           items.value = props.items;
           commandFn.value = props.command;
-          suggestionContainer?.updatePosition(props.clientRect);
+          renderState.suggestionContainer?.updatePosition(props.clientRect);
         },
 
         onKeyDown: (props: { event: KeyboardEvent }) => {
@@ -83,10 +87,10 @@ export function createVizelSlashMenuRenderer(
         },
 
         onExit: () => {
-          app?.unmount();
-          suggestionContainer?.destroy();
-          app = null;
-          suggestionContainer = null;
+          renderState.app?.unmount();
+          renderState.suggestionContainer?.destroy();
+          renderState.app = null;
+          renderState.suggestionContainer = null;
         },
       };
     },

--- a/packages/vue/src/composables/useVizelAutoSave.ts
+++ b/packages/vue/src/composables/useVizelAutoSave.ts
@@ -69,8 +69,10 @@ export function useVizelAutoSave(
     error: null,
   });
 
-  let currentEditor: Editor | null = null;
-  let handlers: ReturnType<typeof createVizelAutoSaveHandlers> | null = null;
+  const subscriptionState: {
+    currentEditor: Editor | null;
+    handlers: ReturnType<typeof createVizelAutoSaveHandlers> | null;
+  } = { currentEditor: null, handlers: null };
 
   const handleStateChange = (partial: Partial<VizelAutoSaveState>) => {
     if (partial.status !== undefined) state.status = partial.status;
@@ -84,21 +86,25 @@ export function useVizelAutoSave(
     const editor = getEditor();
 
     // Unsubscribe from previous editor
-    if (currentEditor && handlers) {
-      currentEditor.off("update", handlers.handleUpdate);
-      handlers.cancel();
+    if (subscriptionState.currentEditor && subscriptionState.handlers) {
+      subscriptionState.currentEditor.off("update", subscriptionState.handlers.handleUpdate);
+      subscriptionState.handlers.cancel();
     }
 
-    currentEditor = editor ?? null;
+    subscriptionState.currentEditor = editor ?? null;
 
-    if (!(currentEditor && opts.enabled)) {
-      handlers = null;
+    if (!(subscriptionState.currentEditor && opts.enabled)) {
+      subscriptionState.handlers = null;
       return;
     }
 
-    handlers = createVizelAutoSaveHandlers(() => currentEditor, opts, handleStateChange);
+    subscriptionState.handlers = createVizelAutoSaveHandlers(
+      () => subscriptionState.currentEditor,
+      opts,
+      handleStateChange
+    );
 
-    currentEditor.on("update", handlers.handleUpdate);
+    subscriptionState.currentEditor.on("update", subscriptionState.handlers.handleUpdate);
   };
 
   // Single setup path: a `watch` with `immediate: true` fires once on mount
@@ -115,18 +121,18 @@ export function useVizelAutoSave(
   );
 
   onBeforeUnmount(() => {
-    if (currentEditor && handlers) {
-      currentEditor.off("update", handlers.handleUpdate);
-      handlers.cancel();
+    if (subscriptionState.currentEditor && subscriptionState.handlers) {
+      subscriptionState.currentEditor.off("update", subscriptionState.handlers.handleUpdate);
+      subscriptionState.handlers.cancel();
     }
   });
 
   async function save(): Promise<void> {
-    await handlers?.saveNow();
+    await subscriptionState.handlers?.saveNow();
   }
 
   async function restore(): Promise<JSONContent | null> {
-    return (await handlers?.restore()) ?? null;
+    return (await subscriptionState.handlers?.restore()) ?? null;
   }
 
   return {

--- a/packages/vue/src/composables/useVizelCollaboration.ts
+++ b/packages/vue/src/composables/useVizelCollaboration.ts
@@ -85,8 +85,10 @@ export function useVizelCollaboration(
     error: null,
   });
 
-  let handlers: ReturnType<typeof createVizelCollaborationHandlers> | null = null;
-  let unsubscribe: (() => void) | null = null;
+  const collaborationState: {
+    handlers: ReturnType<typeof createVizelCollaborationHandlers> | null;
+    unsubscribe: (() => void) | null;
+  } = { handlers: null, unsubscribe: null };
 
   function handleStateChange(partial: Partial<VizelCollaborationState>) {
     if (partial.isConnected !== undefined) state.isConnected = partial.isConnected;
@@ -97,17 +99,21 @@ export function useVizelCollaboration(
 
   function setup() {
     cleanup();
-    handlers = createVizelCollaborationHandlers(getProvider, options, handleStateChange);
+    collaborationState.handlers = createVizelCollaborationHandlers(
+      getProvider,
+      options,
+      handleStateChange
+    );
     const provider = getProvider();
     if (provider && enabled) {
-      unsubscribe = handlers.subscribe();
+      collaborationState.unsubscribe = collaborationState.handlers.subscribe();
     }
   }
 
   function cleanup() {
-    unsubscribe?.();
-    unsubscribe = null;
-    handlers = null;
+    collaborationState.unsubscribe?.();
+    collaborationState.unsubscribe = null;
+    collaborationState.handlers = null;
   }
 
   // Single setup path: a `watch` with `immediate: true` fires once on mount
@@ -132,8 +138,8 @@ export function useVizelCollaboration(
     isSynced: computed(() => state.isSynced),
     peerCount: computed(() => state.peerCount),
     error: computed(() => state.error),
-    connect: () => handlers?.connect(),
-    disconnect: () => handlers?.disconnect(),
-    updateUser: (user) => handlers?.updateUser(user),
+    connect: () => collaborationState.handlers?.connect(),
+    disconnect: () => collaborationState.handlers?.disconnect(),
+    updateUser: (user) => collaborationState.handlers?.updateUser(user),
   };
 }

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -69,7 +69,7 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
   const editor = shallowRef<Editor | null>(null);
 
   // Handle vizel:upload-image custom event from slash command
-  let cleanupHandler: (() => void) | null = null;
+  const cleanup: { handler: (() => void) | null } = { handler: null };
 
   onMounted(() => {
     // Run async editor creation inside an IIFE so a throw becomes a quiet
@@ -87,7 +87,7 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
 
         editor.value = result.editor;
 
-        cleanupHandler = registerVizelUploadEventHandler({
+        cleanup.handler = registerVizelUploadEventHandler({
           getEditor: () => editor.value,
           getImageOptions: () => imageOptions,
         });
@@ -126,7 +126,7 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
   );
 
   onBeforeUnmount(() => {
-    cleanupHandler?.();
+    cleanup.handler?.();
     editor.value?.destroy();
   });
 

--- a/packages/vue/src/composables/useVizelMarkdown.ts
+++ b/packages/vue/src/composables/useVizelMarkdown.ts
@@ -92,18 +92,19 @@ export function useVizelMarkdown(
   const markdown = shallowRef(initialValue ?? "");
   const pendingState = shallowRef(false);
 
-  // Create sync handlers
-  let handlers: VizelMarkdownSyncHandlers | null = null;
+  // Create sync handlers — held in a ref-object so the lazy initializer can
+  // memoize without a mutable let.
+  const handlersRef: { current: VizelMarkdownSyncHandlers | null } = { current: null };
 
   const initHandlers = (): VizelMarkdownSyncHandlers => {
-    if (!handlers) {
-      handlers = createVizelMarkdownSyncHandlers(syncOptions);
+    if (!handlersRef.current) {
+      handlersRef.current = createVizelMarkdownSyncHandlers(syncOptions);
     }
-    return handlers;
+    return handlersRef.current;
   };
 
-  // Track if initial value has been set
-  let initialSet = false;
+  // Track if initial value has been set across watcher re-runs.
+  const initFlag = { value: false };
 
   // Watch for editor availability
   watch(
@@ -114,7 +115,7 @@ export function useVizelMarkdown(
       const h = initHandlers();
 
       // Initial value setup (only once)
-      if (!initialSet) {
+      if (!initFlag.value) {
         if (initialValue === undefined) {
           // Get initial markdown from editor
           markdown.value = getVizelMarkdown(editor);
@@ -122,30 +123,30 @@ export function useVizelMarkdown(
           h.setMarkdown(editor, initialValue);
           markdown.value = initialValue;
         }
-        initialSet = true;
+        initFlag.value = true;
       }
 
       // Subscribe to editor updates (every time editor changes)
-      let rafId: number | null = null;
+      const rafState: { id: number | null } = { id: null };
 
       const handleUpdate = () => {
         h.handleUpdate(editor);
         pendingState.value = h.isPending();
 
         // Cancel any pending rAF before scheduling a new one
-        if (rafId !== null) cancelAnimationFrame(rafId);
+        if (rafState.id !== null) cancelAnimationFrame(rafState.id);
 
         // Schedule state update after debounce
         const checkPending = () => {
           if (h.isPending()) {
-            rafId = requestAnimationFrame(checkPending);
+            rafState.id = requestAnimationFrame(checkPending);
           } else {
-            rafId = null;
+            rafState.id = null;
             markdown.value = h.getMarkdown();
             pendingState.value = false;
           }
         };
-        rafId = requestAnimationFrame(checkPending);
+        rafState.id = requestAnimationFrame(checkPending);
       };
 
       editor.on("update", handleUpdate);
@@ -160,7 +161,7 @@ export function useVizelMarkdown(
           pendingState.value = false;
         }
         editor.off("update", handleUpdate);
-        if (rafId !== null) cancelAnimationFrame(rafId);
+        if (rafState.id !== null) cancelAnimationFrame(rafState.id);
       });
     },
     { immediate: true }
@@ -168,7 +169,7 @@ export function useVizelMarkdown(
 
   // Cleanup on unmount
   onBeforeUnmount(() => {
-    handlers?.destroy();
+    handlersRef.current?.destroy();
   });
 
   const setMarkdown = (newMarkdown: string) => {

--- a/packages/vue/src/composables/useVizelState.ts
+++ b/packages/vue/src/composables/useVizelState.ts
@@ -29,18 +29,18 @@ export function useVizelState(getEditor: () => Editor | null | undefined): Compu
   // mutate the tick from the outside. The shape mirrors the React hook's
   // `number` return and the Svelte rune's `{ readonly version }` getter.
   const updateCount = ref(0);
-  let unsubscribe: (() => void) | null = null;
+  const subscription: { unsubscribe: (() => void) | null } = { unsubscribe: null };
 
   watch(
     getEditor,
     (editor) => {
-      unsubscribe?.();
+      subscription.unsubscribe?.();
       if (!editor) {
-        unsubscribe = null;
+        subscription.unsubscribe = null;
         return;
       }
       const store = createVizelEditorTransactionStore(() => editor);
-      unsubscribe = store.subscribe(() => {
+      subscription.unsubscribe = store.subscribe(() => {
         updateCount.value = store.getVersion();
       });
     },
@@ -48,8 +48,8 @@ export function useVizelState(getEditor: () => Editor | null | undefined): Compu
   );
 
   onBeforeUnmount(() => {
-    unsubscribe?.();
-    unsubscribe = null;
+    subscription.unsubscribe?.();
+    subscription.unsubscribe = null;
   });
 
   return computed(() => updateCount.value);

--- a/packages/vue/src/composables/useVizelVersionHistory.ts
+++ b/packages/vue/src/composables/useVizelVersionHistory.ts
@@ -65,7 +65,9 @@ export function useVizelVersionHistory(
     error: null,
   });
 
-  let handlers: ReturnType<typeof createVizelVersionHistoryHandlers> | null = null;
+  const handlerRef: { handlers: ReturnType<typeof createVizelVersionHistoryHandlers> | null } = {
+    handlers: null,
+  };
 
   function handleStateChange(partial: Partial<VizelVersionHistoryState>) {
     if (partial.snapshots !== undefined) state.snapshots = partial.snapshots;
@@ -74,7 +76,8 @@ export function useVizelVersionHistory(
   }
 
   function setup() {
-    handlers = createVizelVersionHistoryHandlers(getEditor, opts, handleStateChange);
+    const handlers = createVizelVersionHistoryHandlers(getEditor, opts, handleStateChange);
+    handlerRef.handlers = handlers;
     const editor = getEditor();
     if (editor && opts.enabled) {
       void handlers.loadVersions();
@@ -95,30 +98,30 @@ export function useVizelVersionHistory(
   );
 
   onBeforeUnmount(() => {
-    handlers = null;
+    handlerRef.handlers = null;
   });
 
   async function saveVersion(
     description?: string,
     author?: string
   ): Promise<VizelVersionSnapshot | null> {
-    return (await handlers?.saveVersion(description, author)) ?? null;
+    return (await handlerRef.handlers?.saveVersion(description, author)) ?? null;
   }
 
   async function restoreVersion(versionId: string): Promise<boolean> {
-    return (await handlers?.restoreVersion(versionId)) ?? false;
+    return (await handlerRef.handlers?.restoreVersion(versionId)) ?? false;
   }
 
   async function loadVersions(): Promise<VizelVersionSnapshot[]> {
-    return (await handlers?.loadVersions()) ?? [];
+    return (await handlerRef.handlers?.loadVersions()) ?? [];
   }
 
   async function deleteVersion(versionId: string): Promise<void> {
-    await handlers?.deleteVersion(versionId);
+    await handlerRef.handlers?.deleteVersion(versionId);
   }
 
   async function clearVersions(): Promise<void> {
-    await handlers?.clearVersions();
+    await handlerRef.handlers?.clearVersions();
   }
 
   return {

--- a/scripts/check-no-let.ts
+++ b/scripts/check-no-let.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env tsx
+/**
+ * `let` enforcement — scans the project's TypeScript surface and fails
+ * if any source file declares a mutable `let` binding. Vizel's source
+ * is immutability-first; every reassignable counter, accumulator, or
+ * timer handle lives inside a typed state object so the file scope
+ * never needs `let`.
+ *
+ * Scope:
+ *
+ * - `packages/core/src/**\/*.ts`
+ * - `packages/react/src/**\/*.{ts,tsx}`
+ * - `packages/vue/src/**\/*.{ts,vue}` (script blocks only)
+ * - `scripts/**\/*.ts`
+ * - `tests/ct/scenarios/**\/*.ts`
+ * - `tests/ct/react/specs/**\/*.{ts,tsx}`
+ * - `tests/ct/vue/specs/**\/*.{ts,vue}` (script blocks only)
+ * - `apps/demo/{react,vue}/src/**\/*.{ts,tsx,vue}` (script blocks only)
+ *
+ * Excluded:
+ *
+ * - Svelte components and runes (`*.svelte`, `*.svelte.ts`) because
+ *   Svelte's reactivity model intentionally relies on `let` bindings.
+ * - Build artifacts (`node_modules/`, `dist/`, `.svelte-kit/`,
+ *   `.vite/`, `.cache/`) and any TypeScript declaration file (`*.d.ts`).
+ *
+ * Escape hatch:
+ *
+ * Add a `// biome-ignore lint/style/noLet: <reason>` comment on the
+ * preceding line (or the same line) to opt the binding out — the
+ * `<reason>` text is required and is surfaced in code review.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleFile = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(moduleFile), "..");
+
+interface ScanRoot {
+  readonly root: string;
+  readonly extensions: ReadonlyArray<".ts" | ".tsx" | ".vue">;
+}
+
+const SCAN_ROOTS: readonly ScanRoot[] = [
+  { root: "packages/core/src", extensions: [".ts"] },
+  { root: "packages/react/src", extensions: [".ts", ".tsx"] },
+  { root: "packages/vue/src", extensions: [".ts", ".vue"] },
+  { root: "scripts", extensions: [".ts"] },
+  { root: "tests/ct/scenarios", extensions: [".ts"] },
+  { root: "tests/ct/react/specs", extensions: [".ts", ".tsx"] },
+  { root: "tests/ct/vue/specs", extensions: [".ts", ".vue"] },
+  { root: "apps/demo/react/src", extensions: [".ts", ".tsx"] },
+  { root: "apps/demo/vue/src", extensions: [".ts", ".vue"] },
+];
+
+const EXCLUDED_DIR_NAMES = new Set(["node_modules", "dist", ".svelte-kit", ".vite", ".cache"]);
+
+interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly snippet: string;
+}
+
+function isExcludedFile(name: string): boolean {
+  // Svelte components and rune files are excluded; their reactivity
+  // contract requires `let` bindings.
+  if (name.endsWith(".svelte")) return true;
+  if (name.endsWith(".svelte.ts")) return true;
+  if (name.endsWith(".d.ts")) return true;
+  return false;
+}
+
+function collectFiles(
+  dir: string,
+  extensions: ReadonlyArray<".ts" | ".tsx" | ".vue">,
+  out: string[]
+): void {
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_DIR_NAMES.has(entry)) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      collectFiles(full, extensions, out);
+      continue;
+    }
+    if (isExcludedFile(entry)) continue;
+    if (extensions.some((ext) => entry.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Extract the TypeScript regions of a source string. Pure `.ts`/`.tsx`
+ * files return the full source as a single region; `.vue` files return
+ * each `<script ...>` body individually with its original line offset
+ * preserved.
+ */
+function extractTypescriptRegions(
+  file: string,
+  source: string
+): ReadonlyArray<{ readonly text: string; readonly lineOffset: number }> {
+  if (!file.endsWith(".vue")) {
+    return [{ text: source, lineOffset: 0 }];
+  }
+  const regions: { text: string; lineOffset: number }[] = [];
+  const pattern = /<script\b[^>]*>([\s\S]*?)<\/script>/g;
+  const matches = [...source.matchAll(pattern)];
+  for (const match of matches) {
+    const body = match[1] ?? "";
+    const preceding = source.slice(0, match.index ?? 0);
+    const lineOffset = preceding.split("\n").length - 1 + 1;
+    regions.push({ text: body, lineOffset });
+  }
+  return regions;
+}
+
+const LET_PATTERN = /^\s*let\s/;
+const IGNORE_PATTERN = /biome-ignore\s+lint\/style\/noLet\s*:/;
+
+function findRegionViolations(file: string, text: string, lineOffset: number): Violation[] {
+  const lines = text.split("\n");
+  return lines.flatMap((line, idx) => {
+    if (!LET_PATTERN.test(line)) return [];
+    // Same-line ignore comment.
+    if (IGNORE_PATTERN.test(line)) return [];
+    // Preceding-line ignore comment.
+    const previous = lines[idx - 1] ?? "";
+    if (IGNORE_PATTERN.test(previous)) return [];
+    return [
+      {
+        file,
+        line: lineOffset + idx + 1,
+        snippet: line.trim(),
+      },
+    ];
+  });
+}
+
+function findFileViolations(file: string, source: string): Violation[] {
+  const regions = extractTypescriptRegions(file, source);
+  return regions.flatMap((region) => findRegionViolations(file, region.text, region.lineOffset));
+}
+
+function main(): void {
+  const files: string[] = [];
+  for (const { root, extensions } of SCAN_ROOTS) {
+    const abs = join(REPO_ROOT, root);
+    try {
+      statSync(abs);
+    } catch {
+      continue;
+    }
+    collectFiles(abs, extensions, files);
+  }
+
+  const violations = files.flatMap((file) => {
+    const source = readFileSync(file, "utf8");
+    return findFileViolations(file, source);
+  });
+
+  if (violations.length === 0) {
+    process.stdout.write("No-let check passed.\n");
+    process.exit(0);
+  }
+
+  const plural = violations.length === 1 ? "" : "s";
+  process.stderr.write(`No-let check failed (${violations.length} violation${plural}):\n`);
+  for (const v of violations) {
+    const rel = relative(REPO_ROOT, v.file);
+    process.stderr.write(`  ${rel}:${v.line}\n    ${v.snippet}\n`);
+  }
+  process.stderr.write(
+    "\nVizel's TypeScript surface is immutability-first; use a typed state\n" +
+      "object or a functional rewrite instead of `let`. To allow a specific\n" +
+      "binding, add `// biome-ignore lint/style/noLet: <reason>` immediately\n" +
+      "above it.\n"
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-ssr-safety.ts
+++ b/scripts/check-ssr-safety.ts
@@ -60,66 +60,95 @@ function collectFiles(dir: string, out: string[]): void {
  * Depth 0 is module scope; any positive depth is inside a function /
  * class / block. References at depth > 0 are permitted.
  */
-function findModuleScopeViolations(file: string, source: string): Violation[] {
-  const lines = source.split("\n");
-  const violations: Violation[] = [];
-  let depth = 0;
-  let inBlockComment = false;
-  let inLineComment = false;
-  let inString: '"' | "'" | "`" | null = null;
-  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
-    const line = lines[lineIdx] ?? "";
-    inLineComment = false;
-    for (let col = 0; col < line.length; col++) {
-      const ch = line[col];
-      const next = line[col + 1];
-      if (inLineComment) break;
-      if (inBlockComment) {
-        if (ch === "*" && next === "/") {
-          inBlockComment = false;
-          col++;
-        }
-        continue;
-      }
-      if (inString) {
-        if (ch === "\\") {
-          col++;
-          continue;
-        }
-        if (ch === inString) {
-          inString = null;
-        }
-        continue;
-      }
-      if (ch === "/" && next === "/") {
-        inLineComment = true;
-        break;
-      }
-      if (ch === "/" && next === "*") {
-        inBlockComment = true;
-        col++;
-        continue;
-      }
-      if (ch === '"' || ch === "'" || ch === "`") {
-        inString = ch;
-        continue;
-      }
-      if (ch === "{") depth++;
-      else if (ch === "}") depth = Math.max(0, depth - 1);
+interface LexerState {
+  depth: number;
+  inBlockComment: boolean;
+  inString: '"' | "'" | "`" | null;
+}
+
+interface LineLexer {
+  inLineComment: boolean;
+  skipNext: boolean;
+}
+
+/**
+ * Apply a single character to the lexer state. Mutates `lexer` and
+ * `lineLexer` to reflect the new lexer state. Returns `true` when the
+ * caller should `break` out of the per-character loop (line-comment hit).
+ */
+function stepLexer(
+  ch: string | undefined,
+  next: string | undefined,
+  lexer: LexerState,
+  lineLexer: LineLexer
+): boolean {
+  if (lineLexer.skipNext) {
+    lineLexer.skipNext = false;
+    return false;
+  }
+  if (lineLexer.inLineComment) return true;
+  if (lexer.inBlockComment) {
+    if (ch === "*" && next === "/") {
+      lexer.inBlockComment = false;
+      lineLexer.skipNext = true;
     }
-    if (depth !== 0 || inBlockComment) continue;
-    for (const { pattern, label } of BANNED_PATTERNS) {
-      const match = pattern.exec(line);
-      if (!match) continue;
-      const column = (match.index ?? 0) + 1;
-      violations.push({
+    return false;
+  }
+  if (lexer.inString) {
+    if (ch === "\\") {
+      lineLexer.skipNext = true;
+      return false;
+    }
+    if (ch === lexer.inString) lexer.inString = null;
+    return false;
+  }
+  if (ch === "/" && next === "/") {
+    lineLexer.inLineComment = true;
+    return true;
+  }
+  if (ch === "/" && next === "*") {
+    lexer.inBlockComment = true;
+    lineLexer.skipNext = true;
+    return false;
+  }
+  if (ch === '"' || ch === "'" || ch === "`") {
+    lexer.inString = ch;
+    return false;
+  }
+  if (ch === "{") lexer.depth += 1;
+  else if (ch === "}") lexer.depth = Math.max(0, lexer.depth - 1);
+  return false;
+}
+
+function collectLineViolations(file: string, line: string, lineIdx: number): Violation[] {
+  return BANNED_PATTERNS.flatMap(({ pattern, label }) => {
+    const match = pattern.exec(line);
+    if (!match) return [];
+    return [
+      {
         file,
         line: lineIdx + 1,
-        column,
+        column: (match.index ?? 0) + 1,
         snippet: line.trim(),
         label,
-      });
+      },
+    ];
+  });
+}
+
+function findModuleScopeViolations(file: string, source: string): Violation[] {
+  const lexer: LexerState = { depth: 0, inBlockComment: false, inString: null };
+  const lines = source.split("\n");
+  const violations: Violation[] = [];
+
+  for (const [lineIdx, line] of lines.entries()) {
+    const lineLexer: LineLexer = { inLineComment: false, skipNext: false };
+    const chars = [...line];
+    for (const [col, ch] of chars.entries()) {
+      if (stepLexer(ch, line[col + 1], lexer, lineLexer)) break;
     }
+    if (lexer.depth !== 0 || lexer.inBlockComment) continue;
+    violations.push(...collectLineViolations(file, line, lineIdx));
   }
   return violations;
 }

--- a/tests/ct/scenarios/block-clipboard.scenario.ts
+++ b/tests/ct/scenarios/block-clipboard.scenario.ts
@@ -183,13 +183,13 @@ export async function testCutListItemPreservesNesting(
         };
       };
     };
-    let result = -1;
+    const matches: number[] = [];
     editor.state.doc.forEach((node, offset) => {
-      if (node.type.name === "paragraph" && result === -1) {
-        result = offset;
+      if (node.type.name === "paragraph" && matches.length === 0) {
+        matches.push(offset);
       }
     });
-    return result;
+    return matches[0] ?? -1;
   });
   if (trailingPos <= 0) throw new Error("Trailing paragraph not found");
 

--- a/tests/ct/scenarios/bubble-menu.scenario.ts
+++ b/tests/ct/scenarios/bubble-menu.scenario.ts
@@ -336,8 +336,7 @@ export async function testBubbleMenuTextColorReset(component: Locator, page: Pag
 
   // Verify color is applied
   const editor = component.locator(".vizel-editor");
-  let coloredText = editor.locator('span[style*="color"]');
-  await expect(coloredText).toContainText("Select this text");
+  await expect(editor.locator('span[style*="color"]')).toContainText("Select this text");
 
   // Re-select the text
   await page.keyboard.press("ControlOrMeta+a");
@@ -349,8 +348,7 @@ export async function testBubbleMenuTextColorReset(component: Locator, page: Pag
   await defaultSwatch.click();
 
   // Verify color is removed
-  coloredText = editor.locator('span[style*="color"]');
-  await expect(coloredText).toHaveCount(0);
+  await expect(editor.locator('span[style*="color"]')).toHaveCount(0);
 }
 
 /** Verify highlight can be removed */
@@ -368,8 +366,7 @@ export async function testBubbleMenuHighlightReset(component: Locator, page: Pag
 
   // Verify highlight is applied
   const editor = component.locator(".vizel-editor");
-  let highlightedText = editor.locator("mark");
-  await expect(highlightedText).toContainText("Select this text");
+  await expect(editor.locator("mark")).toContainText("Select this text");
 
   // Re-select the text
   await page.keyboard.press("ControlOrMeta+a");
@@ -381,8 +378,7 @@ export async function testBubbleMenuHighlightReset(component: Locator, page: Pag
   await transparentSwatch.click();
 
   // Verify highlight is removed
-  highlightedText = editor.locator("mark");
-  await expect(highlightedText).toHaveCount(0);
+  await expect(editor.locator("mark")).toHaveCount(0);
 }
 
 // Node Selector Tests

--- a/tests/ct/scenarios/save-indicator.scenario.ts
+++ b/tests/ct/scenarios/save-indicator.scenario.ts
@@ -13,29 +13,23 @@ export async function testSaveIndicatorStatuses(
   mount: (status: VizelSaveStatus) => Promise<Locator>,
   _page: Page
 ): Promise<void> {
-  // Test 'saved' status
-  let component = await mount("saved");
-  await expect(component).toBeVisible();
-  await expect(component).toHaveClass(/vizel-save-indicator--saved/);
-  await expect(component).toContainText("Saved");
+  const cases: ReadonlyArray<{
+    status: VizelSaveStatus;
+    classPattern: RegExp;
+    text: string;
+  }> = [
+    { status: "saved", classPattern: /vizel-save-indicator--saved/, text: "Saved" },
+    { status: "saving", classPattern: /vizel-save-indicator--saving/, text: "Saving" },
+    { status: "unsaved", classPattern: /vizel-save-indicator--unsaved/, text: "Unsaved" },
+    { status: "error", classPattern: /vizel-save-indicator--error/, text: "Error" },
+  ];
 
-  // Test 'saving' status
-  component = await mount("saving");
-  await expect(component).toBeVisible();
-  await expect(component).toHaveClass(/vizel-save-indicator--saving/);
-  await expect(component).toContainText("Saving");
-
-  // Test 'unsaved' status
-  component = await mount("unsaved");
-  await expect(component).toBeVisible();
-  await expect(component).toHaveClass(/vizel-save-indicator--unsaved/);
-  await expect(component).toContainText("Unsaved");
-
-  // Test 'error' status
-  component = await mount("error");
-  await expect(component).toBeVisible();
-  await expect(component).toHaveClass(/vizel-save-indicator--error/);
-  await expect(component).toContainText("Error");
+  for (const { status, classPattern, text } of cases) {
+    const component = await mount(status);
+    await expect(component).toBeVisible();
+    await expect(component).toHaveClass(classPattern);
+    await expect(component).toContainText(text);
+  }
 }
 
 /**

--- a/tests/ct/scenarios/slash-menu.scenario.ts
+++ b/tests/ct/scenarios/slash-menu.scenario.ts
@@ -239,17 +239,16 @@ export async function testSlashMenuTabNavigation(component: Locator, page: Page)
   await expect(slashMenu).toBeVisible();
 
   // First item should be selected (in Text group)
-  let selectedItem = slashMenu.locator("[data-selected='true']");
+  const selectedItem = slashMenu.locator("[data-selected='true']");
   await expect(selectedItem).toBeVisible();
   await expect(selectedItem).toContainText("Heading");
 
   // Press Tab to go to next group (Lists)
   await page.keyboard.press("Tab");
 
-  // Check that a different item is selected
-  selectedItem = slashMenu.locator("[data-selected='true']");
-  await expect(selectedItem).toBeVisible();
-  await expect(selectedItem).toContainText("Bullet List");
+  // The selected item now points at the first item of the next group.
+  await expect(slashMenu.locator("[data-selected='true']")).toBeVisible();
+  await expect(slashMenu.locator("[data-selected='true']")).toContainText("Bullet List");
 }
 
 /** Verify fuzzy search works with keywords */

--- a/tests/ct/scenarios/table-controls.scenario.ts
+++ b/tests/ct/scenarios/table-controls.scenario.ts
@@ -758,8 +758,7 @@ export async function testTextAlignmentLeftViaMenu(component: Locator, page: Pag
 
   // First, set center alignment
   await showColumnHandleAndClick(page, 0);
-  let menu = page.locator(TABLE_MENU_SELECTOR);
-  await menu.getByText("Align center").click();
+  await page.locator(TABLE_MENU_SELECTOR).getByText("Align center").click();
 
   // Verify center alignment was applied
   const firstHeaderCell = table.locator("th").first();
@@ -767,8 +766,7 @@ export async function testTextAlignmentLeftViaMenu(component: Locator, page: Pag
 
   // Now change to left alignment
   await showColumnHandleAndClick(page, 0);
-  menu = page.locator(TABLE_MENU_SELECTOR);
-  await menu.getByText("Align left").click();
+  await page.locator(TABLE_MENU_SELECTOR).getByText("Align left").click();
 
   // Verify left alignment was applied
   await expect(firstHeaderCell).toHaveCSS("text-align", "left");


### PR DESCRIPTION
## Summary

Immutability-first sweep — replace every `let` declaration in the TypeScript surface with `const` + functional patterns, and add a CI lint that enforces the policy going forward.

## Scope

| Package | Files |
|---------|-------|
| `@vizel/core` | 38 (utils 8, builders 3, controllers 6, extensions 13, plugins 1, commands 1, icons 1, auto-save/theme/comment/version-history 4, shared types 1) |
| `@vizel/react` | 6 (2 components + 4 hooks) |
| `@vizel/vue` | 14 (6 components + 8 composables) |
| scripts | 2 (`check-ssr-safety.ts` refactored + new `check-no-let.ts`) |
| `tests/ct/scenarios` | 5 |
| Config / docs | 3 (`package.json`, `lefthook.yml`, `.claude/rules/code-style.md`) |
| **Total** | **65 files** (1 new, 64 modified) |

Svelte components and runes are excluded — Svelte 5's reactivity model treats top-level `let` as the canonical reactivity primitive.

## Refactoring patterns

- Loop accumulators → `.reduce` / `.flatMap` / prefix-sum arrays (e.g. block / slash menu `globalIndex`).
- Reassignable timer / cache / handle bindings → `const ref: { current: T | null } = { current: null }` shape.
- `for (let i = ...)` reverse iteration → `[...arr].reverse().reduce(...)` (cleanly applies multiple ProseMirror transactions).
- Nested ternaries → extracted helper (`wrapPromptCommand`, `computeRawPosition`).
- ProseMirror plugin `apply` `let next` → extracted pure `applyFindReplaceMeta` reducer.
- `scripts/check-ssr-safety.ts` lexer extracted into `stepLexer` + `collectLineViolations` helpers (also drops the long-standing complexity warning).

## Enforcement wiring

- `scripts/check-no-let.ts` walks the in-scope directories listed above, skips `*.svelte` / `*.svelte.ts` / `*.d.ts` / `node_modules` / `dist` / `.svelte-kit` / `.vite` / `.cache`, parses `.vue` `<script>` blocks with original-line offsets, and accepts `// biome-ignore lint/style/noLet: <reason>` on preceding or same line.
- `package.json` exposes `"check:nolet": "tsx scripts/check-no-let.ts"`.
- `lefthook.yml`'s `pre-push` runs `nolet` in parallel with `lint`, `typecheck`, `parity`, `ssr`.
- `.claude/rules/code-style.md` gains an **Immutability** section: rationale, scope table, escape hatch with required `<reason>`, pointer at `pnpm check:nolet`.

## Notes

**No `biome-ignore lint/style/noLet` exceptions were needed** — every binding was rewritable as a typed state object, prefix-sum array, ternary, `.reduce`, or extracted helper. ProseMirror NodeView state and module-singleton caches are now expressed as `const state: { ... } = { ... }` ref objects (e.g. `viewState.isEditing` in `mathematics.ts` / `diagram.ts`, `lowlightRef.instance`, `graphvizState.{instance,initPromise}`, `iconRendererRef.current`, `fuseFactory.create`).

## Test Plan

- [x] `pnpm lint` — clean (4 pre-existing warnings unrelated to this PR; `popoverController` complexity warning eliminated).
- [x] `pnpm typecheck` — clean across core / react / vue / svelte.
- [x] `pnpm build` — clean.
- [x] `pnpm check:parity` — pass.
- [x] `pnpm check:ssr` — pass.
- [x] `pnpm check:nolet` (new) — pass.
- [x] `pnpm exec playwright test -c tests/ct/react/playwright-ct.config.ts --project=chromium` — 279 / 279 pass.
