### PR TITLE
chore: align .claude/ docs with shipped v2.0.0 surface (Section 17)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -45,12 +45,12 @@ Vizel is a **block-based visual Markdown editor** built on Tiptap. The product:
    framework-side component file should fit within ~120 lines of view code; if
    it grows past that, the excess is logic that belongs in Core.
 
-3. **UI components ship as Core skeletons + framework renderers.**
+3. **UI components ship as Core specs + framework renderers.**
    Every menu, popover, and form (`VizelSlashMenu`, `VizelMentionMenu`,
    `VizelBlockMenu`, `VizelToolbarDropdown`, `VizelNodeSelector`,
    `VizelLinkEditor`, `VizelFindReplace`, `VizelColorPicker`,
    `VizelBubbleMenu`, ...) declares its DOM scaffolding as a typed spec in
-   `packages/core/src/skeletons/`. The framework component is a thin
+   `packages/core/src/builders/`. The framework component is a thin
    transformer that maps the spec to native template syntax. ARIA attributes,
    identifiers, and section/item structure live in the spec — frameworks do
    not duplicate them.

--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -332,10 +332,18 @@ host framework's idiom. Differences outside this catalog are defects.
 
 `@vizel/core` owns all framework-agnostic code. See `packages/core.md` for the centralization rules.
 
-The framework packages do NOT re-export symbols from `@vizel/core`. Consumers import shared symbols directly:
+The framework packages re-export the full `@vizel/core` surface via
+`export * from "@vizel/core"` in each `packages/{react,vue,svelte}/src/index.ts`.
+Installing one framework package is sufficient to access every Core
+type, constant, extension, builder, controller, and utility — consumers
+do not need a direct `@vizel/core` dependency for normal use (Section 6
+of the v2 redesign, enforced by `pnpm check:parity`).
 
-- Import Vizel types and utilities from `@vizel/core`.
+- Import Vizel symbols from the framework package you already use
+  (`@vizel/react`, `@vizel/vue`, or `@vizel/svelte`).
 - Import Tiptap types (`JSONContent`, `Editor`, etc.) from `@tiptap/core`.
+- Style imports remain explicit: `import "@vizel/<framework>/styles.css"`
+  works because CSS cannot be re-exported across packages.
 
 ### Naming Conventions
 

--- a/.claude/rules/demo.md
+++ b/.claude/rules/demo.md
@@ -74,9 +74,31 @@ All three demos share:
 
 ## CSS
 
-- Import `packages/core/src/styles/index.css` as the editor stylesheet.
-- Use the shared `styles.css` for demo-specific styling.
+- Import `@vizel/<framework>/styles.css` as the editor stylesheet
+  (e.g. `@vizel/react/styles.css`). Framework packages re-export the
+  Core CSS bundles through subpath exports.
+- Add `@vizel/<framework>/mathematics.css` only when the mathematics
+  feature is enabled.
+- Use the shared `apps/demo/shared/styles/base.css` for demo chrome
+  styling.
 - Maintain a consistent look across frameworks.
+
+## Common Pitfalls
+
+- **`features.collaboration.comments` requires `features.collaboration.provider`.**
+  Setting `comments: true` without a provider throws
+  `VizelError("INVALID_CONFIG")` from `createVizelEditorInstance` at
+  mount time. The editor stays `null` and the demo renders an empty
+  wrapper. The comment side-panel UI (`useVizelComment` /
+  `createVizelComment`) runs independently and does not require the
+  feature flag — leave it on the demo controls without forwarding to
+  `features`. The same rule applies to
+  `features.collaboration.presence`.
+- **Do not install a blanket `onError` trampoline on `<Vizel>`.** When
+  the consumer did not pass an `onError` prop / `@error` listener, leave
+  the prop unset so `useVizelEditor` can rethrow configuration errors
+  to the global handler. A blanket wrapper silently swallows
+  `INVALID_CONFIG` and `SSR_NOT_SUPPORTED`.
 
 ## Verification Checklist
 

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -36,7 +36,16 @@ This project uses Conventional Commits. The lefthook `commit-msg` hook validates
 | `react` | `@vizel/react` package |
 | `vue` | `@vizel/vue` package |
 | `svelte` | `@vizel/svelte` package |
-| `demo` | Demo applications |
+| `demo` | Demo applications under `apps/demo/` |
+| `docs` | VitePress docs site under `docs/` |
+| `ct` | Playwright Component Tests under `tests/ct/` |
+| `deps` | Dependency-only changes (typically `chore(deps)`) |
+| `spec` | v2 design spec under `docs/superpowers/specs/` |
+| `guide` | User-facing guide pages under `docs/guide/` |
+| `plan` | Implementation plans under `docs/superpowers/plans/` |
+| `i18n` | Locale files |
+| `a11y` | Accessibility-only fixes |
+| `ci` | CI workflows under `.github/workflows/` |
 | (none) | Multiple packages or project-wide changes |
 
 ### Rules

