### PR TITLE
feat(ct): document seven testing pillars and ship CT parity check (Section 14)

### DIFF
--- a/.claude/agents/cross-framework-reviewer.md
+++ b/.claude/agents/cross-framework-reviewer.md
@@ -23,14 +23,14 @@ This subagent verifies feature parity and API consistency across the three Vizel
    - The hook, composable, and rune share an option interface defined in `@vizel/core`.
    - The return shape matches the framework idiom: `Editor | null` (React), `ShallowRef<Editor | null>` (Vue), `{ get current(): Editor | null }` (Svelte).
    - Shared types, constants, and utilities live in `@vizel/core`.
-4. **Run the four Parity Checks** (see next section).
+4. **Run the six Parity Checks** (see next section).
 5. **Verify the demo apps.** Confirm that each demo under `apps/demo/{react,vue,svelte}/` exercises the new feature.
 6. **Verify the tests.** Confirm that `tests/ct/scenarios/` defines a shared scenario and that `tests/ct/{react,vue,svelte}/specs/` consumes it.
 
 ## Parity Checks
 
 The six SSOT parity tables in `.claude/rules/cross-framework.md` are
-the contract. Run the following four checks against the changed
+the contract. Run the following six checks against the changed
 surface. Any divergence outside Table 6 (Idiom Exception Catalog) is a
 defect.
 
@@ -58,6 +58,20 @@ defect.
    either bringing it back into parity or extending the catalog with a
    documented justification.
 
+5. **CT spec parity.** Every `*.spec.{tsx,ts}` file must exist in all
+   three framework specs directories
+   (`tests/ct/{react,vue,svelte}/specs/`), modulo the idiom prefix
+   stripped from hook / composable / rune specs (`Use*` on React and
+   Vue, `Create*` / `Get*` on Svelte). Run `pnpm check:ct-parity` to
+   confirm; lefthook runs the same script on `pre-push` and the CI
+   `ct-parity` job blocks merge. The seven-pillar rules in
+   `.claude/rules/testing.md` gate review on this check.
+6. **Shared scenario usage.** For each spec touched, confirm it
+   imports its core assertions from `tests/ct/scenarios/`. A spec
+   that hand-rolls framework-specific assertions is a defect: lift
+   the assertions into the shared scenario so the other two
+   frameworks consume the same expectations.
+
 ## Output
 
 Report findings in the following format. Cite file paths in `path:line` form.
@@ -79,6 +93,7 @@ Report findings in the following format. Cite file paths in `path:line` form.
 - [ ] Add a `createVizel<Feature>` rune at `packages/svelte/src/runes/<feature>.svelte.ts`.
 - [ ] Update demos at `apps/demo/{react,vue,svelte}/` to exercise the feature.
 - [ ] Add a shared scenario at `tests/ct/scenarios/<feature>.scenario.ts`.
