### PR TITLE
fix(svelte): align onclose casing and getVizelContextSafe null return (audit Batch I)

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -187,7 +187,7 @@ frameworks. The only divergence is the children form.
 | `editor` | `Editor \| null` | `Editor \| null` | `Editor \| null` |
 | Class prop | `className?: string` | `class?: string` | `class?: string` |
 | `locale` | `VizelLocale` | `VizelLocale` | `VizelLocale` |
-| Close callback | `onClose?: () => void` | (emit `close`) | `onClose?: () => void` |
+| Close callback | `onClose?: () => void` | (emit `close`) | `onclose?: () => void` |
 
 #### `VizelMinimap`
 
@@ -322,7 +322,8 @@ host framework's idiom. Differences outside this catalog are defects.
 | Hook return type | bare value | `Ref` / `ShallowRef` / `ComputedRef` | `{ readonly current }` | See Return Type Table (Table 4) |
 | Class prop name | `className` | `class` | `class` | Each framework's HTML attribute convention |
 | Children / slot | `children: ReactNode` | `<slot />` / `default` slot | `Snippet` | Each framework's children convention |
-| Imperative ref | `forwardRef` + `useImperativeHandle` | `defineExpose` + template ref | mutable ref prop | Each framework's ref convention |
+| Imperative ref | `ref` prop + `useImperativeHandle` | `defineExpose` + template ref | mutable ref prop | Each framework's ref convention (React 19 treats `ref` as a regular prop — no `forwardRef`) |
+| Hook scalar field | semantic name (`theme`, `markdown`, `editor`) | semantic name (`theme`, `markdown`, `editor`) | rune-getter `current` | Svelte runes expose a single getter (`{ readonly current }`); React / Vue keep the semantic name so destructuring `{ theme }` / `{ markdown }` reads naturally |
 | Event handler prop | `onUpdate` | `onUpdate` | `onUpdate` | All frameworks unify on the `on*` callback prop |
 
 ## Supporting Conventions
@@ -374,7 +375,7 @@ binding form differs to honor each framework's reactivity model.
 
 | React | Vue | Svelte |
 |-------|-----|--------|
