### PR TITLE
build(core): ship CSS subpath exports for variables and components (audit Batch B)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,7 +45,8 @@ This package provides:
 | Import | Description |
 |--------|-------------|
 | `@vizel/core/styles.css` | Full stylesheet (CSS variables + component styles) |
-| `@vizel/core/components.css` | Component styles only (for shadcn/ui integration) |
+| `@vizel/core/styles/variables.css` | CSS variables / token catalog only |
+| `@vizel/core/styles/components.css` | Component styles only (no token catalog) |
 | `@vizel/core/mathematics.css` | KaTeX styles for math rendering |
 
 ## Extensions

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
       "default": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./components.css": "./dist/components.css",
+    "./styles/variables.css": "./dist/styles/variables.css",
+    "./styles/components.css": "./dist/styles/components.css",
     "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [
@@ -47,9 +48,10 @@
   ],
   "scripts": {
     "build": "vite build && npm run build:css",
-    "build:css": "npm run build:css:styles && npm run build:css:components && npm run build:css:mathematics",
+    "build:css": "npm run build:css:styles && npm run build:css:variables && npm run build:css:components && npm run build:css:mathematics",
     "build:css:styles": "sass --load-path=src/styles --load-path=node_modules src/styles/index.scss dist/styles.css --style=compressed",
-    "build:css:components": "sass --load-path=src/styles --load-path=node_modules src/styles/components.scss dist/components.css --style=compressed",
+    "build:css:variables": "sass --load-path=src/styles --load-path=node_modules src/styles/entries/variables.scss dist/styles/variables.css --style=compressed",
+    "build:css:components": "sass --load-path=src/styles --load-path=node_modules src/styles/entries/components.scss dist/styles/components.css --style=compressed",
     "build:css:mathematics": "sass --load-path=src/styles --load-path=node_modules src/styles/katex-entry.scss dist/mathematics.css --style=compressed",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/src/styles/entries/components.scss
+++ b/packages/core/src/styles/entries/components.scss
@@ -1,0 +1,13 @@
+/**
+ * Vizel component CSS entry (no token catalog).
+ *
+ * Outputs every component stylesheet without the `--vizel-*` token
+ * blocks. Use this entry when you map another design system's tokens
+ * onto Vizel's variable names:
+ *
+ * ```ts
+ * import "@vizel/core/styles/components.css";
+ * ```
+ */
+
+@use "../components";

--- a/packages/core/src/styles/entries/variables.scss
+++ b/packages/core/src/styles/entries/variables.scss
@@ -1,0 +1,14 @@
+/**
+ * Vizel CSS variables entry (tokens only).
+ *
+ * Outputs the `:root`, `[data-vizel-theme="light"]`, and
+ * `[data-vizel-theme="dark"]` blocks plus the
+ * `prefers-color-scheme: dark` fallback. Use this entry when you want
+ * Vizel's token catalog but ship your own component CSS:
+ *
+ * ```ts
+ * import "@vizel/core/styles/variables.css";
+ * ```
+ */
+
+@use "../variables";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,8 @@
       "import": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./components.css": "./dist/components.css",
+    "./styles/variables.css": "./dist/styles/variables.css",
+    "./styles/components.css": "./dist/styles/components.css",
     "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [

--- a/packages/react/scripts/copy-styles.mjs
+++ b/packages/react/scripts/copy-styles.mjs
@@ -3,10 +3,18 @@
  * Post-build step: copy core CSS bundles into this package's dist/.
  *
  * The CSS source lives in @vizel/core/src/styles/ and is built into
- * @vizel/core/dist/*.css. To let consumers write
- * `import "@vizel/react/styles.css"` instead of pulling from
- * @vizel/core directly, this script copies the built CSS into
- * @vizel/react/dist/ where the package.json subpath exports point.
+ * @vizel/core/dist/. To let consumers write
+ * `import "@vizel/react/styles.css"`, this script copies the built
+ * CSS into @vizel/react/dist/ where the package.json subpath exports
+ * point.
+ *
+ * Layout mirrors @vizel/core's three-pattern split (Section 6c / §13
+ * of the v2.0 design):
+ *
+ * - `dist/styles.css` — full bundle.
+ * - `dist/styles/variables.css` — token catalog only.
+ * - `dist/styles/components.css` — component styles only.
+ * - `dist/mathematics.css` — KaTeX stylesheet.
  */
 import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -16,15 +24,21 @@ const here = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(here, "../dist");
 const coreDistDir = resolve(here, "../../core/dist");
 
-const files = ["styles.css", "components.css", "mathematics.css"];
+const copies = [
+  { src: "styles.css", dest: "styles.css" },
+  { src: "styles/variables.css", dest: "styles/variables.css" },
+  { src: "styles/components.css", dest: "styles/components.css" },
+  { src: "mathematics.css", dest: "mathematics.css" },
+];
 
 await mkdir(distDir, { recursive: true });
+await mkdir(resolve(distDir, "styles"), { recursive: true });
 
 await Promise.all(
-  files.map(async (name) => {
-    const source = resolve(coreDistDir, name);
-    const target = resolve(distDir, name);
+  copies.map(async ({ src, dest }) => {
+    const source = resolve(coreDistDir, src);
+    const target = resolve(distDir, dest);
     await copyFile(source, target);
-    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+    console.log(`Copied ${src} from @vizel/core/dist/ to dist/${dest}`);
   })
 );

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -41,7 +41,8 @@
       "default": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./components.css": "./dist/components.css",
+    "./styles/variables.css": "./dist/styles/variables.css",
+    "./styles/components.css": "./dist/styles/components.css",
     "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [

--- a/packages/svelte/scripts/copy-styles.mjs
+++ b/packages/svelte/scripts/copy-styles.mjs
@@ -3,10 +3,18 @@
  * Post-build step: copy core CSS bundles into this package's dist/.
  *
  * The CSS source lives in @vizel/core/src/styles/ and is built into
- * @vizel/core/dist/*.css. To let consumers write
- * `import "@vizel/svelte/styles.css"` instead of pulling from
- * @vizel/core directly, this script copies the built CSS into
- * @vizel/svelte/dist/ where the package.json subpath exports point.
+ * @vizel/core/dist/. To let consumers write
+ * `import "@vizel/svelte/styles.css"`, this script copies the built
+ * CSS into @vizel/svelte/dist/ where the package.json subpath exports
+ * point.
+ *
+ * Layout mirrors @vizel/core's three-pattern split (Section 6c / §13
+ * of the v2.0 design):
+ *
+ * - `dist/styles.css` — full bundle.
+ * - `dist/styles/variables.css` — token catalog only.
+ * - `dist/styles/components.css` — component styles only.
+ * - `dist/mathematics.css` — KaTeX stylesheet.
  */
 import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -16,15 +24,21 @@ const here = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(here, "../dist");
 const coreDistDir = resolve(here, "../../core/dist");
 
-const files = ["styles.css", "components.css", "mathematics.css"];
+const copies = [
+  { src: "styles.css", dest: "styles.css" },
+  { src: "styles/variables.css", dest: "styles/variables.css" },
+  { src: "styles/components.css", dest: "styles/components.css" },
+  { src: "mathematics.css", dest: "mathematics.css" },
+];
 
 await mkdir(distDir, { recursive: true });
+await mkdir(resolve(distDir, "styles"), { recursive: true });
 
 await Promise.all(
-  files.map(async (name) => {
-    const source = resolve(coreDistDir, name);
-    const target = resolve(distDir, name);
+  copies.map(async ({ src, dest }) => {
+    const source = resolve(coreDistDir, src);
+    const target = resolve(distDir, dest);
     await copyFile(source, target);
-    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+    console.log(`Copied ${src} from @vizel/core/dist/ to dist/${dest}`);
   })
 );

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -38,7 +38,8 @@
       "import": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./components.css": "./dist/components.css",
+    "./styles/variables.css": "./dist/styles/variables.css",
+    "./styles/components.css": "./dist/styles/components.css",
     "./mathematics.css": "./dist/mathematics.css"
   },
   "files": [

--- a/packages/vue/scripts/copy-styles.mjs
+++ b/packages/vue/scripts/copy-styles.mjs
@@ -3,10 +3,17 @@
  * Post-build step: copy core CSS bundles into this package's dist/.
  *
  * The CSS source lives in @vizel/core/src/styles/ and is built into
- * @vizel/core/dist/*.css. To let consumers write
- * `import "@vizel/vue/styles.css"` instead of pulling from
- * @vizel/core directly, this script copies the built CSS into
- * @vizel/vue/dist/ where the package.json subpath exports point.
+ * @vizel/core/dist/. To let consumers write
+ * `import "@vizel/vue/styles.css"`, this script copies the built CSS
+ * into @vizel/vue/dist/ where the package.json subpath exports point.
+ *
+ * Layout mirrors @vizel/core's three-pattern split (Section 6c / §13
+ * of the v2.0 design):
+ *
+ * - `dist/styles.css` — full bundle.
+ * - `dist/styles/variables.css` — token catalog only.
+ * - `dist/styles/components.css` — component styles only.
+ * - `dist/mathematics.css` — KaTeX stylesheet.
  */
 import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -16,15 +23,21 @@ const here = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(here, "../dist");
 const coreDistDir = resolve(here, "../../core/dist");
 
-const files = ["styles.css", "components.css", "mathematics.css"];
+const copies = [
+  { src: "styles.css", dest: "styles.css" },
+  { src: "styles/variables.css", dest: "styles/variables.css" },
+  { src: "styles/components.css", dest: "styles/components.css" },
+  { src: "mathematics.css", dest: "mathematics.css" },
+];
 
 await mkdir(distDir, { recursive: true });
+await mkdir(resolve(distDir, "styles"), { recursive: true });
 
 await Promise.all(
-  files.map(async (name) => {
-    const source = resolve(coreDistDir, name);
-    const target = resolve(distDir, name);
+  copies.map(async ({ src, dest }) => {
+    const source = resolve(coreDistDir, src);
+    const target = resolve(distDir, dest);
     await copyFile(source, target);
-    console.log(`Copied ${name} from @vizel/core/dist/ to dist/`);
+    console.log(`Copied ${src} from @vizel/core/dist/ to dist/${dest}`);
   })
 );


### PR DESCRIPTION
## Summary

Audit fix Batch B — spec §6 / §13 promise three CSS import patterns (full bundle, variables-only, components-only). The previous build only emitted `dist/styles.css` and `dist/components.css`; the variables-only entry was missing entirely and the export paths did not match the documented `@vizel/core/styles/variables.css` / `@vizel/core/styles/components.css` URLs.

- New SCSS entries at `packages/core/src/styles/entries/{variables,components}.scss` re-export the existing `_variables.scss` and `components.scss` partials. They land at `dist/styles/variables.css` and `dist/styles/components.css` to match the spec subpath.
- `packages/core/package.json` adds matching `exports` entries and appends `build:css:variables` to the build pipeline.
- Framework `copy-styles.mjs` scripts (React / Vue / Svelte) mirror the new layout into each adapter's `dist/styles/`. Subpath exports on the framework `package.json`s point at the copied files.
- `packages/core/README.md` lists the new entries; the obsolete `/components.css` row is replaced by the `/styles/components.css` + `/styles/variables.css` pair.

## Breaking Changes

`@vizel/<framework>/components.css` no longer resolves. Consumers that imported that path move to `@vizel/<framework>/styles/components.css` (token-free) or `@vizel/<framework>/styles.css` (full bundle).

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build` — emits `dist/styles/{variables,components}.css` in core + every framework package.
- [x] `pnpm check:parity`.
- [x] `pnpm check:ssr`.
- [x] `pnpm check:nolet`.