+- [ ] Confirm `pnpm check:ct-parity` exits 0 after adding the per-framework specs.
 ```
 
 ## Constraints

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -6,26 +6,90 @@ paths:
 
 # Testing
 
-This project uses Playwright Component Testing for end-to-end (E2E) tests across React, Vue, and Svelte.
+Vizel ships seven testing pillars. Section 14 of the v2.0.0 spec
+(`docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`,
+lines 1175-1210) is the SSOT; this file is the project-rule projection
+of that spec and is what PR review uses to gate coverage.
 
-## Directory Structure
+## The Seven Pillars
+
+| # | Pillar | Status | Surface |
+|---|--------|--------|---------|
+| 1 | Framework parity | shipped | `scripts/check-ct-parity.ts` + lefthook + CI |
+| 2 | Behavior tests | shipped | `tests/ct/scenarios/` + `tests/ct/{react,vue,svelte}/specs/` |
+| 3 | Markdown round-trip | shipped (sample-light) | `tests/markdown-roundtrip/` |
+| 4 | SSR | shipped (Node smoke test) | `scripts/test-static-html.ts` |
+| 5 | Accessibility | not yet | `tests/a11y/` (planned) |
+| 6 | Visual regression | not yet | CI-only snapshots (planned) |
+| 7 | Coverage discipline | shipped (this document) | Required-test matrix below |
+
+Pillars 5 and 6 are tracked as follow-up work for the v2.0.0 push. Do
+not block PRs on missing a11y or visual snapshots until those suites
+land — but every other pillar gates merge.
+
+---
+
+## Pillar 1 — Mechanical framework parity
+
+Every Playwright CT spec must exist under all three framework
+packages. The single permitted asymmetry is the idiom prefix:
+
+| React / Vue | Svelte | Parity stem |
+|-------------|--------|-------------|
+| `UseEditorState.spec.{tsx,ts}` | `CreateEditorState.spec.ts` | `EditorState` |
+| `UseVizelContext.spec.{tsx,ts}` | `GetVizelContext.spec.ts` | `VizelContext` |
+
+The `Use*` to `Create*` / `Get*` mapping mirrors the symbol parity
+rules in `scripts/check-cross-framework-parity.ts`.
+
+### How to verify
+
+```bash
+pnpm check:ct-parity
+```
+
+Lefthook runs the same check on `pre-push`; the `ct-parity` GitHub
+Actions job blocks merge.
+
+### How to add a parity exception
+
+Spec parity has **no** exception catalog. If a component genuinely
+does not exist on one framework (rare; the cross-framework rules in
+`.claude/rules/cross-framework.md` already forbid this), revisit the
+component before adding a spec asymmetry.
+
+---
+
+## Pillar 2 — Behavior tests for every shipped feature
+
+Sections 1-13 of the v2.0.0 spec each introduce features (builders,
+controllers, commands, block operations, static view modes, etc.).
+Each feature receives:
+
+1. A shared scenario at `tests/ct/scenarios/<feature>.scenario.ts`.
+2. Three per-framework specs at
+   `tests/ct/{react,vue,svelte}/specs/<Feature>.spec.{tsx,ts,ts}`.
+3. Each spec imports and invokes the shared scenario; framework code
+   inside the spec is limited to mounting and idiom-specific wiring.
+
+### Directory structure
 
 ```
 tests/ct/
 ├── scenarios/                # Framework-agnostic shared scenarios
 │   └── *.scenario.ts
 ├── react/
-│   ├── specs/                # *.spec.tsx
+│   ├── specs/                # *.spec.tsx, *Fixture.tsx
 │   └── playwright-ct.config.ts
 ├── vue/
-│   ├── specs/                # *.spec.ts
+│   ├── specs/                # *.spec.ts, *Fixture.vue
 │   └── playwright-ct.config.ts
 └── svelte/
-    ├── specs/                # *.spec.ts
+    ├── specs/                # *.spec.ts, *Fixture.svelte
     └── playwright-ct.config.ts
 ```
 
-## Commands
+### Commands
 
 | Command | Description |
 |---------|-------------|
@@ -35,7 +99,7 @@ tests/ct/
 | `pnpm test:ct:vue` | Run Vue tests only |
 | `pnpm test:ct:svelte` | Run Svelte tests only |
 
-### Browser and File Selection
+### Browser and file selection
 
 ```bash
 # Choose a browser.
@@ -50,11 +114,7 @@ pnpm test:ct:react -- --headed
 pnpm test:ct:react -- tests/ct/react/specs/Editor.spec.tsx
 ```
 
-## Authoring Tests
-
-### Shared Scenarios
-
-Define reusable scenarios under `tests/ct/scenarios/`:
+### Authoring a shared scenario
 
 ```typescript
 // tests/ct/scenarios/example.scenario.ts
@@ -65,9 +125,7 @@ export async function testFeature(component: Locator, page: Page): Promise<void>
 }
 ```
 
-### Framework-Specific Specs
-
-Import shared scenarios into framework specs:
+### Authoring a framework spec
 
 ```typescript
 // tests/ct/react/specs/Example.spec.tsx
