### PR TITLE
feat(core): add generateVizelStaticHtml with linkedom DOM shim (audit Batch F)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,34 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  ssr:
+    name: SSR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run SSR static HTML smoke test
+        run: pnpm test:ssr
+
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, ssr]
     if: always()
     steps:
       - name: Download all results

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "check:nolet": "tsx scripts/check-no-let.ts",
+    "test:ssr": "tsx scripts/test-static-html.ts",
     "prepare": "lefthook install",
     "deps:check": "pnpm dlx taze major -r",
     "deps:update": "pnpm dlx taze major -r -w && pnpm install"
@@ -107,6 +108,7 @@
     "c8": "^11.0.0",
     "concurrently": "^9.2.1",
     "lefthook": "^2.1.6",
+    "linkedom": "^0.18.12",
     "mermaid": "^11.15.0",
     "oxc-minify": "^0.131.0",
     "playwright": "~1.58.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,6 +103,7 @@
     "@tiptap/suggestion": "^3.23.4",
     "fuse.js": "^7.1.0",
     "katex": "^0.16.0",
+    "linkedom": "^0.18.0",
     "lowlight": "^3.0.0",
     "mermaid": "^11.0.0",
     "y-websocket": "^2.0.0 || ^3.0.0",
@@ -122,6 +123,9 @@
       "optional": true
     },
     "katex": {
+      "optional": true
+    },
+    "linkedom": {
       "optional": true
     },
     "lowlight": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -526,6 +526,8 @@ export {
   // Keyboard shortcut utilities
   formatVizelShortcut,
   formatVizelTooltip,
+  // Static HTML rendering (Section 12 Mode 1)
+  generateVizelStaticHtml,
   // Block path utility
   getVizelBlockPath,
   getVizelEditorState,
@@ -582,6 +584,7 @@ export {
   type VizelErrorOptions,
   type VizelErrorSeverity,
   type VizelFlavorConfig,
+  type VizelGenerateStaticHtmlOptions,
   type VizelMarkdownSyncHandlers,
   type VizelMinimapRenderOptions,
   type VizelMountPortalOptions,

--- a/packages/core/src/utils/errorHandling.ts
+++ b/packages/core/src/utils/errorHandling.ts
@@ -18,6 +18,7 @@ export type VizelErrorCode =
   | "MISSING_CONTEXT"
   | "INVALID_LOCALE"
   | "SSR_NOT_SUPPORTED"
+  | "SSR_DOM_SHIM_MISSING"
   | "MISSING_OPTIONAL_DEP"
   // Input errors (runtime data issues — emitted via onError).
   | "INVALID_MARKDOWN"

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -104,6 +104,11 @@ export {
   type VizelThemeInitScriptOptions,
   vizelThemeInitScript,
 } from "./ssr.ts";
+// Static HTML rendering (Section 12 Mode 1)
+export {
+  generateVizelStaticHtml,
+  type VizelGenerateStaticHtmlOptions,
+} from "./staticHtml.ts";
 // Text highlight utilities
 export { splitVizelTextByMatches, type VizelTextSegment } from "./textHighlight.ts";
 // Type guard utilities

--- a/packages/core/src/utils/staticHtml.ts
+++ b/packages/core/src/utils/staticHtml.ts
@@ -1,0 +1,290 @@
+/**
+ * Static HTML rendering for Vizel content.
+ *
+ * `generateVizelStaticHtml` produces server-renderable HTML from a
+ * Markdown source. It is the building block for Section 12 Mode 1 —
+ * the read-only `VizelStaticView` component that consumers embed in
+ * blog pages, CMS view pages, and documentation sites where the
+ * editor itself never mounts.
+ *
+ * The function is callable on both the browser and Node / edge
+ * runtimes:
+ *
+ * - On the browser it uses the native `document` straight away.
+ * - On Node it dynamically imports `linkedom` and installs a minimal
+ *   DOM shim on `globalThis` so the Tiptap / ProseMirror DOM
+ *   serializers can run without a real browser. `linkedom` is declared
+ *   as an optional peer dependency; when it is missing the function
+ *   throws `VizelError("SSR_DOM_SHIM_MISSING")` so consumers learn
+ *   exactly what to install.
+ *
+ * Diagram-style nodes (`mermaid`, `graphviz`) are not rendered on the
+ * server — the source content survives as a fenced code block with
+ * the language tag, matching the v2.0 spec. Client-side hydration
+ * later transforms those code blocks into live diagrams.
+ */
+
+import { generateHTML, generateJSON } from "@tiptap/core";
+import MarkdownIt from "markdown-it";
+import { createVizelExtensions } from "../extensions/base.ts";
+import {
+  vizelCommonMarkFlavor,
+  vizelDocusaurusFlavor,
+  vizelGfmFlavor,
+  vizelObsidianFlavor,
+  vizelPandocFlavor,
+} from "../markdown/flavors/index.ts";
+import type { VizelMarkdownFlavor, VizelMarkdownItInstance } from "../markdown/types.ts";
+import type { VizelFeatureOptions } from "../types.ts";
+import { vizelDefaultFeatures } from "./default-features.ts";
+import { createVizelError } from "./errorHandling.ts";
+
+/**
+ * Options accepted by {@link generateVizelStaticHtml}.
+ */
+export interface VizelGenerateStaticHtmlOptions {
+  /** Markdown source to render. Required. */
+  readonly markdown: string;
+  /** Flavor controlling parser tuning. Required (no implicit default). */
+  readonly flavor: VizelMarkdownFlavor;
+  /** Feature opt-ins; falls back to {@link vizelDefaultFeatures} when omitted. */
+  readonly features?: VizelFeatureOptions;
+}
+
+/**
+ * Render Markdown into a static, hydration-friendly HTML string.
+ *
+ * The result is wrapped in `<div class="vizel-static"
+ * data-vizel-static="true">…</div>` so consumers can target the
+ * server-rendered tree from CSS or hydration logic without
+ * conflating it with the editable surface.
+ *
+ * @example Basic usage
+ * ```ts
+ * const html = await generateVizelStaticHtml({
+ *   markdown: "# Hello\n\nWorld.",
+ *   flavor: vizelGfmFlavor,
+ * });
+ * ```
+ *
+ * @throws {@link VizelError} with code `SSR_DOM_SHIM_MISSING` when the
+ *   function runs on Node and the optional `linkedom` peer dependency
+ *   is not installed.
+ */
+export async function generateVizelStaticHtml(
+  options: VizelGenerateStaticHtmlOptions
+): Promise<string> {
+  const { markdown, flavor, features } = options;
+
+  // Install the DOM shim before touching Tiptap or markdown-it.
+  // The shim is a no-op on the browser; on Node it loads linkedom and
+  // exposes `document`, `window`, and DOMParser on globalThis.
+  await ensureVizelSsrDomShim();
+
+  const resolvedFeatures = features ?? vizelDefaultFeatures();
+  const extensions = await createVizelExtensions({
+    features: resolvedFeatures,
+    flavor,
+  });
+
+  const md = buildVizelStaticMarkdownIt(flavor);
+  const renderedHTML = md.render(markdown);
+  const json = generateJSON(`<div>${renderedHTML}</div>`, extensions);
+  const innerHTML = generateHTML(json, extensions);
+
+  return `<div class="vizel-static" data-vizel-static="true">${innerHTML}</div>`;
+}
+
+/**
+ * Build a markdown-it instance configured with every built-in
+ * flavor's plugins plus the consumer's selected flavor plugins.
+ *
+ * Parses are intentionally tolerant — the parser recognizes syntax
+ * from any built-in flavor so static rendering matches what the
+ * editable surface would parse. The serializer side (which would
+ * narrow output to the chosen flavor) is unused here because the
+ * function returns HTML, not Markdown.
+ */
+function buildVizelStaticMarkdownIt(selected: VizelMarkdownFlavor): MarkdownIt {
+  const md = new MarkdownIt({
+    html: true,
+    linkify: true,
+    breaks: false,
+  });
+
+  const allFlavors: readonly VizelMarkdownFlavor[] = [
+    vizelCommonMarkFlavor,
+    vizelGfmFlavor,
+    vizelObsidianFlavor,
+    vizelDocusaurusFlavor,
+    vizelPandocFlavor,
+    selected,
+  ];
+  // Deduplicate by name so applying the selected flavor on top of
+  // its built-in twin does not double-register identical plugins.
+  const applied = new Set<string>();
+  for (const candidate of allFlavors) {
+    if (applied.has(candidate.name)) continue;
+    applied.add(candidate.name);
+    const plugins = candidate.markdownItPlugins ?? [];
+    for (const plugin of plugins) {
+      plugin(md as unknown as VizelMarkdownItInstance);
+    }
+  }
+
+  return md;
+}
+
+/**
+ * Globals that the Tiptap / ProseMirror DOM serializers reach for. The
+ * shim copies these from linkedom onto `globalThis` so server-side
+ * rendering does not need a global `document` patch elsewhere.
+ */
+const VIZEL_SSR_DOM_GLOBALS: readonly string[] = [
+  "Document",
+  "DocumentFragment",
+  "DOMParser",
+  "Element",
+  "Event",
+  "CustomEvent",
+  "HTMLDivElement",
+  "HTMLDocument",
+  "HTMLElement",
+  "Node",
+  "NodeList",
+  "Text",
+];
+
+/**
+ * Sentinel guarding against double initialization. The shim is
+ * idempotent — calling it twice from concurrent renders only installs
+ * the globals once.
+ */
+const ssrDomShimState: { installed: boolean } = { installed: false };
+
+/**
+ * Install the DOM shim required for SSR rendering when no native DOM
+ * exists. On the browser the function is a no-op.
+ */
+async function ensureVizelSsrDomShim(): Promise<void> {
+  if (typeof document !== "undefined" && typeof window !== "undefined") {
+    return;
+  }
+  if (ssrDomShimState.installed) {
+    return;
+  }
+
+  const linkedom = await loadVizelLinkedom();
+  const { window: shimWindow, document: shimDocument } = linkedom.parseHTML(
+    "<!doctype html><html><head></head><body></body></html>"
+  );
+
+  // Tiptap's `elementFromString` wraps its input in `<body>...</body>`
+  // and reads `.body`. linkedom's DOMParser, on a "text/html" parse,
+  // hoists the inner `<body>` out of the outer one and leaves `.body`
+  // empty. The custom DOMParser strips the outermost `<body>` wrapper
+  // before parsing so the result satisfies Tiptap's contract.
+  const ShimDomParser = createVizelShimDomParser(linkedom);
+
+  // ProseMirror calls `document.implementation.createHTMLDocument()`
+  // from `getHTMLFromFragment`. linkedom 0.18 does not expose
+  // `implementation`, so polyfill the single method the call site uses.
+  if (!shimDocument.implementation) {
+    Object.defineProperty(shimDocument, "implementation", {
+      configurable: true,
+      value: {
+        createHTMLDocument(title?: string): Document {
+          const titleMarkup = title ? `<title>${title}</title>` : "";
+          return linkedom.parseHTML(
+            `<!doctype html><html><head>${titleMarkup}</head><body></body></html>`
+          ).document as unknown as Document;
+        },
+      },
+    });
+  }
+
+  // linkedom returns a Proxy-backed window whose properties cannot be
+  // reassigned (`window.DOMParser = ...` silently fails). Wrap the
+  // window in a Proxy that returns the shim DOMParser while forwarding
+  // every other property read to the real linkedom window. Tiptap's
+  // `elementFromString` resolves `window.DOMParser` through this proxy.
+  const windowProxy = new Proxy(shimWindow as object, {
+    get(target, prop, receiver): unknown {
+      if (prop === "DOMParser") return ShimDomParser;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+
+  const globals = globalThis as unknown as Record<string, unknown>;
+  globals.window = windowProxy;
+  globals.document = shimDocument;
+  globals.DOMParser = ShimDomParser;
+  for (const key of VIZEL_SSR_DOM_GLOBALS) {
+    const value = (shimWindow as unknown as Record<string, unknown>)[key];
+    if (value !== undefined && globals[key] === undefined) {
+      globals[key] = value;
+    }
+  }
+
+  ssrDomShimState.installed = true;
+}
+
+/**
+ * Loose typing for the linkedom `window` / `document` returned by
+ * `parseHTML`. The shim only reads a handful of fields; declaring the
+ * full DOM surface would couple Vizel to a major linkedom type
+ * version, so we treat each as `Record<string, unknown>` plus the
+ * narrow properties we touch directly.
+ */
+interface VizelLinkedomWindow extends Record<string, unknown> {
+  DOMParser?: unknown;
+}
+
+interface VizelLinkedomDocument {
+  implementation?: unknown;
+}
+
+/**
+ * Shape of the linkedom subset {@link ensureVizelSsrDomShim} consumes.
+ */
+interface VizelLinkedomModule {
+  parseHTML(html: string): { window: VizelLinkedomWindow; document: VizelLinkedomDocument };
+}
+
+async function loadVizelLinkedom(): Promise<VizelLinkedomModule> {
+  try {
+    const mod = (await import("linkedom")) as unknown as VizelLinkedomModule;
+    if (typeof mod.parseHTML !== "function") {
+      throw createVizelError(
+        "SSR_DOM_SHIM_MISSING",
+        "The installed `linkedom` package does not expose a `parseHTML` export. Upgrade to linkedom ^0.18.0 or later.",
+        { context: { dependency: "linkedom" } }
+      );
+    }
+    return mod;
+  } catch (cause) {
+    throw createVizelError(
+      "SSR_DOM_SHIM_MISSING",
+      "generateVizelStaticHtml requires the optional `linkedom` peer dependency on Node. Install it with `pnpm add linkedom` (or `npm install linkedom`) in the host application.",
+      { context: { dependency: "linkedom" }, cause }
+    );
+  }
+}
+
+/**
+ * Build a `DOMParser`-shaped class backed by linkedom's `parseHTML`.
+ *
+ * The shim trims the outermost `<body>...</body>` wrapper that Tiptap
+ * adds before delegating to linkedom, so the returned document's
+ * `.body` element contains the original content unchanged.
+ */
+function createVizelShimDomParser(linkedom: VizelLinkedomModule): {
+  new (): { parseFromString(html: string, type: string): unknown };
+} {
+  return class {
+    parseFromString(html: string, _type: string): unknown {
+      const inner = String(html).replace(/^<body>([\s\S]*)<\/body>$/i, "$1");
+      return linkedom.parseHTML(`<!doctype html><html><body>${inner}</body></html>`).document;
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -449,6 +452,9 @@ importers:
       katex:
         specifier: ^0.16.0
         version: 0.16.45
+      linkedom:
+        specifier: ^0.18.0
+        version: 0.18.12
       lowlight:
         specifier: ^3.0.0
         version: 3.3.0
@@ -2590,6 +2596,9 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -2685,6 +2694,16 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2881,11 +2900,24 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   dompurify@3.4.3:
     resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   electron-to-chromium@1.5.353:
     resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
@@ -3009,8 +3041,14 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3232,6 +3270,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -3360,6 +3407,9 @@ packages:
 
   non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3695,6 +3745,9 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -5571,6 +5624,8 @@ snapshots:
 
   birpc@2.9.0: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -5668,6 +5723,18 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  cssom@0.5.0: {}
 
   csstype@3.2.3: {}
 
@@ -5879,6 +5946,18 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -5886,6 +5965,12 @@ snapshots:
   dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   electron-to-chromium@1.5.353: {}
 
@@ -6060,7 +6145,16 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-escaper@3.0.3: {}
+
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   iconv-lite@0.6.3:
     dependencies:
@@ -6224,6 +6318,14 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   linkify-it@5.0.0:
     dependencies:
@@ -6397,6 +6499,10 @@ snapshots:
 
   non-layered-tidy-tree-layout@2.0.2:
     optional: true
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   obug@2.1.1: {}
 
@@ -6826,6 +6932,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
+
+  uhyphen@0.2.0: {}
 
   undici-types@7.24.6: {}
 

--- a/scripts/test-static-html.ts
+++ b/scripts/test-static-html.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env tsx
+/**
+ * SSR static rendering smoke test.
+ *
+ * Drives `generateVizelStaticHtml` against a handful of canonical
+ * Markdown samples and asserts the produced HTML contains the
+ * expected DOM markers. Replaces a full unit-test harness (Vitest)
+ * with a Node-only script so the SSR path stays exercised in CI
+ * without adding another test runner dependency.
+ *
+ * Exit code is 0 on success, 1 on any assertion failure.
+ */
+
+import {
+  generateVizelStaticHtml,
+  vizelGfmFlavor,
+  vizelObsidianFlavor,
+} from "../packages/core/src/index.ts";
+
+interface StaticHtmlCase {
+  readonly name: string;
+  readonly markdown: string;
+  readonly mustInclude: readonly string[];
+  readonly mustNotInclude?: readonly string[];
+  readonly flavor?: "gfm" | "obsidian";
+}
+
+const CASES: readonly StaticHtmlCase[] = [
+  {
+    name: "heading and paragraph",
+    markdown: "# Hello SSR\n\nFirst paragraph.",
+    mustInclude: [
+      `<div class="vizel-static" data-vizel-static="true">`,
+      "<h1>Hello SSR</h1>",
+      "<p>First paragraph.</p>",
+    ],
+  },
+  {
+    name: "bullet list",
+    markdown: "- one\n- two\n- three\n",
+    mustInclude: ["<ul", "<li>", "one", "two", "three"],
+  },
+  {
+    name: "ordered list",
+    markdown: "1. first\n2. second\n3. third\n",
+    mustInclude: ["<ol", "<li>", "first", "second", "third"],
+  },
+  {
+    name: "fenced code block (js)",
+    markdown: "```js\nconsole.log('hi');\n```\n",
+    mustInclude: ["<pre", "<code", "language-js"],
+  },
+  {
+    name: "mermaid fenced block stays a code block on the server",
+    markdown: "```mermaid\ngraph TD;\nA-->B;\n```\n",
+    // Diagram nodes must NOT render to a diagram on the server — Section 12
+    // promises the client hydrates them later. Verify the source survives
+    // verbatim inside a <code> element with the language tag.
+    mustInclude: ["<pre", "<code", "language-mermaid", "graph TD"],
+    mustNotInclude: ["<svg"],
+  },
+  {
+    name: "link inside paragraph",
+    markdown: "See [the docs](https://example.com/docs) for details.",
+    mustInclude: [`<a `, `href="https://example.com/docs"`, "the docs"],
+  },
+  {
+    name: "image inside paragraph",
+    markdown: "![alt text](https://example.com/cat.png)",
+    mustInclude: [`<img `, `src="https://example.com/cat.png"`, `alt="alt text"`],
+  },
+  {
+    name: "mention plus wiki-link survive without crashing",
+    flavor: "obsidian",
+    markdown: "Hello @alice — see [[Welcome Page]] for next steps.",
+    // The exact serialization depends on flavor wiring; we only assert that
+    // the wrapper exists and the surrounding paragraph survives so the path
+    // does not throw for these lossy node types.
+    mustInclude: [`<div class="vizel-static" data-vizel-static="true">`, "Hello", "next steps"],
+  },
+];
+
+interface CaseFailure {
+  readonly name: string;
+  readonly message: string;
+  readonly html: string;
+}
+
+async function runCase(testCase: StaticHtmlCase): Promise<CaseFailure | null> {
+  const flavor = testCase.flavor === "obsidian" ? vizelObsidianFlavor : vizelGfmFlavor;
+  const html = await generateVizelStaticHtml({
+    markdown: testCase.markdown,
+    flavor,
+  });
+
+  const missing = testCase.mustInclude.filter((needle) => !html.includes(needle));
+  if (missing.length > 0) {
+    return {
+      name: testCase.name,
+      message: `output is missing required substrings: ${missing.map((s) => JSON.stringify(s)).join(", ")}`,
+      html,
+    };
+  }
+
+  const forbidden = (testCase.mustNotInclude ?? []).filter((needle) => html.includes(needle));
+  if (forbidden.length > 0) {
+    return {
+      name: testCase.name,
+      message: `output unexpectedly contains: ${forbidden.map((s) => JSON.stringify(s)).join(", ")}`,
+      html,
+    };
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  const results = await Promise.all(CASES.map((testCase) => runCase(testCase)));
+  const failures = results.filter((result): result is CaseFailure => result !== null);
+
+  if (failures.length === 0) {
+    process.stdout.write(`SSR static HTML check passed (${CASES.length} cases).\n`);
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `SSR static HTML check failed (${failures.length}/${CASES.length} cases):\n\n`
+  );
+  for (const failure of failures) {
+    process.stderr.write(`- ${failure.name}: ${failure.message}\n`);
+    process.stderr.write(`  HTML: ${failure.html}\n\n`);
+  }
+  process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`SSR static HTML check threw: ${String(err)}\n`);
+  if (err instanceof Error && err.stack) {
+    process.stderr.write(`${err.stack}\n`);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `generateVizelStaticHtml({ markdown, flavor, features? })` in `@vizel/core` — a Node / edge / browser callable helper that renders Markdown into the static HTML payload powering Section 12 Mode 1 (`VizelStaticView`).
- Lazily load `linkedom` (declared as an optional peer dependency) and install a minimal `document` / `window` / `DOMParser` shim on `globalThis` so the Tiptap and ProseMirror DOM serializers operate on Node without a real browser. Missing dependency surfaces as a typed `VizelError("SSR_DOM_SHIM_MISSING")`.
- Render diagram / mermaid / graphviz sources as `<pre><code class="language-…">` fences on the server so client-side renderers can hydrate them later (no `<svg>` leaks into static output).
- Wrap the result in `<div class="vizel-static" data-vizel-static="true">…</div>` so CSS and hydration logic can target the server tree without conflating it with the editable surface.

## Why

Section 12 of the v2.0.0 spec promises three rendering modes; Mode 1 (read-only static HTML) is the foundation the editable progressive-enhancement mode also depends on. Until this helper exists, consumers cannot embed Vizel content in blog pages, CMS view pages, or documentation sites without hydrating the full editor — which defeats SEO and inflates initial bundle size.

`linkedom` is preferred over `jsdom` because it is roughly two orders of magnitude smaller (~50 KB vs ~10 MB) and ships ESM out of the box. Two adapters in this PR work around `linkedom` quirks:

- linkedom returns a proxy-backed `window` whose properties cannot be reassigned, so `window.DOMParser = shim` silently fails. The shim wraps the window in a Proxy that returns the custom DOMParser on the `DOMParser` key and forwards every other read.
- linkedom's "text/html" parse hoists nested `<body>` tags out of their parent and leaves `.body` empty, which breaks Tiptap's `elementFromString`. The custom DOMParser strips the outermost `<body>…</body>` wrapper before delegating.
- linkedom 0.18 does not expose `document.implementation`, so the single `createHTMLDocument` call site used by ProseMirror is polyfilled.

## Test plan

- [x] Run `pnpm lint` (no new warnings introduced).
- [x] Run `pnpm typecheck`.
- [x] Run `pnpm check:nolet`.
- [x] Run `pnpm check:ssr`.
- [x] Run `pnpm check:parity`.
- [x] Run `pnpm build`.
- [x] Run `pnpm test:ssr` — eight cases cover heading + paragraph, bullet / ordered lists, fenced code block, mermaid fence (must survive as `<code class="language-mermaid">`), link, image, and mention + wiki-link.

## Follow-ups

- The framework `VizelStaticView` components in `@vizel/{react,vue,svelte}` are intentionally left for a later batch — they will consume this helper as their server renderer.
- Documentation and recipes for the SSR Mode 1 workflow will land alongside the framework components.
