### PR TITLE
fix(react): drop render-time ref mutation and guard BlockMenu rAF in strict mode

### DIFF
--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -81,6 +81,12 @@ export function VizelBlockMenu({
   }, []);
 
   useEffect(() => {
+    // `isMounted` guards the rAF callback against the React 19 strict-mode
+    // setup → cleanup → setup sequence, where the rAF scheduled in the
+    // first setup can fire after the first cleanup has detached the
+    // listener — without the guard the callback would call setMenuState
+    // against a stale closure.
+    const lifecycle = { isMounted: true };
     const handler = (e: Event) => {
       if (!(e instanceof CustomEvent)) return;
       const detail = e.detail as VizelBlockMenuOpenDetail;
@@ -94,6 +100,7 @@ export function VizelBlockMenu({
       setShowTurnInto(false);
 
       vizelRequestAnimationFrame(() => {
+        if (!lifecycle.isMounted) return;
         const el = menuRef.current;
         if (!el) return;
         const clamped = clampMenuPosition(detail.handleRect, el.offsetWidth, el.offsetHeight);
@@ -102,7 +109,10 @@ export function VizelBlockMenu({
     };
 
     document.addEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
-    return () => document.removeEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
+    return () => {
+      lifecycle.isMounted = false;
+      document.removeEventListener(VIZEL_BLOCK_MENU_EVENT, handler);
+    };
   }, [boundEditor]);
 
   useEffect(() => {

--- a/packages/react/src/components/VizelBubbleMenu.tsx
+++ b/packages/react/src/components/VizelBubbleMenu.tsx
@@ -72,9 +72,16 @@ export function VizelBubbleMenu({
   const editor = editorProp ?? contextEditor;
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Store shouldShow in ref to avoid recreating plugin when callback changes
+  // Store shouldShow in a ref so the plugin closure always reads the latest
+  // callback without re-registering when the parent passes a new function
+  // identity. The assignment runs inside a `useEffect` (not at render time)
+  // to honor React's "no side effects during render" contract. The
+  // one-tick lag between a re-render and the ref update is fine because
+  // the closure only fires on subsequent ProseMirror events.
   const shouldShowRef = useRef(shouldShow);
-  shouldShowRef.current = shouldShow;
+  useEffect(() => {
+    shouldShowRef.current = shouldShow;
+  }, [shouldShow]);
 
   useEffect(() => {
     if (!(editor && menuRef.current)) {

--- a/packages/react/src/hooks/useVizelAutoSave.ts
+++ b/packages/react/src/hooks/useVizelAutoSave.ts
@@ -57,9 +57,16 @@ export function useVizelAutoSave(
   editor: Editor | null | undefined,
   options: VizelAutoSaveOptions = {}
 ): UseVizelAutoSaveResult {
-  // Store full options in ref to access callbacks without recreating handlers
+  // Store full options in a ref so handlers can read callbacks
+  // (onSave, onError, ...) without forcing a memo rebuild when the
+  // options object identity changes. The assignment runs inside a
+  // `useEffect` (not at render time) to honor React's "no side effects
+  // during render" contract; the one-tick lag is fine because handlers
+  // fire on subsequent editor events.
   const optionsRef = useRef(options);
-  optionsRef.current = options;
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
 
   // Merge with defaults - use individual primitives as dependencies to avoid
   // recreating when object reference changes but values are the same
@@ -76,9 +83,13 @@ export function useVizelAutoSave(
   });
 
   // Keep a ref to the editor for the handlers so they always read the latest
-  // value without forcing a memo rebuild on every render.
+  // value without forcing a memo rebuild on every render. The assignment runs
+  // inside a `useEffect` (not at render time) to honor React's "no side
+  // effects during render" contract.
   const editorRef = useRef(editor);
-  editorRef.current = editor;
+  useEffect(() => {
+    editorRef.current = editor;
+  }, [editor]);
 
   const handleStateChange = useCallback((partial: Partial<VizelAutoSaveState>) => {
     setState((prev) => ({ ...prev, ...partial }));


### PR DESCRIPTION
## Summary

Three small React 19 strict-mode / react-compiler-correctness fixes surfaced in round 2 of the consumer review:

1. **`VizelBubbleMenu`** mutated `shouldShowRef.current = shouldShow` at render time. The assignment now lives inside a `useEffect` that tracks `shouldShow`.
2. **`useVizelAutoSave`** did the same render-time mutation on `editorRef` and `optionsRef`. Both now live inside `useEffect` blocks.
3. **`VizelBlockMenu`** document-listener `useEffect` schedules a rAF to clamp the menu position after open. In React 19 strict mode the rAF queued by the first setup can fire after that setup's cleanup ran, leaving `setMenuState` pointing at a stale closure. Added a closure-shared `isMounted` guard and bail out of the rAF callback when the listener has been detached.

No public API change. Behavior in non-strict mode is unchanged.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check` on the three files
