### PR TITLE
docs: align guides and READMEs with v2 feature/rune/composable surface

### DIFF
--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -425,11 +425,11 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
                       Save
                     </button>
                   </div>
-                  <div v-if="versionHistory.snapshots.value.length === 0" class="panel-list-empty">
+                  <div v-if="versionHistory.snapshots.length === 0" class="panel-list-empty">
                     No versions saved yet
                   </div>
                   <div
-                    v-for="snapshot in versionHistory.snapshots.value"
+                    v-for="snapshot in versionHistory.snapshots"
                     :key="snapshot.id"
                     class="panel-item"
                   >
@@ -465,11 +465,11 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
                       Add
                     </button>
                   </div>
-                  <div v-if="commentManager.comments.value.length === 0" class="panel-list-empty">
+                  <div v-if="commentManager.comments.length === 0" class="panel-list-empty">
                     No comments yet
                   </div>
                   <div
-                    v-for="comment in commentManager.comments.value"
+                    v-for="comment in commentManager.comments"
                     :key="comment.id"
                     :class="['panel-item', comment.resolved ? 'panel-item-resolved' : '']"
                     role="button"

--- a/docs/guide/collaboration.md
+++ b/docs/guide/collaboration.md
@@ -8,15 +8,16 @@ others.
 
 | Concern | Hook / composable / rune | Feature flag | Default storage |
 |---------|--------------------------|--------------|-----------------|
