### PR TITLE
ci: replace removed test:ssr with check:ssr lint-only step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
-        run: pnpm build
-
-      - name: Run SSR static HTML smoke test
-        run: pnpm test:ssr
+      - name: Verify core stays free of top-level browser globals
+        run: pnpm check:ssr
 
   visual:
     name: Visual Regression


### PR DESCRIPTION
Static View removal (#535) deleted `scripts/test-static-html.ts` and the `test:ssr` package script, but the CI SSR job still invoked it and started failing on every PR that rebased onto the new main. This switches the job to `pnpm check:ssr` which is what the updated testing rules now describe as the canonical Section 11 enforcement (lint-only).

Without this every other open PR will keep failing SSR after rebase.