### PR TITLE
feat(react,vue,svelte): add resetToSystem to theme hook/composable/rune

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -41,20 +41,15 @@ function readStoredThemeMode(): ThemeMode {
   return stored === "light" || stored === "dark" ? stored : "system";
 }
 
-interface ThemeToggleProps {
-  /** Triggered when the user chooses "system" so the provider remounts. */
-  onResetToSystem: () => void;
-}
-
 /**
  * Three-state theme toggle (light / dark / system).
  *
- * `useVizelTheme().setTheme` only accepts concrete `VizelResolvedTheme`
- * values by design (cross-framework.md Table 4). To re-enter "system"
- * mode the demo clears the persisted preference and asks the parent to
- * remount the provider so its `defaultTheme="system"` initializer runs.
+ * `useVizelTheme().setTheme` accepts only concrete `VizelResolvedTheme`
+ * values to keep the toggle ergonomics tight; the dedicated
+ * `resetToSystem()` method re-enters the "follow OS preference" mode
+ * without remounting the provider.
  */
-function ThemeToggle({ onResetToSystem }: ThemeToggleProps) {
+function ThemeToggle() {
   const themeApi = useVizelThemeSafe();
   const resolvedTheme = themeApi?.theme;
   const storedMode = readStoredThemeMode();
@@ -87,12 +82,7 @@ function ThemeToggle({ onResetToSystem }: ThemeToggleProps) {
         data-active={storedMode === "system"}
         aria-label={`System (currently ${resolvedTheme ?? "light"})`}
         title="System"
-        onClick={() => {
-          if (typeof localStorage !== "undefined") {
-            localStorage.removeItem(THEME_STORAGE_KEY);
-          }
-          onResetToSystem();
-        }}
+        onClick={() => themeApi?.resetToSystem()}
       >
         ⎙
       </button>
@@ -128,11 +118,7 @@ interface DemoFeatures {
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
 
-interface AppContentProps {
-  onResetThemeToSystem: () => void;
-}
-
-function AppContent({ onResetThemeToSystem }: AppContentProps) {
+function AppContent() {
   // Feature toggles (all enabled by default).
   const [features, setFeatures] = useState<DemoFeatures>({
     toolbar: true,
@@ -256,7 +242,7 @@ function AppContent({ onResetThemeToSystem }: AppContentProps) {
             <h1>Vizel Editor</h1>
             <span className="framework-badge">React 19</span>
           </div>
-          {features.theme && <ThemeToggle onResetToSystem={onResetThemeToSystem} />}
+          {features.theme && <ThemeToggle />}
         </div>
         <p className="header-description">
           A block-based rich text editor with slash commands and inline formatting
@@ -648,20 +634,9 @@ function AppContent({ onResetThemeToSystem }: AppContentProps) {
 }
 
 export function App() {
-  // The provider seeds its theme state once at mount from
-  // `localStorage[storageKey]` (or `defaultTheme`). The System button
-  // clears the persisted preference and bumps `providerKey` so the
-  // provider remounts and re-runs that seed against the now-clean
-  // storage — the simplest way to re-enter "follow system" mode without
-  // adding a runtime "system" path to `useVizelTheme().setTheme` (which
-  // is intentionally narrowed to concrete `light` / `dark`).
-  const [providerKey, setProviderKey] = useState(0);
-  const handleResetThemeToSystem = useCallback(() => {
-    setProviderKey((key) => key + 1);
-  }, []);
   return (
-    <VizelThemeProvider key={providerKey} defaultTheme="system" storageKey="vizel-theme">
-      <AppContent onResetThemeToSystem={handleResetThemeToSystem} />
+    <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
+      <AppContent />
     </VizelThemeProvider>
   );
 }

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -148,21 +148,8 @@ function handleJsonChange(event: Event) {
     // Invalid JSON, ignore
   }
 }
-
-// The provider seeds its theme state once at mount from
-// `localStorage[storageKey]` (or `defaultTheme`). The System button
-// clears the persisted preference and bumps `providerKey` so the
-// provider remounts and re-runs that seed against the now-clean
-// storage — the simplest way to re-enter "follow system" mode without
-// adding a runtime "system" path to `getVizelTheme().setTheme` (which
-// is intentionally narrowed to concrete `light` / `dark`).
-let providerKey = $state(0);
-function handleResetThemeToSystem(): void {
-  providerKey += 1;
-}
 </script>
 
-{#key providerKey}
 <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
 <div class="app">
   <header class="header">
@@ -173,7 +160,7 @@ function handleResetThemeToSystem(): void {
         <span class="framework-badge">Svelte 5</span>
       </div>
       {#if features.theme}
-        <ThemeToggle onResetToSystem={handleResetThemeToSystem} />
+        <ThemeToggle />
       {/if}
     </div>
     <p class="header-description">
@@ -481,4 +468,3 @@ function handleResetThemeToSystem(): void {
   </footer>
 </div>
 </VizelThemeProvider>
-{/key}

--- a/apps/demo/svelte/src/ThemeToggle.svelte
+++ b/apps/demo/svelte/src/ThemeToggle.svelte
@@ -11,13 +11,6 @@ function readStoredThemeMode(): ThemeMode {
   return stored === "light" || stored === "dark" ? stored : "system";
 }
 
-interface Props {
-  /** Triggered when the user picks "system" so the provider remounts. */
-  onResetToSystem?: () => void;
-}
-
-let { onResetToSystem }: Props = $props();
-
 const themeApi = getVizelThemeSafe();
 let storedMode = $state<ThemeMode>(readStoredThemeMode());
 
@@ -32,11 +25,8 @@ function pickDark(): void {
 }
 
 function pickSystem(): void {
-  if (typeof localStorage !== "undefined") {
-    localStorage.removeItem(THEME_STORAGE_KEY);
-  }
+  themeApi?.resetToSystem();
   storedMode = "system";
-  onResetToSystem?.();
 }
 </script>
 

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -147,22 +147,10 @@ async function handleReply(commentId: string) {
 }
 
 const showPanel = computed(() => features.syncPanel || features.history || features.comments);
-
-// The provider seeds its theme state once at mount from
-// `localStorage[storageKey]` (or `defaultTheme`). The System button
-// clears the persisted preference and bumps `providerKey` so the
-// provider remounts and re-runs that seed against the now-clean
-// storage — the simplest way to re-enter "follow system" mode without
-// adding a runtime "system" path to `useVizelTheme().setTheme` (which
-// is intentionally narrowed to concrete `light` / `dark`).
-const providerKey = ref(0);
-function handleResetThemeToSystem(): void {
-  providerKey.value += 1;
-}
 </script>
 
 <template>
-  <VizelThemeProvider :key="providerKey" defaultTheme="system" storageKey="vizel-theme">
+  <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
     <div class="app">
       <header class="header">
         <div class="header-content">
@@ -171,7 +159,7 @@ function handleResetThemeToSystem(): void {
             <h1>Vizel Editor</h1>
             <span class="framework-badge">Vue 3</span>
           </div>
-          <ThemeToggle v-if="features.theme" :on-reset-to-system="handleResetThemeToSystem" />
+          <ThemeToggle v-if="features.theme" />
         </div>
         <p class="header-description">
           A block-based rich text editor with slash commands and inline formatting

--- a/apps/demo/vue/src/ThemeToggle.vue
+++ b/apps/demo/vue/src/ThemeToggle.vue
@@ -12,11 +12,6 @@ function readStoredThemeMode(): ThemeMode {
   return stored === "light" || stored === "dark" ? stored : "system";
 }
 
-const props = defineProps<{
-  /** Triggered when the user picks "system" so the provider remounts. */
-  onResetToSystem?: () => void;
-}>();
-
 const themeApi = useVizelThemeSafe();
 const resolvedTheme = computed(() => themeApi?.theme.value);
 const storedMode = ref<ThemeMode>(readStoredThemeMode());
@@ -32,11 +27,8 @@ function pickDark(): void {
 }
 
 function pickSystem(): void {
-  if (typeof localStorage !== "undefined") {
-    localStorage.removeItem(THEME_STORAGE_KEY);
-  }
+  themeApi?.resetToSystem();
   storedMode.value = "system";
-  props.onResetToSystem?.();
 }
 </script>
 

--- a/packages/react/src/hooks/useVizelTheme.ts
+++ b/packages/react/src/hooks/useVizelTheme.ts
@@ -5,17 +5,25 @@ import { VizelThemeContext } from "../components/VizelThemeContext.tsx";
 /**
  * Public return shape for `useVizelTheme`.
  *
- * The flat `{ theme, setTheme }` shape mirrors the Vue composable and Svelte
- * rune. `theme` is the currently applied (resolved) theme so a toggle is a
- * one-liner. `setTheme` accepts only concrete `VizelResolvedTheme` values
- * because entering "system" mode is the provider's `defaultTheme` concern,
- * not a runtime toggle.
+ * The flat `{ theme, setTheme, resetToSystem }` shape mirrors the Vue
+ * composable and Svelte rune. `theme` is the currently applied (resolved)
+ * theme so a toggle is a one-liner. `setTheme` accepts only concrete
+ * `VizelResolvedTheme` values to keep the toggle ergonomics tight;
+ * re-entering the "follow OS preference" mode is the dedicated
+ * `resetToSystem` method instead of an overload.
  */
 export interface UseVizelThemeResult {
   /** Currently applied theme (resolved from the user's preference). */
   theme: VizelResolvedTheme;
   /** Switch the editor theme to a concrete value. */
   setTheme: (next: VizelResolvedTheme) => void;
+  /**
+   * Drop the user's manual selection and resume tracking the OS
+   * `prefers-color-scheme` preference. The provider's stored selection is
+   * replaced with `"system"`, and `theme` updates to whatever the OS
+   * currently reports.
+   */
+  resetToSystem: () => void;
 }
 
 /**
@@ -58,6 +66,7 @@ export function useVizelTheme(): UseVizelThemeResult {
     () => ({
       theme: context.resolvedTheme,
       setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+      resetToSystem: () => context.setTheme("system"),
     }),
     [context]
   );
@@ -80,6 +89,7 @@ export function useVizelThemeSafe(): UseVizelThemeResult | null {
         ? {
             theme: context.resolvedTheme,
             setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+            resetToSystem: () => context.setTheme("system"),
           }
         : null,
     [context]

--- a/packages/svelte/src/runes/getVizelTheme.ts
+++ b/packages/svelte/src/runes/getVizelTheme.ts
@@ -22,6 +22,13 @@ export interface GetVizelThemeResult {
   readonly current: VizelResolvedTheme;
   /** Switch the editor theme to a concrete value. */
   setTheme: (next: VizelResolvedTheme) => void;
+  /**
+   * Drop the user's manual selection and resume tracking the OS
+   * `prefers-color-scheme` preference. The provider's stored selection is
+   * replaced with `"system"`, and `current` updates to whatever the OS
+   * currently reports.
+   */
+  resetToSystem: () => void;
 }
 
 /**
@@ -65,6 +72,7 @@ export function getVizelTheme(): GetVizelThemeResult {
       return context.resolvedTheme;
     },
     setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+    resetToSystem: () => context.setTheme("system"),
   };
 }
 
@@ -82,5 +90,6 @@ export function getVizelThemeSafe(): GetVizelThemeResult | null {
       return context.resolvedTheme;
     },
     setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+    resetToSystem: () => context.setTheme("system"),
   };
 }

--- a/packages/vue/src/composables/useVizelTheme.ts
+++ b/packages/vue/src/composables/useVizelTheme.ts
@@ -5,18 +5,25 @@ import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext";
 /**
  * Public return shape for `useVizelTheme`.
  *
- * The flat `{ theme, setTheme }` shape mirrors the React hook and Svelte
- * rune. `theme` reflects the currently applied (resolved) theme so consumers
- * can build a simple toggle without reading any other field. `setTheme`
- * accepts only concrete `VizelResolvedTheme` values because entering
- * "system" mode is the provider's `defaultTheme` concern, not a runtime
- * toggle.
+ * The flat `{ theme, setTheme, resetToSystem }` shape mirrors the React hook
+ * and Svelte rune. `theme` reflects the currently applied (resolved) theme
+ * so consumers can build a simple toggle without reading any other field.
+ * `setTheme` accepts only concrete `VizelResolvedTheme` values to keep the
+ * toggle ergonomics tight; re-entering the "follow OS preference" mode is
+ * the dedicated `resetToSystem` method instead of an overload.
  */
 export interface UseVizelThemeResult {
   /** Currently applied theme (resolved from the user's preference). */
   theme: ComputedRef<VizelResolvedTheme>;
   /** Switch the editor theme to a concrete value. */
   setTheme: (next: VizelResolvedTheme) => void;
+  /**
+   * Drop the user's manual selection and resume tracking the OS
+   * `prefers-color-scheme` preference. The provider's stored selection is
+   * replaced with `"system"`, and `theme` updates to whatever the OS
+   * currently reports.
+   */
+  resetToSystem: () => void;
 }
 
 /**
@@ -57,6 +64,7 @@ export function useVizelTheme(): UseVizelThemeResult {
     // type matches the runtime guarantee; the underlying provider's
     // setter accepts the wider `VizelTheme` including "system".
     setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+    resetToSystem: () => context.setTheme("system"),
   };
 }
 
@@ -75,5 +83,6 @@ export function useVizelThemeSafe(): UseVizelThemeResult | null {
     // type matches the runtime guarantee; the underlying provider's
     // setter accepts the wider `VizelTheme` including "system".
     setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+    resetToSystem: () => context.setTheme("system"),
   };
 }


### PR DESCRIPTION
## Summary

Re-entering "follow OS preference" mode previously required a provider remount because `useVizelTheme().setTheme` is narrowed to concrete `light` / `dark` values. Demo apps worked around it with a `providerKey` bump that re-ran the provider's seed against the cleared storage — correct but consumer-hostile.

Add `resetToSystem()` to the result shape of `useVizelTheme` / `useVizelThemeSafe` / `getVizelTheme` / `getVizelThemeSafe`. The method delegates to the underlying provider's wider `setTheme("system")`, which the public hook setter intentionally hides to keep the toggle ergonomics tight. `setTheme` keeps its narrow signature; consumers that need the system mode call the dedicated method.

Drop the `providerKey` remount hack from all three demo apps in favor of the new method.

## Cross-framework parity

- React: `useVizelTheme()` returns `{ theme, setTheme, resetToSystem }`.
- Vue: `useVizelTheme()` returns `{ theme: ComputedRef<...>, setTheme, resetToSystem }`.
- Svelte: `getVizelTheme()` returns `{ readonly current, setTheme, resetToSystem }`.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Manual: in each demo, toggle light → dark → system and confirm the System button restores OS preference without remounting the editor.