### PR TITLE
fix(svelte): void-prefix the remaining floating tick() in VizelFindReplace

### DIFF
--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -73,7 +73,7 @@ $effect(() => {
 // Focus input when panel opens
 $effect(() => {
   if (isOpen && findInputRef) {
-    tick().then(() => {
+    void tick().then(() => {
       findInputRef?.focus();
       findInputRef?.select();
     });


### PR DESCRIPTION
## Summary

- `VizelFindReplace.svelte:76` left `tick().then(...)` unprefixed while every other Svelte component (`VizelMentionMenu`, `VizelSlashMenu`, `VizelBlockMenu`) had already migrated to `void tick().then(...)` in PR #544. Add the missing `void` so the floating promise is intentional everywhere in the package.

Found during Phase 3 Round 4 final verification.

## Test Plan

- [x] `grep -n 'tick()\.then' packages/svelte/src` — only `void tick().then(...)` remains.