### PR TITLE
fix(core,react,vue,svelte): replay initialValue updates and SSR-guard rAF in useVizelMarkdown

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -585,6 +585,7 @@ export {
   type VizelTextSegment,
   // SSR utilities (Section 12)
   type VizelThemeInitScriptOptions,
+  vizelCancelAnimationFrame,
   vizelCommonMarkFlavor,
   vizelDefaultEditorProps,
   vizelDefaultFeatures,
@@ -592,6 +593,7 @@ export {
   vizelGfmFlavor,
   vizelObsidianFlavor,
   vizelPandocFlavor,
+  vizelRequestAnimationFrame,
   vizelThemeInitScript,
   type WrapAsVizelErrorOptions,
   wrapAsVizelError,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -94,6 +94,11 @@ export {
 } from "./markdown-flavors.ts";
 // Menu positioning utilities
 export { clampMenuPosition, type MenuPosition, shouldFlipSubmenu } from "./menuPositioning.ts";
+// SSR-safe rAF helpers (used by markdown sync hooks)
+export {
+  vizelCancelAnimationFrame,
+  vizelRequestAnimationFrame,
+} from "./raf.ts";
 // SSR utilities (Section 12)
 export {
   type VizelThemeInitScriptOptions,

--- a/packages/core/src/utils/raf.ts
+++ b/packages/core/src/utils/raf.ts
@@ -1,0 +1,44 @@
+/**
+ * SSR-safe wrappers around `requestAnimationFrame` /
+ * `cancelAnimationFrame`.
+ *
+ * On Node, edge runtimes, and any environment that does not expose
+ * `requestAnimationFrame`, the request shim falls back to a
+ * microtask-deferred callback so consumers that schedule one tick of
+ * work (debouncers, render flushers) still observe completion. The
+ * cancel shim becomes a no-op when the underlying function is missing.
+ *
+ * These helpers exist because Vizel's framework hooks
+ * (`useVizelMarkdown` / `createVizelMarkdown`) schedule a poll loop on
+ * editor `update` events. Calling `requestAnimationFrame`
+ * unconditionally crashed in `happy-dom`-based tests and Nuxt
+ * `<ClientOnly>` boundaries where `window` is defined but `rAF` is not.
+ */
+
+const HAS_RAF = typeof requestAnimationFrame === "function";
+const HAS_CANCEL_RAF = typeof cancelAnimationFrame === "function";
+
+/**
+ * Schedule `callback` for the next animation frame, or — when the
+ * environment does not implement rAF — for the next microtask. Returns
+ * a numeric handle that {@link vizelCancelAnimationFrame} accepts.
+ */
+export function vizelRequestAnimationFrame(callback: () => void): number {
+  if (HAS_RAF) return requestAnimationFrame(callback);
+  // Use queueMicrotask so the callback still runs asynchronously,
+  // matching rAF's call-after-current-task semantics for consumers
+  // that depend on the deferral (debouncers, paint-coalesced poll
+  // loops).
+  queueMicrotask(callback);
+  return 0;
+}
+
+/**
+ * Cancel a previously scheduled animation-frame callback. Becomes a
+ * no-op when the underlying API is unavailable or when the handle is
+ * the sentinel `0` returned by the SSR fallback path.
+ */
+export function vizelCancelAnimationFrame(id: number | null): void {
+  if (id === null || id === 0) return;
+  if (HAS_CANCEL_RAF) cancelAnimationFrame(id);
+}

--- a/packages/react/src/hooks/useVizelMarkdown.ts
+++ b/packages/react/src/hooks/useVizelMarkdown.ts
@@ -4,6 +4,8 @@ import {
   getVizelMarkdown,
   type VizelMarkdownSyncHandlers,
   type VizelMarkdownSyncOptions,
+  vizelCancelAnimationFrame,
+  vizelRequestAnimationFrame,
 } from "@vizel/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -94,23 +96,32 @@ export function useVizelMarkdown(
   const editorRef = useRef(editor);
   editorRef.current = editor;
 
-  // Track if initial value has been set
-  const initialSetRef = useRef(false);
+  // Track the last `initialValue` we applied so suspense-resolved updates
+  // (data arriving after the first render) are still honored, while
+  // re-renders with the same value remain no-ops. The previous single
+  // latch ignored every change after the first apply, leaving editors
+  // blank when server-side markdown arrived asynchronously.
+  const appliedInitialValueRef = useRef<string | undefined>(undefined);
 
-  // Set initial markdown when editor is ready
+  // Set initial markdown when editor is ready or when `initialValue` changes
   useEffect(() => {
-    if (!editor || initialSetRef.current) return;
+    if (!editor) return;
 
     if (initialValue === undefined) {
-      // Get initial markdown from editor
-      const currentMarkdown = getVizelMarkdown(editor);
-      setMarkdownState(currentMarkdown);
-    } else {
-      handlersRef.current?.setMarkdown(editor, initialValue);
-      setMarkdownState(initialValue);
+      // Uncontrolled path: pull the current markdown from the editor exactly
+      // once so the consumer sees the server-rendered seed value.
+      if (appliedInitialValueRef.current === undefined) {
+        setMarkdownState(getVizelMarkdown(editor));
+        appliedInitialValueRef.current = "";
+      }
+      return;
     }
 
-    initialSetRef.current = true;
+    if (appliedInitialValueRef.current === initialValue) return;
+
+    handlersRef.current?.setMarkdown(editor, initialValue);
+    setMarkdownState(initialValue);
+    appliedInitialValueRef.current = initialValue;
   }, [editor, initialValue]);
 
   // Subscribe to editor updates
@@ -127,19 +138,19 @@ export function useVizelMarkdown(
       setIsPending(handlers.isPending());
 
       // Cancel any pending rAF before scheduling a new one
-      if (rafState.id !== null) cancelAnimationFrame(rafState.id);
+      vizelCancelAnimationFrame(rafState.id);
 
       // Schedule state update after debounce
       const checkPending = () => {
         if (handlers.isPending()) {
-          rafState.id = requestAnimationFrame(checkPending);
+          rafState.id = vizelRequestAnimationFrame(checkPending);
         } else {
           rafState.id = null;
           setMarkdownState(handlers.getMarkdown());
           setIsPending(false);
         }
       };
-      rafState.id = requestAnimationFrame(checkPending);
+      rafState.id = vizelRequestAnimationFrame(checkPending);
     };
 
     editor.on("update", handleUpdate);
@@ -153,7 +164,7 @@ export function useVizelMarkdown(
         setIsPending(false);
       }
       editor.off("update", handleUpdate);
-      if (rafState.id !== null) cancelAnimationFrame(rafState.id);
+      vizelCancelAnimationFrame(rafState.id);
     };
   }, [editor]);
 

