### PR TITLE
feat(react,vue,svelte): mention menu renderer seams and JSDoc wording

### DIFF
--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -203,12 +203,24 @@ frameworks. The only divergence is the children form.
 |------|-------|-----|--------|
 | `items` | `VizelSlashCommandItem[]` | `VizelSlashCommandItem[]` | `VizelSlashCommandItem[]` |
 | Class prop | `className?: string` | `class?: string` | `class?: string` |
-| Selection callback | `onSelect: (item) => void` | emit `select` | `onselect?: (item) => void` |
+| Selection callback | `onSelect: (item) => void` | emit `select` | `onselect: (item) => void` |
 | `showGroups` | `boolean` | `boolean` | `boolean` |
 | `groupOrder` | `string[]` | `string[]` | `string[]` |
 | Item renderer | `renderItem?: (state) => ReactNode` | `#item` slot | `renderItem?: Snippet<[state]>` |
 | Empty renderer | `renderEmpty?: () => ReactNode` | `#empty` slot | `renderEmpty?: Snippet` |
 | Imperative ref | `ref?: Ref<VizelSlashMenuRef>` | template ref → `defineExpose` | `ref?: VizelSlashMenuRef` (mutable prop) |
+
+#### `VizelMentionMenu`
+
+| Prop | React | Vue | Svelte |
+|------|-------|-----|--------|
+| `items` | `VizelMentionItem[]` | `VizelMentionItem[]` | `VizelMentionItem[]` |
+| Class prop | `className?: string` | `class?: string` | `class?: string` |
+| Selection callback | `onSelect: (item) => void` | emit `select` | `onselect: (item) => void` |
+| `locale` | `VizelLocale` | `VizelLocale` | `VizelLocale` |
+| Item renderer | `renderItem?: (state) => ReactNode` | `#item` slot | `renderItem?: Snippet<[state]>` |
+| Empty renderer | `renderEmpty?: () => ReactNode` | `#empty` slot | `renderEmpty?: Snippet` |
+| Imperative ref | `ref?: Ref<VizelMentionMenuRef>` | template ref → `defineExpose` | `ref?: VizelMentionMenuRef` (mutable prop) |
 
 #### `VizelColorPicker`
 

