### PR TITLE
fix(react): route VizelBlockMenu rAF calls through SSR-safe helper

### DIFF
--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -13,6 +13,7 @@ import {
   type VizelNodeTypeOption,
   vizelDefaultBlockMenuActions,
   vizelDefaultNodeTypes,
+  vizelRequestAnimationFrame,
 } from "@vizel/core";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
@@ -92,7 +93,7 @@ export function VizelBlockMenu({
       });
       setShowTurnInto(false);
 
-      requestAnimationFrame(() => {
+      vizelRequestAnimationFrame(() => {
         const el = menuRef.current;
         if (!el) return;
         const clamped = clampMenuPosition(detail.handleRect, el.offsetWidth, el.offsetHeight);
@@ -146,7 +147,7 @@ export function VizelBlockMenu({
       setSubmenuFlipped(false);
       return;
     }
-    requestAnimationFrame(() => {
+    vizelRequestAnimationFrame(() => {
       const parentRect = menuRef.current?.getBoundingClientRect();
       if (parentRect) {
         setSubmenuFlipped(shouldFlipSubmenu(parentRect, 200));


### PR DESCRIPTION
## Summary

`VizelBlockMenu.tsx` called `requestAnimationFrame` directly at two sites (menu-open clamp on line 95, submenu-flip detection on line 149) while the surrounding code base — `useVizelMarkdown` after the Phase 1 sweep, and the policy spelled out in the `vizelRequestAnimationFrame` JSDoc — routes all rAF scheduling through the SSR-safe helper that falls back to `queueMicrotask` when the browser global is absent.

Both call sites are inside React effects so they only run in the browser today, but the inconsistency would trip the same review the next time the Section 11 SSR audit revisits the React surface. Vue and Svelte BlockMenu equivalents already avoid the bare global and need no change.

## Test plan
- [x] `pnpm --filter @vizel/react typecheck`
