### PR TITLE
fix(react,svelte): document or implement on* callback freshness

### DIFF
--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -21,12 +21,14 @@ export type UseVizelEditorOptions = VizelCreateEditorOptions;
  *
  * The Tiptap editor instance is created once on mount. To avoid expensive
  * teardowns, most options are read once at mount and ignored on subsequent
- * renders. The following options are an exception:
+ * renders. The single exception is `editable`, which is mirrored through
+ * `editor.setEditable()` whenever the prop value changes.
  *
- * - `editable` — propagated through `editor.setEditable()` whenever the prop
- *   value changes.
- * - All `on*` callbacks (`onUpdate`, `onError`, etc.) — read through a ref
- *   each time they fire, so passing a fresh closure on every render is fine.
+ * `on*` callbacks (`onUpdate`, `onError`, etc.) are also captured at mount,
+ * matching Vue's `useVizelEditor` and Svelte's `createVizelEditor`. Passing a
+ * fresh closure on every render is silently ignored. Wrap callbacks in
+ * `useLatest` (or any stable ref) when you need them to read live state —
+ * the high-level `<Vizel />` component does exactly this with its own props.
  *
  * Changing `initialContent`, `initialMarkdown`, `placeholder`, `features`,
  * `extensions`, `flavor`, `locale`, or `autofocus` after mount has no effect.

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -122,18 +122,22 @@ let {
   ...restProps
 }: VizelProps = $props();
 
-// Wrap onUpdate to sync markdown. Read restProps.onUpdate inside the
-// callback (not via a captured local) so later prop changes are picked up.
+// Wrap every lifecycle callback so the editor invokes the current prop
+// value at fire time instead of the closure captured when the editor was
+// constructed. Without this, replacing any `on*` prop after mount would
+// be silently ignored — Tiptap captures callbacks at construction. The
+// `restProps.onX?.(...)` reads happen inside the wrapper bodies, so each
+// fire picks up whatever the caller passed on the most recent render.
 //
-// The previous shape used a synchronous `isUpdatingFromMarkdown` flag to
-// suppress write-back during an external markdown update. Tiptap does not
-// guarantee the `update` event fires synchronously inside
-// `setVizelMarkdown` — when it lands in a microtask the flag is already
-// false and the editor's just-applied markdown gets written back to the
-// bound prop, occasionally creating a tick of feedback. Comparing the new
-// markdown against the bound prop directly avoids the timing race
-// altogether: when the editor's content matches the prop, there is
-// nothing to propagate.
+// `onUpdate` additionally syncs `bind:markdown`. The previous shape used
+// a synchronous `isUpdatingFromMarkdown` flag to suppress write-back
+// during an external markdown update, but Tiptap does not guarantee the
+// `update` event fires synchronously inside `setVizelMarkdown` — when it
+// lands in a microtask the flag is already false and the editor's
+// just-applied markdown gets written back to the bound prop, occasionally
+// creating a tick of feedback. Comparing the new markdown against the
+// bound prop directly avoids the timing race altogether: when the
+// editor's content matches the prop, there is nothing to propagate.
 const wrappedOnUpdate = (e: { editor: import("@vizel/core").Editor }) => {
   restProps.onUpdate?.(e);
   if (markdown === undefined) return;
@@ -141,6 +145,17 @@ const wrappedOnUpdate = (e: { editor: import("@vizel/core").Editor }) => {
   if (nextMarkdown === markdown) return;
   markdown = nextMarkdown;
 };
+const wrappedOnCreate = (e: { editor: import("@vizel/core").Editor }) =>
+  restProps.onCreate?.(e);
+const wrappedOnDestroy = () => restProps.onDestroy?.();
+const wrappedOnSelectionUpdate = (e: { editor: import("@vizel/core").Editor }) =>
+  restProps.onSelectionUpdate?.(e);
+const wrappedOnFocus = (e: { editor: import("@vizel/core").Editor }) =>
+  restProps.onFocus?.(e);
+const wrappedOnBlur = (e: { editor: import("@vizel/core").Editor }) =>
+  restProps.onBlur?.(e);
+const wrappedOnError = (error: import("@vizel/core").VizelError) =>
+  restProps.onError?.(error);
 
 // Capture initial values for editor creation (these are intentionally not reactive)
 // The editor is created once and should not be recreated when props change
@@ -166,12 +181,15 @@ const editorState = createVizelEditor({
   ...(restProps.locale !== undefined && { locale: restProps.locale }),
   ...(restProps.extensions !== undefined && { extensions: restProps.extensions }),
   onUpdate: wrappedOnUpdate,
-  ...(restProps.onCreate !== undefined && { onCreate: restProps.onCreate }),
-  ...(restProps.onDestroy !== undefined && { onDestroy: restProps.onDestroy }),
-  ...(restProps.onSelectionUpdate !== undefined && { onSelectionUpdate: restProps.onSelectionUpdate }),
-  ...(restProps.onFocus !== undefined && { onFocus: restProps.onFocus }),
-  ...(restProps.onBlur !== undefined && { onBlur: restProps.onBlur }),
-  ...(restProps.onError !== undefined && { onError: restProps.onError }),
+  onCreate: wrappedOnCreate,
+  onDestroy: wrappedOnDestroy,
+  onSelectionUpdate: wrappedOnSelectionUpdate,
+  onFocus: wrappedOnFocus,
+  onBlur: wrappedOnBlur,
+  // Only install the error trampoline when the consumer actually passed an
+  // onError prop. A blanket wrapper would intercept thrown configuration
+  // errors and swallow them silently inside createVizelEditor.
+  ...(restProps.onError !== undefined && { onError: wrappedOnError }),
 });
 
 const editor = $derived(editorState.current);


### PR DESCRIPTION
## Summary

- **React**: `useVizelEditor`'s docstring previously promised that `on*` callbacks are re-read from a ref on every fire — but the implementation captures them once at mount, and the high-level `<Vizel />` component already wraps each callback in `useLatest` to work around that. Update the docstring to match reality so consumers know to bring their own ref when they need fresh closures (and steer them at `useLatest` / `<Vizel />` as the worked example).
- **Svelte**: `Vizel.svelte` wrapped only `onUpdate` to keep the markdown sync trampoline fresh, leaving `onCreate` / `onDestroy` / `onSelectionUpdate` / `onFocus` / `onBlur` / `onError` captured at editor construction. Reassigning any of those props after mount was silently ignored. Wrap each callback the same way `onUpdate` is wrapped so every fire picks up the current prop value. `onError` keeps its `is the prop defined` gate so unwrapped throws still bubble out of `createVizelEditor`.

Found during Phase 3 Round 3 consumer review. Brings React (`<Vizel />`) and Svelte (`<Vizel />`) into parity for prop-update behavior on all lifecycle callbacks; Vue's `<Vizel />` already routes everything through `emit()` which dispatches against the latest listener.

## Test Plan

- [x] `pnpm typecheck` — React + Vue + Svelte all clean.
- [ ] Manual: edit a `<Vizel onCreate={...} />` parent state after mount and confirm the new handler fires on a programmatic editor recreation.