### PR TITLE
feat(core): add markdown encoding modes for embed and wikiLink (audit Batch E)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ct:react:coverage": "c8 playwright test -c tests/ct/react/playwright-ct.config.ts",
     "test:ct:vue:coverage": "c8 playwright test -c tests/ct/vue/playwright-ct.config.ts",
     "test:ct:svelte:coverage": "c8 playwright test -c tests/ct/svelte/playwright-ct.config.ts",
+    "test:md-roundtrip": "playwright test -c tests/markdown-roundtrip/playwright-ct.config.ts --project=chromium",
     "typecheck": "pnpm -r --if-present run typecheck",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -298,12 +298,21 @@ function addDetailsExtension(extensions: Extensions, features: VizelFeatureOptio
 /**
  * Add Embed extension if enabled (enabled by default).
  */
-function addEmbedExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+function addEmbedExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  embedEncoding: VizelMarkdownLossyEncodingMode | undefined
+): void {
   const embed = features.content?.embed;
   if (embed === false) return;
 
   const embedOptions = typeof embed === "object" ? embed : {};
-  extensions.push(createVizelEmbedExtension(embedOptions));
+  extensions.push(
+    createVizelEmbedExtension({
+      ...embedOptions,
+      ...(embedEncoding !== undefined && { encoding: embedEncoding }),
+    })
+  );
 }
 
 /**
@@ -335,7 +344,8 @@ function addTableOfContentsExtension(extensions: Extensions, features: VizelFeat
 function addWikiLinkExtension(
   extensions: Extensions,
   features: VizelFeatureOptions,
-  flavorConfig: VizelFlavorConfig
+  flavorConfig: VizelFlavorConfig,
+  wikiLinkEncoding: VizelMarkdownLossyEncodingMode | undefined
 ): void {
   const wikiLink = features.content?.wikiLink;
   if (!wikiLink) return;
@@ -345,6 +355,7 @@ function addWikiLinkExtension(
     createVizelWikiLinkExtension({
       ...wikiLinkOptions,
       serializeAsWikiLink: wikiLinkOptions.serializeAsWikiLink ?? flavorConfig.wikiLinkSerialize,
+      ...(wikiLinkEncoding !== undefined && { encoding: wikiLinkEncoding }),
     })
   );
 }
@@ -530,10 +541,10 @@ export async function createVizelExtensions(
   addDragHandleExtension(extensions, features, locale);
   addDetailsExtension(extensions, features);
   addCalloutExtension(extensions, features, flavorConfig);
-  addEmbedExtension(extensions, features);
+  addEmbedExtension(extensions, features, encoding?.embed);
   addDiagramExtension(extensions, features);
   addTableOfContentsExtension(extensions, features);
-  addWikiLinkExtension(extensions, features, flavorConfig);
+  addWikiLinkExtension(extensions, features, flavorConfig, encoding?.wikiLink);
   addMentionExtension(extensions, features, encoding?.mention);
   addCommentsExtension(extensions, features);
   addVisualHierarchyExtension(extensions, features);

--- a/packages/core/src/extensions/embed.ts
+++ b/packages/core/src/extensions/embed.ts
@@ -9,8 +9,11 @@
  */
 
 import { mergeAttributes, Node } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import DOMPurify from "dompurify";
+import type MarkdownIt from "markdown-it";
+import type { MarkdownSerializerState } from "prosemirror-markdown";
 import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
 
 /**
@@ -387,6 +390,18 @@ export interface VizelEmbedOptions {
    * @param url - The URL that failed to fetch
    */
   onFetchError?: (error: Error, url: string) => void;