--- a/packages/react/src/components/VizelBubbleMenu.tsx
+++ b/packages/react/src/components/VizelBubbleMenu.tsx
@@ -10,7 +10,7 @@ import { VizelBubbleMenuDefault } from "./VizelBubbleMenuDefault.tsx";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelBubbleMenuProps {
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name for the menu container */
   className?: string;

--- a/packages/react/src/components/VizelEditor.tsx
+++ b/packages/react/src/components/VizelEditor.tsx
@@ -6,7 +6,7 @@ import { useVizelContextSafe } from "./VizelContext.tsx";
 export interface VizelEditorProps {
   /** Ref to access editor container */
   ref?: Ref<VizelEditorRef>;
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Optional className for the editor container */
   className?: string;

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -28,6 +28,18 @@ export interface VizelMentionMenuProps {
   className?: string;
   /** Locale for translated UI strings */
   locale?: VizelLocale;
+  /**
+   * Custom render function for items. Receives the item, the selection
+   * state, and a click handler that selects the item. Mirrors the
+   * `renderItem` seam on `VizelSlashMenu` (cross-framework Table 6).
+   */
+  renderItem?: (props: {
+    item: VizelMentionItem;
+    isSelected: boolean;
+    onClick: () => void;
+  }) => ReactNode;
+  /** Custom empty state component. Mirrors `VizelSlashMenu.renderEmpty`. */
+  renderEmpty?: () => ReactNode;
 }
 
 /**
@@ -44,6 +56,8 @@ export function VizelMentionMenu({
   onSelect,
   className,
   locale,
+  renderItem,
+  renderEmpty,
 }: VizelMentionMenuProps): ReactNode {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -103,9 +117,11 @@ export function VizelMentionMenu({
         role="listbox"
         aria-label={spec.root["aria-label"]}
       >
-        <div className="vizel-mention-menu-empty">
-          {locale?.mentionMenu?.noResults ?? "No results"}
-        </div>
+        {renderEmpty?.() ?? (
+          <div className="vizel-mention-menu-empty">
+            {locale?.mentionMenu?.noResults ?? "No results"}
+          </div>
+        )}
       </div>
     );
   }
@@ -121,39 +137,49 @@ export function VizelMentionMenu({
       })}
     >
       {spec.sections.flatMap((section) =>
-        section.items.map((slot) => (
-          <div
-            key={slot.key}
-            id={slot.attrs.id}
-            ref={(el) => {
-              itemRefs.current[slot.index] = el;
-            }}
-            className={`vizel-mention-menu-item ${slot.data.isSelected ? "is-selected" : ""}`}
-            onClick={() => selectItem(slot.index)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") selectItem(slot.index);
-            }}
-            tabIndex={slot.attrs.tabIndex}
-            role="option"
-            aria-selected={slot.attrs["aria-selected"]}
-          >
-            <div className="vizel-mention-menu-item-avatar">
-              {slot.data.item.avatar ? (
-                <img src={slot.data.item.avatar} alt={slot.data.item.label} />
-              ) : (
-                slot.data.item.label.charAt(0).toUpperCase()
-              )}
+        section.items.map((slot) => {
+          const onClick = () => selectItem(slot.index);
+          const content = renderItem ? (
+            renderItem({ item: slot.data.item, isSelected: slot.data.isSelected, onClick })
+          ) : (
+            <>
+              <div className="vizel-mention-menu-item-avatar">
+                {slot.data.item.avatar ? (
+                  <img src={slot.data.item.avatar} alt={slot.data.item.label} />
+                ) : (
+                  slot.data.item.label.charAt(0).toUpperCase()
+                )}
+              </div>
+              <div className="vizel-mention-menu-item-content">
+                <div className="vizel-mention-menu-item-label">{slot.data.item.label}</div>
+                {slot.data.item.description && (
+                  <div className="vizel-mention-menu-item-description">
+                    {slot.data.item.description}
+                  </div>
+                )}
+              </div>
+            </>
+          );
+          return (
+            <div
+              key={slot.key}
+              id={slot.attrs.id}
+              ref={(el) => {
+                itemRefs.current[slot.index] = el;
+              }}
+              className={`vizel-mention-menu-item ${slot.data.isSelected ? "is-selected" : ""}`}
+              onClick={onClick}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") selectItem(slot.index);
+              }}
+              tabIndex={slot.attrs.tabIndex}
+              role="option"
+              aria-selected={slot.attrs["aria-selected"]}
+            >
+              {content}
             </div>
-            <div className="vizel-mention-menu-item-content">
-              <div className="vizel-mention-menu-item-label">{slot.data.item.label}</div>
-              {slot.data.item.description && (
-                <div className="vizel-mention-menu-item-description">
-                  {slot.data.item.description}
-                </div>
-              )}
-            </div>
-          </div>
-        ))
+          );
+        })
       )}
     </div>
   );

--- a/packages/react/src/components/VizelOutline.tsx
+++ b/packages/react/src/components/VizelOutline.tsx
@@ -9,7 +9,7 @@ import { useVizelState } from "../hooks/useVizelState.ts";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelOutlineProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Additional CSS class name */
   className?: string;

--- a/packages/react/src/components/VizelToolbar.tsx
+++ b/packages/react/src/components/VizelToolbar.tsx
@@ -4,7 +4,7 @@ import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelToolbarDefault } from "./VizelToolbarDefault.tsx";
 
 export interface VizelToolbarProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Additional CSS class name */
   className?: string;

--- a/packages/svelte/src/components/VizelBubbleMenu.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenu.svelte
@@ -3,7 +3,7 @@ import type { Editor, VizelLocale } from "@vizel/core";
 import type { Snippet } from "svelte";
 
 export interface VizelBubbleMenuProps {
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name for the menu container */
   class?: string;

--- a/packages/svelte/src/components/VizelEditor.svelte
+++ b/packages/svelte/src/components/VizelEditor.svelte
@@ -15,7 +15,7 @@ export interface VizelEditorRef {
 }
 
 export interface VizelEditorProps {
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -1,16 +1,32 @@
 <script lang="ts" module>
 import type { VizelLocale, VizelMentionItem } from "@vizel/core";
+import type { Snippet } from "svelte";
 
 export interface VizelMentionMenuRef {
   onKeyDown?: (event: KeyboardEvent) => boolean;
 }
 
 export interface VizelMentionMenuProps {
+  /** Mention items to display */
   items: VizelMentionItem[];
+  /** Custom class name */
   class?: string;
-  onselect?: (item: VizelMentionItem) => void;
+  /**
+   * Callback fired when a consumer selects a mention item. Required for
+   * parity with React's `onSelect` and Vue's `@select` — the menu has no
+   * meaningful behavior without it.
+   */
+  onselect: (item: VizelMentionItem) => void;
   /** Locale for translated UI strings */
   locale?: VizelLocale;
+  /**
+   * Custom item renderer. Mirrors `VizelSlashMenu.renderItem` — the
+   * container, keyboard navigation, ARIA, and click handling stay owned
+   * by VizelMentionMenu; the snippet only paints the per-item content.
+   */
+  renderItem?: Snippet<[{ item: VizelMentionItem; isSelected: boolean; onclick: () => void }]>;
+  /** Custom empty-state renderer. Mirrors `VizelSlashMenu.renderEmpty`. */
+  renderEmpty?: Snippet;
   /**
    * Mutable ref object the component populates with imperative handles
    * (notably `onKeyDown`). Pass an object; this component assigns to its
@@ -32,6 +48,8 @@ let {
   class: className,
   onselect,
   locale,
+  renderItem,
+  renderEmpty,
   ref,
 }: VizelMentionMenuProps = $props();
 
@@ -66,7 +84,7 @@ function scrollToSelected() {
 function selectItem(index: number) {
   const item = items[index];
   if (item) {
-    onselect?.(item);
+    onselect(item);
   }
 }
 
@@ -103,7 +121,11 @@ if (ref) {
   aria-activedescendant={spec.root["aria-activedescendant"]}
 >
   {#if spec.sections.length === 0}
-    <div class="vizel-mention-menu-empty">{locale?.mentionMenu?.noResults ?? "No results"}</div>
+    {#if renderEmpty}
+      {@render renderEmpty()}
+    {:else}
+      <div class="vizel-mention-menu-empty">{locale?.mentionMenu?.noResults ?? "No results"}</div>
+    {/if}
   {:else}
     {#each slots as slot (slot.key)}
       <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -117,19 +139,27 @@ if (ref) {
         onkeydown={(e) => { if (e.key === "Enter") selectItem(slot.index); }}
         tabindex={slot.attrs.tabIndex}
       >
-        <div class="vizel-mention-menu-item-avatar">
-          {#if slot.data.item.avatar}
-            <img src={slot.data.item.avatar} alt={slot.data.item.label} />
-          {:else}
-            {slot.data.item.label.charAt(0).toUpperCase()}
-          {/if}
-        </div>
-        <div class="vizel-mention-menu-item-content">
-          <div class="vizel-mention-menu-item-label">{slot.data.item.label}</div>
-          {#if slot.data.item.description}
-            <div class="vizel-mention-menu-item-description">{slot.data.item.description}</div>
-          {/if}
-        </div>
+        {#if renderItem}
+          {@render renderItem({
+            item: slot.data.item,
+            isSelected: slot.data.isSelected,
+            onclick: () => selectItem(slot.index),
+          })}
+        {:else}
+          <div class="vizel-mention-menu-item-avatar">
+            {#if slot.data.item.avatar}
+              <img src={slot.data.item.avatar} alt={slot.data.item.label} />
+            {:else}
+              {slot.data.item.label.charAt(0).toUpperCase()}
+            {/if}
+          </div>
+          <div class="vizel-mention-menu-item-content">
+            <div class="vizel-mention-menu-item-label">{slot.data.item.label}</div>
+            {#if slot.data.item.description}
+              <div class="vizel-mention-menu-item-description">{slot.data.item.description}</div>
+            {/if}
+          </div>
+        {/if}
       </div>
     {/each}
   {/if}

--- a/packages/svelte/src/components/VizelOutline.svelte
+++ b/packages/svelte/src/components/VizelOutline.svelte
@@ -2,7 +2,7 @@
 import type { Editor, VizelLocale } from "@vizel/core";
 
 export interface VizelOutlineProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;

--- a/packages/svelte/src/components/VizelToolbar.svelte
+++ b/packages/svelte/src/components/VizelToolbar.svelte
@@ -3,7 +3,7 @@ import type { Editor, VizelLocale } from "@vizel/core";
 import type { Snippet } from "svelte";
 
 export interface VizelToolbarProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;

--- a/packages/vue/src/components/VizelBubbleMenu.vue
+++ b/packages/vue/src/components/VizelBubbleMenu.vue
@@ -10,7 +10,7 @@ import VizelBubbleMenuDefault from "./VizelBubbleMenuDefault.vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
 export interface VizelBubbleMenuProps {
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name for the menu container */
   class?: string;

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -4,7 +4,7 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
 export interface VizelEditorProps {
-  /** Override the editor from context */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -81,9 +81,18 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
     :aria-label="spec.root['aria-label']"
     :aria-activedescendant="spec.root['aria-activedescendant']"
   >
-    <div v-if="spec.sections.length === 0" class="vizel-mention-menu-empty">
-      {{ props.locale?.mentionMenu?.noResults ?? 'No results' }}
-    </div>
+    <template v-if="spec.sections.length === 0">
+      <!--
+        Mirrors VizelSlashMenu's `#empty` slot — consumers swap the
+        no-results affordance without re-implementing keyboard / ARIA
+        wiring.
+      -->
+      <slot name="empty">
+        <div class="vizel-mention-menu-empty">
+          {{ props.locale?.mentionMenu?.noResults ?? 'No results' }}
+        </div>
+      </slot>
+    </template>
     <template v-else>
       <div
         v-for="slot in slots"
@@ -97,16 +106,28 @@ defineExpose<VizelMentionMenuRef>({ onKeyDown });
         @click="selectItem(slot.index)"
         @keydown.enter="selectItem(slot.index)"
       >
-        <div class="vizel-mention-menu-item-avatar">
-          <img v-if="slot.data.item.avatar" :src="slot.data.item.avatar" :alt="slot.data.item.label" />
-          <template v-else>{{ slot.data.item.label.charAt(0).toUpperCase() }}</template>
-        </div>
-        <div class="vizel-mention-menu-item-content">
-          <div class="vizel-mention-menu-item-label">{{ slot.data.item.label }}</div>
-          <div v-if="slot.data.item.description" class="vizel-mention-menu-item-description">
-            {{ slot.data.item.description }}
+        <!--
+          Item slot mirrors VizelSlashMenu's `#item` seam. The container,
+          keyboard navigation, ARIA, and click handling stay owned by
+          VizelMentionMenu; consumers only swap the per-item markup.
+        -->
+        <slot
+          name="item"
+          :item="slot.data.item"
+          :is-selected="slot.data.isSelected"
+          :onclick="() => selectItem(slot.index)"
+        >
+          <div class="vizel-mention-menu-item-avatar">
+            <img v-if="slot.data.item.avatar" :src="slot.data.item.avatar" :alt="slot.data.item.label" />
+            <template v-else>{{ slot.data.item.label.charAt(0).toUpperCase() }}</template>
           </div>
-        </div>
+          <div class="vizel-mention-menu-item-content">
+            <div class="vizel-mention-menu-item-label">{{ slot.data.item.label }}</div>
+            <div v-if="slot.data.item.description" class="vizel-mention-menu-item-description">
+              {{ slot.data.item.description }}
+            </div>
+          </div>
+        </slot>
       </div>
     </template>
   </div>

--- a/packages/vue/src/components/VizelOutline.vue
+++ b/packages/vue/src/components/VizelOutline.vue
@@ -2,7 +2,7 @@
 import type { Editor, VizelLocale } from "@vizel/core";
 
 export interface VizelOutlineProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;

--- a/packages/vue/src/components/VizelToolbar.vue
+++ b/packages/vue/src/components/VizelToolbar.vue
@@ -5,7 +5,7 @@ import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelToolbarDefault from "./VizelToolbarDefault.vue";
 
 export interface VizelToolbarProps {
-  /** Editor instance. Falls back to context if not provided. */
+  /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Custom class name */
   class?: string;


### PR DESCRIPTION
## Summary

Address three related hostile-review findings:

- **`VizelMentionMenu` renderer seams.** The cross-framework parity contract (Table 6 "Custom Item Renderers") promised consumers could swap per-item markup on every list-iterating menu, but `VizelMentionMenu` only exposed the default avatar / label / description layout — no `renderItem`, no `renderEmpty`, no `#item` / `#empty` slots. Add the seams across all three frameworks so a consumer can swap markup the same way they already do for `VizelSlashMenu`. Add a dedicated `VizelMentionMenu` row to the parity table.
- **Svelte `onselect` required.** The parity table treats the selection callback as the menu's one load-bearing prop. React / Vue already required it; Svelte declared `onselect?: ...` as optional, which let a typo silently render a dead menu. Drop the `?` and the optional call inside `selectItem` — there is no meaningful behavior without a consumer-supplied handler.
- **Editor-prop JSDoc wording.** Eight components shipped with one of three inconsistent phrasings ("Override the editor from context", "Falls back to context if not provided.", or the longer "Falls back to the editor from `VizelProvider` / `Vizel` context"). Standardize on the third — it names the providers, says what happens on omission, and reads the same across all three frameworks.

## Breaking changes

Svelte's `VizelMentionMenu.onselect` is now required. Consumers that omitted it previously got a silent no-op; the typed API now flags the omission.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:parity`