### PR TITLE
fix: tighten Vizel.vue embed prop and Svelte floating-promise voids

### DIFF
--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -55,7 +55,7 @@ $effect(() => {
 });
 
 function scrollToSelected() {
-  tick().then(() => {
+  void tick().then(() => {
     const el = itemRefs[selectedIndex];
     if (el) {
       el.scrollIntoView({ block: "nearest", behavior: "smooth" });

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -80,7 +80,7 @@ $effect(() => {
 // Scroll selected item into view when selection changes
 $effect(() => {
   const index = selectedIndex;
-  tick().then(() => {
+  void tick().then(() => {
     const selectedElement = itemRefs[index];
     if (selectedElement) {
       selectedElement.scrollIntoView({ block: "nearest", behavior: "smooth" });

--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -146,13 +146,8 @@ const editor = useVizelEditor({
   onSelectionUpdate: (e) => emit("selectionUpdate", e),
   onFocus: (e) => emit("focus", e),
   onBlur: (e) => emit("blur", e),
-  // Always forward errors through the `error` emit. The previous shape
-  // gated the trampoline on `useAttrs().onError !== undefined`, but
-  // Vue 3 deliberately strips declared emits from `$attrs` / `useAttrs()`
-  // so that check was always `false` and runtime errors funneled through
-  // `emitVizelError` (UPLOAD_FAILED, EMBED_LOAD_FAILED, MARKDOWN_LOSSY)
-  // never reached the consumer. Vue's `emit` is a no-op when no parent
-  // listener is attached, so unwiring the gate does not silently swallow
+  // Always forward errors through the `error` emit; Vue's `emit` is a
+  // no-op when no parent listener is attached, so this never swallows
   // configuration errors — `useVizelEditor` still rethrows
   // INVALID_CONFIG to the global handler regardless of this callback.
   onError: (e: VizelError) => emit("error", e),
@@ -208,7 +203,7 @@ const localeProps = computed(() => (props.locale ? { locale: props.locale } : {}
       </template>
     </VizelToolbar>
     <VizelEditor :editor="editor" />
-    <VizelBubbleMenu v-if="showBubbleMenu && editor" :enable-embed="enableEmbed ?? false" v-bind="localeProps">
+    <VizelBubbleMenu v-if="showBubbleMenu && editor" :enable-embed="enableEmbed" v-bind="localeProps">
       <template v-if="slots['bubble-menu']" #default>
         <slot name="bubble-menu" :editor="editor" />
       </template>


### PR DESCRIPTION
## Summary

- Drop the redundant `?? false` fallback on `Vizel.vue`'s `enable-embed` binding; `withDefaults` already coerces the prop to `false`.
- Shorten the historical comment block around the `onError` trampoline so future readers see a current explanation, not the rejected-alternative history.
- Prefix `tick().then(...)` calls in `VizelMentionMenu.svelte` and `VizelSlashMenu.svelte` with `void` so the floating promises are intentional.

## Test Plan

- [x] `pnpm exec biome check packages/vue/src/components/Vizel.vue packages/svelte/src/components/Vizel{Mention,Slash}Menu.svelte`
- [x] `pnpm typecheck`