### PR TITLE
refactor(react,vue,svelte): rename VizelExposed to VizelEditorRef

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -125,7 +125,7 @@ per-framework component source for the full set.
 |------|-------|-----|--------|
 | `editor` | `Editor \| null` | `Editor \| null` | `Editor \| null` |
 | Class prop | `className?: string` | `class?: string` | `class?: string` |
-| Ref prop | `ref?: Ref<VizelExposed>` | template ref → `defineExpose` | `ref?: VizelExposed` |
+| Ref prop | `ref?: Ref<VizelEditorRef>` | template ref → `defineExpose` | `ref?: VizelEditorRef` |
 
 #### `VizelProvider`
 

--- a/docs/guide/react.md
+++ b/docs/guide/react.md
@@ -325,7 +325,7 @@ When wrapped in a `VizelProvider`, the `editor` prop is optional — the compone
 |------|------|-------------|
 | `editor` | `Editor \| null` | Editor instance. Defaults to the value provided by `VizelProvider` when omitted. |
 | `className` | `string` | Custom class name |
-| `ref` | `Ref<VizelExposed>` | Forwarded ref exposing the container DOM element. |
+| `ref` | `Ref<VizelEditorRef>` | Forwarded ref exposing the container DOM element. |
 
 ### VizelBubbleMenu
 

--- a/packages/react/src/components/VizelEditor.tsx
+++ b/packages/react/src/components/VizelEditor.tsx
@@ -5,14 +5,14 @@ import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelEditorProps {
   /** Ref to access editor container */
-  ref?: Ref<VizelExposed>;
+  ref?: Ref<VizelEditorRef>;
   /** Override the editor from context */
   editor?: Editor | null;
   /** Optional className for the editor container */
   className?: string;
 }
 
-export interface VizelExposed {
+export interface VizelEditorRef {
   /** The container DOM element */
   container: HTMLDivElement | null;
   /**
@@ -41,7 +41,7 @@ export interface VizelExposed {
  * <VizelEditor editor={editor} className="prose" />
  *
  * // With ref to access container DOM
- * const editorRef = useRef<VizelExposed>(null);
+ * const editorRef = useRef<VizelEditorRef>(null);
  * <VizelEditor ref={editorRef} editor={editor} />
  * // editorRef.current?.container gives you the container element
  * ```

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -24,7 +24,7 @@ export {
 export { VizelColorPicker, type VizelColorPickerProps } from "./VizelColorPicker.tsx";
 export { useVizelContext, useVizelContextSafe } from "./VizelContext.tsx";
 // Editor components
-export { VizelEditor, type VizelEditorProps, type VizelExposed } from "./VizelEditor.tsx";
+export { VizelEditor, type VizelEditorProps, type VizelEditorRef } from "./VizelEditor.tsx";
 // VizelEmbedView component
 export { VizelEmbedView, type VizelEmbedViewProps } from "./VizelEmbedView.tsx";
 // VizelFindReplace component

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -46,10 +46,10 @@ export {
   // Editor components
   VizelEditor,
   type VizelEditorProps,
+  type VizelEditorRef,
   // EmbedView
   VizelEmbedView,
   type VizelEmbedViewProps,
-  type VizelExposed,
   // FindReplace
   VizelFindReplace,
   type VizelFindReplaceProps,

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 import type { Editor } from "@vizel/core";
 
-export interface VizelExposed {
+export interface VizelEditorRef {
   /** The container DOM element */
   container: HTMLDivElement | null;
   /**
@@ -25,7 +25,7 @@ export interface VizelEditorProps {
    * `ref.container` directly — symmetric with React's `useImperativeHandle`
    * and Vue's `defineExpose`.
    */
-  ref?: VizelExposed;
+  ref?: VizelEditorRef;
 }
 </script>
 

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -49,7 +49,7 @@ export { getVizelContext, getVizelContextSafe } from "./VizelContext.js";
 export {
   default as VizelEditor,
   type VizelEditorProps,
-  type VizelExposed,
+  type VizelEditorRef,
 } from "./VizelEditor.svelte";
 // ============================================================================
 // Vizel EmbedView component

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -44,10 +44,10 @@ export {
   // Editor components
   VizelEditor,
   type VizelEditorProps,
+  type VizelEditorRef,
   // EmbedView
   VizelEmbedView,
   type VizelEmbedViewProps,
-  type VizelExposed,
   // FindReplace
   VizelFindReplace,
   type VizelFindReplaceProps,

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -10,7 +10,7 @@ export interface VizelEditorProps {
   class?: string;
 }
 
-export interface VizelExposed {
+export interface VizelEditorRef {
   /** The container DOM element */
   container: HTMLDivElement | null;
   /**
@@ -32,7 +32,7 @@ const resolvedEditor = computed(() => props.editor ?? contextEditor?.value ?? nu
 // Expose container ref and resolved editor instance to parent components.
 // Getters ensure consumers read the live values rather than the snapshots
 // captured at setup time.
-defineExpose<VizelExposed>({
+defineExpose<VizelEditorRef>({
   get container() {
     return containerRef.value;
   },

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -33,7 +33,7 @@ export { useVizelContext, useVizelContextSafe } from "./VizelContext.ts";
 export {
   default as VizelEditor,
   type VizelEditorProps,
-  type VizelExposed,
+  type VizelEditorRef,
 } from "./VizelEditor.vue";
 // VizelEmbedView component
 export { default as VizelEmbedView, type VizelEmbedViewProps } from "./VizelEmbedView.vue";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -45,10 +45,10 @@ export {
   // Editor components
   VizelEditor,
   type VizelEditorProps,
+  type VizelEditorRef,
   // EmbedView
   VizelEmbedView,
   type VizelEmbedViewProps,
-  type VizelExposed,
   // FindReplace
   VizelFindReplace,
   type VizelFindReplaceProps,


### PR DESCRIPTION
## Summary

Every other imperative-handle type in the framework packages uses the `Vizel<Component>Ref` suffix (`VizelRef`, `VizelSlashMenuRef`, `VizelMentionMenuRef`). `VizelExposed` was the only `Ref`-shaped type that did not follow the convention, which made the imperative-handle naming pattern an exception rather than the rule.

Rename to `VizelEditorRef` across all three framework packages, the public index re-exports, the cross-framework parity table, and the React guide. No behavior changes — pure rename.

## Breaking changes

Consumers importing `VizelExposed` must rename to `VizelEditorRef`:

```ts
// Before
import { type VizelExposed } from "@vizel/react";

// After
import { type VizelEditorRef } from "@vizel/react";
```

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:parity`