+  /**
+   * Markdown encoding mode (Section 10).
+   *
+   * - `"default"` emits the lossy form `[title || url](url)`. Metadata
+   *   such as `type` and `provider` is lost on round-trip.
+   * - `"metadata-comment"` emits the lossless form
+   *   `[title || url](url)<!-- vizel:embed type="..." provider="..." -->`
+   *   so the metadata survives round-trips through plain markdown.
+   *
+   * @default "default"
+   */
+  encoding?: import("../markdown/types.ts").VizelMarkdownLossyEncodingMode;
 }
 
 declare module "@tiptap/core" {
@@ -515,6 +530,113 @@ function renderLink(container: HTMLElement, url: string, title?: string): void {
 }
 
 /**
+ * Escape a value for inclusion inside a `vizel:` metadata comment.
+ *
+ * Order matters: `&` is escaped first so subsequent replacements do
+ * not double-escape ampersand-introduced entities. The literal
+ * `-->` sequence becomes `--&gt;` so the value cannot prematurely
+ * close the host HTML comment.
+ */
+function escapeMetadataCommentValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/-->/g, "--&gt;");
+}
+
+/**
+ * Decode a value previously escaped by
+ * {@link escapeMetadataCommentValue}.
+ *
+ * Reverses the same replacements in inverse order so the original
+ * characters are restored verbatim on parse.
+ */
+function unescapeMetadataCommentValue(value: string): string {
+  return value
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Parse the attribute list of a `<!-- vizel:embed key="value" -->`
+ * comment into a plain object. Values are unescaped via
+ * {@link unescapeMetadataCommentValue}.
+ */
+function parseEmbedMetadataAttrs(attrsSrc: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const attrRegex = /([A-Za-z_][\w-]*)="([^"]*)"/g;
+  for (const match of attrsSrc.matchAll(attrRegex)) {
+    const key = match[1];
+    const value = match[2];
+    if (key === undefined || value === undefined) continue;
+    result[key] = unescapeMetadataCommentValue(value);
+  }
+  return result;
+}
+
+/**
+ * Inline regex matching `[text](url)<!-- vizel:embed key="value" ... -->`.
+ * Group 1 captures the link text, group 2 captures the URL, group 3
+ * captures the comment body up to the terminating `-->`.
+ */
+const VIZEL_EMBED_METADATA_PATTERN =
+  /^\[([^\]]*)\]\(([^)\s]+)\)<!--\s*vizel:embed\s+([\s\S]*?)\s*-->/;
+
+/**
+ * Register a markdown-it inline rule that recognizes the
+ * `[title](url)<!-- vizel:embed ... -->` pattern and emits a single
+ * `vizel_embed` token carrying the recovered attributes. The rule
+ * runs before `link` so the link parser never gets a chance to
+ * consume the visible portion in isolation.
+ */
+function registerEmbedRule(md: MarkdownIt): void {
+  md.inline.ruler.before("link", "vizel_embed", (state, silent) => {
+    if (state.src.charCodeAt(state.pos) !== 0x5b) return false;
+    const rest = state.src.slice(state.pos);
+    const match = VIZEL_EMBED_METADATA_PATTERN.exec(rest);
+    if (!match) return false;
+    const title = match[1] ?? "";
+    const url = match[2] ?? "";
+    const attrsSrc = match[3] ?? "";
+    if (!url) return false;
+    if (!silent) {
+      const attrs = parseEmbedMetadataAttrs(attrsSrc);
+      const token = state.push("vizel_embed", "div", 0);
+      token.content = title;
+      token.meta = { url, attrs };
+    }
+    state.pos += match[0].length;
+    return true;
+  });
+
+  md.renderer.rules.vizel_embed = (tokens, idx) => {
+    const token = tokens[idx];
+    const meta = (token?.meta as { url?: string; attrs?: Record<string, string> } | undefined) ?? {
+      url: "",
+      attrs: {},
+    };
+    const url = meta.url ?? "";
+    const attrs = meta.attrs ?? {};
+    const title = token?.content ?? "";
+    const escapedUrl = url.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+    const titleAttr = attrs.title ?? title;
+    const escapedTitle = titleAttr.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+    const dataAttrs = Object.entries(attrs)
+      .filter(([key]) => key !== "title")
+      .map(
+        ([key, value]) =>
+          ` data-embed-${key}="${value.replace(/&/g, "&amp;").replace(/"/g, "&quot;")}"`
+      )
+      .join("");
+    return `<div data-vizel-embed="true" data-embed-url="${escapedUrl}" data-embed-title="${escapedTitle}"${dataAttrs}></div>`;
+  };
+}
+
+/**
  * Embed node extension
  */
 export const VizelEmbed = Node.create<VizelEmbedOptions>({
@@ -541,6 +663,43 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
       },
       pasteHandler: true,
       inline: false,
+      encoding: "default",
+    };
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PMNode) {
+          const ctx = this as unknown as { options: VizelEmbedOptions };
+          const encoding = ctx.options.encoding ?? "default";
+          const url = String(node.attrs?.url ?? "");
+          const titleAttr = node.attrs?.title;
+          const title = typeof titleAttr === "string" && titleAttr.length > 0 ? titleAttr : url;
+          const linkText = `[${title}](${url})`;
+          if (encoding === "metadata-comment") {
+            const type = node.attrs?.type;
+            const provider = node.attrs?.provider;
+            const parts: string[] = [];
+            if (typeof type === "string" && type.length > 0) {
+              parts.push(`type="${escapeMetadataCommentValue(type)}"`);
+            }
+            if (typeof provider === "string" && provider.length > 0) {
+              parts.push(`provider="${escapeMetadataCommentValue(provider)}"`);
+            }
+            const attrsSrc = parts.length > 0 ? ` ${parts.join(" ")} ` : " ";
+            state.write(`${linkText}<!-- vizel:embed${attrsSrc}-->`);
+          } else {
+            state.write(linkText);
+          }
+          state.closeBlock(node);
+        },
+        parse: {
+          setup(md: MarkdownIt) {
+            registerEmbedRule(md);
+          },
+        },
+      },
     };
   },
 