-| Real-time editing | `useVizelCollaboration` / `createVizelCollaboration` | `features.collaboration` | Yjs provider |
-| Comments | `useVizelComment` / `createVizelComment` | `features.comment` | `localStorage` |
-| Version history | `useVizelVersionHistory` / `createVizelVersionHistory` | always available | `localStorage` |
+| Real-time editing | `useVizelCollaboration` / `createVizelCollaboration` | `features.collaboration.provider` | Yjs provider |
+| Comments | `useVizelComment` / `createVizelComment` | `features.collaboration.comments` (requires `provider`) | `localStorage` |
+| Version history | `useVizelVersionHistory` / `createVizelVersionHistory` | `features.collaboration.versionHistory` (always available without flag) | `localStorage` |
 
 ## Real-time editing
 
 Vizel integrates with [Yjs](https://yjs.dev/), a CRDT-based framework
 that lets multiple users edit the same document simultaneously without
-conflicts. Setting `features.collaboration` to `true` automatically
+conflicts. Setting `features.collaboration.provider` to any truthy
+value (boolean or a `VizelCollaborationProvider` adapter) automatically
 disables the built-in `History` extension because Yjs owns undo / redo
 through `Y.UndoManager`.
 
@@ -592,9 +593,9 @@ interface VizelVersionSnapshot {
    like cursor positions, user names, and colors. Awareness state is
    separate from the document and is not persisted.
 3. **History extension conflict.** Always set
-   `features.collaboration` to `true` when Yjs is in play. The
-   built-in `History` extension does not understand CRDT operations
-   and conflicts with `Y.UndoManager`.
+   `features.collaboration.provider` (boolean or adapter) when Yjs is
+   in play. The built-in `History` extension does not understand CRDT
+   operations and conflicts with `Y.UndoManager`.
 4. **Offline support.** Yjs stores edits made offline locally and
    syncs them on reconnect without data loss.
 
@@ -602,7 +603,7 @@ interface VizelVersionSnapshot {
 
 | Symptom | Resolution |
 |---------|------------|
-| Undo / redo behaves unexpectedly | Set `features.collaboration: true` so the built-in `History` extension is disabled |
+| Undo / redo behaves unexpectedly | Set `features.collaboration.provider` (boolean or adapter) so the built-in `History` extension is disabled |
 | WebSocket disconnects in production | Verify the reverse proxy supports WebSocket upgrades; check the `ws://` vs `wss://` protocol |
 | Remote cursors appear without color | Pass `user.color` to both `CollaborationCursor.configure()` and the collaboration hook / composable / rune |
 | Comments do not persist | Confirm the storage backend resolves both `save` and `load` |

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -136,18 +136,24 @@ disable it or pass an options object to configure it.
 ```ts
 const editor = useVizelEditor({
   features: {
-    // Most features are enabled by default
-    slashCommand: true,
-    table: true,
-    image: { onUpload: async (file) => "https://example.com/image.png" },
-    dragHandle: true,
-    markdown: true,
-
-    // Opt-in: must be explicitly enabled
-    comment: true,
-    collaboration: true,
-    wikiLink: true,
-    mention: true,
+    content: {
+      // Most features are enabled by default
+      table: true,
+      image: { onUpload: async (file) => "https://example.com/image.png" },
+      // Opt-in: must be explicitly enabled
+      wikiLink: true,
+    },
+    interaction: {
+      dragHandle: true,
+      slashMenu: true,
+      // Opt-in: requires consumer-supplied items
+      mention: { items: async (query) => [] },
+    },
+    collaboration: {
+      // Opt-in: comments require a provider
+      provider: true,
+      comments: true,
+    },
   },
 });
 ```

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -96,19 +96,35 @@ You can override the flavor-driven defaults for individual extensions. For examp
 
 ---
 
-## Disabling Features
+## Feature Categories
 
-Set a feature to `false` to disable it:
+`VizelFeatureOptions` groups every opt-in into three categories:
+
+| Category | Consumer question | Examples |
+|----------|-------------------|----------|
+| `content` | What can the document contain? | `image`, `table`, `mathematics`, `diagram`, `embed`, `details`, `callout`, `textColor`, `highlight`, `taskList`, `wikiLink`, `tableOfContents` |
+| `interaction` | How does the user edit? | `slashMenu`, `dragHandle`, `mention`, `characterCount`, `typography`, `placeholder`, `historyDepth`, `visualHierarchy` |
+| `collaboration` | Who edits together? | `comments`, `provider`, `versionHistory`, `presence` |
+
+A leaf accepts `true` (enable with defaults), `false` (disable), or an options object.
 
 ```typescript
 const editor = useVizelEditor({
   features: {
-    slashCommand: false,  // Disable slash commands
-    dragHandle: false,    // Disable drag handle
-    table: false,         // Disable tables
+    interaction: {
+      slashMenu: false,  // Disable slash commands
+      dragHandle: false, // Disable drag handle
+    },
+    content: {
+      table: false,      // Disable tables
+    },
   },
 });
 ```
+
+::: tip
+Code blocks, links, Markdown import/export, find / replace, multi-block selection, and block clipboard are part of the always-on core and are not gated by `VizelFeatureOptions`. Configure Markdown via the top-level `markdown` option (e.g. `markdown: { flavor: vizelGfmFlavor }`).
+:::
 
 ---
 
@@ -146,8 +162,10 @@ const customItems: VizelSlashCommandItem[] = [
 
 const editor = useVizelEditor({
   features: {
-    slashCommand: {
-      items: customItems, // Add custom items
+    interaction: {
+      slashMenu: {
+        items: customItems, // Add custom items
+      },
     },
   },
 });
@@ -191,31 +209,33 @@ The image feature supports drag and drop, paste, and resize.
 ```typescript
 const editor = useVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        const formData = new FormData();
-        formData.append('image', file);
-        
-        const res = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        });
-        
-        const { url } = await res.json();
-        return url;
-      },
-      maxFileSize: 5 * 1024 * 1024, // 5MB
-      allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
-      onValidationError: (error) => {
-        if (error.type === 'file_too_large') {
-          alert('File is too large. Maximum size is 5MB.');
-        } else if (error.type === 'invalid_type') {
-          alert('Invalid file type. Only JPEG, PNG, and WebP are allowed.');
-        }
-      },
-      onUploadError: (error, file) => {
-        console.error(`Failed to upload ${file.name}:`, error);
-        alert('Upload failed. Please try again.');
+    content: {
+      image: {
+        onUpload: async (file) => {
+          const formData = new FormData();
+          formData.append('image', file);
+
+          const res = await fetch('/api/upload', {
+            method: 'POST',
+            body: formData,
+          });
+
+          const { url } = await res.json();
+          return url;
+        },
+        maxFileSize: 5 * 1024 * 1024, // 5MB
+        allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
+        onValidationError: (error) => {
+          if (error.type === 'file_too_large') {
+            alert('File is too large. Maximum size is 5MB.');
+          } else if (error.type === 'invalid_type') {
+            alert('Invalid file type. Only JPEG, PNG, and WebP are allowed.');
+          }
+        },
+        onUploadError: (error, file) => {
+          console.error(`Failed to upload ${file.name}:`, error);
+          alert('Upload failed. Please try again.');
+        },
       },
     },
   },
@@ -226,33 +246,7 @@ const editor = useVizelEditor({
 
 ## Code Blocks
 
-This feature provides code blocks with syntax highlighting and language selection.
-
-### Options
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `defaultLanguage` | `string` | `"plaintext"` | Default language |
-| `lineNumbers` | `boolean` | `false` | Show line numbers |
-| `lowlight` | `Lowlight` | All languages | Custom Lowlight instance |
-
-### Example: Limited Languages
-
-```typescript
-import { createLowlight, common } from 'lowlight';
-
-const lowlight = createLowlight(common);
-
-const editor = useVizelEditor({
-  features: {
-    codeBlock: {
-      defaultLanguage: 'typescript',
-      lineNumbers: true,
-      lowlight, // Only common languages
-    },
-  },
-});
-```
+Code blocks with syntax highlighting are part of the always-on core. Use the language picker in the slash menu or the bubble menu's node selector to choose a language. Lowlight ships every language by default — pass a custom Lowlight instance via the `extensions` array only if you need to restrict the available grammars.
 
 ---
 
@@ -273,9 +267,11 @@ This feature tracks character and word counts.
 ```typescript
 const editor = useVizelEditor({
   features: {
-    characterCount: {
-      limit: 10000, // Max 10,000 characters
-      mode: 'textSize',
+    interaction: {
+      characterCount: {
+        limit: 10000, // Max 10,000 characters
+        mode: 'textSize',
+      },
     },
   },
 });
@@ -315,12 +311,16 @@ const customColors: VizelColorDefinition[] = [
 
 const editor = useVizelEditor({
   features: {
-    textColor: {
-      textColors: customColors,
-      highlightColors: customColors.map(c => ({
-        ...c,
-        color: `${c.color}40`, // Add transparency
-      })),
+    content: {
+      textColor: {
+        textColors: customColors,
+      },
+      highlight: {
+        highlightColors: customColors.map(c => ({
+          ...c,
+          color: `${c.color}40`, // Add transparency
+        })),
+      },
     },
   },
 });
@@ -330,50 +330,35 @@ const editor = useVizelEditor({
 
 ## Markdown
 
-This feature enables Markdown import/export.
+Markdown import/export is part of the always-on core. The serializer flavor is selected via the top-level `markdown` option, not via `features`.
 
 ### Options
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `indentation` | `{ style, size }` | `{ style: 'space', size: 2 }` | Indentation config |
-| `gfm` | `boolean` | `true` | GitHub Flavored Markdown |
-| `breaks` | `boolean` | `false` | Convert newlines to `<br>` |
+| `flavor` | `VizelMarkdownFlavor` | `vizelGfmFlavor` | Output flavor (commonmark / GFM / Obsidian / Docusaurus / Pandoc) |
+| `encoding` | `VizelMarkdownEncodingOptions` | `{}` | Per-node encoding mode (`"default"` or `"metadata-comment"`) for nodes without a canonical Markdown form (`embed`, `mention`, `wikiLink`) |
 
 ### Example
 
 ```typescript
+import { useVizelEditor, vizelObsidianFlavor } from '@vizel/react';
+
 const editor = useVizelEditor({
-  features: {
-    markdown: {
-      gfm: true,
-      breaks: false,
-      indentation: {
-        style: 'space',
-        size: 2,
-      },
+  markdown: {
+    flavor: vizelObsidianFlavor,
+    encoding: {
+      mention: 'metadata-comment',
     },
   },
 });
 
 // Export to Markdown
-const md = editor.storage.markdown.getMarkdown();
+const md = editor.getMarkdown();
 
 // Import from Markdown
-editor.commands.setContent(
-  editor.storage.markdown.parseMarkdown('# Hello\n\nWorld')
-);
+editor.commands.setContent('# Hello\n\nWorld');
 ```
-
-::: tip Recommended API
-Use `editor.getMarkdown()` for Markdown export:
-
-```typescript
-const md = editor.getMarkdown();
-```
-
-The `editor.storage.markdown.getMarkdown()` method is an internal storage accessor. Prefer `editor.getMarkdown()` for application code.
-:::
 
 ---
 
@@ -394,13 +379,15 @@ This feature renders LaTeX math equations with KaTeX.
 ```typescript
 const editor = useVizelEditor({
   features: {
-    mathematics: {
-      katexOptions: {
-        throwOnError: false,
-        strict: false,
+    content: {
+      mathematics: {
+        katexOptions: {
+          throwOnError: false,
+          strict: false,
+        },
+        inlineInputRules: true,
+        blockInputRules: true,
       },
-      inlineInputRules: true,
-      blockInputRules: true,
     },
   },
 });
@@ -450,9 +437,11 @@ const customProvider: VizelEmbedProvider = {
 
 const editor = useVizelEditor({
   features: {
-    embed: {
-      providers: [customProvider],
-      pasteHandler: true,
+    content: {
+      embed: {
+        providers: [customProvider],
+        pasteHandler: true,
+      },
     },
   },
 });
@@ -477,7 +466,9 @@ This feature provides collapsible content blocks (accordion/disclosure).
 ```typescript
 const editor = useVizelEditor({
   features: {
-    details: true, // Enable with defaults
+    content: {
+      details: true, // Enable with defaults
+    },
   },
 });
 ```
@@ -516,14 +507,16 @@ This feature supports Mermaid and GraphViz diagrams.
 ```typescript
 const editor = useVizelEditor({
   features: {
-    diagram: {
-      mermaidConfig: {
-        theme: 'neutral',
-        securityLevel: 'loose',
-      },
-      defaultType: 'mermaid',
-      defaultCode: `graph TD
+    content: {
+      diagram: {
+        mermaidConfig: {
+          theme: 'neutral',
+          securityLevel: 'loose',
+        },
+        defaultType: 'mermaid',
+        defaultCode: `graph TD
     A[Start] --> B[End]`,
+      },
     },
   },
 });
@@ -533,36 +526,7 @@ const editor = useVizelEditor({
 
 ## Links
 
-This feature provides link editing and auto-linking.
-
-### Options
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `openOnClick` | `boolean` | `true` | Open links on click |
-| `autolink` | `boolean` | `true` | Auto-link URLs while typing |
-| `linkOnPaste` | `boolean` | `true` | Link pasted URLs |
-| `defaultProtocol` | `string` | `"https"` | Default protocol |
-| `HTMLAttributes` | `object` | - | HTML attributes for links |
-
-### Example
-
-```typescript
-const editor = useVizelEditor({
-  features: {
-    link: {
-      openOnClick: true,
-      autolink: true,
-      linkOnPaste: true,
-      defaultProtocol: 'https',
-      HTMLAttributes: {
-        target: '_blank',
-        rel: 'noopener noreferrer',
-      },
-    },
-  },
-});
-```
+Link editing and auto-linking are part of the always-on core. The defaults follow industry conventions (HTTPS protocol, autolink on paste, click opens in a new tab). Pass a custom `@tiptap/extension-link` configuration through the `extensions` array if you need to override the defaults.
 
 ---
 
@@ -593,9 +557,11 @@ These shortcuts also work for bullet lists and ordered lists.
 ```typescript
 const editor = useVizelEditor({
   features: {
-    taskList: {
-      taskItem: {
-        nested: true, // Allow nested task lists
+    content: {
+      taskList: {
+        taskItem: {
+          nested: true, // Allow nested task lists
+        },
       },
     },
   },
@@ -632,8 +598,10 @@ The drag handle is automatically positioned next to the hovered block. For list 
 ```typescript
 const editor = useVizelEditor({
   features: {
-    dragHandle: {
-      enabled: true,
+    interaction: {
+      dragHandle: {
+        enabled: true,
+      },
     },
   },
 });
@@ -684,9 +652,11 @@ This feature adds wiki-style `[[page-name]]` links for linking between pages. It
 ```typescript
 const editor = useVizelEditor({
   features: {
-    wikiLink: {
-      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
-      pageExists: (page) => knownPages.has(page),
+    content: {
+      wikiLink: {
+        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+        pageExists: (page) => knownPages.has(page),
+      },
     },
   },
 });
@@ -700,21 +670,22 @@ See the [Wiki Links Guide](/guide/wiki-links) for detailed usage.
 
 This feature adds text annotation marks for reviewing and discussion.
 
-### Options
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `enabled` | `boolean` | `true` | Enable comment marks |
-
 ### Example
 
 ```typescript
 const editor = useVizelEditor({
   features: {
-    comment: true,
+    collaboration: {
+      provider: true,  // comments require a provider
+      comments: true,
+    },
   },
 });
 ```
+
+::: warning
+`comments` requires `provider`. Setting `comments: true` without a provider throws `VizelError("INVALID_CONFIG")` at editor creation.
+:::
 
 Comment management (storage, replies, resolution) uses the framework-specific hooks/composables/runes. See [Collaboration: Comments](/guide/collaboration#comments) for details.
 
@@ -733,7 +704,9 @@ This opt-in feature requires additional dependencies: `yjs`, a Yjs provider, `@t
 ```typescript
 const editor = useVizelEditor({
   features: {
-    collaboration: true, // Disables History
+    collaboration: {
+      provider: true, // Disables built-in History; Yjs handles undo/redo
+    },
   },
   extensions: [
     Collaboration.configure({ document: ydoc }),

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -452,34 +452,39 @@ See [Markdown - Flavors](/guide/markdown#flavors) for details on each flavor.
 
 ## Enabling Features
 
-All features are enabled by default except `collaboration`, `comment`, `mention`, and `wikiLink`. You can disable specific features by setting them to `false`, or pass an options object to configure them:
+`VizelFeatureOptions` is grouped into three categories: `content` (what the document can contain), `interaction` (how the user edits), and `collaboration` (who edits together). Set any leaf to `false` to disable, or pass an options object to configure. Use `vizelDefaultFeatures()` to enable the curated default set without listing every key.
 
 ::: code-group
 
 ```tsx [React]
 const editor = useVizelEditor({
   features: {
-    // All features below are enabled by default.
-    // Set to false to disable, or pass options to configure.
-    slashCommand: true,
-    table: true,
-    image: { onUpload: async (file) => 'https://example.com/image.png' },
-    codeBlock: true,
-    dragHandle: true,
-    characterCount: true,
-    textColor: true,
-    taskList: true,
-    link: true,
-    markdown: true,
-    mathematics: true,
-    embed: true,
-    details: true,
-    diagram: true,
-    wikiLink: true,
-
-    // Opt-in: must be explicitly enabled
-    comment: true,
-    collaboration: true,
+    content: {
+      // Enabled by default; set to false to disable, or pass options to configure.
+      table: true,
+      image: { onUpload: async (file) => 'https://example.com/image.png' },
+      mathematics: true,
+      embed: true,
+      details: true,
+      diagram: true,
+      callout: true,
+      textColor: true,
+      taskList: true,
+      // Opt-in: must be explicitly enabled.
+      wikiLink: true,
+    },
+    interaction: {
+      dragHandle: true,
+      characterCount: true,
+      typography: true,
+      // Opt-in: requires consumer-supplied items.
+      mention: { items: async (query) => [] },
+    },
+    collaboration: {
+      // Opt-in: comments require a provider.
+      provider: true,
+      comments: true,
+    },
   },
 });
 ```
@@ -487,10 +492,12 @@ const editor = useVizelEditor({
 ```vue [Vue]
 const editor = useVizelEditor({
   features: {
-    // Disable specific features
-    dragHandle: false,
-    // Configure with options
-    image: { onUpload: async (file) => 'https://example.com/image.png' },
+    content: {
+      image: { onUpload: async (file) => 'https://example.com/image.png' },
+    },
+    interaction: {
+      dragHandle: false,
+    },
   },
 });
 ```
@@ -498,10 +505,12 @@ const editor = useVizelEditor({
 ```svelte [Svelte]
 const editor = createVizelEditor({
   features: {
-    // Disable specific features
-    dragHandle: false,
-    // Configure with options
-    image: { onUpload: async (file) => 'https://example.com/image.png' },
+    content: {
+      image: { onUpload: async (file) => 'https://example.com/image.png' },
+    },
+    interaction: {
+      dragHandle: false,
+    },
   },
 });
 ```
@@ -601,7 +610,7 @@ import '@vizel/core/styles.css';
 function App() {
   const editor = useVizelEditor({
     placeholder: "Start writing...",
-    features: { image: { onUpload: uploadImage } },
+    features: { content: { image: { onUpload: uploadImage } } },
     onUpdate: ({ editor }) => console.log(editor.getMarkdown()),
   });
 
@@ -632,7 +641,7 @@ import '@vizel/core/styles.css';
 
 const editor = useVizelEditor({
   placeholder: "Start writing...",
-  features: { image: { onUpload: uploadImage } },
+  features: { content: { image: { onUpload: uploadImage } } },
   onUpdate: ({ editor }) => console.log(editor.getMarkdown()),
 });
 </script>
@@ -663,7 +672,7 @@ import '@vizel/core/styles.css';
 
 const editorState = createVizelEditor({
   placeholder: "Start writing...",
-  features: { image: { onUpload: uploadImage } },
+  features: { content: { image: { onUpload: uploadImage } } },
   onUpdate: ({ editor }) => console.log(editor.getMarkdown()),
 });
 
@@ -698,22 +707,24 @@ You can configure image uploads with a custom handler:
 ```tsx [React]
 const editor = useVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        // Upload to your server/CDN
-        const formData = new FormData();
-        formData.append('file', file);
-        
-        const response = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        });
-        
-        const { url } = await response.json();
-        return url;
+    content: {
+      image: {
+        onUpload: async (file) => {
+          // Upload to your server/CDN
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const response = await fetch('/api/upload', {
+            method: 'POST',
+            body: formData,
+          });
+
+          const { url } = await response.json();
+          return url;
+        },
+        maxFileSize: 10 * 1024 * 1024, // 10MB
+        allowedTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
       },
-      maxFileSize: 10 * 1024 * 1024, // 10MB
-      allowedTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
     },
   },
 });
@@ -722,18 +733,20 @@ const editor = useVizelEditor({
 ```vue [Vue]
 const editor = useVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        const formData = new FormData();
-        formData.append('file', file);
-        
-        const response = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        });
-        
-        const { url } = await response.json();
-        return url;
+    content: {
+      image: {
+        onUpload: async (file) => {
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const response = await fetch('/api/upload', {
+            method: 'POST',
+            body: formData,
+          });
+
+          const { url } = await response.json();
+          return url;
+        },
       },
     },
   },
@@ -743,18 +756,20 @@ const editor = useVizelEditor({
 ```svelte [Svelte]
 const editor = createVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        const formData = new FormData();
-        formData.append('file', file);
-        
-        const response = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        });
-        
-        const { url } = await response.json();
-        return url;
+    content: {
+      image: {
+        onUpload: async (file) => {
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const response = await fetch('/api/upload', {
+            method: 'POST',
+            body: formData,
+          });
+
+          const { url } = await response.json();
+          return url;
+        },
       },
     },
   },
@@ -782,11 +797,11 @@ function App() {
 }
 
 function ThemeToggle() {
-  const { resolvedTheme, setTheme } = useVizelTheme();
-  
+  const { theme, setTheme } = useVizelTheme();
+
   return (
-    <button onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}>
-      {resolvedTheme === 'dark' ? '☀️' : '🌙'}
+    <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      {theme === 'dark' ? '☀️' : '🌙'}
     </button>
   );
 }
@@ -810,16 +825,16 @@ import ThemeToggle from './ThemeToggle.vue';
 <script setup lang="ts">
 import { useVizelTheme } from '@vizel/vue';
 
-const { resolvedTheme, setTheme } = useVizelTheme();
+const { theme, setTheme } = useVizelTheme();
 
 function toggleTheme() {
-  setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  setTheme(theme.value === 'dark' ? 'light' : 'dark');
 }
 </script>
 
 <template>
   <button @click="toggleTheme">
-    {{ resolvedTheme === 'dark' ? '☀️' : '🌙' }}
+    {{ theme === 'dark' ? '☀️' : '🌙' }}
   </button>
 </template>
 ```
@@ -843,12 +858,12 @@ function toggleTheme() {
   const theme = getVizelTheme();
 
   function toggleTheme() {
-    theme.setTheme(theme.resolvedTheme === 'dark' ? 'light' : 'dark');
+    theme.setTheme(theme.current === 'dark' ? 'light' : 'dark');
   }
 </script>
 
 <button onclick={toggleTheme}>
-  {theme.resolvedTheme === 'dark' ? '☀️' : '🌙'}
+  {theme.current === 'dark' ? '☀️' : '🌙'}
 </button>
 ```
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -11,31 +11,37 @@ Vizel enables all features by default. Disable features you don't use to reduce 
 ```typescript
 const editor = useVizelEditor({
   features: {
-    mathematics: false,  // KaTeX (~80KB gzipped)
-    diagram: false,      // Mermaid (~40KB gzipped, lazy-loaded)
-    embed: false,        // oEmbed/OGP processing
-    codeBlock: false,    // lowlight/highlight.js (~20KB gzipped)
-    table: false,
-    dragHandle: false,
+    content: {
+      mathematics: false,  // KaTeX (~80KB gzipped)
+      diagram: false,      // Mermaid (~40KB gzipped, lazy-loaded)
+      embed: false,        // oEmbed/OGP processing
+      table: false,
+    },
+    interaction: {
+      dragHandle: false,
+    },
   },
 });
 ```
+
+::: tip
+Code blocks, links, and Markdown import/export are part of the always-on core and cannot be disabled. To restrict the syntax-highlighter language set, pass a custom Lowlight instance through `extensions` instead.
+:::
 
 ### Feature Size Impact
 
 The following table shows approximate sizes (minified + gzipped) of optional features:
 
-| Feature | Approximate Size | Dependencies |
-|---------|-----------------|--------------|
-| `mathematics` | ~80KB gzipped | KaTeX |
-| `diagram` | ~40KB gzipped | Mermaid (lazy-loaded); GraphViz via `@hpcc-js/wasm-graphviz` adds additional size |
-| `codeBlock` | ~20KB gzipped | lowlight / highlight.js |
-| `embed` | ~5KB gzipped | Built-in oEmbed |
-| `table` | ~8KB gzipped | @tiptap/extension-table |
-| `dragHandle` | ~3KB gzipped | Built-in |
-| `textColor` | ~2KB gzipped | Built-in |
-| `taskList` | ~2KB gzipped | Built-in |
-| `details` | ~2KB gzipped | Built-in |
+| Feature | Path | Approximate Size | Dependencies |
+|---------|------|-----------------|--------------|
+| `mathematics` | `content` | ~80KB gzipped | KaTeX |
+| `diagram` | `content` | ~40KB gzipped | Mermaid (lazy-loaded); GraphViz via `@hpcc-js/wasm-graphviz` adds additional size |
+| `embed` | `content` | ~5KB gzipped | Built-in oEmbed |
+| `table` | `content` | ~8KB gzipped | @tiptap/extension-table |
+| `dragHandle` | `interaction` | ~3KB gzipped | Built-in |
+| `textColor` | `content` | ~2KB gzipped | Built-in |
+| `taskList` | `content` | ~2KB gzipped | Built-in |
+| `details` | `content` | ~2KB gzipped | Built-in |
 
 ::: tip Measurement
 Actual bundle sizes depend on your bundler configuration and tree-shaking. You can use tools like [bundlephobia](https://bundlephobia.com/) or your bundler's analysis output to measure exact sizes:
@@ -77,10 +83,12 @@ lowlight.register('javascript', javascript);
 lowlight.register('typescript', typescript);
 lowlight.register('css', css);
 
+// Code block syntax highlighting is part of the always-on core. Pass a
+// restricted Lowlight instance through the `extensions` array.
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+
 const editor = useVizelEditor({
-  features: {
-    codeBlock: { lowlight },
-  },
+  extensions: [CodeBlockLowlight.configure({ lowlight })],
 });
 ```
 
@@ -104,8 +112,10 @@ You can use the character count feature to enforce document size limits:
 ```typescript
 const editor = useVizelEditor({
   features: {
-    characterCount: {
-      limit: 50000, // Maximum characters
+    interaction: {
+      characterCount: {
+        limit: 50000, // Maximum characters
+      },
     },
   },
 });

--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -76,7 +76,9 @@ import { Vizel } from '@vizel/react';
   enableEmbed={true}
   className="my-editor"
   features={{
-    image: { onUpload: async (file) => 'url' },
+    content: {
+      image: { onUpload: async (file) => 'url' },
+    },
   }}
   onUpdate={({ editor }) => {}}
   onCreate={({ editor }) => {}}
@@ -130,8 +132,9 @@ function Editor() {
     initialContent: { type: 'doc', content: [] },
     placeholder: 'Start writing...',
     features: {
-      markdown: true,
-      mathematics: true,
+      content: {
+        mathematics: true,
+      },
     },
     onUpdate: ({ editor }) => {
       console.log(editor.getJSON());
@@ -279,11 +282,11 @@ This hook accesses theme state within `VizelThemeProvider`.
 import { useVizelTheme, VizelThemeProvider } from '@vizel/react';
 
 function ThemeToggle() {
-  const { theme, resolvedTheme, setTheme } = useVizelTheme();
+  const { theme, setTheme } = useVizelTheme();
 
   return (
-    <button onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}>
-      {resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
     </button>
   );
 }

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -76,7 +76,9 @@ All-in-one editor component with built-in bubble menu.
   enableEmbed={true}
   class="my-editor"
   features={{
-    image: { onUpload: async (file) => 'url' },
+    content: {
+      image: { onUpload: async (file) => 'url' },
+    },
   }}
   onUpdate={({ editor }) => {}}
   onCreate={({ editor }) => {}}
@@ -128,8 +130,9 @@ This rune creates and manages a Vizel editor instance using Svelte 5 reactivity.
     initialContent: { type: 'doc', content: [] },
     placeholder: 'Start writing...',
     features: {
-      markdown: true,
-      mathematics: true,
+      content: {
+        mathematics: true,
+      },
     },
     onUpdate: ({ editor }) => {
       console.log(editor.getJSON());
@@ -238,7 +241,7 @@ This rune provides two-way Markdown synchronization with debouncing.
 </script>
 
 <VizelEditor editor={editor.current} />
-<textarea value={md.markdown} oninput={(e) => md.setMarkdown(e.target.value)} />
+<textarea value={md.current} oninput={(e) => md.setMarkdown(e.target.value)} />
 {#if md.isPending}
   <span>Syncing...</span>
 {/if}
@@ -248,9 +251,10 @@ This rune provides two-way Markdown synchronization with debouncing.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `markdown` | `string` | Current Markdown content (reactive) |
+| `current` | `string` | Current Markdown content (reactive getter) |
 | `setMarkdown` | `(md: string) => void` | Update editor from Markdown |
-| `isPending` | `boolean` | Whether sync is pending (reactive) |
+| `isPending` | `boolean` | Whether sync is pending (reactive getter) |
+| `flush` | `() => void` | Force-flush pending updates immediately |
 
 ### getVizelTheme
 
@@ -263,14 +267,14 @@ This rune accesses theme state within `VizelThemeProvider` context.
   const theme = getVizelTheme();
 
   function toggleTheme() {
-    theme.setTheme(theme.resolvedTheme === 'dark' ? 'light' : 'dark');
+    theme.setTheme(theme.current === 'dark' ? 'light' : 'dark');
   }
 </script>
 
 <VizelThemeProvider defaultTheme="system">
   <Editor />
   <button onclick={toggleTheme}>
-    {theme.resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    {theme.current === 'dark' ? 'Light Mode' : 'Dark Mode'}
   </button>
 </VizelThemeProvider>
 ```

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -88,14 +88,12 @@ import { VizelThemeProvider } from '@vizel/vue';
 import { useVizelTheme } from '@vizel/react';
 
 function ThemeToggle() {
-  const { theme, resolvedTheme, setTheme } = useVizelTheme();
-  
+  const { theme, setTheme } = useVizelTheme();
+
   return (
-    <select value={theme} onChange={(e) => setTheme(e.target.value)}>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-      <option value="system">System</option>
-    </select>
+    <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    </button>
   );
 }
 ```
@@ -104,42 +102,38 @@ function ThemeToggle() {
 <script setup lang="ts">
 import { useVizelTheme } from '@vizel/vue';
 
-const { theme, resolvedTheme, setTheme } = useVizelTheme();
+const { theme, setTheme } = useVizelTheme();
 </script>
 
 <template>
-  <select :value="theme" @change="setTheme($event.target.value)">
-    <option value="light">Light</option>
-    <option value="dark">Dark</option>
-    <option value="system">System</option>
-  </select>
+  <button @click="setTheme(theme === 'dark' ? 'light' : 'dark')">
+    {{ theme === 'dark' ? 'Light Mode' : 'Dark Mode' }}
+  </button>
 </template>
 ```
 
 ```svelte [Svelte]
 <script lang="ts">
   import { getVizelTheme } from '@vizel/svelte';
-  
+
   const theme = getVizelTheme();
 </script>
 
-<select value={theme.theme} onchange={(e) => theme.setTheme(e.target.value)}>
-  <option value="light">Light</option>
-  <option value="dark">Dark</option>
-  <option value="system">System</option>
-</select>
+<button onclick={() => theme.setTheme(theme.current === 'dark' ? 'light' : 'dark')}>
+  {theme.current === 'dark' ? 'Light Mode' : 'Dark Mode'}
+</button>
 ```
 
 :::
 
 ### Theme State Properties
 
+The `useVizelTheme` / `getVizelTheme` return surfaces only the **resolved** theme (`"light" | "dark"`). The user-preference setting (`"system"` etc.) is owned by the provider's `defaultTheme` and is not a runtime-toggleable value.
+
 | Property | Type | Description |
 |----------|------|-------------|
-| `theme` | `"light" \| "dark" \| "system"` | Current theme setting |
-| `resolvedTheme` | `"light" \| "dark"` | Actual resolved theme |
-| `systemTheme` | `"light" \| "dark"` | System preference |
-| `setTheme` | `(theme) => void` | Function to change theme |
+| `theme` (React/Vue) / `current` (Svelte) | `"light" \| "dark"` | Currently applied theme |
+| `setTheme` | `(next: "light" \| "dark") => void` | Switch to a concrete theme |
 
 ---
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -88,22 +88,24 @@ By default, Vizel converts images to Base64. For production, you should configur
 ```typescript
 const editor = useVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        const formData = new FormData();
-        formData.append('image', file);
+    content: {
+      image: {
+        onUpload: async (file) => {
+          const formData = new FormData();
+          formData.append('image', file);
 
-        const response = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        });
+          const response = await fetch('/api/upload', {
+            method: 'POST',
+            body: formData,
+          });
 
-        if (!response.ok) {
-          throw new Error('Upload failed');
-        }
+          if (!response.ok) {
+            throw new Error('Upload failed');
+          }
 
-        const { url } = await response.json();
-        return url;
+          const { url } = await response.json();
+          return url;
+        },
       },
     },
   },
@@ -117,12 +119,14 @@ You can configure `maxFileSize` and handle validation errors:
 ```typescript
 const editor = useVizelEditor({
   features: {
-    image: {
-      maxFileSize: 5 * 1024 * 1024, // 5MB
-      onValidationError: (error) => {
-        if (error.type === 'file_too_large') {
-          alert(`File too large: ${error.message}`);
-        }
+    content: {
+      image: {
+        maxFileSize: 5 * 1024 * 1024, // 5MB
+        onValidationError: (error) => {
+          if (error.type === 'file_too_large') {
+            alert(`File too large: ${error.message}`);
+          }
+        },
       },
     },
   },
@@ -136,12 +140,14 @@ You can configure allowed MIME types:
 ```typescript
 const editor = useVizelEditor({
   features: {
-    image: {
-      allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
-      onValidationError: (error) => {
-        if (error.type === 'invalid_type') {
-          alert('Only JPEG, PNG, and WebP images are allowed');
-        }
+    content: {
+      image: {
+        allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
+        onValidationError: (error) => {
+          if (error.type === 'invalid_type') {
+            alert('Only JPEG, PNG, and WebP images are allowed');
+          }
+        },
       },
     },
   },
@@ -155,14 +161,16 @@ You should handle upload failures gracefully:
 ```typescript
 const editor = useVizelEditor({
   features: {
-    image: {
-      onUpload: async (file) => {
-        // Your upload logic
-      },
-      onUploadError: (error, file) => {
-        console.error(`Failed to upload ${file.name}:`, error);
-        // Show user-friendly error message
-        alert('Upload failed. Please check your connection and try again.');
+    content: {
+      image: {
+        onUpload: async (file) => {
+          // Your upload logic
+        },
+        onUploadError: (error, file) => {
+          console.error(`Failed to upload ${file.name}:`, error);
+          // Show user-friendly error message
+          alert('Upload failed. Please check your connection and try again.');
+        },
       },
     },
   },
@@ -198,9 +206,11 @@ For large documents, consider the following approaches:
 ```typescript
 const editor = useVizelEditor({
   features: {
-    mathematics: false,  // Disable if not needed
-    diagram: false,      // Disable if not needed
-    embed: false,        // Disable if not needed
+    content: {
+      mathematics: false,  // Disable if not needed
+      diagram: false,      // Disable if not needed
+      embed: false,        // Disable if not needed
+    },
   },
 });
 ```
@@ -307,12 +317,14 @@ Verify that you enabled the required features:
 
 ```typescript
 // Error when trying to use disabled feature
-editor.commands.toggleMathInline(); // Fails if mathematics: false
+editor.commands.toggleMathInline(); // Fails if content.mathematics: false
 
 // Solution: Enable the feature
 const editor = useVizelEditor({
   features: {
-    mathematics: true,
+    content: {
+      mathematics: true,
+    },
   },
 });
 ```

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -79,7 +79,9 @@ import { Vizel } from '@vizel/vue';
     :enableEmbed="true"
     class="my-editor"
     :features="{
-      image: { onUpload: async (file) => 'url' },
+      content: {
+        image: { onUpload: async (file) => 'url' },
+      },
     }"
     @update="({ editor }) => {}"
     @create="({ editor }) => {}"
@@ -144,8 +146,9 @@ const editor = useVizelEditor({
   initialContent: { type: 'doc', content: [] },
   placeholder: 'Start writing...',
   features: {
-    markdown: true,
-    mathematics: true,
+    content: {
+      mathematics: true,
+    },
   },
   onUpdate: ({ editor }) => {
     console.log(editor.getJSON());
@@ -270,9 +273,10 @@ const { markdown, setMarkdown, isPending } = useVizelMarkdown(() => editor.value
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `markdown` | `Ref<string>` | Current Markdown content |
+| `markdown` | `Readonly<ShallowRef<string>>` | Current Markdown content. Templates auto-unwrap the ref; in `<script setup>` read `markdown.value`. |
 | `setMarkdown` | `(md: string) => void` | Update editor from Markdown |
-| `isPending` | `Ref<boolean>` | Whether sync is pending |
+| `isPending` | `ComputedRef<boolean>` | Whether sync is pending |
+| `flush` | `() => void` | Force-flush pending updates immediately |
 
 ### useVizelTheme
 
@@ -298,16 +302,16 @@ import ThemeToggle from './ThemeToggle.vue';
 <script setup lang="ts">
 import { useVizelTheme } from '@vizel/vue';
 
-const { resolvedTheme, setTheme } = useVizelTheme();
+const { theme, setTheme } = useVizelTheme();
 
 function toggleTheme() {
-  setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  setTheme(theme.value === 'dark' ? 'light' : 'dark');
 }
 </script>
 
 <template>
   <button @click="toggleTheme">
-    {{ resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode' }}
+    {{ theme === 'dark' ? 'Light Mode' : 'Dark Mode' }}
   </button>
 </template>
 ```

--- a/docs/guide/wiki-links.md
+++ b/docs/guide/wiki-links.md
@@ -25,7 +25,9 @@ import { useVizelEditor } from "@vizel/react";
 
 const editor = useVizelEditor({
   features: {
-    wikiLink: true,
+    content: {
+      wikiLink: true,
+    },
   },
 });
 ```
@@ -35,10 +37,12 @@ const editor = useVizelEditor({
 ```typescript
 const editor = useVizelEditor({
   features: {
-    wikiLink: {
-      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
-      pageExists: (page) => knownPages.has(page),
-      onLinkClick: (page) => router.push(`/wiki/${page}`),
+    content: {
+      wikiLink: {
+        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+        pageExists: (page) => knownPages.has(page),
+        onLinkClick: (page) => router.push(`/wiki/${page}`),
+      },
     },
   },
 });
@@ -82,8 +86,10 @@ Converts a page name to a URL. Vizel uses this value for the `href` attribute on
 
 ```typescript
 {
-  wikiLink: {
-    resolveLink: (page) => `/docs/${page.toLowerCase().replace(/\s+/g, "-")}`,
+  content: {
+    wikiLink: {
+      resolveLink: (page) => `/docs/${page.toLowerCase().replace(/\s+/g, "-")}`,
+    },
   },
 }
 ```
@@ -96,8 +102,10 @@ Determines if a linked page exists. This function controls visual styling: exist
 const existingPages = new Set(["Getting Started", "API Reference", "FAQ"]);
 
 {
-  wikiLink: {
-    pageExists: (page) => existingPages.has(page),
+  content: {
+    wikiLink: {
+      pageExists: (page) => existingPages.has(page),
+    },
   },
 }
 ```
@@ -108,10 +116,12 @@ Intercepts wiki link clicks for client-side navigation. Without this callback, l
 
 ```typescript
 {
-  wikiLink: {
-    onLinkClick: (pageName, event) => {
-      // SPA navigation
-      router.push(`/wiki/${pageName}`);
+  content: {
+    wikiLink: {
+      onLinkClick: (pageName, event) => {
+        // SPA navigation
+        router.push(`/wiki/${pageName}`);
+      },
     },
   },
 }
@@ -123,11 +133,13 @@ Provides autocomplete suggestions. You can use this callback for future autocomp
 
 ```typescript
 {
-  wikiLink: {
-    getPageSuggestions: (query) =>
-      allPages
-        .filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
-        .slice(0, 10),
+  content: {
+    wikiLink: {
+      getPageSuggestions: (query) =>
+        allPages
+          .filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
+          .slice(0, 10),
+    },
   },
 }
 ```
@@ -185,11 +197,13 @@ function WikiEditor() {
 
   const editor = useVizelEditor({
     features: {
-      wikiLink: {
-        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
-        pageExists: (page) => knownPages.has(page),
-        onLinkClick: (page) => {
-          console.log(`Navigate to: ${page}`);
+      content: {
+        wikiLink: {
+          resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+          pageExists: (page) => knownPages.has(page),
+          onLinkClick: (page) => {
+            console.log(`Navigate to: ${page}`);
+          },
         },
       },
     },
@@ -213,11 +227,13 @@ const knownPages = new Set(["Home", "About", "Contact"]);
 
 const editor = useVizelEditor({
   features: {
-    wikiLink: {
-      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
-      pageExists: (page) => knownPages.has(page),
-      onLinkClick: (page) => {
-        console.log(`Navigate to: ${page}`);
+    content: {
+      wikiLink: {
+        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+        pageExists: (page) => knownPages.has(page),
+        onLinkClick: (page) => {
+          console.log(`Navigate to: ${page}`);
+        },
       },
     },
   },
@@ -241,11 +257,13 @@ const knownPages = new Set(["Home", "About", "Contact"]);
 
 const editor = createVizelEditor({
   features: {
-    wikiLink: {
-      resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
-      pageExists: (page) => knownPages.has(page),
-      onLinkClick: (page) => {
-        console.log(`Navigate to: ${page}`);
+    content: {
+      wikiLink: {
+        resolveLink: (page) => `/wiki/${encodeURIComponent(page)}`,
+        pageExists: (page) => knownPages.has(page),
+        onLinkClick: (page) => {
+          console.log(`Navigate to: ${page}`);
+        },
       },
     },
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -44,7 +44,9 @@ import "@vizel/core/styles.css";
 function App() {
   const editor = useVizelEditor({
     features: {
-      image: { onUpload: async (file) => "https://example.com/image.png" },
+      content: {
+        image: { onUpload: async (file) => "https://example.com/image.png" },
+      },
     },
   });
 
@@ -64,7 +66,7 @@ import { useVizelEditor, useVizelMarkdown } from "@vizel/react";
 
 function App() {
   const editor = useVizelEditor();
-  const { markdown, setMarkdown } = useVizelMarkdown(() => editor);
+  const { markdown, setMarkdown } = useVizelMarkdown(editor);
 
   return <VizelEditor editor={editor} />;
 }

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -46,7 +46,9 @@ import "@vizel/core/styles.css";
 
 const editor = createVizelEditor({
   features: {
-    image: { onUpload: async (file) => "https://example.com/image.png" },
+    content: {
+      image: { onUpload: async (file) => "https://example.com/image.png" },
+    },
   },
 });
 </script>
@@ -66,7 +68,7 @@ import { createVizelEditor, createVizelMarkdown } from "@vizel/svelte";
 const editor = createVizelEditor();
 const md = createVizelMarkdown(() => editor.current);
 
-// Access: md.markdown, md.setMarkdown(value)
+// Access: md.current, md.setMarkdown(value)
 </script>
 ```
 
@@ -117,7 +119,7 @@ const md = createVizelMarkdown(() => editor.current);
 | `createVizelComment` | Comment and annotation management |
 | `createVizelVersionHistory` | Document version history |
 | `getVizelContext` | Access editor from context |
-| `getVizelContextSafe` | Access editor from context (returns undefined outside provider) |
+| `getVizelContextSafe` | Access editor from context (returns null outside provider) |
 | `getVizelTheme` | Access theme from context |
 | `getVizelIconContext` | Access icon context |
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -46,7 +46,9 @@ import "@vizel/core/styles.css";
 
 const editor = useVizelEditor({
   features: {
-    image: { onUpload: async (file) => "https://example.com/image.png" },
+    content: {
+      image: { onUpload: async (file) => "https://example.com/image.png" },
+    },
   },
 });
 </script>


### PR DESCRIPTION
## Summary

Consumer-review audits of `@vizel/react`, `@vizel/vue`, and `@vizel/svelte` surfaced multiple copy-paste-fail mismatches between published guides/READMEs and the shipped API. This PR fixes the docs only — no code changes — so following the Quick Start, Features, Configuration, Comments, Collaboration, Theming, and Troubleshooting pages now produces compilable code.

### Key fixes

- **`features` is nested**: every example now uses `features.{content,interaction,collaboration}.<feature>`. Flat shapes (`features.image`, `features.collaboration: true`, `features.comment: true`, `features.markdown: ...`) no longer compile in v2.
- **`useVizelTheme` / `getVizelTheme`**: React/Vue return `{ theme, setTheme }`; Svelte returns `{ current, setTheme }`. `resolvedTheme` is gone — the surface exposes only the resolved theme.
- **Svelte `createVizelMarkdown`**: returns `{ current, setMarkdown, isPending, flush }`, not `{ markdown, ... }`.
- **React `useVizelMarkdown(editor)`**: takes the editor directly. The getter form (`() => editor.value` / `() => editor.current`) is Vue/Svelte only.
- **Always-on core docs**: code blocks, links, and Markdown import/export are no longer documented under `features` (they ship as part of the always-on core; Markdown flavor is configured at the top-level `markdown` option).
- **`getVizelContextSafe`**: now correctly documented as returning `null` outside a provider.
- **Demo cleanup**: dropped `.value` reads inside Vue demo templates (auto-unwrap covers the cases that previously had explicit `.value` chains).

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @vizel/demo-vue` Vite build succeeds (Vue demo template references updated)
- [x] Spot-check every example block now matches the shipped TypeScript types in `packages/core/src/types.ts`