--- a/packages/svelte/src/runes/createVizelMarkdown.svelte.ts
+++ b/packages/svelte/src/runes/createVizelMarkdown.svelte.ts
@@ -4,6 +4,8 @@ import {
   getVizelMarkdown,
   type VizelMarkdownSyncHandlers,
   type VizelMarkdownSyncOptions,
+  vizelCancelAnimationFrame,
+  vizelRequestAnimationFrame,
 } from "@vizel/core";
 
 export interface CreateVizelMarkdownOptions extends VizelMarkdownSyncOptions {
@@ -92,8 +94,10 @@ export function createVizelMarkdown(
     return handlers;
   };
 
-  // Track if initial value has been set
-  let initialSet = false;
+  // Track the last `initialValue` we applied across effect re-runs so
+  // Suspense-resolved / lazy-loaded updates apply while no-op re-renders
+  // stay quiet. A primitive `let` is allowed in `.svelte.ts` files.
+  let lastInitialApplied: string | undefined;
 
   // Watch for editor availability and subscribe to updates
   $effect(() => {
@@ -102,16 +106,17 @@ export function createVizelMarkdown(
 
     const h = initHandlers();
 
-    // Initialize markdown on first editor availability
-    if (!initialSet) {
-      if (initialValue === undefined) {
-        // Get initial markdown from editor
+    // Initialize markdown on first editor availability, then re-apply when
+    // the caller swaps `initialValue` (e.g. async data resolves later).
+    if (initialValue === undefined) {
+      if (lastInitialApplied === undefined) {
         markdown = getVizelMarkdown(editor);
-      } else {
-        h.setMarkdown(editor, initialValue);
-        markdown = initialValue;
+        lastInitialApplied = "";
       }
-      initialSet = true;
+    } else if (lastInitialApplied !== initialValue) {
+      h.setMarkdown(editor, initialValue);
+      markdown = initialValue;
+      lastInitialApplied = initialValue;
     }
 
     // Subscribe to editor updates
@@ -122,19 +127,19 @@ export function createVizelMarkdown(
       isPending = h.isPending();
 
       // Cancel any pending rAF before scheduling a new one
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      vizelCancelAnimationFrame(rafId);
 
       // Schedule state update after debounce
       const checkPending = () => {
         if (h.isPending()) {
-          rafId = requestAnimationFrame(checkPending);
+          rafId = vizelRequestAnimationFrame(checkPending);
         } else {
           rafId = null;
           markdown = h.getMarkdown();
           isPending = false;
         }
       };
-      rafId = requestAnimationFrame(checkPending);
+      rafId = vizelRequestAnimationFrame(checkPending);
     };
 
     editor.on("update", handleUpdate);
@@ -147,7 +152,7 @@ export function createVizelMarkdown(
         markdown = h.getMarkdown();
       }
       editor.off("update", handleUpdate);
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      vizelCancelAnimationFrame(rafId);
       handlers?.destroy();
       handlers = null;
       isPending = false;

--- a/packages/vue/src/composables/useVizelMarkdown.ts
+++ b/packages/vue/src/composables/useVizelMarkdown.ts
@@ -4,6 +4,8 @@ import {
   getVizelMarkdown,
   type VizelMarkdownSyncHandlers,
   type VizelMarkdownSyncOptions,
+  vizelCancelAnimationFrame,
+  vizelRequestAnimationFrame,
 } from "@vizel/core";
 import type { ComputedRef, ShallowRef } from "vue";
 import { computed, onBeforeUnmount, shallowRef, watch } from "vue";
@@ -103,8 +105,9 @@ export function useVizelMarkdown(
     return handlersRef.current;
   };
 
-  // Track if initial value has been set across watcher re-runs.
-  const initFlag = { value: false };
+  // Track the last `initialValue` we applied across watcher re-runs so
+  // Suspense-resolved updates apply while no-op re-renders stay quiet.
+  const lastInitialApplied: { value: string | undefined } = { value: undefined };
 
   // Watch for editor availability
   watch(
@@ -114,16 +117,20 @@ export function useVizelMarkdown(
 
       const h = initHandlers();
 
-      // Initial value setup (only once)
-      if (!initFlag.value) {
-        if (initialValue === undefined) {
-          // Get initial markdown from editor
+      // Initial value setup. The previous single latch ignored every change
+      // after the first apply, leaving editors blank when the server-side
+      // markdown arrived asynchronously (Suspense, SWR, etc.). Track the
+      // last applied value so repeated re-renders with the same value remain
+      // no-ops while genuine updates still propagate.
+      if (initialValue === undefined) {
+        if (lastInitialApplied.value === undefined) {
           markdown.value = getVizelMarkdown(editor);
-        } else {
-          h.setMarkdown(editor, initialValue);
-          markdown.value = initialValue;
+          lastInitialApplied.value = "";
         }
-        initFlag.value = true;
+      } else if (lastInitialApplied.value !== initialValue) {
+        h.setMarkdown(editor, initialValue);
+        markdown.value = initialValue;
+        lastInitialApplied.value = initialValue;
       }
 
       // Subscribe to editor updates (every time editor changes)
@@ -134,19 +141,19 @@ export function useVizelMarkdown(
         pendingState.value = h.isPending();
 
         // Cancel any pending rAF before scheduling a new one
-        if (rafState.id !== null) cancelAnimationFrame(rafState.id);
+        vizelCancelAnimationFrame(rafState.id);
 
         // Schedule state update after debounce
         const checkPending = () => {
           if (h.isPending()) {
-            rafState.id = requestAnimationFrame(checkPending);
+            rafState.id = vizelRequestAnimationFrame(checkPending);
           } else {
             rafState.id = null;
             markdown.value = h.getMarkdown();
             pendingState.value = false;
           }
         };
-        rafState.id = requestAnimationFrame(checkPending);
+        rafState.id = vizelRequestAnimationFrame(checkPending);
       };
 
       editor.on("update", handleUpdate);
@@ -161,7 +168,7 @@ export function useVizelMarkdown(
           pendingState.value = false;
         }
         editor.off("update", handleUpdate);
-        if (rafState.id !== null) cancelAnimationFrame(rafState.id);
+        vizelCancelAnimationFrame(rafState.id);
       });
     },
     { immediate: true }


### PR DESCRIPTION
## Summary

The markdown sync hook latched the first `initialValue` it saw and ignored every later one. Common async-data flows broke: a Suspense boundary or an SWR query that resolved the server-side markdown after the first render left the editor blank because the latch was already set.

The replacement tracks the last applied value and replays the sync only when the value actually changes. Repeated re-renders with the same value remain no-ops; first paint plus async resolution now both land in the editor.

The same hook scheduled `requestAnimationFrame` unconditionally to poll the debounced export's pending flag. Environments that expose `window` but not `requestAnimationFrame` (Nuxt SSR `<ClientOnly>`, happy-dom unit tests) crashed with `ReferenceError`. Two new SSR-safe shims in `@vizel/core/utils/raf` fall back to `queueMicrotask` when rAF is unavailable, returning a sentinel `0` the cancel shim recognizes as a no-op.

All three framework hooks now route their poll loop through `vizelRequestAnimationFrame` / `vizelCancelAnimationFrame`.

Consumer-review IDs: P1-4 (React initialValue latch), P1-3 (Vue rAF SSR guard).

## Test Plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm check:ssr\`
- [ ] CI runs the Playwright matrix