### PR TITLE
fix(core): align bullet, ordered, and task list indents

### DIFF
--- a/packages/core/src/styles/_block-hierarchy.scss
+++ b/packages/core/src/styles/_block-hierarchy.scss
@@ -5,38 +5,26 @@
  * `data-vizel-depth="N"` decoration. The extension only decorates
  * *container* block nodes (`bulletList`, `orderedList`, `taskList`,
  * `blockquote`, `details`, `detailsContent`, `callout`) — see
- * `extensions/visual-hierarchy.ts`. Each container at depth >= 2
- * receives one indent step plus a thin guide line on its inline
- * start, so nesting is conveyed by a single rule per level without
- * fighting the container's own marker offset (list bullets, callout
- * padding, etc.).
+ * `extensions/visual-hierarchy.ts`.
+ *
+ * Container responsibilities are split deliberately:
+ *
+ * - Each container owns its **indent step** via its own
+ *   `padding-inline-start` (`ul` / `ol` / `.vizel-task-list` /
+ *   `ul[data-type="taskList"]` in `editor.scss` and `task-list.scss`,
+ *   `blockquote` in `editor.scss`, `callout` / `details` in their own
+ *   files). This guarantees the marker / checkbox / quote bar sits a
+ *   consistent distance from the container's inline-start regardless
+ *   of node type.
+ * - This file owns the **guide line** drawn at the container's
+ *   inline-start edge. The line therefore lands flush against the
+ *   parent block's content edge, exactly where the indent begins.
  *
  * Activated by `features.interaction.visualHierarchy`.
  */
 
 .vizel-root .ProseMirror {
-  [data-vizel-depth="2"] {
-    padding-inline-start: 1rem;
-    border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
-  }
-
-  [data-vizel-depth="3"] {
-    padding-inline-start: 1.25rem;
-    border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
-  }
-
-  [data-vizel-depth="4"] {
-    padding-inline-start: 1.5rem;
-    border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
-  }
-
-  [data-vizel-depth="5"] {
-    padding-inline-start: 1.75rem;
-    border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
-  }
-
-  [data-vizel-depth="6"] {
-    padding-inline-start: 2rem;
+  [data-vizel-depth] {
     border-inline-start: 1px solid var(--vizel-border-subtle, rgb(0 0 0 / 6%));
   }
 }

--- a/packages/core/src/styles/editor.scss
+++ b/packages/core/src/styles/editor.scss
@@ -70,9 +70,13 @@
     line-height: 1.7;
   }
 
+  // Use rem (not em) so the indent step matches across list types
+  // regardless of font size at the nesting point. Task lists use the
+  // same rem-based step (see `task-list.scss`), keeping ul / ol / task
+  // list markers aligned at the same inline-start position.
   ul,
   ol {
-    padding-left: 1.5em;
+    padding-inline-start: 1.5rem;
   }
 
   li {

--- a/packages/core/src/styles/task-list.scss
+++ b/packages/core/src/styles/task-list.scss
@@ -6,11 +6,15 @@
 
 .vizel-task-list {
   list-style: none;
-  padding-left: 0;
+  // Top-level task lists sit flush with the editor's inline edge so the
+  // checkbox aligns with paragraphs. Nested lists pick up the shared
+  // 1.5rem indent step below to match bullet / ordered lists.
+  padding-inline-start: 0;
   margin: 0.5rem 0;
 
   .vizel-task-list {
-    margin: 0.25rem 0 0.25rem 1.5rem;
+    margin: 0.25rem 0;
+    padding-inline-start: 1.5rem;
   }
 }
 
@@ -88,7 +92,18 @@
 .vizel-editor {
   ul[data-type="taskList"] {
     list-style: none;
-    padding-left: 0;
+    padding-inline-start: 0;
+  }
+
+  // Nested task lists pick up the shared 1.5rem indent step so they
+  // line up with bullet / ordered nesting. Without this, the generic
+  // `ul { padding-inline-start: 1.5rem }` rule would also apply, but
+  // ProseMirror renders task lists with the `data-type="taskList"`
+  // attribute on the same element that the parent `padding-inline-start: 0`
+  // resets, so this targeted override re-establishes the indent for
+  // children only.
+  ul[data-type="taskList"] ul[data-type="taskList"] {
+    padding-inline-start: 1.5rem;
   }
 
   li[data-type="taskItem"] {


### PR DESCRIPTION
## Summary

- Strip the per-depth `padding-inline-start` ramp from the visual-hierarchy decoration so it only draws the guide line. The ramp was overriding `ul, ol { padding-left: 1.5em }` (higher selector specificity) and making nested lists indent *less* than top-level lists.
- Switch nested task lists from `margin-left: 1.5rem` to `padding-inline-start: 1.5rem` so the guide line lands at the indent boundary the same way it does for bullet / ordered lists.
- Standardize ul, ol, and nested task lists on a shared `padding-inline-start: 1.5rem` step so marker positions match across list types at every nesting depth.

Reported by @sage: in the React demo, bullet / ordered / task lists rendered with three different indent widths and the vertical guide line did not align with the actual content edge.

## Test Plan

- [x] `pnpm --filter @vizel/core build` — SCSS compiles cleanly.
- [x] React demo (`pnpm dev:react`) — verified bullet, ordered, and nested task lists all snap to a 24px indent step and the guide line sits at the inline-start of every nested container.