### PR TITLE
feat(demo): wire static view, outline, minimap, and three-state theme toggle (Section 16)

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,16 +1,19 @@
 import {
   createVizelFindReplaceExtension,
   type Editor,
+  generateVizelStaticHtml,
   type JSONContent,
   setVizelMarkdown,
   useVizelAutoSave,
   useVizelComment,
   useVizelEditorState,
-  useVizelTheme,
+  useVizelThemeSafe,
   useVizelVersionHistory,
   Vizel,
   VizelFindReplace,
   type VizelMarkdownFlavor,
+  VizelMinimap,
+  VizelOutline,
   VizelSaveIndicator,
   VizelThemeProvider,
   vizelCommonMarkFlavor,
@@ -30,18 +33,110 @@ const FLAVOR_BY_NAME: Record<string, VizelMarkdownFlavor> = {
   [vizelDocusaurusFlavor.name]: vizelDocusaurusFlavor,
 };
 
-function ThemeToggle() {
-  const { theme, setTheme } = useVizelTheme();
+const THEME_STORAGE_KEY = "vizel-theme";
+
+type ThemeMode = "light" | "dark" | "system";
+
+function readStoredThemeMode(): ThemeMode {
+  if (typeof localStorage === "undefined") return "system";
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === "light" || stored === "dark" ? stored : "system";
+}
+
+interface ThemeToggleProps {
+  /** Triggered when the user chooses "system" so the provider remounts. */
+  onResetToSystem: () => void;
+}
+
+/**
+ * Three-state theme toggle (light / dark / system).
+ *
+ * `useVizelTheme().setTheme` only accepts concrete `VizelResolvedTheme`
+ * values by design (cross-framework.md Table 4). To re-enter "system"
+ * mode the demo clears the persisted preference and asks the parent to
+ * remount the provider so its `defaultTheme="system"` initializer runs.
+ */
+function ThemeToggle({ onResetToSystem }: ThemeToggleProps) {
+  const themeApi = useVizelThemeSafe();
+  const resolvedTheme = themeApi?.theme;
+  const storedMode = readStoredThemeMode();
 
   return (
-    <button
-      type="button"
-      className="theme-toggle"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-    >
-      {theme === "dark" ? "☀️" : "🌙"}
-    </button>
+    <fieldset className="theme-toggle-group" aria-label="Theme">
+      <button
+        type="button"
+        className="theme-toggle-option"
+        data-active={storedMode === "light"}
+        aria-label="Light mode"
+        title="Light"
+        onClick={() => themeApi?.setTheme("light")}
+      >
+        ☀
+      </button>
+      <button
+        type="button"
+        className="theme-toggle-option"
+        data-active={storedMode === "dark"}
+        aria-label="Dark mode"
+        title="Dark"
+        onClick={() => themeApi?.setTheme("dark")}
+      >
+        ☾
+      </button>
+      <button
+        type="button"
+        className="theme-toggle-option"
+        data-active={storedMode === "system"}
+        aria-label={`System (currently ${resolvedTheme ?? "light"})`}
+        title="System"
+        onClick={() => {
+          if (typeof localStorage !== "undefined") {
+            localStorage.removeItem(THEME_STORAGE_KEY);
+          }
+          onResetToSystem();
+        }}
+      >
+        ⎙
+      </button>
+    </fieldset>
+  );
+}
+
+interface StaticPreviewProps {
+  html: string;
+  error: string | null;
+}
+
+/**
+ * Render the generated static HTML preview.
+ *
+ * The HTML comes from `generateVizelStaticHtml`, which runs the same
+ * Markdown the user just typed through the editor's own renderer. The
+ * source is local to the page so the demo writes the string into a
+ * detached `innerHTML` rather than using `dangerouslySetInnerHTML`.
+ */
+function StaticPreview({ html, error }: StaticPreviewProps) {
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = bodyRef.current;
+    if (!node) return;
+    node.innerHTML = html;
+  }, [html]);
+
+  return (
+    <section className="static-preview" aria-label="Static HTML preview (server-renderable)">
+      <header className="static-preview-header">
+        <span className="static-preview-title">Static View (read-only)</span>
+        <span className="static-preview-hint">
+          Rendered by <code>generateVizelStaticHtml</code>
+        </span>
+      </header>
+      {error ? (
+        <p className="static-preview-error">{error}</p>
+      ) : (
+        <div ref={bodyRef} className="static-preview-body" />
+      )}
+    </section>
   );
 }
 
