### PR TITLE
fix(core): improve dark mode visibility for borders and diagrams

### DIFF
--- a/packages/core/src/extensions/diagram.ts
+++ b/packages/core/src/extensions/diagram.ts
@@ -162,25 +162,48 @@ function registerDiagramFenceRenderer(md: MarkdownIt): void {
 }
 
 /**
+ * Resolve the Mermaid theme that matches the host page's current
+ * `data-vizel-theme`. Mermaid's `"default"` theme assumes a light
+ * canvas and renders nearly-invisible strokes against Vizel's dark
+ * tokens, so the diagram extension re-initializes Mermaid whenever
+ * the resolved theme changes.
+ */
+function resolveMermaidTheme(): "default" | "dark" {
+  if (typeof document === "undefined") return "default";
+  const attr = document.documentElement.getAttribute("data-vizel-theme");
+  if (attr === "dark") return "dark";
+  if (attr === "light") return "default";
+  return typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "default";
+}
+
+/**
  * Initialize Mermaid with the provided configuration.
- * Loads the mermaid module dynamically on first use.
+ *
+ * Loads the mermaid module dynamically on first use and re-runs the
+ * initializer whenever the host page flips between light and dark
+ * themes (Mermaid's `initialize` is idempotent — repeated calls
+ * overwrite the previous config, so the cost is bounded).
  */
 async function initializeMermaid(
   config: MermaidConfig | undefined,
-  storage: { mermaidInitialized: boolean }
+  storage: { mermaidInitializedTheme: "default" | "dark" | null }
 ): Promise<void> {
-  if (storage.mermaidInitialized) return;
+  const resolvedTheme = config?.theme ?? resolveMermaidTheme();
+  if (storage.mermaidInitializedTheme === resolvedTheme) return;
 
   const mermaid = await loadMermaid();
   mermaid.initialize({
     startOnLoad: false,
-    theme: "default",
+    theme: resolvedTheme,
     fontFamily: "var(--vizel-font-sans)",
     ...config,
     securityLevel: config?.securityLevel ?? "strict",
   });
 
-  storage.mermaidInitialized = true;
+  storage.mermaidInitializedTheme = resolvedTheme === "dark" ? "dark" : "default";
 }
 
 /**
@@ -320,8 +343,12 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
 
   addStorage() {
     return {
-      /** Whether mermaid has been initialized for this editor instance */
-      mermaidInitialized: false,
+      /**
+       * Theme Mermaid was last initialized for. `null` means Mermaid
+       * has not been initialized yet; switching themes re-initializes
+       * Mermaid in {@link initializeMermaid}.
+       */
+      mermaidInitializedTheme: null as "default" | "dark" | null,
       markdown: {
         serialize(state: MarkdownSerializerState, node: PMNode) {
           const code = String(node.attrs?.code ?? "");
@@ -388,7 +415,9 @@ export const VizelDiagram = Node.create<VizelDiagramOptions>({
   addNodeView() {
     return ({ node, getPos, editor }) => {
       const mermaidConfig = this.options.mermaidConfig;
-      const diagramStorage = this.storage as { mermaidInitialized: boolean };
+      const diagramStorage = this.storage as {
+        mermaidInitializedTheme: "default" | "dark" | null;
+      };
 
       const dom = document.createElement("div");
       dom.classList.add("vizel-diagram");

--- a/packages/core/src/styles/_tokens.scss
+++ b/packages/core/src/styles/_tokens.scss
@@ -128,9 +128,12 @@ $dark-colors: (
   "accent": oklch(0.279 0.041 260.031),
   "accent-foreground": oklch(0.985 0 0),
 
-  // Border
-  "border": oklch(0.279 0.041 260.031),
-  "border-hover": oklch(0.372 0.044 257.287),
+  // Border — slightly above background-tertiary (L=0.279) so dividers,
+  // table cell borders, blockquote rules, and other 1px strokes stay
+  // visible against the L=0.21 base. Anything below L≈0.40 hides
+  // against a dark canvas.
+  "border": oklch(0.42 0.025 257.287),
+  "border-hover": oklch(0.55 0.03 257.287),
 
   // Hover/Active States
   "hover-bg": oklch(1 0 0 / 0.05),

--- a/packages/core/src/styles/diagram.scss
+++ b/packages/core/src/styles/diagram.scss
@@ -173,11 +173,49 @@
   --vizel-diagram-editing-bg: v("background-tertiary");
 }
 
+// GraphViz emits SVGs with hard-coded `stroke="black"` and
+// `fill="white"`, which collapse into invisible strokes on a dark
+// canvas. Mermaid embeds its own `<style>` block with theme-aware
+// colors and does not rely on these literal attributes, so the
+// attribute selectors below only catch GraphViz output and leave
+// Mermaid alone.
+[data-vizel-theme="dark"] .vizel-diagram-render svg {
+  [stroke="black"] {
+    stroke: v("foreground");
+  }
+  [fill="white"] {
+    fill: v("background-secondary");
+  }
+  [fill="black"]:not([stroke]) {
+    fill: v("foreground");
+  }
+  text {
+    fill: v("foreground");
+  }
+}
+
 @media (prefers-color-scheme: dark) {
-  .vizel-diagram {
-    --vizel-diagram-bg: v("background-secondary");
-    --vizel-diagram-hover-bg: v("background-tertiary");
-    --vizel-diagram-selected-bg: v("primary-bg");
-    --vizel-diagram-editing-bg: v("background-tertiary");
+  :root:not([data-vizel-theme="light"]):not([data-vizel-theme]) {
+    .vizel-diagram {
+      --vizel-diagram-bg: v("background-secondary");
+      --vizel-diagram-hover-bg: v("background-tertiary");
+      --vizel-diagram-selected-bg: v("primary-bg");
+      --vizel-diagram-editing-bg: v("background-tertiary");
+    }
+
+    .vizel-diagram-render svg {
+      [stroke="black"] {
+        stroke: v("foreground");
+      }
+      [fill="white"] {
+        fill: v("background-secondary");
+      }
+      [fill="black"]:not([stroke]) {
+        fill: v("foreground");
+      }
+      text {
+        fill: v("foreground");
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Three changes to address low-contrast strokes that the user flagged against the dark canvas (\"horizontal rules, table borders, Mermaid lines are hard to see\").

1. **Border token bump.** Dark-mode `border` lifted from `oklch(0.279)` to `oklch(0.42)`. The previous value collapsed against `background-tertiary` (also L=0.279) so 1px strokes around tables, `<hr>`, `<details>`, and other chrome were essentially invisible.
2. **Theme-aware Mermaid.** The diagram extension now reads `data-vizel-theme` (with a `prefers-color-scheme` fallback) and re-initializes Mermaid whenever the resolved theme changes, so flowchart / sequence / class diagrams render with their dark-canvas color set instead of the default light theme.
3. **GraphViz SVG overrides.** New attribute selectors under `[data-vizel-theme=\"dark\"] .vizel-diagram-render svg` rewrite `stroke=\"black\"` / `fill=\"white\"` / `fill=\"black\"` to theme tokens. GraphViz emits these literal attributes; Mermaid uses its own inline `<style>` block so the selectors do not affect it.

## Test plan

- [x] React demo at `http://localhost:3000` — hr, table cells, blockquote, details, Mermaid flowchart, Mermaid sequence, GraphViz Dependency Graph all readable in dark mode.
- [x] Light mode unchanged: same visual confirmed after toggling back.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm check:nolet`, `pnpm check:ssr`, `pnpm check:parity` — all green.
- [x] `pnpm build` succeeds.