@@ -83,11 +141,17 @@ test.describe("Example", () => {
 });
 ```
 
-## Best Practices
+### How to add a new behavior test
 
-### Locator Priority
+1. Create a shared scenario under `tests/ct/scenarios/`.
+2. Create one spec per framework, each importing the shared scenario.
+3. Use the same stem across the three specs (Pillar 1).
+4. Run `pnpm test:ct` to verify parity.
+5. Run `pnpm check:ct-parity` to confirm spec-name balance.
 
-Pick locators from the most stable source first.
+### Best practices
+
+**Locator priority** — pick locators from the most stable source first.
 
 | Priority | Method | Example |
 |----------|--------|---------|
@@ -96,9 +160,9 @@ Pick locators from the most stable source first.
 | 3 | CSS class | `.vizel-*` |
 | 4 | Element type | `locator("button")` |
 
-### Portals
-
-Components rendered to `document.body` (portals) require `page.locator()`. Components rendered inside the mount target use `component.locator()`.
+**Portals.** Components rendered to `document.body` use
+`page.locator()`. Components rendered inside the mount target use
+`component.locator()`.
 
 ```typescript
 // Inside mount target.
@@ -108,9 +172,7 @@ const button = component.locator(".vizel-button");
 const popup = page.locator("[data-vizel-popup]");
 ```
 
-### Waiting
-
-Prefer assertion-based waits over fixed timeouts.
+**Waiting.** Prefer assertion-based waits over fixed timeouts.
 
 ```typescript
 // GOOD.
@@ -121,9 +183,7 @@ await expect(element).toHaveText("Expected");
 await page.waitForTimeout(1000);
 ```
 
-### Assertions
-
-Use Playwright's auto-retrying assertions.
+**Assertions.** Use Playwright's auto-retrying assertions.
 
 ```typescript
 await expect(element).toBeVisible();
