### PR TITLE
fix(demo): wire ThemeToggle System button so it actually re-enters system mode

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -256,7 +256,7 @@ function AppContent({ onResetThemeToSystem }: AppContentProps) {
             <h1>Vizel Editor</h1>
             <span className="framework-badge">React 19</span>
           </div>
-          {features.theme && <ThemeToggle />}
+          {features.theme && <ThemeToggle onResetToSystem={onResetThemeToSystem} />}
         </div>
         <p className="header-description">
           A block-based rich text editor with slash commands and inline formatting
@@ -648,9 +648,20 @@ function AppContent({ onResetThemeToSystem }: AppContentProps) {
 }
 
 export function App() {
+  // The provider seeds its theme state once at mount from
+  // `localStorage[storageKey]` (or `defaultTheme`). The System button
+  // clears the persisted preference and bumps `providerKey` so the
+  // provider remounts and re-runs that seed against the now-clean
+  // storage — the simplest way to re-enter "follow system" mode without
+  // adding a runtime "system" path to `useVizelTheme().setTheme` (which
+  // is intentionally narrowed to concrete `light` / `dark`).
+  const [providerKey, setProviderKey] = useState(0);
+  const handleResetThemeToSystem = useCallback(() => {
+    setProviderKey((key) => key + 1);
+  }, []);
   return (
-    <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
-      <AppContent />
+    <VizelThemeProvider key={providerKey} defaultTheme="system" storageKey="vizel-theme">
+      <AppContent onResetThemeToSystem={handleResetThemeToSystem} />
     </VizelThemeProvider>
   );
 }

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -148,8 +148,21 @@ function handleJsonChange(event: Event) {
     // Invalid JSON, ignore
   }
 }
+
+// The provider seeds its theme state once at mount from
+// `localStorage[storageKey]` (or `defaultTheme`). The System button
+// clears the persisted preference and bumps `providerKey` so the
+// provider remounts and re-runs that seed against the now-clean
+// storage — the simplest way to re-enter "follow system" mode without
+// adding a runtime "system" path to `getVizelTheme().setTheme` (which
+// is intentionally narrowed to concrete `light` / `dark`).
+let providerKey = $state(0);
+function handleResetThemeToSystem(): void {
+  providerKey += 1;
+}
 </script>
 
+{#key providerKey}
 <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
 <div class="app">
   <header class="header">
@@ -160,7 +173,7 @@ function handleJsonChange(event: Event) {
         <span class="framework-badge">Svelte 5</span>
       </div>
       {#if features.theme}
-        <ThemeToggle />
+        <ThemeToggle onResetToSystem={handleResetThemeToSystem} />
       {/if}
     </div>
     <p class="header-description">
@@ -468,3 +481,4 @@ function handleJsonChange(event: Event) {
   </footer>
 </div>
 </VizelThemeProvider>
+{/key}

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -147,10 +147,22 @@ async function handleReply(commentId: string) {
 }
 
 const showPanel = computed(() => features.syncPanel || features.history || features.comments);
+
+// The provider seeds its theme state once at mount from
+// `localStorage[storageKey]` (or `defaultTheme`). The System button
+// clears the persisted preference and bumps `providerKey` so the
+// provider remounts and re-runs that seed against the now-clean
+// storage — the simplest way to re-enter "follow system" mode without
+// adding a runtime "system" path to `useVizelTheme().setTheme` (which
+// is intentionally narrowed to concrete `light` / `dark`).
+const providerKey = ref(0);
+function handleResetThemeToSystem(): void {
+  providerKey.value += 1;
+}
 </script>
 
 <template>
-  <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
+  <VizelThemeProvider :key="providerKey" defaultTheme="system" storageKey="vizel-theme">
     <div class="app">
       <header class="header">
         <div class="header-content">
@@ -159,7 +171,7 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
             <h1>Vizel Editor</h1>
             <span class="framework-badge">Vue 3</span>
           </div>
-          <ThemeToggle v-if="features.theme" />
+          <ThemeToggle v-if="features.theme" :on-reset-to-system="handleResetThemeToSystem" />
         </div>
         <p class="header-description">
           A block-based rich text editor with slash commands and inline formatting


### PR DESCRIPTION
## Summary

All three demo apps shipped a three-state theme toggle whose System button cleared the persisted preference in `localStorage` but never re-seeded the theme provider — the clear only took effect on the next reload, so clicking **System** looked like a no-op.

The React demo additionally **crashed at runtime** because `ThemeToggle`'s required `onResetToSystem` prop was never threaded from `App` (`apps/demo/react/src/App.tsx:259` passes no props to `<ThemeToggle />`, the prop type marks `onResetToSystem` required).

## Fix

Each demo App now owns a `providerKey` (incremented by the System button) and keys the `<VizelThemeProvider>` against it. A click remounts the provider and the constructor re-reads `localStorage[storageKey] || defaultTheme="system"` against the now-clean storage — re-entering "follow system" without adding a runtime `"system"` path to `useVizelTheme().setTheme`, which is intentionally narrowed to concrete `"light" | "dark"` per the cross-framework Return Type table.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vite build` in all three demos (React/Vue/Svelte)
- [ ] Manual: in each demo, toggle Dark → System; verify the page follows the OS preference