-| `Editor \| null` (`useVizelContext()` throws outside a provider; `useVizelContextSafe()` returns `null` both outside a provider and while the provider's editor is still `null`) | `ShallowRef<Editor \| null>` (both `useVizelContext()` and `useVizelContextSafe()`; the safe variant returns `null` outside a provider) | `{ get current(): Editor \| null }` |
+| `Editor \| null` (`useVizelContext()` throws outside a provider; `useVizelContextSafe()` returns `null` both outside a provider and while the provider's editor is still `null`) | `ShallowRef<Editor \| null>` (both `useVizelContext()` and `useVizelContextSafe()`; the safe variant returns `null` outside a provider) | `{ readonly current: Editor \| null }` (`getVizelContext()` throws outside a provider; `getVizelContextSafe()` returns `null` outside a provider) |
 
 ### Context API Equivalence
 

--- a/packages/svelte/src/components/VizelContext.ts
+++ b/packages/svelte/src/components/VizelContext.ts
@@ -46,11 +46,15 @@ export function getVizelContext(): VizelContextAccessor {
 /**
  * Get the editor instance accessor from context.
  *
- * Returns `undefined` when called outside of `VizelProvider` (does not
+ * Returns `null` when called outside of `VizelProvider` (does not
  * throw). Mirrors {@link getVizelContext} but is non-throwing so optional
  * consumers (e.g. components that work both inside and outside a provider)
  * can fall back gracefully.
+ *
+ * The `null` sentinel matches the React / Vue equivalents
+ * (`useVizelContextSafe`) — every framework returns `null` when no
+ * provider is present.
  */
-export function getVizelContextSafe(): VizelContextAccessor | undefined {
-  return getContext<VizelContextAccessor | undefined>(VIZEL_CONTEXT_KEY);
+export function getVizelContextSafe(): VizelContextAccessor | null {
+  return getContext<VizelContextAccessor | undefined>(VIZEL_CONTEXT_KEY) ?? null;
 }

--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -9,7 +9,7 @@ export interface VizelFindReplaceProps {
   /** Locale for translated UI strings */
   locale?: VizelLocale;
   /** Callback when the panel is closed */
-  onClose?: () => void;
+  onclose?: () => void;
 }
 </script>
 
@@ -22,7 +22,7 @@ import {
 } from "@vizel/core";
 import { tick } from "svelte";
 
-let { editor, class: className, locale, onClose }: VizelFindReplaceProps = $props();
+let { editor, class: className, locale, onclose }: VizelFindReplaceProps = $props();
 const labels = $derived(resolveVizelFindReplaceLabels(locale?.findReplace));
 
 // Empty state for initial value
@@ -105,7 +105,7 @@ function handleClose() {
   findText = "";
   replaceText = "";
   editor?.view.dom.focus();
-  onClose?.();
+  onclose?.();
 }
 
 function handleCaseSensitiveChange(e: Event) {

--- a/packages/svelte/src/runes/getVizelTheme.ts
+++ b/packages/svelte/src/runes/getVizelTheme.ts
@@ -5,11 +5,17 @@ import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
 /**
  * Public return shape for `getVizelTheme`.
  *
- * The flat `{ current, setTheme }` shape mirrors the React hook and Vue
- * composable. `current` is the currently applied (resolved) theme so a
- * toggle is a one-liner. `setTheme` accepts only concrete
- * `VizelResolvedTheme` values because entering "system" mode is the
- * provider's `defaultTheme` concern, not a runtime toggle.
+ * The flat `{ current, setTheme }` shape parallels the React hook's
+ * `{ theme, setTheme }` and the Vue composable's
+ * `{ theme: ComputedRef<…>, setTheme }`. The scalar field is renamed
+ * to `current` here so it lines up with every other Svelte rune
+ * accessor (`editor.current`, `state.current`, etc.) — the rename is
+ * documented as Table 6's "Hook scalar field" idiom exception in
+ * `.claude/rules/cross-framework.md`. `current` is the currently
+ * applied (resolved) theme so a toggle is a one-liner. `setTheme`
+ * accepts only concrete `VizelResolvedTheme` values because entering
+ * "system" mode is the provider's `defaultTheme` concern, not a
+ * runtime toggle.
  */
 export interface GetVizelThemeResult {
   /** Currently applied theme (resolved from the user's preference). */


### PR DESCRIPTION
## Summary

Audit fix Batch I — framework-idiom polish from the deep audit subagent's findings.

- `packages/svelte/src/components/VizelFindReplace.svelte` renames the `onClose` prop to `onclose`. Sibling `VizelLinkEditor.svelte` already used `onclose`; the cross-framework Event Payload Table enumerates `onclose` as the Svelte convention.
- `packages/svelte/src/components/VizelContext.ts` changes `getVizelContextSafe` to return `VizelContextAccessor | null` (was `... | undefined`). React and Vue equivalents already return `null`; the safe-variant null sentinel is consistent across all three frameworks now.
- `.claude/rules/cross-framework.md`:
  - Table 3 row for `VizelFindReplace.onClose` flips to `onclose` on the Svelte column to match the implementation and Table 5.
  - Table 6 "Imperative ref" row drops the obsolete `forwardRef` reference (React 19 treats `ref` as a regular prop) and points at the prop-with-`useImperativeHandle` shape that `packages/react.md` already mandates.
  - Table 6 gains a "Hook scalar field" idiom exception documenting the React/Vue `theme` / `markdown` ↔ Svelte `current` rename. Future audits will recognise the rename as a documented exception rather than a defect.
  - Context Consumer Return Shape clarifies the Svelte `null` sentinel emitted by `getVizelContextSafe`.
- `packages/svelte/src/runes/getVizelTheme.ts` JSDoc no longer claims the shape "mirrors" React/Vue. The rune accessor convention is spelled out together with a pointer at the new Table 6 entry.

## Breaking Changes

Consumers of `<VizelFindReplace>` in Svelte that wired `onClose={...}` switch to `onclose={...}` (DOM-attribute lowercase convention, matching `<VizelLinkEditor>` and every other Svelte component).

Consumers that destructured `getVizelContextSafe()`'s result as `undefined` now see `null`. The check pattern `if (!result)` keeps working for both.

## Test Plan

- [x] `pnpm lint`.
- [x] `pnpm typecheck`.
- [x] `pnpm build`.
- [x] `pnpm check:parity`.
- [x] `pnpm check:ssr`.
- [x] `pnpm check:nolet`.