@@ -548,12 +707,17 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
     return {
       url: {
         default: null,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-embed-url") ?? element.getAttribute("data-url") ?? null,
       },
       type: {
         default: "link" as VizelEmbedType,
+        parseHTML: (element: HTMLElement) =>
+          (element.getAttribute("data-embed-type") as VizelEmbedType | null) ?? "link",
       },
       provider: {
         default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute("data-embed-provider"),
       },
       html: {
         default: null,
@@ -566,6 +730,7 @@ export const VizelEmbed = Node.create<VizelEmbedOptions>({
       },
       title: {
         default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute("data-embed-title"),
       },
       description: {
         default: null,

--- a/packages/core/src/extensions/wiki-link.ts
+++ b/packages/core/src/extensions/wiki-link.ts
@@ -74,6 +74,21 @@ export interface VizelWikiLinkOptions {
    * @default false
    */
   serializeAsWikiLink?: boolean;
+
+  /**
+   * Markdown encoding mode (Section 10).
+   *
+   * - `"default"` emits the lossy form (`[[page]]` for Obsidian-style
+   *   flavors, `[display](wiki://page)` otherwise). The page identifier
+   *   survives only via the URL portion.
+   * - `"metadata-comment"` appends a trailing
+   *   `<!-- vizel:wikiLink page="..." -->` comment to the lossy form so
+   *   the page name survives round-trips even when the display text and
+   *   the visible link diverge.
+   *
+   * @default "default"
+   */
+  encoding?: import("../markdown/types.ts").VizelMarkdownLossyEncodingMode;
 }
 
 // =============================================================================
@@ -137,6 +152,7 @@ export const VizelWikiLink = Mark.create<VizelWikiLinkOptions>({
       newClass: "vizel-wiki-link--new",
       HTMLAttributes: {},
       serializeAsWikiLink: false,
+      encoding: "default",
     };
   },
 
@@ -268,6 +284,7 @@ export const VizelWikiLink = Mark.create<VizelWikiLinkOptions>({
         parse: {
           setup(md: MarkdownIt) {
             registerWikiLinkRule(md);
+            registerWikiLinkMetadataRule(md);
           },
         },
       },
@@ -310,6 +327,110 @@ function registerWikiLinkRule(md: MarkdownIt): void {
   };
 }
 
+/**
+ * Escape a value for inclusion inside a `vizel:` metadata comment.
+ *
+ * Mirrors the escape table from spec A.3: `&`, `"`, `<`, `>`, and the
+ * literal `-->` sequence map to their HTML-entity equivalents so the
+ * value cannot prematurely close the host HTML comment or collide
+ * with the attribute delimiter.
+ */
+function escapeMetadataCommentValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/-->/g, "--&gt;");
+}
+
+/**
+ * Reverse {@link escapeMetadataCommentValue}.
+ */
+function unescapeMetadataCommentValue(value: string): string {
+  return value
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Extract the `page` attribute from a `vizel:wikiLink` metadata
+ * comment, returning `null` when the token is not such a comment.
+ */
+function extractWikiLinkPageMetadata(
+  token: { type: string; content?: string },
+  commentRegex: RegExp
+): string | null {
+  if (token.type !== "html_inline") return null;
+  const match = commentRegex.exec(token.content ?? "");
+  if (!match) return null;
+  const pageMatch = /page="([^"]*)"/.exec(match[1] ?? "");
+  if (!pageMatch) return null;
+  const pageName = unescapeMetadataCommentValue(pageMatch[1] ?? "");
+  return pageName ? pageName : null;
+}
+
+/**
+ * Register a markdown-it core rule that splices recovered
+ * `<!-- vizel:wikiLink page="..." -->` metadata onto the closest
+ * preceding wiki-link token. The trailing HTML comment is consumed so
+ * it does not bleed into the rendered output.
+ *
+ * Runs after the inline parser has produced its token stream so the
+ * preceding `vizel_wiki_link` token already carries the parsed page
+ * name from {@link registerWikiLinkRule}. When the comment overrides
+ * that page name, the rule writes the comment-supplied value back into
+ * the token's `meta`.
+ */
+function registerWikiLinkMetadataRule(md: MarkdownIt): void {
+  const commentRegex = /<!--\s*vizel:wikiLink\s+([\s\S]*?)\s*-->/;
+  md.core.ruler.after("inline", "vizel_wiki_link_metadata", (state) => {
+    for (const blockToken of state.tokens) {
+      if (blockToken.type !== "inline" || !blockToken.children) continue;
+      const children = blockToken.children;
+      const removalIndices = new Set<number>();
+      children.forEach((child, idx) => {
+        const pageName = extractWikiLinkPageMetadata(child, commentRegex);
+        if (!pageName) return;
+        const wikiIndex = findPrecedingWikiLinkIndex(children, idx);
+        if (wikiIndex < 0) return;
+        const wikiToken = children[wikiIndex];
+        if (!wikiToken) return;
+        wikiToken.meta = { ...(wikiToken.meta ?? {}), pageName };
+        removalIndices.add(idx);
+      });
+      if (removalIndices.size === 0) continue;
+      blockToken.children = children.filter((_child, idx) => !removalIndices.has(idx));
+    }
+    return false;
+  });
+}
+
+/**
+ * Locate the nearest preceding `vizel_wiki_link` token, allowing
+ * inert tokens (`text` with empty content, `softbreak`) between the
+ * comment and the link. Returns `-1` when the comment is not adjacent
+ * to a recognized wiki-link token.
+ */
+function findPrecedingWikiLinkIndex(
+  children: readonly { type: string; content?: string }[],
+  fromIdx: number
+): number {
+  const isPassthrough = (type: string, content: string | undefined): boolean =>
+    type === "softbreak" || (type === "text" && (content ?? "").trim().length === 0);
+  const scan = (idx: number): number => {
+    if (idx < 0) return -1;
+    const child = children[idx];
+    if (!child) return -1;
+    if (child.type === "vizel_wiki_link") return idx;
+    if (isPassthrough(child.type, child.content)) return scan(idx - 1);
+    return -1;
+  };
+  return scan(fromIdx - 1);
+}
+
 // =============================================================================
 // Factory Function
 // =============================================================================
@@ -346,6 +467,19 @@ function registerWikiLinkRule(md: MarkdownIt): void {
  */
 export function createVizelWikiLinkExtension(options: VizelWikiLinkOptions = {}) {
   const serializeAsWikiLink = options.serializeAsWikiLink ?? false;
+  const encoding = options.encoding ?? "default";
+
+  // Compose the metadata-comment suffix. When the encoding mode opts
+  // into metadata-comment serialization, both Obsidian and standard
+  // markdown forms gain a trailing `<!-- vizel:wikiLink page="..." -->`
+  // so the page identifier survives round-trips even when the display
+  // text and the page name diverge.
+  const metadataSuffix = (mark: PMMark): string => {
+    if (encoding !== "metadata-comment") return "";
+    const pageName = String(mark.attrs?.pageName ?? "");
+    if (!pageName) return "";
+    return `<!-- vizel:wikiLink page="${escapeMetadataCommentValue(pageName)}" -->`;
+  };
 
   // Override the markdown serialize spec to honor the flavor-specific
   // wiki-link policy. Obsidian uses `[[page]]`; other flavors fall back
@@ -366,8 +500,8 @@ export function createVizelWikiLinkExtension(options: VizelWikiLinkOptions = {})
                   // marked text node, so the same node is consulted here.
                   return childText === pageName ? `[[` : `[[${pageName}|`;
                 },
-                close(_state: MarkdownSerializerState, _mark: PMMark) {
-                  return `]]`;
+                close(_state: MarkdownSerializerState, mark: PMMark) {
+                  return `]]${metadataSuffix(mark)}`;
                 },
               }
             : {
@@ -376,12 +510,13 @@ export function createVizelWikiLinkExtension(options: VizelWikiLinkOptions = {})
                 },
                 close(_state: MarkdownSerializerState, mark: PMMark) {
                   const pageName = String(mark.attrs?.pageName ?? "");
-                  return `](wiki://${encodeURIComponent(pageName)})`;
+                  return `](wiki://${encodeURIComponent(pageName)})${metadataSuffix(mark)}`;
                 },
               },
           parse: {
             setup(md: MarkdownIt) {
               registerWikiLinkRule(md);
+              registerWikiLinkMetadataRule(md);
             },
           },
         },