@@ -131,24 +191,177 @@ await expect(element).toHaveClass(/active/);
 await expect(element).toContainText("Hello");
 ```
 
-## Cross-Framework Coverage
+---
 
-- Every component requires equivalent tests in React, Vue, and Svelte.
-- Share scenarios under `tests/ct/scenarios/` to keep coverage consistent.
-- Name spec files `ComponentName.spec.{tsx,ts}`.
+## Pillar 3 — Markdown round-trip suite
 
-### Adding a New Test
+`tests/markdown-roundtrip/` drives the Section 10 round-trip matrix:
+every supported flavor parses and re-serializes a corpus of samples
+without lossy edits.
 
-1. Create a shared scenario under `tests/ct/scenarios/`.
-2. Create a spec file under each framework's `specs/` directory.
-3. Import the shared scenario in each spec.
-4. Run the tests for all frameworks to verify parity.
+The Section 10 long-term target is 100+ samples per flavor. The
+current corpus ships a representative cross-section (heading,
+paragraph, list, blockquote, inline emphasis, inline code, fenced
+code, image, link, plus the flavor-specific syntax). Expanding the
+corpus is itself a coverage task.
 
-## Continuous Integration
+### Files
 
-GitHub Actions runs the E2E tests on every push and pull request.
+| Path | Purpose |
+|------|---------|
+| `tests/markdown-roundtrip/samples/index.ts` | Sample buckets (one `export const` per flavor) |
+| `tests/markdown-roundtrip/specs/Roundtrip.spec.tsx` | Drives every sample through Vizel |
+| `tests/markdown-roundtrip/specs/Probe.spec.tsx` | Single-case diagnostic harness |
 
-- The runner executes the tests for React, Vue, and Svelte in parallel.
-- The runner uses only Chromium for speed.
-- The runner uploads Playwright reports as artifacts.
-- The summary shows pass and fail counts per framework.
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm test:md-roundtrip` | Run the full round-trip suite (Chromium only) |
+
+### How to add a new flavor
+
+1. Extend `packages/core/src/markdown/flavors/` with the flavor's
+   serializer / parser.
+2. Add a `<flavor>Samples: readonly VizelRoundtripSample[]` bucket
+   to `tests/markdown-roundtrip/samples/index.ts`. Start with the
+   ten canonical baselines plus every flavor-specific syntax form.
+3. Wire the bucket into `Roundtrip.spec.tsx`.
+4. Run `pnpm test:md-roundtrip` and confirm zero diffs.
+
+### How to add a new sample to an existing flavor
+
+1. Append an entry to the relevant `<flavor>Samples` array with a
+   stable `name` and the exact input Markdown Vizel must emit on
+   round-trip.
+2. Run `pnpm test:md-roundtrip` to confirm the round-trip succeeds.
+
+---
+
+## Pillar 4 — SSR suite
+
+The Section 11 server-rendering path is exercised by a Node-only
+smoke test that drives `generateVizelStaticHtml` against canonical
+Markdown samples. Running the full SSR matrix through Playwright is
+gratuitous; the script asserts DOM markers directly.
+
+### Files
+
+| Path | Purpose |
+|------|---------|
+| `scripts/test-static-html.ts` | Node smoke test for `generateVizelStaticHtml` |
+| `scripts/check-ssr-safety.ts` | Static lint for top-level `document` / `window` access |
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm test:ssr` | Run the SSR static-HTML smoke test |
+| `pnpm check:ssr` | Confirm Core stays free of top-level browser globals |
+
+### How to add a new SSR case
+
+1. Append a `StaticHtmlCase` entry to `scripts/test-static-html.ts`.
+2. Set `mustInclude` / `mustNotInclude` to DOM markers that uniquely
+   identify the rendered output.
+3. Run `pnpm test:ssr` and confirm exit 0.
+
+`pnpm check:ssr` runs on `pre-push` and CI to guarantee Core never
+references `document` or `window` at module scope. Lazy access
+inside function bodies remains permitted.
+
+---
+
+## Pillar 5 — Accessibility suite (NOT YET SHIPPED)
+
+The Section 14 target is `tests/a11y/` driven by `@axe-core/playwright`
+asserting WCAG 2.1 AA conformance against every component. The
+Section 2 spec-based ARIA wiring keeps the per-component cost low.
+
+### Status
+
+- Directory: not yet created.
+- Dependency: `@axe-core/playwright` not yet added.
+- Tracking: follow-up work for the v2.0.0 release push.
+
+### How to bootstrap (when work starts)
+
+1. Add `@axe-core/playwright` to root `devDependencies`.
+2. Create `tests/a11y/<framework>/playwright-ct.config.ts` per
+   framework (mirror the CT layout).
+3. Add a shared `axe-scan.scenario.ts` that runs `AxeBuilder` against
+   every component fixture.
+4. Add `pnpm test:a11y` and gate it on CI.
+5. Update this section's status from "NOT YET SHIPPED" to "shipped".
+
+---
+
+## Pillar 6 — Visual regression (NOT YET SHIPPED)
+
+The Section 14 target is a CI-only visual snapshot suite covering
+~20 essential views (editor light/dark, slash menu open, block menu
+open, bubble menu over selection, color picker, outline, minimap,
+link editor, find/replace). Local execution is skipped to avoid
+OS-level rendering noise.
+
+### Status
+
+- Snapshot store: not yet created.
+- Workflow: not yet created.
+- Tracking: follow-up work for the v2.0.0 release push.
+
+### How to bootstrap (when work starts)
+
+1. Add a `tests/visual/` directory with Playwright `toHaveScreenshot`
+   specs gated on `process.env.CI === "true"`.
+2. Add a `workflow_dispatch` GitHub Actions workflow that updates
+   baselines on demand.
+3. Add `pnpm test:visual` (CI-only) and an opt-in
+   `pnpm test:visual:local`.
+4. Update this section's status from "NOT YET SHIPPED" to "shipped".
+
+---
+
+## Pillar 7 — Coverage discipline
+
+Every new feature checks in the rows of the table below before
+merge. PR review verifies the rows are filled in or that the row
+explicitly marks the test type as not applicable.
+
+| Feature kind | Pillar 1 (parity) | Pillar 2 (behavior) | Pillar 3 (round-trip) | Pillar 4 (SSR) | Pillar 5 (a11y) | Pillar 6 (visual) |
+|--------------|:-----------------:|:-------------------:|:---------------------:|:--------------:|:---------------:|:-----------------:|
+| New component or controller | required | required | n/a | required | follow-up | follow-up |
+| New hook / composable / rune | required | required | n/a | required | n/a | n/a |
+| New command or block operation | required | required | n/a | n/a | n/a | n/a |
+| New Markdown extension or flavor | required | required | required | required | n/a | n/a |
+| New static view mode | required | required | n/a | required | follow-up | follow-up |
+| Pure refactor (no behavior change) | required | n/a | n/a | n/a | n/a | n/a |
+
+"n/a" means the pillar does not apply to that feature kind.
+"follow-up" means the pillar is not yet shipped and the row will
+become "required" once it lands.
+
+### How to apply at PR time
+
+1. Identify the feature kind from the left column.
+2. For each "required" pillar, confirm a spec / scenario / sample /
+   case exists in the PR diff.
+3. For each "follow-up" pillar, note the future work in the PR body
+   under "Follow-up" so the v2.0.0 push retains the tracking.
+4. Run `pnpm check:ct-parity` and the relevant `pnpm test:*` commands
+   before requesting review.
+
+---
+
+## Continuous integration
+
+GitHub Actions enforces the pillars on every push and pull request:
+
+| Job | Pillar | Notes |
+|-----|--------|-------|
+| `test` (matrix of framework x browser) | 2 | React, Vue, Svelte x Chromium, Firefox, WebKit |
+| `ssr` | 4 | Builds packages, runs `pnpm test:ssr` |
+| `ct-parity` | 1 | Runs `pnpm check:ct-parity` |
+| `test-summary` | aggregator | Fails if any of the above failed |
+
+Pillars 5 and 6 will earn their own CI jobs when they ship.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -24,6 +24,77 @@ This skill runs Playwright Component Tests across the React, Vue, and Svelte fra
 | `pnpm test:ct:react` | Run React tests only |
 | `pnpm test:ct:vue` | Run Vue tests only |
 | `pnpm test:ct:svelte` | Run Svelte tests only |
+| `pnpm test:md-roundtrip` | Run the Markdown round-trip suite (Pillar 3) |
+| `pnpm test:ssr` | Run the SSR static-HTML smoke test (Pillar 4) |
+| `pnpm check:ct-parity` | Verify CT spec parity across frameworks (Pillar 1) |
+
+
+## Section 14 Pillars
+
+The seven-pillar testing rules in `.claude/rules/testing.md` govern
+the broader test surface. This skill drives all pillars that ship
+runnable suites today.
+
+| Pillar | Status | How to run |
+|--------|--------|------------|
+| 1. Framework parity | shipped | `pnpm check:ct-parity` |
+| 2. Behavior tests | shipped | `pnpm test:ct` (and variants above) |
+| 3. Markdown round-trip | shipped | `pnpm test:md-roundtrip` |
+| 4. SSR | shipped | `pnpm test:ssr` |
+| 5. Accessibility | not yet | follow-up; `tests/a11y/` not yet created |
+| 6. Visual regression | not yet | follow-up; CI-only suite not yet created |
+| 7. Coverage discipline | shipped | reviewed at PR time against the Pillar 7 matrix |
+
+### Run the full local matrix
+
+```bash
+pnpm check:ct-parity   # Pillar 1
+pnpm test:ct           # Pillar 2
+pnpm test:md-roundtrip # Pillar 3
+pnpm test:ssr          # Pillar 4
+```
+
+### CT spec parity
+
+`pnpm check:ct-parity` lints `tests/ct/{react,vue,svelte}/specs/`
+for matching spec filenames, modulo the `Use*` / `Create*` / `Get*`
+idiom prefix. A non-zero exit means a spec exists in one or two
+frameworks but not all three.
+
+```bash
+pnpm check:ct-parity
+# CT spec parity check (react=33, vue=33, svelte=33)
+# CT spec parity check passed.
+```
+
+### Markdown round-trip
+
+`pnpm test:md-roundtrip` drives `generateVizelStaticHtml` against
+every sample in `tests/markdown-roundtrip/samples/index.ts` and
+asserts the round-tripped Markdown matches the input. Add a new
+sample by appending to the relevant `<flavor>Samples` array.
+
+### SSR static HTML smoke test
+
+`pnpm test:ssr` runs `scripts/test-static-html.ts`. The script
+boots the Core SSR path in Node, renders fixed Markdown samples,
+and asserts the produced HTML contains the expected DOM markers.
+Add a case by appending a `StaticHtmlCase` entry to the same
+script.
+
+### Accessibility (NOT YET SHIPPED)
+
+`tests/a11y/` will run `@axe-core/playwright` against every
+component. The directory and dependency are tracked as follow-up
+work; the test skill will gain a `pnpm test:a11y` command once
+the suite lands.
+
+### Visual regression (NOT YET SHIPPED)
+
+A CI-only visual snapshot suite covering ~20 essential views is
+planned. Local execution is intentionally skipped to avoid
+OS-level rendering noise. The test skill will gain a
+`pnpm test:visual` (CI-only) command once the suite lands.
 
 ## Process
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,31 @@ jobs:
       - name: Run SSR static HTML smoke test
         run: pnpm test:ssr
 
+  ct-parity:
+    name: CT Spec Parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify CT spec parity across frameworks
+        run: pnpm check:ct-parity
+
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [test, ssr]
+    needs: [test, ssr, ct-parity]
     if: always()
     steps:
       - name: Download all results

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,6 +52,9 @@ pre-push:
     parity:
       run: pnpm check:parity
 
+    ct-parity:
+      run: pnpm check:ct-parity
+
     ssr:
       run: pnpm check:ssr
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
+    "check:ct-parity": "tsx scripts/check-ct-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "check:nolet": "tsx scripts/check-no-let.ts",
     "test:ssr": "tsx scripts/test-static-html.ts",

--- a/scripts/check-ct-parity.ts
+++ b/scripts/check-ct-parity.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env tsx
+/**
+ * Playwright CT spec parity check.
+ *
+ * Verifies that `tests/ct/{react,vue,svelte}/specs/` contain matching
+ * spec files, modulo the framework idiom prefix stripped from hook /
+ * composable / rune-named specs (`UseFoo` in React and Vue,
+ * `CreateFoo` in Svelte). The seventh testing pillar in Section 14 of
+ * the v2.0.0 spec requires this check; lefthook runs it on `pre-push`
+ * and CI gates merges on a green run.
+ *
+ * Scope and conventions:
+ *
+ * - Only files matching `*.spec.tsx` (React) or `*.spec.ts` (Vue,
+ *   Svelte) are considered. Fixture and helper files (`*Fixture.tsx`,
+ *   `*.helper.ts`) are intentionally excluded — they live next to
+ *   specs but do not represent a coverage unit.
+ * - Idiom prefixes mirror the symbol parity rules in
+ *   `scripts/check-cross-framework-parity.ts`. React and Vue may
+ *   prefix a spec with `Use` (e.g. `UseEditorState.spec.tsx`); Svelte
+ *   prefixes the equivalent rune spec with `Create` (e.g.
+ *   `CreateEditorState.spec.ts`). Both forms reduce to the same stem
+ *   `EditorState`.
+ *
+ * Exits with code 0 on success, 1 on any spec-name imbalance.
+ */
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleFile = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(moduleFile), "..");
+
+interface FrameworkSpec {
+  readonly framework: "react" | "vue" | "svelte";
+  readonly specsDir: string;
+  readonly extensions: readonly string[];
+  /**
+   * Idiom prefixes stripped from a spec basename to derive its parity
+   * stem. The order matters: longer / more-specific prefixes appear
+   * first so a name like `UseFoo` does not collapse to `seFoo`.
+   */
+  readonly prefixes: readonly string[];
+}
+
+const FRAMEWORKS: readonly FrameworkSpec[] = [
+  {
+    framework: "react",
+    specsDir: join(REPO_ROOT, "tests/ct/react/specs"),
+    extensions: [".spec.tsx", ".spec.ts"],
+    prefixes: ["Use", "Create"],
+  },
+  {
+    framework: "vue",
+    specsDir: join(REPO_ROOT, "tests/ct/vue/specs"),
+    extensions: [".spec.ts"],
+    prefixes: ["Use", "Create"],
+  },
+  {
+    framework: "svelte",
+    specsDir: join(REPO_ROOT, "tests/ct/svelte/specs"),
+    extensions: [".spec.ts"],
+    prefixes: ["Create", "Get"],
+  },
+];
+
+interface ParitySpec {
+  /** Basename minus extension (e.g. `Editor`, `UseEditorState`). */
+  readonly literalName: string;
+  /** Parity stem after idiom prefix stripping (e.g. `EditorState`). */
+  readonly stem: string;
+}
+
+/**
+ * Strip a recognized idiom prefix from a spec basename and return the
+ * stem. Returns the original name when no prefix applies (the literal
+ * name itself is the stem in that case — components, integration
+ * specs, and shared scenarios fall here).
+ */
+function deriveStem(name: string, prefixes: readonly string[]): string {
+  for (const prefix of prefixes) {
+    if (!name.startsWith(prefix) || name.length <= prefix.length) continue;
+    // Next character must be uppercase to avoid swallowing names like
+    // `Userflows` matching the `User` prefix.
+    const next = name.charAt(prefix.length);
+    if (next === next.toUpperCase() && next !== next.toLowerCase()) {
+      return name.slice(prefix.length);
+    }
+  }
+  return name;
+}
+
+/**
+ * Strip the longest matching spec extension from a file name. Returns
+ * `null` when no spec extension matches (i.e. the file is a fixture
+ * or helper).
+ */
+function stripSpecExtension(file: string, extensions: readonly string[]): string | null {
+  // Sort by descending length so `.spec.tsx` is tried before `.spec.ts`.
+  const sorted = [...extensions].sort((a, b) => b.length - a.length);
+  for (const ext of sorted) {
+    if (file.endsWith(ext)) return file.slice(0, -ext.length);
+  }
+  return null;
+}
+
+function collectSpecs(config: FrameworkSpec): readonly ParitySpec[] {
+  try {
+    statSync(config.specsDir);
+  } catch {
+    return [];
+  }
+  const entries = readdirSync(config.specsDir);
+  return entries.flatMap((entry) => {
+    const full = join(config.specsDir, entry);
+    const stat = statSync(full);
+    if (!stat.isFile()) return [];
+    const literalName = stripSpecExtension(entry, config.extensions);
+    if (literalName === null) return [];
+    return [{ literalName, stem: deriveStem(literalName, config.prefixes) }];
+  });
+}
+
+interface ParityViolation {
+  readonly stem: string;
+  readonly missing: readonly ("react" | "vue" | "svelte")[];
+  readonly present: ReadonlyMap<"react" | "vue" | "svelte", string>;
+}
+
+function findViolations(
+  specsByFramework: ReadonlyMap<"react" | "vue" | "svelte", readonly ParitySpec[]>
+): readonly ParityViolation[] {
+  const stemToFramework = new Map<string, Map<"react" | "vue" | "svelte", string>>();
+  for (const [framework, specs] of specsByFramework) {
+    for (const spec of specs) {
+      const bucket = stemToFramework.get(spec.stem) ?? new Map();
+      bucket.set(framework, spec.literalName);
+      stemToFramework.set(spec.stem, bucket);
+    }
+  }
+
+  const violations: ParityViolation[] = [];
+  for (const [stem, present] of stemToFramework) {
+    const missing: ("react" | "vue" | "svelte")[] = [];
+    for (const config of FRAMEWORKS) {
+      if (!present.has(config.framework)) missing.push(config.framework);
+    }
+    if (missing.length > 0) {
+      violations.push({ stem, missing, present });
+    }
+  }
+  return violations;
+}
+
+function main(): void {
+  const specsByFramework = new Map<"react" | "vue" | "svelte", readonly ParitySpec[]>();
+  for (const config of FRAMEWORKS) {
+    specsByFramework.set(config.framework, collectSpecs(config));
+  }
+
+  const counts = [...specsByFramework.entries()]
+    .map(([framework, specs]) => `${framework}=${specs.length}`)
+    .join(", ");
+  process.stdout.write(`CT spec parity check (${counts})\n`);
+
+  const violations = findViolations(specsByFramework);
+
+  if (violations.length === 0) {
+    process.stdout.write("CT spec parity check passed.\n");
+    process.exit(0);
+  }
+
+  const plural = violations.length === 1 ? "" : "s";
+  process.stderr.write(`CT spec parity check failed (${violations.length} violation${plural}):\n`);
+  for (const violation of violations) {
+    const presentParts = [...violation.present.entries()]
+      .map(([fw, name]) => `${fw}=${name}`)
+      .join(", ");
+    process.stderr.write(
+      `  stem "${violation.stem}" missing from ${violation.missing.join(", ")} (have: ${presentParts})\n`
+    );
+  }
+  process.stderr.write(
+    "\nEach Playwright CT spec must exist in all three framework packages.\n" +
+      "React and Vue specs that wrap a hook / composable may use a `Use` prefix;\n" +
+      "the Svelte rune counterpart uses `Create` (or `Get` for context getters).\n" +
+      "Both forms reduce to the same parity stem.\n"
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds the mechanical framework-parity check the v2 design treats as "pillar 1" of the testing strategy, and rewrites `.claude/rules/testing.md` around the seven-pillar structure so the rule matches the shipped testing surface.

- **`scripts/check-ct-parity.ts`** walks `tests/ct/{react,vue,svelte}/specs/` and exits non-zero whenever the three frameworks publish a different set of spec basenames. Currently green at 33 / 33 / 33.
- **Lefthook pre-push** and **GitHub Actions** wire `pnpm check:ct-parity` in alongside the existing parity / nolet / ssr checks so drift is blocked at three layers (local push, PR CI, merge gate).
- **`.claude/rules/testing.md`** rewritten from the prior "structure + commands" outline to the seven-pillar outline described in Section 14 of the v2 design (parity / behavior CT / markdown roundtrip / SSR / a11y / visual / coverage discipline). Each pillar has a "How to add" recipe; a11y and visual are flagged as follow-ups (suite skeletons do not exist yet).
- **`.claude/skills/test/SKILL.md`** refreshed so the test skill knows about the markdown roundtrip and SSR scripts in addition to the existing CT entry points.
- **`.claude/agents/cross-framework-reviewer.md`** now calls the new parity check before reviewing cross-framework changes.

## Test plan

- [x] `pnpm check:ct-parity` exits 0 (`react=33, vue=33, svelte=33`).
- [x] `pnpm check:nolet`, `pnpm check:parity` still green.
- [x] CI workflow accepts the new `ssr`-style independent job.

## Follow-ups (out of scope for this PR)

- Pillar 5 (`tests/a11y/`, `@axe-core/playwright`) — skeleton not in repo yet.
- Pillar 6 (`tests/visual/`, snapshot baselines) — skeleton not in repo yet.