### PR TITLE
fix(react,vue,svelte): guard slash menu and toolbar dropdown nav on empty items

### DIFF
--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -1,6 +1,7 @@
 import {
   buildVizelSlashMenuSpec,
   getNextVizelSlashMenuGroupIndex,
+  resolveVizelListNavigation,
   type VizelSlashCommandItem,
 } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
@@ -105,24 +106,26 @@ export function VizelSlashMenu({
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
-      if (event.key === "ArrowUp") {
-        setSelectedIndex((i) => (i + flatItemCount - 1) % flatItemCount);
-        return true;
-      }
-      if (event.key === "ArrowDown") {
-        setSelectedIndex((i) => (i + 1) % flatItemCount);
-        return true;
-      }
-      if (event.key === "Enter") {
-        selectItem(selectedIndex);
-        return true;
-      }
       if (event.key === "Tab") {
+        if (flatItemCount === 0) return false;
         event.preventDefault();
         setSelectedIndex(getNextVizelSlashMenuGroupIndex(spec, selectedIndex));
         return true;
       }
-      return false;
+      if (event.key === "Enter") {
+        if (flatItemCount === 0) return false;
+        selectItem(selectedIndex);
+        return true;
+      }
+      // ArrowUp/ArrowDown/Home/End — delegate to the core helper. It
+      // returns `null` for unknown keys *and* for `flatItemCount === 0`,
+      // so the empty-menu case naturally falls through and lets Tiptap
+      // consume the key instead of being silently swallowed with a `NaN`
+      // write to `selectedIndex`.
+      const next = resolveVizelListNavigation(event.key, selectedIndex, flatItemCount);
+      if (next === null) return false;
+      setSelectedIndex(next);
+      return true;
     },
   }));
 

--- a/packages/react/src/components/VizelToolbarDropdown.tsx
+++ b/packages/react/src/components/VizelToolbarDropdown.tsx
@@ -1,5 +1,9 @@
 import type { Editor, VizelToolbarDropdownAction } from "@vizel/core";
