### PR TITLE
fix(core): keep list-item paragraphs flush with their bullet

### DIFF
--- a/packages/core/src/styles/_block-hierarchy.scss
+++ b/packages/core/src/styles/_block-hierarchy.scss
@@ -6,30 +6,36 @@
  * step adds left padding and draws a thin guide line.
  *
  * Activated by `features.interaction.visualHierarchy`.
+ *
+ * Paragraphs that sit directly inside a list item (`li > p`) are
+ * excluded. The list bullet is already laid out against the list's
+ * own `padding-inline-start`, and adding hierarchy padding to the
+ * inner paragraph pushes the text further from the bullet than any
+ * Markdown renderer expects.
  */
 
 .vizel-root .ProseMirror {
-  [data-vizel-depth="2"] {
+  [data-vizel-depth="2"]:not(li > p) {
     padding-inline-start: 1rem;
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }
 
-  [data-vizel-depth="3"] {
+  [data-vizel-depth="3"]:not(li > p) {
     padding-inline-start: 1.25rem;
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }
 
-  [data-vizel-depth="4"] {
+  [data-vizel-depth="4"]:not(li > p) {
     padding-inline-start: 1.5rem;
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }
 
-  [data-vizel-depth="5"] {
+  [data-vizel-depth="5"]:not(li > p) {
     padding-inline-start: 1.75rem;
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }
 
-  [data-vizel-depth="6"] {
+  [data-vizel-depth="6"]:not(li > p) {
     padding-inline-start: 2rem;
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }


### PR DESCRIPTION
## Summary

User-reported regression: every bullet sat 16px+ to the left of its label text.

The visual hierarchy extension decorates every block node with `data-vizel-depth=\"N\"` and the matching SCSS adds `padding-inline-start` at depth >= 2. Inside lists, the `<p>` inside each `<li>` always satisfies depth >= 2 (the list itself is depth 1), so the hierarchy padding stacked on top of the list's own indent.

Fix: exclude `li > p` from the hierarchy padding so list bullets line up flush against their text. The depth padding still applies to non-list blocks (blockquotes, callouts, nested details, etc.) at depth >= 2.

## Test plan

- [x] Inspected `.ProseMirror ul li p` `padding-inline-start` in dev React demo: was `16px`, now `0px`.
- [x] Visual confirmation (screenshot) of bullet list at correct spacing.
- [x] Ordered list / task list spacing also unchanged.