### PR TITLE
docs: fix drift in troubleshooting, theming, and SSR guides

### DIFF
--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -433,7 +433,13 @@ changes are ignored. Use `bind:markdown` when you intend two-way sync.
 </div>
 ```
 
-### Reactive Content with $state (JSON)
+### Mirror Editor JSON into $state via onUpdate
+
+`initialContent` is captured once when the editor mounts — writing to
+the same `$state` later does not push the new value into the editor.
+Use `onUpdate` to read the editor's JSON back into a `$state` for
+display, and call `editor.current.commands.setContent(...)`
+imperatively when you need to push from outside:
 
 ```svelte
 <script lang="ts">
@@ -442,11 +448,14 @@ changes are ignored. Use `bind:markdown` when you intend two-way sync.
   let content = $state<JSONContent>({ type: 'doc', content: [] });
 
   const editor = createVizelEditor({
-    initialContent: content,
     onUpdate: ({ editor }) => {
       content = editor.getJSON();
     },
   });
+
+  function reset(): void {
+    editor.current?.commands.setContent({ type: 'doc', content: [] });
+  }
 </script>
 ```
 
@@ -575,31 +584,27 @@ changes are ignored. Use `bind:markdown` when you intend two-way sync.
 
 ## SSR/SvelteKit Considerations
 
-The editor runs on the client side only. Use a `browser` check or `onMount`:
+The editor runs on the client side only. `createVizelEditor` is safe
+to call unconditionally at script top — its internal `$effect` is a
+no-op on the server, and `editor.current` is `null` until the editor
+finishes initializing in the browser:
 
 ```svelte
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import { onMount } from 'svelte';
+  import { createVizelEditor, VizelEditor } from '@vizel/svelte';
 
-  let mounted = $state(false);
-
-  onMount(() => {
-    mounted = true;
-  });
-
-  // Only create editor on client
-  const editor = browser ? createVizelEditor() : { current: null };
+  const editor = createVizelEditor();
 </script>
 
