### PR TITLE
fix(demo): unblock editor render by removing comments-without-provider

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -301,9 +301,6 @@ function AppContent() {
                   typography: true,
                   mention: { items: mockMentionItems },
                 },
-                collaboration: {
-                  comments: true,
-                },
               }}
               onCreate={({ editor: newEditor }) => {
                 setEditor(newEditor);

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -248,9 +248,6 @@ function handleJsonChange(event: Event) {
               typography: true,
               mention: { items: mockMentionItems },
             },
-            collaboration: {
-              comments: true,
-            },
           }}
           onCreate={handleCreate}
           onUpdate={handleUpdate}

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -243,9 +243,6 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
                   typography: true,
                   mention: { items: mockMentionItems },
                 },
-                collaboration: {
-                  comments: true,
-                },
               }"
               @create="handleCreate"
               @update="handleUpdate"

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -227,7 +227,10 @@ export function Vizel({
     onSelectionUpdate: (e) => onSelectionUpdateRef.current?.(e),
     onFocus: (e) => onFocusRef.current?.(e),
     onBlur: (e) => onBlurRef.current?.(e),
-    onError: (e) => onErrorRef.current?.(e),
+    // Only install the error trampoline when the consumer actually passed an
+    // onError prop. A blanket wrapper would intercept thrown configuration
+    // errors and swallow them silently inside useVizelEditor.
+    ...(onError !== undefined && { onError: (e) => onErrorRef.current?.(e) }),
   });
 
   // Watch for external markdown changes (controlled mode)

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -14,7 +14,7 @@ import {
   type VizelLocale,
   type VizelMarkdownFlavor,
 } from "@vizel/core";
-import { computed, useSlots, watch } from "vue";
+import { computed, useAttrs, useSlots, watch } from "vue";
 import { useVizelEditor } from "../composables/useVizelEditor.ts";
 import VizelBlockMenu from "./VizelBlockMenu.vue";
 import VizelBubbleMenu from "./VizelBubbleMenu.vue";
@@ -141,7 +141,13 @@ const editor = useVizelEditor({
   onSelectionUpdate: (e) => emit("selectionUpdate", e),
   onFocus: (e) => emit("focus", e),
   onBlur: (e) => emit("blur", e),
-  onError: (e) => emit("error", e),
+  // Vue's `emit` always succeeds — even when no parent listener exists. To
+  // mirror the React component's behavior (let configuration errors surface
+  // when no consumer is interested), only wire the trampoline when the
+  // parent actually registered an `@error` listener.
+  ...(useAttrs().onError !== undefined && {
+    onError: (e: VizelError) => emit("error", e),
+  }),
 });
 
 // Watch for external markdown changes (v-model:markdown)


### PR DESCRIPTION
## Summary

The three demo apps were configuring `features.collaboration.comments: true` without a matching `features.collaboration.provider`. Section 8e wired `validateVizelCollaborationFeatures` to throw `VizelError(\"INVALID_CONFIG\")` from `createVizelEditorInstance` when comments lacks a provider, but the demo configs were not updated to match. The thrown error was then silently swallowed by `useVizelEditor`'s error path, leaving every demo with an empty editor wrapper and no initial sample content.

## Two fixes

1. **Demo apps** — drop `collaboration.comments: true` from all three demos. The comment side-panel UI (`useVizelComment` / `createVizelComment`) already runs independently of the editor extension; the editor option was never required for the demos to work.

2. **`Vizel` components (React + Vue)** — stop installing a blanket `onError` trampoline when the consumer did not pass an `onError` prop / listener. The trampoline made `useVizelEditor` believe a handler existed and skip the rethrow path, hiding configuration errors. Now React only wires the wrapper when `onError` is actually supplied; Vue only wires it when an `@error` listener exists in `useAttrs()`. Svelte already had the correct behavior.

## Verification

- Reproduced the regression locally: `http://localhost:3000` (React demo) showed an empty editor.
- Identified the silent failure via `createVizelEditorInstance({ features: { collaboration: { comments: true } } })` returning `VizelError(\"INVALID_CONFIG\")`.
- After the fix, the React demo reloads with the full sample Markdown rendered (Vizel header, drag handle scenarios, nested lists, task list).

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm check:nolet`, `pnpm check:ssr`, `pnpm check:parity` — all green.
- [x] `pnpm build` succeeds.
- [x] React demo at `http://localhost:3000` shows initial Markdown content (Chrome DevTools verified `.ProseMirror` mounted with 84 children).