### PR TITLE
fix(react,vue,svelte): align theme/context errors and VizelNodeSelector ergonomics

### DIFF
--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -8,13 +8,14 @@ import {
 } from "@vizel/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useVizelState } from "../hooks/useVizelState.ts";
+import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
 
 export interface VizelNodeSelectorProps {
-  /** The editor instance */
-  editor: Editor;
-  /** Custom node types (defaults to vizelDefaultNodeTypes) */
-  nodeTypes?: VizelNodeTypeOption[];
+  /** Editor instance. Falls back to the editor from `VizelProvider`/`Vizel` context if omitted. */
+  editor?: Editor | null;
+  /** Custom node types (defaults to `vizelDefaultNodeTypes`) */
+  nodeTypes?: readonly VizelNodeTypeOption[];
   /** Custom class name */
   className?: string;
   /** Locale for translated UI strings */
@@ -30,11 +31,13 @@ export interface VizelNodeSelectorProps {
  * navigation, and binding `nodeType.command(editor)` to each option.
  */
 export function VizelNodeSelector({
-  editor,
+  editor: editorProp,
   nodeTypes,
   className,
   locale,
 }: VizelNodeSelectorProps) {
+  const contextEditor = useVizelContextSafe();
+  const editor = editorProp ?? contextEditor;
   const effectiveNodeTypes =
     nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes);
   useVizelState(editor);
@@ -46,7 +49,10 @@ export function VizelNodeSelector({
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const spec = useMemo(
-    () => buildVizelNodeSelectorSpec(editor, effectiveNodeTypes, isOpen, focusedIndex, locale),
+    () =>
+      editor
+        ? buildVizelNodeSelectorSpec(editor, effectiveNodeTypes, isOpen, focusedIndex, locale)
+        : null,
     [editor, effectiveNodeTypes, isOpen, focusedIndex, locale]
   );
 
@@ -119,10 +125,15 @@ export function VizelNodeSelector({
   };
 
   const handleSelectNodeType = (nodeType: VizelNodeTypeOption) => {
+    if (!editor) return;
     nodeType.command(editor);
     setIsOpen(false);
     triggerRef.current?.focus();
   };
+
+  if (!(editor && spec)) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/react/src/hooks/useVizelTheme.ts
+++ b/packages/react/src/hooks/useVizelTheme.ts
@@ -1,4 +1,4 @@
-import type { VizelResolvedTheme } from "@vizel/core";
+import { VizelError, type VizelResolvedTheme } from "@vizel/core";
 import { useContext, useMemo } from "react";
 import { VizelThemeContext } from "../components/VizelThemeContext.tsx";
 
@@ -38,7 +38,10 @@ export function useVizelTheme(): UseVizelThemeResult {
   const context = useContext(VizelThemeContext);
 
   if (!context) {
-    throw new Error("useVizelTheme must be used within a VizelThemeProvider");
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "useVizelTheme must be used within a VizelThemeProvider"
+    );
   }
 
   // Surface only the resolved theme through the public `theme` field. The

--- a/packages/svelte/src/components/VizelNodeSelector.svelte
+++ b/packages/svelte/src/components/VizelNodeSelector.svelte
@@ -2,10 +2,10 @@
 import type { Editor, VizelLocale, VizelNodeTypeOption } from "@vizel/core";
 
 export interface VizelNodeSelectorProps {
-  /** The editor instance */
-  editor: Editor;
-  /** Custom node types (defaults to vizelDefaultNodeTypes) */
-  nodeTypes?: VizelNodeTypeOption[];
+  /** Editor instance. Falls back to the editor from `VizelProvider`/`Vizel` context if omitted. */
+  editor?: Editor | null;
+  /** Custom node types (defaults to `vizelDefaultNodeTypes`) */
+  nodeTypes?: readonly VizelNodeTypeOption[];
   /** Custom class name */
   class?: string;
   /** Locale for translated UI strings */
@@ -16,9 +16,13 @@ export interface VizelNodeSelectorProps {
 <script lang="ts">
 import { buildVizelNodeSelectorSpec, createVizelNodeTypes, vizelDefaultNodeTypes } from "@vizel/core";
 import { createVizelState } from "../runes/createVizelState.svelte.js";
+import { getVizelContextSafe } from "./VizelContext.js";
 import VizelIcon from "./VizelIcon.svelte";
 
-let { editor, nodeTypes, class: className, locale }: VizelNodeSelectorProps = $props();
+let { editor: editorProp, nodeTypes, class: className, locale }: VizelNodeSelectorProps = $props();
+
+const contextEditor = getVizelContextSafe();
+const editor = $derived(editorProp ?? contextEditor?.current ?? null);
 
 const effectiveNodeTypes = $derived(nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes));
 
@@ -32,6 +36,7 @@ let triggerRef: HTMLButtonElement | undefined = $state();
 
 const spec = $derived.by(() => {
   void editorState.version;
+  if (!editor) return null;
   return buildVizelNodeSelectorSpec(editor, effectiveNodeTypes, isOpen, focusedIndex, locale);
 });
 
@@ -101,12 +106,14 @@ function handleKeyDown(event: KeyboardEvent) {
 }
 
 function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
+  if (!editor) return;
   nodeType.command(editor);
   isOpen = false;
   triggerRef?.focus();
 }
 </script>
 
+{#if editor && spec}
 <div
   bind:this={containerRef}
   class="vizel-node-selector {className ?? ''}"
@@ -169,3 +176,4 @@ function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
     </div>
   {/if}
 </div>
+{/if}

--- a/packages/svelte/src/runes/getVizelTheme.ts
+++ b/packages/svelte/src/runes/getVizelTheme.ts
@@ -1,4 +1,4 @@
-import type { VizelResolvedTheme, VizelThemeState } from "@vizel/core";
+import { VizelError, type VizelResolvedTheme, type VizelThemeState } from "@vizel/core";
 import { getContext } from "svelte";
 import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
 
@@ -44,7 +44,10 @@ export function getVizelTheme(): GetVizelThemeResult {
   const context = getContext<VizelThemeState | undefined>(VIZEL_THEME_CONTEXT_KEY);
 
   if (!context) {
-    throw new Error("getVizelTheme must be used within a VizelThemeProvider");
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "getVizelTheme must be used within a VizelThemeProvider"
+    );
   }
 
   // Surface the resolved theme through the public `current` field. The

--- a/packages/vue/src/components/VizelNodeSelector.vue
+++ b/packages/vue/src/components/VizelNodeSelector.vue
@@ -9,13 +9,14 @@ import {
 } from "@vizel/core";
 import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { useVizelState } from "../composables/useVizelState.ts";
+import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelNodeSelectorProps {
-  /** The editor instance */
-  editor: Editor;
-  /** Custom node types (defaults to vizelDefaultNodeTypes) */
-  nodeTypes?: VizelNodeTypeOption[];
+  /** Editor instance. Falls back to the editor from `VizelProvider`/`Vizel` context if omitted. */
+  editor?: Editor | null;
+  /** Custom node types (defaults to `vizelDefaultNodeTypes`) */
+  nodeTypes?: readonly VizelNodeTypeOption[];
   /** Custom class name */
   class?: string;
   /** Locale for translated UI strings */
@@ -24,12 +25,15 @@ export interface VizelNodeSelectorProps {
 
 const props = defineProps<VizelNodeSelectorProps>();
 
+const contextEditor = useVizelContextSafe();
+const resolvedEditor = computed<Editor | null>(() => props.editor ?? contextEditor?.value ?? null);
+
 const effectiveNodeTypes = computed(
   () =>
     props.nodeTypes ?? (props.locale ? createVizelNodeTypes(props.locale) : vizelDefaultNodeTypes)
 );
 
-const editorStateVersion = useVizelState(() => props.editor);
+const editorStateVersion = useVizelState(() => resolvedEditor.value);
 
 const isOpen = ref(false);
 const focusedIndex = ref(0);
@@ -39,8 +43,10 @@ const triggerRef = ref<HTMLButtonElement | null>(null);
 
 const spec = computed(() => {
   void editorStateVersion.value;
+  const e = resolvedEditor.value;
+  if (!e) return null;
   return buildVizelNodeSelectorSpec(
-    props.editor,
+    e,
     effectiveNodeTypes.value,
     isOpen.value,
     focusedIndex.value,
@@ -124,7 +130,9 @@ function handleKeyDown(event: KeyboardEvent) {
 }
 
 function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
-  nodeType.command(props.editor);
+  const e = resolvedEditor.value;
+  if (!e) return;
+  nodeType.command(e);
   isOpen.value = false;
   triggerRef.value?.focus();
 }
@@ -132,6 +140,7 @@ function handleSelectNodeType(nodeType: VizelNodeTypeOption) {
 
 <template>
   <div
+    v-if="resolvedEditor && spec"
     ref="containerRef"
     :class="['vizel-node-selector', $props.class]"
     data-vizel-node-selector

--- a/packages/vue/src/composables/useVizelTheme.ts
+++ b/packages/vue/src/composables/useVizelTheme.ts
@@ -1,4 +1,4 @@
-import type { VizelResolvedTheme } from "@vizel/core";
+import { VizelError, type VizelResolvedTheme } from "@vizel/core";
 import { type ComputedRef, computed, inject } from "vue";
 import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext";
 
@@ -41,7 +41,10 @@ export function useVizelTheme(): UseVizelThemeResult {
   const context = inject(VIZEL_THEME_CONTEXT_KEY);
 
   if (!context) {
-    throw new Error("useVizelTheme must be used within a VizelThemeProvider");
+    throw new VizelError(
+      "MISSING_CONTEXT",
+      "useVizelTheme must be used within a VizelThemeProvider"
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

Two related polish items surfaced by a hostile cross-framework review:

- **Theme context error class.** `useVizelTheme` / `getVizelTheme` threw a plain `Error` while the sibling editor-context hooks already throw a typed `VizelError("MISSING_CONTEXT", ...)`. Consumer pipelines that catch `VizelError` to classify boundary mistakes saw two different shapes for the same configuration class. Swap each theme variant to the typed error so the boundary discipline holds across every context hook.
- **`VizelNodeSelector` context fallback.** Every other consumer-facing component that accepts an `editor` prop (`VizelEditor`, `VizelBubbleMenu`, `VizelToolbar`, `VizelBlockMenu`, `VizelOutline`, `VizelFindReplace`, `VizelLinkEditor`) makes the prop optional and falls back to the `VizelProvider` / `Vizel` context. `VizelNodeSelector` required `editor: Editor` and never read context, which broke the pattern. Match the sibling shape: prop is optional, missing editor renders nothing, `nodeTypes` picks up `readonly` to mirror `VizelBlockMenu.actions`.

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (no warnings)
- [x] `pnpm build`