-{#if mounted}
+{#if editor.current}
   <VizelEditor editor={editor.current} />
 {:else}
   <div>Loading editor...</div>
 {/if}
 ```
 
-Or use dynamic import:
+If you want to defer loading the editor bundle until the client
+needs it, use a dynamic import:
 
 ```svelte
 <script lang="ts">
@@ -613,11 +618,14 @@ Or use dynamic import:
 </script>
 
 {#if Editor}
-  <svelte:component this={Editor} />
+  <Editor />
 {:else}
   <div>Loading...</div>
 {/if}
 ```
+
+The `<svelte:component>` wrapper used in earlier Svelte versions is
+deprecated in Svelte 5 — render the component variable directly.
 
 ## Svelte 5 Runes vs Svelte 4
 

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -19,7 +19,7 @@ This includes CSS variable definitions (light and dark themes), component styles
 For projects using shadcn/ui or custom CSS variables:
 
 ```typescript
-import '@vizel/core/components.css';
+import '@vizel/core/styles/components.css';
 ```
 
 This includes only component styles without CSS variable definitions.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -58,7 +58,7 @@ If the editor appears unstyled or broken, ensure you import the CSS:
 import '@vizel/core/styles.css';
 
 // For components like Bubble Menu (optional)
-import '@vizel/core/components.css';
+import '@vizel/core/styles/components.css';
 
 // For mathematics support (optional)
 import '@vizel/core/mathematics.css';
@@ -231,14 +231,14 @@ const editor = useVizelEditor({
 You can increase the debounce time for auto-save:
 
 ```typescript
-import { useVizelAutoSave } from '@vizel/react';
+import { useVizelAutoSave, useVizelEditor } from '@vizel/react';
 
-useVizelAutoSave({
-  getEditor: () => editor,
+const editor = useVizelEditor();
+useVizelAutoSave(editor, {
+  debounceMs: 2000, // Wait 2 seconds after last change
   onSave: async (content) => {
     await saveToServer(content);
   },
-  debounceMs: 2000, // Wait 2 seconds after last change
 });
 ```
 
@@ -399,22 +399,22 @@ export default defineConfig({
 });
 ```
 
-3. **Multiple editor instances** sharing extensions:
+3. **Multiple editor instances** sharing the `extensions` array:
 
-You must create fresh extension instances for each editor:
+`useVizelEditor` / `createVizelEditor` build the always-on extension
+set internally; the `extensions` option is for *additional* Tiptap
+extensions a consumer wants to stack on top. Sharing the same array
+across editors works, but sharing a single ProseMirror plugin
+instance across editors does not. Create a fresh extension list per
+editor whenever any of the items is stateful:
 
 ```typescript
-// Wrong: Sharing extensions
-const extensions = createVizelExtensions({});
-const editor1 = useVizelEditor({ extensions });
-const editor2 = useVizelEditor({ extensions }); // Error!
-
-// Correct: Create extensions per editor
+// Correct: each editor builds its own extensions list
 const editor1 = useVizelEditor({
-  extensions: createVizelExtensions({}),
+  extensions: [createVizelFindReplaceExtension()],
 });
 const editor2 = useVizelEditor({
-  extensions: createVizelExtensions({}),
+  extensions: [createVizelFindReplaceExtension()],
 });
 ```
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -94,6 +94,7 @@ function App() {
 | `VizelToolbarDropdown` | Toolbar dropdown button |
 | `VizelToolbarOverflow` | Toolbar overflow menu |
 | `VizelMentionMenu` | @mention suggestion menu |
+| `VizelOutline` | Heading-tree overview / navigation panel |
 | `VizelLinkEditor` | Link editing popover |
 | `VizelNodeSelector` | Node type selector |
 | `VizelColorPicker` | Color picker |
@@ -121,6 +122,7 @@ function App() {
 | `useVizelContext` | Access editor from context |
 | `useVizelContextSafe` | Access editor from context (returns null outside provider) |
 | `useVizelTheme` | Access theme from context |
+| `useVizelThemeSafe` | Access theme from context (returns `null` outside `VizelThemeProvider`) |
 | `useVizelIconContext` | Access icon context |
 
 ## Documentation

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -94,6 +94,7 @@ const md = createVizelMarkdown(() => editor.current);
 | `VizelToolbarDropdown` | Toolbar dropdown button |
 | `VizelToolbarOverflow` | Toolbar overflow menu |
 | `VizelMentionMenu` | @mention suggestion menu |
+| `VizelOutline` | Heading-tree overview / navigation panel |
 | `VizelLinkEditor` | Link editing popover |
 | `VizelNodeSelector` | Node type selector |
 | `VizelColorPicker` | Color picker |
@@ -121,6 +122,7 @@ const md = createVizelMarkdown(() => editor.current);
 | `getVizelContext` | Access editor from context |
 | `getVizelContextSafe` | Access editor from context (returns null outside provider) |
 | `getVizelTheme` | Access theme from context |
+| `getVizelThemeSafe` | Access theme from context (returns `null` outside `VizelThemeProvider`) |
 | `getVizelIconContext` | Access icon context |
 
 ## Documentation

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -92,6 +92,7 @@ const { markdown, setMarkdown } = useVizelMarkdown(() => editor.value);
 | `VizelToolbarDropdown` | Toolbar dropdown button |
 | `VizelToolbarOverflow` | Toolbar overflow menu |
 | `VizelMentionMenu` | @mention suggestion menu |
+| `VizelOutline` | Heading-tree overview / navigation panel |
 | `VizelLinkEditor` | Link editing popover |
 | `VizelNodeSelector` | Node type selector |
 | `VizelColorPicker` | Color picker |
@@ -119,6 +120,7 @@ const { markdown, setMarkdown } = useVizelMarkdown(() => editor.value);
 | `useVizelContext` | Access editor from context |
 | `useVizelContextSafe` | Access editor from context (returns null outside provider) |
 | `useVizelTheme` | Access theme from context |
+| `useVizelThemeSafe` | Access theme from context (returns `null` outside `VizelThemeProvider`) |
 | `useVizelIconContext` | Access icon context |
 
 ## Documentation


### PR DESCRIPTION
## Summary

Round 2 of the consumer review caught several copy-paste-fail mismatches between the docs and the shipped API surface.

### Fixes
- `@vizel/core/components.css` is not a valid subpath export → use `@vizel/core/styles/components.css`. Two files affected.
- `useVizelAutoSave` accepts `(editor, options)` since the v2 redesign — troubleshooting snippet updated to match `docs/guide/react.md`.
- "Multiple editor instances sharing extensions" snippet used a bogus `createVizelExtensions({})` call — rewritten with a realistic stateful extension example.
- All three READMEs missing `useVizelThemeSafe` / `getVizelThemeSafe` rows; added.
- All three READMEs missing `VizelOutline` row; added.
- Svelte SSR example used deprecated `<svelte:component>` wrapper and fragile `browser ? createVizelEditor() : { current: null }` ternary — rewritten.
- Svelte "Reactive Content with $state" example misleadingly implied `initialContent: content` was reactive (it is captured once at mount) — rewritten with the correct `onUpdate` + imperative `setContent` pattern.

## Test plan
- [x] `pnpm typecheck`
- [x] All snippet API names cross-checked against current source