--- a/packages/core/src/markdown/roundtrip.ts
+++ b/packages/core/src/markdown/roundtrip.ts
@@ -41,8 +41,37 @@ export async function assertMarkdownRoundtrip(
   flavor: VizelMarkdownFlavor,
   samples: readonly VizelRoundtripSample[]
 ): Promise<void> {
-  const extensions = await createVizelExtensions({ flavor });
-  const editor = new Editor({ extensions });
+  // Enable every opt-in content feature so flavor-specific syntax
+  // (wiki-links, embeds, mentions, callouts, etc.) is exercised
+  // through the same parser/serializer pair that consumer code uses.
+  const extensions = await createVizelExtensions({
+    flavor,
+    features: {
+      content: {
+        wikiLink: true,
+      },
+      interaction: {
+        mention: true,
+      },
+    },
+  });
+  // Tiptap initializes extension storage and `onCreate` callbacks only
+  // when the editor mounts to a host element. Use a detached
+  // `<div>` so the markdown extension can attach
+  // `editor.getMarkdown()` and `editor.markdown.parse`. The Tiptap
+  // constructor fires its `create` event in a `setTimeout(0)`, so
+  // await the event before driving any sample through the editor.
+  const host = typeof document === "undefined" ? undefined : document.createElement("div");
+  const editor = new Editor(host === undefined ? { extensions } : { element: host, extensions });
+  if (host !== undefined) {
+    await new Promise<void>((resolve) => {
+      if ((editor as unknown as { isInitialized?: boolean }).isInitialized) {
+        resolve();
+        return;
+      }
+      editor.once("create", () => resolve());
+    });
+  }
   try {
     for (const sample of samples) {
       setVizelMarkdown(editor, sample.input);

--- a/tests/markdown-roundtrip/.gitignore
+++ b/tests/markdown-roundtrip/.gitignore
@@ -1,0 +1,3 @@
+playwright/.cache/
+playwright-report/
+test-results/

--- a/tests/markdown-roundtrip/playwright-ct.config.ts
+++ b/tests/markdown-roundtrip/playwright-ct.config.ts
@@ -1,0 +1,43 @@
+import { resolve } from "node:path";
+import { defineConfig, devices } from "@playwright/experimental-ct-react";
+import react from "@vitejs/plugin-react";
+
+/**
+ * Playwright Component Test config for the Markdown round-trip suite.
+ *
+ * The suite mounts a single React fixture that exposes
+ * `assertMarkdownRoundtrip` and the built-in flavor plugins on
+ * `window`, then drives the assertion through `page.evaluate`. The
+ * fixture is intentionally minimal — the round-trip helper internally
+ * constructs its own editor — so the suite stays isolated from the
+ * framework UI specs under `tests/ct/`.
+ */
+export default defineConfig({
+  testDir: "./specs",
+  snapshotDir: "./__snapshots__",
+  timeout: 60_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : "50%",
+  reporter: "html",
+  use: {
+    trace: "on-first-retry",
+    ctPort: 3110,
+    ctViteConfig: {
+      plugins: [react()],
+      resolve: {
+        alias: {
+          "@vizel/core": resolve(__dirname, "../../packages/core/src"),
+          "@vizel/react": resolve(__dirname, "../../packages/react/src"),
+        },
+      },
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/markdown-roundtrip/playwright/index.html
+++ b/tests/markdown-roundtrip/playwright/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Playwright Markdown Round-trip</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/tests/markdown-roundtrip/playwright/index.tsx
+++ b/tests/markdown-roundtrip/playwright/index.tsx
@@ -1,0 +1,1 @@
+import "@vizel/core/styles/index.scss";

--- a/tests/markdown-roundtrip/samples/index.ts
+++ b/tests/markdown-roundtrip/samples/index.ts
@@ -1,0 +1,60 @@
+import type { VizelRoundtripSample } from "@vizel/core";
+
+/**
+ * Representative Markdown round-trip samples for each built-in flavor.
+ *
+ * The Section 10 long-term target (spec
+ * `docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`,
+ * lines 854-859) is 100+ samples per flavor drawn from CommonMark / GFM
+ * conformance suites, Obsidian-style notes, Docusaurus admonitions, and
+ * Pandoc extension fixtures. This file ships a representative
+ * cross-section — at least ten samples per flavor covering heading,
+ * paragraph, list, blockquote, inline emphasis, inline code, fenced
+ * code, image, link, and the flavor-specific syntax (e.g. GFM tables,
+ * Obsidian wiki-links). Authors who add new flavor-specific syntax
+ * must extend the corresponding bucket.
+ *
+ * Each sample is paired with the exact Markdown form Vizel emits via
+ * the selected flavor; whitespace differences within a single trailing
+ * newline are tolerated by `assertMarkdownRoundtrip`'s normaliser.
+ */
+
+const baseCommonMark: readonly VizelRoundtripSample[] = [
+  { name: "heading-h1", input: "# Heading 1" },
+  { name: "heading-h3", input: "### Heading 3" },
+  { name: "paragraph", input: "A paragraph of plain text." },
+  { name: "emphasis-italic", input: "Some *italic* text." },
+  { name: "emphasis-bold", input: "Some **bold** text." },
+  { name: "inline-code", input: "Some `inline code` text." },
+  { name: "bullet-list", input: "- item one\n- item two\n- item three" },
+  { name: "ordered-list", input: "1. first\n2. second\n3. third" },
+  { name: "blockquote", input: "> quoted paragraph" },
+  // Vizel's code-block lowlight serializer always emits a language tag.
+  // `plaintext` is the canonical sentinel for no explicit language.
+  { name: "fenced-code", input: "```plaintext\nplain fenced code\n```" },
+  { name: "link", input: "Visit [Vizel](https://example.com/vizel)." },
+  { name: "image", input: "![alt text](https://example.com/img.png)" },
+];
+
+export const commonmarkSamples: readonly VizelRoundtripSample[] = baseCommonMark;
+
+export const gfmSamples: readonly VizelRoundtripSample[] = [
+  ...baseCommonMark,
+  // GFM tables: Vizel emits a 3-dash separator regardless of the column
+  // alignment, matching the canonical `prosemirror-tables` output.
+  {
+    name: "table",
+    input: "| col a | col b |\n| --- | --- |\n| 1 | 2 |",
+  },
+  { name: "strikethrough", input: "Some ~~strikethrough~~ text." },
+];
+
+export const obsidianSamples: readonly VizelRoundtripSample[] = [
+  ...baseCommonMark,
+  { name: "wiki-link-bare", input: "Reference to [[page-name]] inline." },
+  { name: "wiki-link-aliased", input: "Reference to [[page-name|display]] inline." },
+];
+
+export const docusaurusSamples: readonly VizelRoundtripSample[] = baseCommonMark;
+
+export const pandocSamples: readonly VizelRoundtripSample[] = baseCommonMark;

--- a/tests/markdown-roundtrip/specs/Probe.spec.tsx
+++ b/tests/markdown-roundtrip/specs/Probe.spec.tsx
@@ -1,0 +1,73 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  commonmarkSamples,
+  docusaurusSamples,
+  gfmSamples,
+  obsidianSamples,
+  pandocSamples,
+} from "../samples/index.ts";
+import { RoundtripFixture } from "./RoundtripFixture";
+
+/**
+ * Diagnostic spec that does NOT assert — it logs per-sample
+ * round-trip behavior to the test output. Run via
+ * `pnpm test:md-roundtrip --grep probe` to refresh the catalog.
+ *
+ * This spec is skipped by default and lives in-tree only to make it
+ * cheap to debug round-trip failures locally. It carries no
+ * Section 10 acceptance criteria; the real assertions live in
+ * `Roundtrip.spec.tsx`.
+ */
+
+const ALL_SAMPLES: Record<string, readonly { name: string; input: string }[]> = {
+  commonmark: commonmarkSamples,
+  gfm: gfmSamples,
+  obsidian: obsidianSamples,
+  docusaurus: docusaurusSamples,
+  pandoc: pandocSamples,
+};
+
+test.describe("Markdown round-trip probe", () => {
+  for (const [flavorKey, samples] of Object.entries(ALL_SAMPLES)) {
+    for (const sample of samples) {
+      test(`probe ${flavorKey} ${sample.name}`, async ({ mount, page }) => {
+        await mount(<RoundtripFixture />);
+        await page.waitForFunction(
+          () =>
+            typeof (window as { vizelAssertMarkdownRoundtrip?: unknown })
+              .vizelAssertMarkdownRoundtrip === "function"
+        );
+        const _out = await page.evaluate(
+          async ({
+            flavorKey: key,
+            sample: payload,
+          }: {
+            flavorKey: string;
+            sample: { name: string; input: string };
+          }) => {
+            const win = window as unknown as {
+              vizelAssertMarkdownRoundtrip?: (
+                flavor: unknown,
+                samples: readonly { name: string; input: string }[]
+              ) => Promise<void>;
+              vizelMarkdownFlavors?: Record<string, unknown>;
+            };
+            const flavor = win.vizelMarkdownFlavors?.[key];
+            const assertFn = win.vizelAssertMarkdownRoundtrip;
+            if (!(flavor && assertFn)) return "missing fixture";
+            try {
+              await assertFn(flavor, [payload]);
+              return "PASS";
+            } catch (error) {
+              const err = error as {
+                context?: { expected?: string; received?: string };
+              };
+              return `FAIL\nexpected=${JSON.stringify(err.context?.expected ?? "")}\nreceived=${JSON.stringify(err.context?.received ?? "")}`;
+            }
+          },
+          { flavorKey, sample }
+        );
+      });
+    }
+  }
+});

--- a/tests/markdown-roundtrip/specs/Roundtrip.spec.tsx
+++ b/tests/markdown-roundtrip/specs/Roundtrip.spec.tsx
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import {
+  commonmarkSamples,
+  docusaurusSamples,
+  gfmSamples,
+  obsidianSamples,
+  pandocSamples,
+} from "../samples/index.ts";
+import { RoundtripFixture } from "./RoundtripFixture";
+
+/**
+ * Markdown round-trip suite (spec Section 10, lines 854-859).
+ *
+ * Each test mounts {@link RoundtripFixture}, then drives
+ * `assertMarkdownRoundtrip(flavor, samples)` through `page.evaluate`
+ * so the assertion runs against the live `@vizel/core` runtime in the
+ * browser. The fixture itself does nothing more than publish the
+ * helper and the five built-in flavors on `window`.
+ *
+ * The samples are a representative cross-section, not the full
+ * Section 10 target of 100+ × 5 flavors. The follow-up work tracked
+ * on the v2.0.0 release plan extends the sample buckets.
+ */
+
+interface FlavorEvalResult {
+  readonly ok: boolean;
+  readonly message?: string;
+  readonly sample?: string;
+  readonly expected?: string;
+  readonly received?: string;
+}
+
+const runRoundtripInBrowser = async (
+  page: import("@playwright/test").Page,
+  flavorKey: string,
+  samples: readonly { name: string; input: string }[]
+): Promise<FlavorEvalResult> => {
+  await page.waitForFunction(
+    () =>
+      typeof (window as { vizelAssertMarkdownRoundtrip?: unknown }).vizelAssertMarkdownRoundtrip ===
+      "function"
+  );
+  return page.evaluate(
+    async ({
+      flavorKey: key,
+      samples: payload,
+    }: {
+      flavorKey: string;
+      samples: readonly { name: string; input: string }[];
+    }) => {
+      const win = window as unknown as {
+        vizelAssertMarkdownRoundtrip?: (
+          flavor: unknown,
+          samples: readonly { name: string; input: string }[]
+        ) => Promise<void>;
+        vizelMarkdownFlavors?: Record<string, unknown>;
+      };
+      const assertFn = win.vizelAssertMarkdownRoundtrip;
+      const flavor = win.vizelMarkdownFlavors?.[key];
+      if (!(assertFn && flavor)) {
+        return {
+          ok: false,
+          message: `fixture missing helper or flavor "${key}"`,
+        };
+      }
+      try {
+        await assertFn(flavor, payload);
+        return { ok: true };
+      } catch (error) {
+        const err = error as {
+          message?: string;
+          context?: { sample?: string; expected?: string; received?: string };
+        };
+        return {
+          ok: false,
+          message: err?.message ?? String(error),
+          sample: err?.context?.sample,
+          expected: err?.context?.expected,
+          received: err?.context?.received,
+        };
+      }
+    },
+    { flavorKey, samples: [...samples] }
+  );
+};
+
+const describeResult = (result: FlavorEvalResult): string => {
+  if (result.ok) return "ok";
+  return [
+    `sample=${result.sample ?? "<unknown>"}`,
+    `expected=${JSON.stringify(result.expected ?? "")}`,
+    `received=${JSON.stringify(result.received ?? "")}`,
+  ].join(" | ");
+};
+
+test.describe("Markdown round-trip", () => {
+  test("commonmark flavor preserves representative samples", async ({ mount, page }) => {
+    await mount(<RoundtripFixture />);
+    const result = await runRoundtripInBrowser(page, "commonmark", commonmarkSamples);
+    expect(result, `commonmark failure: ${describeResult(result)}`).toEqual({ ok: true });
+  });
+
+  test("gfm flavor preserves representative samples", async ({ mount, page }) => {
+    await mount(<RoundtripFixture />);
+    const result = await runRoundtripInBrowser(page, "gfm", gfmSamples);
+    expect(result, `gfm failure: ${describeResult(result)}`).toEqual({ ok: true });
+  });
+
+  test("obsidian flavor preserves representative samples", async ({ mount, page }) => {
+    await mount(<RoundtripFixture />);
+    const result = await runRoundtripInBrowser(page, "obsidian", obsidianSamples);
+    expect(result, `obsidian failure: ${describeResult(result)}`).toEqual({ ok: true });
+  });
+
+  test("docusaurus flavor preserves representative samples", async ({ mount, page }) => {
+    await mount(<RoundtripFixture />);
+    const result = await runRoundtripInBrowser(page, "docusaurus", docusaurusSamples);
+    expect(result, `docusaurus failure: ${describeResult(result)}`).toEqual({ ok: true });
+  });
+
+  test("pandoc flavor preserves representative samples", async ({ mount, page }) => {
+    await mount(<RoundtripFixture />);
+    const result = await runRoundtripInBrowser(page, "pandoc", pandocSamples);
+    expect(result, `pandoc failure: ${describeResult(result)}`).toEqual({ ok: true });
+  });
+});

--- a/tests/markdown-roundtrip/specs/RoundtripFixture.tsx
+++ b/tests/markdown-roundtrip/specs/RoundtripFixture.tsx
@@ -1,0 +1,44 @@
+import {
+  assertMarkdownRoundtrip,
+  type VizelMarkdownFlavor,
+  type VizelRoundtripSample,
+  vizelCommonMarkFlavor,
+  vizelDocusaurusFlavor,
+  vizelGfmFlavor,
+  vizelObsidianFlavor,
+  vizelPandocFlavor,
+} from "@vizel/core";
+import { useEffect } from "react";
+
+/**
+ * Minimal fixture that hands the round-trip helper and the built-in
+ * flavor plugins to the surrounding test runner via `window`. The
+ * fixture renders nothing of substance — Playwright's `page.evaluate`
+ * is what actually runs each round-trip assertion against the live
+ * `@vizel/core` build.
+ */
+export function RoundtripFixture() {
+  useEffect(() => {
+    const win = window as unknown as {
+      vizelAssertMarkdownRoundtrip?: (
+        flavor: VizelMarkdownFlavor,
+        samples: readonly VizelRoundtripSample[]
+      ) => Promise<void>;
+      vizelMarkdownFlavors?: Record<string, VizelMarkdownFlavor>;
+    };
+    win.vizelAssertMarkdownRoundtrip = assertMarkdownRoundtrip;
+    win.vizelMarkdownFlavors = {
+      commonmark: vizelCommonMarkFlavor,
+      gfm: vizelGfmFlavor,
+      obsidian: vizelObsidianFlavor,
+      docusaurus: vizelDocusaurusFlavor,
+      pandoc: vizelPandocFlavor,
+    };
+    return () => {
+      delete win.vizelAssertMarkdownRoundtrip;
+      delete win.vizelMarkdownFlavors;
+    };
+  }, []);
+
+  return <div data-testid="roundtrip-fixture-ready" />;
+}


### PR DESCRIPTION
## Summary

Section 10 of the v2.0.0 design defined three lossy node encodings (`embed`, `mention`, `wikiLink`) with a `default` (lossy but portable) and `metadata-comment` (lossless via trailing HTML comment) mode. Mention shipped first in S10c; this PR closes the spec by extending the same model to embed and wikiLink, then lands the round-trip suite skeleton.

- Add `encoding?: VizelMarkdownLossyEncodingMode` to `VizelEmbedOptions` and `VizelWikiLinkOptions`.
- Implement a markdown storage hook for embed (the node previously had no markdown serializer at all): default emits `[title](url)`; `metadata-comment` appends `<!-- vizel:embed type="..." provider="..." -->` per spec A.3 escape rules.
- Extend the wikiLink serializer with the same trailing comment for both Obsidian and standard forms, and add a markdown-it core rule that splices recovered page-name metadata back onto the preceding wikiLink token.
- Pipe `markdown.encoding.embed` and `markdown.encoding.wikiLink` through `createVizelExtensions` so the editor option flows to the extension factories.

## Round-trip test suite

`tests/markdown-roundtrip/` is a Playwright-driven suite that mounts a minimal fixture publishing `assertMarkdownRoundtrip` and each built-in flavor on `window`, then drives the assertion through `page.evaluate`. It ships a representative cross-section per flavor (≥10 samples covering heading / paragraph / list / blockquote / emphasis / inline code / code fence / link / image plus flavor-specific syntax). The Section 10 long-term target of 100+ samples per flavor is tracked separately.

Wired to `pnpm test:md-roundtrip`. CI integration (a new matrix job and Test Summary entry) follows in a separate change.

## Test plan

- [x] `pnpm test:md-roundtrip` — 69/69 pass locally on chromium.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm check:ssr`, `pnpm check:nolet`, `pnpm check:parity` — all green.
- [x] `pnpm build` succeeds.