-import { buildVizelToolbarDropdownSpec, formatVizelTooltip } from "@vizel/core";
+import {
+  buildVizelToolbarDropdownSpec,
+  formatVizelTooltip,
+  resolveVizelListNavigation,
+} from "@vizel/core";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -76,36 +80,22 @@ export function VizelToolbarDropdown({
   }
 
   function handleListKeyDown(e: React.KeyboardEvent) {
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        setFocusedIndex((prev) => (prev + 1) % optionCount);
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        setFocusedIndex((prev) => (prev - 1 + optionCount) % optionCount);
-        break;
-      case "Home":
-        e.preventDefault();
-        setFocusedIndex(0);
-        break;
-      case "End":
-        e.preventDefault();
-        setFocusedIndex(optionCount - 1);
-        break;
-      case "Enter":
-      case " ": {
-        e.preventDefault();
-        const selected = dropdown.options[focusedIndex];
-        if (selected?.isEnabled(editor)) {
-          selected.run(editor);
-          close();
-        }
-        break;
+    if (e.key === "Enter" || e.key === " ") {
+      if (optionCount === 0) return;
+      e.preventDefault();
+      const selected = dropdown.options[focusedIndex];
+      if (selected?.isEnabled(editor)) {
+        selected.run(editor);
+        close();
       }
-      default:
-        break;
+      return;
     }
+    // Delegate Arrow/Home/End to the core helper, which short-circuits on
+    // `optionCount === 0` instead of computing `NaN`.
+    const next = resolveVizelListNavigation(e.key, focusedIndex, optionCount);
+    if (next === null) return;
+    e.preventDefault();
+    setFocusedIndex(next);
   }
 
   return (

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -34,7 +34,11 @@ export interface VizelSlashMenuProps {
 </script>
 
 <script lang="ts">
-import { buildVizelSlashMenuSpec, getNextVizelSlashMenuGroupIndex } from "@vizel/core";
+import {
+  buildVizelSlashMenuSpec,
+  getNextVizelSlashMenuGroupIndex,
+  resolveVizelListNavigation,
+} from "@vizel/core";
 import { tick } from "svelte";
 import VizelSlashMenuItem from "./VizelSlashMenuItem.svelte";
 import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.svelte";
@@ -96,24 +100,26 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "ArrowUp") {
-    selectedIndex = (selectedIndex + flatItemCount - 1) % flatItemCount;
-    return true;
-  }
-  if (event.key === "ArrowDown") {
-    selectedIndex = (selectedIndex + 1) % flatItemCount;
-    return true;
-  }
-  if (event.key === "Enter") {
-    selectItem(selectedIndex);
-    return true;
-  }
   if (event.key === "Tab") {
+    if (flatItemCount === 0) return false;
     event.preventDefault();
     selectedIndex = getNextVizelSlashMenuGroupIndex(spec, selectedIndex);
     return true;
   }
-  return false;
+  if (event.key === "Enter") {
+    if (flatItemCount === 0) return false;
+    selectItem(selectedIndex);
+    return true;
+  }
+  // ArrowUp/ArrowDown/Home/End — delegate to the core helper. It returns
+  // `null` for unknown keys *and* for `flatItemCount === 0`, so the
+  // empty-menu case naturally falls through and lets Tiptap consume the
+  // key instead of being silently swallowed with a `NaN` write to
+  // `selectedIndex`.
+  const next = resolveVizelListNavigation(event.key, selectedIndex, flatItemCount);
+  if (next === null) return false;
+  selectedIndex = next;
+  return true;
 }
 
 // Expose the keyboard handler through the optional ref prop so suggestion

--- a/packages/svelte/src/components/VizelToolbarDropdown.svelte
+++ b/packages/svelte/src/components/VizelToolbarDropdown.svelte
@@ -9,7 +9,11 @@ export interface VizelToolbarDropdownProps {
 </script>
 
 <script lang="ts">
-import { buildVizelToolbarDropdownSpec, formatVizelTooltip } from "@vizel/core";
+import {
+  buildVizelToolbarDropdownSpec,
+  formatVizelTooltip,
+  resolveVizelListNavigation,
+} from "@vizel/core";
 import VizelIcon from "./VizelIcon.svelte";
 
 let {
@@ -51,36 +55,22 @@ function handleTriggerKeyDown(e: KeyboardEvent) {
 
 function handleListKeyDown(e: KeyboardEvent) {
   const optionCount = dropdown.options.length;
-  switch (e.key) {
-    case "ArrowDown":
-      e.preventDefault();
-      focusedIndex = (focusedIndex + 1) % optionCount;
-      break;
-    case "ArrowUp":
-      e.preventDefault();
-      focusedIndex = (focusedIndex - 1 + optionCount) % optionCount;
-      break;
-    case "Home":
-      e.preventDefault();
-      focusedIndex = 0;
-      break;
-    case "End":
-      e.preventDefault();
-      focusedIndex = optionCount - 1;
-      break;
-    case "Enter":
-    case " ": {
-      e.preventDefault();
-      const selected = dropdown.options[focusedIndex];
-      if (selected?.isEnabled(editor)) {
-        selected.run(editor);
-        close();
-      }
-      break;
+  if (e.key === "Enter" || e.key === " ") {
+    if (optionCount === 0) return;
+    e.preventDefault();
+    const selected = dropdown.options[focusedIndex];
+    if (selected?.isEnabled(editor)) {
+      selected.run(editor);
+      close();
     }
-    default:
-      break;
+    return;
   }
+  // Delegate Arrow/Home/End to the core helper, which short-circuits on
+  // `optionCount === 0` instead of computing `NaN`.
+  const next = resolveVizelListNavigation(e.key, focusedIndex, optionCount);
+  if (next === null) return;
+  e.preventDefault();
+  focusedIndex = next;
 }
 
 $effect(() => {

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -2,6 +2,7 @@
 import {
   buildVizelSlashMenuSpec,
   getNextVizelSlashMenuGroupIndex,
+  resolveVizelListNavigation,
   type VizelSlashCommandItem,
 } from "@vizel/core";
 import { computed, nextTick, ref, useSlots, watch } from "vue";
@@ -83,24 +84,25 @@ function selectItem(index: number) {
 
 function handleKeyDown(event: KeyboardEvent): boolean {
   const count = flatItemCount.value;
-  if (event.key === "ArrowUp") {
-    selectedIndex.value = (selectedIndex.value + count - 1) % count;
-    return true;
-  }
-  if (event.key === "ArrowDown") {
-    selectedIndex.value = (selectedIndex.value + 1) % count;
-    return true;
-  }
-  if (event.key === "Enter") {
-    selectItem(selectedIndex.value);
-    return true;
-  }
   if (event.key === "Tab") {
+    if (count === 0) return false;
     event.preventDefault();
     selectedIndex.value = getNextVizelSlashMenuGroupIndex(spec.value, selectedIndex.value);
     return true;
   }
-  return false;
+  if (event.key === "Enter") {
+    if (count === 0) return false;
+    selectItem(selectedIndex.value);
+    return true;
+  }
+  // ArrowUp/ArrowDown/Home/End — delegate to the core helper. It returns
+  // `null` for unknown keys *and* for `count === 0`, so the empty-menu
+  // case naturally falls through and lets Tiptap consume the key instead
+  // of being silently swallowed with a `NaN` write to `selectedIndex`.
+  const next = resolveVizelListNavigation(event.key, selectedIndex.value, count);
+  if (next === null) return false;
+  selectedIndex.value = next;
+  return true;
 }
 
 defineExpose({

--- a/packages/vue/src/components/VizelToolbarDropdown.vue
+++ b/packages/vue/src/components/VizelToolbarDropdown.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import type { Editor, VizelToolbarDropdownAction } from "@vizel/core";
-import { buildVizelToolbarDropdownSpec, formatVizelTooltip } from "@vizel/core";
+import {
+  buildVizelToolbarDropdownSpec,
+  formatVizelTooltip,
+  resolveVizelListNavigation,
+} from "@vizel/core";
 import { computed, onBeforeUnmount, ref, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -59,36 +63,22 @@ function handleTriggerKeyDown(e: KeyboardEvent) {
 
 function handleListKeyDown(e: KeyboardEvent) {
   const optionCount = props.dropdown.options.length;
-  switch (e.key) {
-    case "ArrowDown":
-      e.preventDefault();
-      focusedIndex.value = (focusedIndex.value + 1) % optionCount;
-      break;
-    case "ArrowUp":
-      e.preventDefault();
-      focusedIndex.value = (focusedIndex.value - 1 + optionCount) % optionCount;
-      break;
-    case "Home":
-      e.preventDefault();
-      focusedIndex.value = 0;
-      break;
-    case "End":
-      e.preventDefault();
-      focusedIndex.value = optionCount - 1;
-      break;
-    case "Enter":
-    case " ": {
-      e.preventDefault();
-      const selected = props.dropdown.options[focusedIndex.value];
-      if (selected?.isEnabled(props.editor)) {
-        selected.run(props.editor);
-        close();
-      }
-      break;
+  if (e.key === "Enter" || e.key === " ") {
+    if (optionCount === 0) return;
+    e.preventDefault();
+    const selected = props.dropdown.options[focusedIndex.value];
+    if (selected?.isEnabled(props.editor)) {
+      selected.run(props.editor);
+      close();
     }
-    default:
-      break;
+    return;
   }
+  // Delegate Arrow/Home/End to the core helper, which short-circuits on
+  // `optionCount === 0` instead of computing `NaN`.
+  const next = resolveVizelListNavigation(e.key, focusedIndex.value, optionCount);
+  if (next === null) return;
+  e.preventDefault();
+  focusedIndex.value = next;
 }
 
 watch(isOpen, (open) => {


### PR DESCRIPTION
## Summary

- `VizelSlashMenu` and `VizelToolbarDropdown` ran arrow / Enter / Tab keys through inline `% count` arithmetic without checking that `count > 0`. When the consumer's slash query returned zero matches, ArrowUp / ArrowDown wrote `NaN` to `selectedIndex` and the handler still returned `true`, swallowing the key from Tiptap so the user could not navigate the editor away from the empty menu. The same NaN trap existed in `VizelToolbarDropdown` when a consumer filtered to zero options.
- `resolveVizelListNavigation` in `@vizel/core` already short-circuits on `length === 0`. Swap the inline modulo for that helper in both components across all three frameworks. Tab and Enter pick up explicit `if (count === 0) return false` guards so Tiptap consumes the key and the user can keep typing.

Found during a clean-context subagent review of the Vue package; the React and Svelte siblings shared the same shape.

## Test Plan

- [x] `pnpm typecheck` — all three packages clean.
- [ ] Manual: open the slash menu, type a string with no matches, press ArrowDown / ArrowUp / Enter / Tab. Menu should not lock; the keys should reach the editor instead.