### PR TITLE
fix(react,vue,svelte): guard mention menu Enter and trim Vizel root class

### DIFF
--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -271,7 +271,7 @@ export function Vizel({
   // not cross-trigger each other's menus.
   return (
     <VizelInternalProvider editor={editor}>
-      <div className={`vizel-root ${className ?? ""}`} data-vizel-root="">
+      <div className={`vizel-root ${className ?? ""}`.trim()} data-vizel-root="">
         {showToolbar &&
           editor &&
           (toolbarContent ? (

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -79,6 +79,7 @@ export function VizelMentionMenu({
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
       if (event.key === "Enter") {
+        if (items.length === 0) return false;
         selectItem(selectedIndex);
         return true;
       }

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -218,7 +218,7 @@ $effect(() => {
 });
 </script>
 
-<div class="vizel-root {className ?? ''}" data-vizel-root>
+<div class={className ? `vizel-root ${className}` : "vizel-root"} data-vizel-root>
   {#if showToolbar && editor && toolbar}
     <VizelToolbar {editor} {...(restProps.locale ? { locale: restProps.locale } : {})}>
       {#snippet children({ editor: e })}

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -72,6 +72,7 @@ function selectItem(index: number) {
 
 function onKeyDown(event: KeyboardEvent): boolean {
   if (event.key === "Enter") {
+    if (items.length === 0) return false;
     selectItem(selectedIndex);
     return true;
   }

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -59,6 +59,7 @@ function selectItem(index: number) {
 
 function onKeyDown(event: KeyboardEvent): boolean {
   if (event.key === "Enter") {
+    if (props.items.length === 0) return false;
     selectItem(selectedIndex.value);
     return true;
   }


### PR DESCRIPTION
## Summary

- **VizelMentionMenu**: Enter called `selectItem(selectedIndex)` and returned `true` regardless of `items.length`. When the suggestion list was empty (consumer query had zero matches), Tiptap treated the Enter as handled by the menu and the user could not commit a newline. Match the slash menu fix from PR #548 — early-return `false` when `items.length === 0` so Tiptap consumes the key.
- **Vizel root class**: `Vizel.tsx` and `Vizel.svelte` composed the root class as `vizel-root ${className ?? ""}`, leaving a trailing space when the consumer omitted `className`. Their sibling `VizelProvider` files already trim or branch around the empty case. Apply the same shape so the rendered class attribute matches across the two entry points and DOM snapshots stay stable.

Found by a clean-context React subagent during Round 7; both bugs were mirrored across Vue and Svelte siblings.

## Test Plan

- [x] `pnpm typecheck` — all three packages clean.
- [ ] Manual: open a mention menu, type a string with zero matches, press Enter — newline should land in the editor; menu should not swallow.