### PR TITLE
fix(react,vue,svelte): throw VizelError(MISSING_CONTEXT) from context hooks

### DIFF
--- a/packages/react/src/components/VizelContext.tsx
+++ b/packages/react/src/components/VizelContext.tsx
@@ -1,4 +1,4 @@
-import type { Editor } from "@vizel/core";
+import { type Editor, VizelError } from "@vizel/core";
 import { createContext, type ReactNode, useContext } from "react";
 
 /**
@@ -56,12 +56,10 @@ export function VizelInternalProvider({ editor, children }: VizelInternalProvide
 export function useVizelContext(): Editor | null {
   const context = useContext(VizelContext);
   if (context === VIZEL_CONTEXT_UNSET) {
-    throw new Error(
-      "[Vizel] useVizelContext must be used within <VizelProvider> or <Vizel>.\n" +
-        "Example:\n" +
-        "  <VizelProvider editor={editor}>\n" +
-        "    <YourComponent />\n" +
-        "  </VizelProvider>"
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "useVizelContext must be used within <VizelProvider> or <Vizel>. " +
+        "Wrap the consumer in <VizelProvider editor={editor}>...</VizelProvider>."
     );
   }
   return context;

--- a/packages/svelte/src/components/VizelContext.ts
+++ b/packages/svelte/src/components/VizelContext.ts
@@ -1,4 +1,4 @@
-import type { Editor } from "@vizel/core";
+import { type Editor, VizelError } from "@vizel/core";
 import { getContext } from "svelte";
 
 export const VIZEL_CONTEXT_KEY = Symbol("vizel-editor");
@@ -38,7 +38,11 @@ export interface VizelContextAccessor {
 export function getVizelContext(): VizelContextAccessor {
   const accessor = getContext<VizelContextAccessor | undefined>(VIZEL_CONTEXT_KEY);
   if (!accessor) {
-    throw new Error("getVizelContext must be used within a VizelProvider");
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "getVizelContext must be used within <VizelProvider> or <Vizel>. " +
+        "Wrap the consumer in <VizelProvider editor={editor.current}>...</VizelProvider>."
+    );
   }
   return accessor;
 }

--- a/packages/vue/src/components/VizelContext.ts
+++ b/packages/vue/src/components/VizelContext.ts
@@ -1,4 +1,4 @@
-import type { Editor } from "@vizel/core";
+import { type Editor, VizelError } from "@vizel/core";
 import { type InjectionKey, inject, type ShallowRef } from "vue";
 
 /**
@@ -39,7 +39,11 @@ export const VIZEL_CONTEXT_KEY: InjectionKey<ShallowRef<Editor | null>> = Symbol
 export function useVizelContext(): ShallowRef<Editor | null> {
   const editorRef = inject(VIZEL_CONTEXT_KEY);
   if (!editorRef) {
-    throw new Error("useVizelContext must be used within a VizelProvider");
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "useVizelContext must be used within <VizelProvider> or <Vizel>. " +
+        'Wrap the consumer in <VizelProvider :editor="editor">...</VizelProvider>.'
+    );
   }
   return editorRef;
 }


### PR DESCRIPTION
## Summary

`useVizelContext` / `getVizelContext` were throwing plain `Error` instances when called outside a provider. The architecture rule (`.claude/rules/architecture.md`) and the troubleshooting reference (`docs/guide/troubleshooting.md`) both promise this case surfaces as a typed `VizelError("MISSING_CONTEXT")` so consumers that centralize error handling on `isVizelError(err)` can catch it.

Each framework now throws `new VizelError("MISSING_CONTEXT", ...)` with a one-line example pointing at the right provider snippet for that framework. The error class already shipped from `@vizel/core` with the `MISSING_CONTEXT` code declared in `VizelErrorCode`; the hooks just needed to use it.

The "safe" variants (`useVizelContextSafe` / `getVizelContextSafe`) remain non-throwing and unchanged.

## Test plan
- [x] `pnpm typecheck`