--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -126,12 +126,28 @@ Heading.configure({
 | Comment | `extensions/comment.ts` | Text annotations and comments |
 | MultiBlockSelection | `extensions/multi-block-selection.ts` | Always-on multi-block range selection with block-aware Backspace / Delete / Tab / Shift+Tab |
 | BlockClipboard | `extensions/block-clipboard.ts` | Always-on block-aware copy / cut / paste; writes `application/x-vizel-blocks` (lossless JSON) plus `text/html` / `text/markdown` / `text/plain` mirrors and accepts the same payloads on paste |
+| BlockMenu | `extensions/block-menu.ts` | Block-level action menu surface (used by `VizelBlockMenu`) |
+| Mention | `extensions/mention.ts` | `@`-mention suggestion menu with markdown encoding modes |
+| FindReplace | `extensions/find-replace.ts` | In-document find / replace with highlight decorations |
+| Highlight | `extensions/highlight.ts` | Text highlight mark (yellow / orange / green / blue / pink palette) |
+| Callout | `extensions/callout.ts` | Note / tip / warning / danger callout blocks |
+| ImageResize | `extensions/image-resize.ts` | Resize handles for the `image` node |
+| FileHandler | `extensions/file-handler.ts` | Paste / drop handler for file uploads |
+| Presence | `extensions/presence.ts` | Cursor / selection presence overlays for collaboration |
+| Typography | `extensions/typography.ts` | Smart quote / em-dash / ellipsis input rules |
+| VisualHierarchy | `extensions/visual-hierarchy.ts` | Visual cues for nested block depth |
+| TableBase | `extensions/table-base.ts` | Base Tiptap Table family (without UI controls) |
+| TableControls | `extensions/table-controls.ts` | Row / column control overlays for the table feature |
+| TableOfContents | `extensions/table-of-contents.ts` | Live-updated outline node sourced from headings |
+| CommandShortcuts | `extensions/command-shortcuts.ts` | Keyboard shortcut bindings derived from `VizelCommand.shortcut` |
+| NodeTypes | `extensions/node-types.ts` | Helper extension for `VizelNodeTypeOption` lookups |
 
 The following extensions are part of the always-on core and are NOT
-gated by `VizelFeatureOptions`: Markdown, Link, CodeBlock,
-MultiBlockSelection, BlockClipboard. To configure
-them, use the corresponding top-level options on `VizelEditorOptions`
-(e.g. the Markdown flavor lives at `flavor`, not under `features`).
+gated by `VizelFeatureOptions`: Base, Markdown, Link, CodeBlock,
+MultiBlockSelection, BlockClipboard, BlockMenu, FindReplace,
+CommandShortcuts, NodeTypes. To configure them, use the corresponding
+top-level options on `VizelEditorOptions` (e.g. the Markdown flavor
+lives at `flavor`, not under `features`).
 
 ## Feature Categories
 

--- a/.claude/skills/lint-instructions/SKILL.md
+++ b/.claude/skills/lint-instructions/SKILL.md
@@ -67,7 +67,7 @@ For each applicable rule file, verify the following.
 - [ ] Each component exists in all three framework packages.
 - [ ] Props match across frameworks (allowing `class` versus `className`).
 - [ ] Hooks, composables, and runes share an option interface defined in `@vizel/core`.
-- [ ] No framework package re-exports symbols from `@vizel/core`.
+- [ ] Each framework package re-exports the full `@vizel/core` surface via `export * from "@vizel/core"` in its `src/index.ts` (Section 6 of the v2 redesign — verified by `pnpm check:parity`).
 
 #### Core Package (`packages/core.md`)
 
@@ -130,4 +130,4 @@ For each fixable violation:
 | Type defined inside a framework package | `cross-framework.md` | Move the type to `@vizel/core` |
 | Component missing in one framework | `cross-framework.md` | Add the equivalent component |
 | `default export` | Biome | Use a named export |
-| Re-export from `@vizel/core` in a framework package | `cross-framework.md` | Import directly from `@vizel/core` |
+| Framework `src/index.ts` missing `export * from "@vizel/core"` | `cross-framework.md` | Add the mirror re-export so consumers do not need a direct `@vizel/core` dependency |


### PR DESCRIPTION
## Summary

Sweep the `.claude/` documentation for drift against the shipped v2.0.0 surface. All six SSOT documents were checked against actual code; the items below were stale.

## Drifts fixed

- **`architecture.md`** — replaced the stale `packages/core/src/skeletons/` path with the canonical `packages/core/src/builders/` and switched the invariant wording from "skeletons + framework renderers" to "specs + framework renderers" so it matches `packages/core.md`.
- **`cross-framework.md`** — inverted the misleading \"framework packages do NOT re-export from `@vizel/core`\" claim. Section 6 of the v2 redesign introduced `export * from \"@vizel/core\"` mirrors that `pnpm check:parity` now enforces.
- **`demo.md`** — pointed the CSS guidance at the published subpath (`@vizel/<framework>/styles.css`) instead of the internal source path, and added a Common Pitfalls section capturing the two regressions surfaced this release (`comments` without `provider`; blanket `onError` trampoline).
- **`git.md`** — extended the Scopes table to cover the additional scopes used during the v2 cycle (`docs`, `ct`, `deps`, `spec`, `guide`, `plan`, `i18n`, `a11y`, `ci`).
- **`packages/core.md`** — enumerated the extension files that exist on disk but were missing from the Extension Catalog (15 additions including `BlockMenu`, `Mention`, `FindReplace`, `Highlight`, `Callout`, `ImageResize`, `FileHandler`, `Presence`, `Typography`, `VisualHierarchy`, `TableBase`, `TableControls`, `TableOfContents`, `CommandShortcuts`, `NodeTypes`), and updated the always-on list to include `BlockMenu` / `FindReplace` / `CommandShortcuts` / `NodeTypes` / `Base`.
- **`lint-instructions/SKILL.md`** — inverted the same re-export rule so the audit skill no longer flags the now-canonical mirror pattern.

## Test plan

- [x] `pnpm lint` passes.
- [x] `pnpm check:parity` still green (no code change).
- [x] `pnpm check:nolet` still green.
- [x] Each modified table compared against shipped source on `main`.