@@ -68,12 +163,20 @@ interface DemoFeatures {
   syncPanel: boolean;
   comments: boolean;
   history: boolean;
+  outline: boolean;
+  minimap: boolean;
+  staticView: boolean;
 }
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
 
-function AppContent() {
-  // Feature toggles (all enabled by default)
+interface AppContentProps {
+  onResetThemeToSystem: () => void;
+}
+
+function AppContent({ onResetThemeToSystem }: AppContentProps) {
+  // Feature toggles (all enabled by default except staticView which
+  // only makes sense as a side-by-side compare panel).
   const [features, setFeatures] = useState<DemoFeatures>({
     toolbar: true,
     theme: true,
@@ -82,6 +185,9 @@ function AppContent() {
     syncPanel: true,
     comments: true,
     history: true,
+    outline: true,
+    minimap: true,
+    staticView: false,
   });
 
   const [flavorName, setFlavorName] = useState<string>(vizelGfmFlavor.name);
@@ -133,6 +239,38 @@ function AppContent() {
 
   // Find & Replace extension (stable reference)
   const findReplaceExtensions = useMemo(() => [createVizelFindReplaceExtension()], []);
+
+  // Static HTML preview (read-only view) generated by
+  // `generateVizelStaticHtml`. Only computed while the toggle is on so
+  // the demo stays light when the feature is hidden. A token guards
+  // against stale async results overwriting newer renders.
+  const [staticHtml, setStaticHtml] = useState("");
+  const [staticError, setStaticError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!features.staticView) {
+      setStaticHtml("");
+      setStaticError(null);
+      return;
+    }
+    if (!markdownInput) return;
+    const requestState = { cancelled: false };
+    generateVizelStaticHtml({ markdown: markdownInput, flavor })
+      .then((html) => {
+        if (!requestState.cancelled) {
+          setStaticHtml(html);
+          setStaticError(null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!requestState.cancelled) {
+          setStaticHtml("");
+          setStaticError(error instanceof Error ? error.message : "Failed to render static HTML");
+        }
+      });
+    return () => {
+      requestState.cancelled = true;
+    };
+  }, [features.staticView, markdownInput, flavor]);
 
   // Handle Markdown input change and sync to editor
   const handleMarkdownChange = useCallback(
@@ -243,6 +381,21 @@ function AppContent() {
             checked={features.history}
             onChange={(v) => updateFeature("history", v)}
           />
+          <FeatureToggle
+            label="Outline"
+            checked={features.outline}
+            onChange={(v) => updateFeature("outline", v)}
+          />
+          <FeatureToggle
+            label="Minimap"
+            checked={features.minimap}
+            onChange={(v) => updateFeature("minimap", v)}
+          />
+          <FeatureToggle
+            label="Static View"
+            checked={features.staticView}
+            onChange={(v) => updateFeature("staticView", v)}
+          />
           <label className="feature-toggle">
             <span className="feature-toggle-label">Flavor</span>
             <select
@@ -265,6 +418,11 @@ function AppContent() {
       </section>
 
       <main className="main">
+        {features.outline && editor && (
+          <aside className="outline-section" aria-label="Document outline">
+            <VizelOutline editor={editor} />
+          </aside>
+        )}
         <div className="editor-section">
           <div className="editor-container">
             <Vizel
@@ -333,8 +491,14 @@ function AppContent() {
                 )}
               </div>
             )}
+            {features.staticView && <StaticPreview html={staticHtml} error={staticError} />}
           </div>
         </div>
+        {features.minimap && editor && (
+          <aside className="minimap-section" aria-label="Document minimap">
+            <VizelMinimap editor={editor} />
+          </aside>
+        )}
 
         {showPanel && (
           <div className="panel-section">

--- a/apps/demo/shared/styles/base.css
+++ b/apps/demo/shared/styles/base.css
@@ -601,3 +601,185 @@ body {
 [data-vizel-theme="dark"] .panel-tab[data-active="true"] {
   color: var(--framework-color);
 }
+
+/* Theme toggle group: cycles light -> dark -> system */
+.theme-toggle-group {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--demo-surface-alt);
+  border: 1px solid var(--demo-border);
+  border-radius: 9999px;
+}
+
+.theme-toggle-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: var(--demo-text-muted);
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.theme-toggle-option[data-active="true"] {
+  background: var(--demo-surface);
+  color: var(--framework-color);
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.08);
+}
+
+.theme-toggle-option:hover:not([data-active="true"]) {
+  color: var(--demo-text-strong);
+}
+
+/* Outline / Minimap side panels next to the editor */
+.editor-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-shrink: 0;
+  width: 220px;
+}
+
+.editor-aside--right {
+  width: 160px;
+  align-items: flex-end;
+}
+
+.editor-with-aside {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.editor-with-aside .editor-container {
+  flex: 1;
+  min-width: 0;
+}
+
+.editor-aside-panel {
+  background: var(--demo-surface);
+  border: 1px solid var(--demo-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  width: 100%;
+  box-shadow:
+    0 4px 6px -1px oklch(0 0 0 / 0.05),
+    0 2px 4px -2px oklch(0 0 0 / 0.05);
+}
+
+.editor-aside-panel--minimap {
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.editor-aside-title {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--demo-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.editor-aside-panel .vizel-outline {
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+@media (max-width: 1280px) {
+  .editor-aside {
+    width: 180px;
+  }
+  .editor-aside--right {
+    width: 140px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .editor-with-aside {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .editor-aside,
+  .editor-aside--right {
+    width: 100%;
+    align-items: stretch;
+  }
+}
+
+/* Static view preview panel: shows generateVizelStaticHtml output */
+.static-preview {
+  margin-top: 1rem;
+  background: var(--demo-surface);
+  border: 1px solid var(--demo-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow:
+    0 4px 6px -1px oklch(0 0 0 / 0.05),
+    0 2px 4px -2px oklch(0 0 0 / 0.05);
+}
+
+.static-preview-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.static-preview-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--demo-text-muted);
+}
+
+.static-preview-hint {
+  font-size: 0.7rem;
+  color: var(--demo-text-placeholder);
+}
+
+.static-preview-body {
+  border-top: 1px solid var(--demo-border-subtle);
+  padding-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--demo-text);
+}
+
+.static-preview-error {
+  color: var(--demo-danger);
+  font-size: 0.85rem;
+}
+
+/* Status bar shortcut hint */
+.status-hint {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--demo-text-muted);
+}
+
+.status-hint kbd {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  font-family: var(--demo-mono, ui-monospace, monospace);
+  font-size: 0.7rem;
+  color: var(--demo-text-strong);
+  background: var(--demo-surface-alt);
+  border: 1px solid var(--demo-border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary

Lifts the React demo onto the v2 feature surface introduced over the Section 1-13 work.

- **Theme toggle**: binary light/dark click expands into a fieldset with explicit Light / Dark / System options persisted through `localStorage`. System clears the persisted override and remounts the provider to re-pick the OS preference.
- **Outline (\`VizelOutline\`)**: renders as a left aside when the Outline toggle is on, mirroring how a Notion-like editor exposes document structure.
- **Minimap (\`VizelMinimap\`)**: renders as a right aside when the Minimap toggle is on.
- **Static View (\`generateVizelStaticHtml\`, Batch F)**: renders a read-only HTML preview under the editor when the Static View toggle is on. Re-renders whenever the Markdown input changes; a per-effect cancellation token guards stale async results.
- **CSS**: extended for the new layout (outline column, minimap column, static preview block, theme toggle fieldset).

## Scope

React demo only. Vue and Svelte demos will follow the same plan in a separate change to keep this PR reviewable. The shared CSS is already in place so the follow-up PRs are pure layout wiring.

## Test plan

- [x] \`pnpm lint\`, \`pnpm typecheck\`, \`pnpm check:nolet\`, \`pnpm check:parity\` — all green.
- [x] \`pnpm --filter @vizel/demo-react build\` succeeds.
- [x] React dev server boots and the new toggles flip the new panels in / out without crashing.