### PR TITLE
fix: hostile-review polish across the three framework packages

### DIFF
--- a/packages/react/src/components/VizelIcon.tsx
+++ b/packages/react/src/components/VizelIcon.tsx
@@ -42,10 +42,9 @@ export interface VizelIconProps extends Omit<ComponentProps<typeof IconifyIcon>,
  */
 export function VizelIcon({ name, customIcons, style, ...props }: VizelIconProps) {
   const { customIcons: contextIcons } = useVizelIconContext();
-  const iconId =
-    customIcons?.[name] ??
-    contextIcons?.[name] ??
-    vizelDefaultIconIds[name as keyof typeof vizelDefaultIconIds] ??
-    name;
+  // `vizelDefaultIconIds` is typed `Record<VizelIconName, string>`, so the
+  // direct index is type-safe — the previous `as keyof typeof` cast was a
+  // no-op flagged by the project's `as`-cast policy.
+  const iconId = customIcons?.[name] ?? contextIcons?.[name] ?? vizelDefaultIconIds[name] ?? name;
   return <IconifyIcon icon={iconId} style={{ pointerEvents: "none", ...style }} {...props} />;
 }

--- a/packages/react/src/components/VizelToolbarOverflow.tsx
+++ b/packages/react/src/components/VizelToolbarOverflow.tsx
@@ -7,7 +7,7 @@ import { VizelToolbarDropdown } from "./VizelToolbarDropdown.tsx";
 
 export interface VizelToolbarOverflowProps {
   editor: Editor;
-  actions: VizelToolbarActionItem[];
+  actions: readonly VizelToolbarActionItem[];
   className?: string;
   /** Locale for translated UI strings */
   locale?: VizelLocale;

--- a/packages/react/src/hooks/useLatest.ts
+++ b/packages/react/src/hooks/useLatest.ts
@@ -1,6 +1,8 @@
 import { type RefObject, useRef } from "react";
 
 /**
+ * @internal
+ *
  * Track the latest value in a stable `RefObject`.
  *
  * Each render synchronously updates `ref.current` to the passed value,

--- a/packages/svelte/src/components/VizelColorPicker.svelte
+++ b/packages/svelte/src/components/VizelColorPicker.svelte
@@ -33,6 +33,7 @@ export interface VizelColorPickerProps {
 
 <script lang="ts">
 import { isVizelValidHexColor, normalizeVizelHexColor } from "@vizel/core";
+import { untrack } from "svelte";
 import VizelIcon from "./VizelIcon.svelte";
 
 const GRID_COLUMNS = 4;
@@ -174,14 +175,20 @@ $effect(() => {
   }
 });
 
-// Focus first swatch or current value on mount (run only once)
+// Focus first swatch or current value on mount. Wrap the body in
+// `untrack` so a later `value` / `allColors` change does not yank
+// `focusedIndex` back to the selected swatch in the middle of keyboard
+// navigation (the previous shape registered both reactive reads and
+// re-ran on every prop tick).
 $effect(() => {
-  const currentIndex = value ? allColors.indexOf(value) : -1;
-  if (currentIndex >= 0) {
-    focusedIndex = currentIndex;
-  } else if (allColors.length > 0) {
-    focusedIndex = 0;
-  }
+  untrack(() => {
+    const currentIndex = value ? allColors.indexOf(value) : -1;
+    if (currentIndex >= 0) {
+      focusedIndex = currentIndex;
+    } else if (allColors.length > 0) {
+      focusedIndex = 0;
+    }
+  });
 });
 
 const isInputValid = $derived(isVizelValidHexColor(normalizeVizelHexColor(inputValue)));

--- a/packages/svelte/src/components/VizelToolbarOverflow.svelte
+++ b/packages/svelte/src/components/VizelToolbarOverflow.svelte
@@ -3,7 +3,7 @@ import type { Editor, VizelLocale, VizelToolbarActionItem } from "@vizel/core";
 
 export interface VizelToolbarOverflowProps {
   editor: Editor;
-  actions: VizelToolbarActionItem[];
+  actions: readonly VizelToolbarActionItem[];
   class?: string;
   /** Locale for translated UI strings */
   locale?: VizelLocale;

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -42,8 +42,8 @@ export type CreateVizelEditorOptions = Omit<VizelCreateEditorOptions, "editable"
  *
  * Changing `initialContent`, `initialMarkdown`, `placeholder`, `features`,
  * `extensions`, `flavor`, `locale`, or `autofocus` after mount has no effect.
- * Use `editor.current.commands.setContent(...)` (or the corresponding feature
- * command) to update the document after mount.
+ * Use `editor.current?.commands.setContent(...)` (or the corresponding
+ * feature command) to update the document after mount.
  *
  * @example
  * ```svelte

--- a/packages/vue/src/components/VizelOutline.vue
+++ b/packages/vue/src/components/VizelOutline.vue
@@ -1,5 +1,9 @@
-<script lang="ts">
-import type { Editor, VizelLocale } from "@vizel/core";
+<script setup lang="ts">
+import { buildVizelOutlineSpec, type Editor, type VizelLocale, vizelEnLocale } from "@vizel/core";
+import { computed } from "vue";
+import { useVizelState } from "../composables/useVizelState.ts";
+import { useVizelContextSafe } from "./VizelContext.ts";
+import VizelOutlineItems from "./VizelOutlineItems.vue";
 
 export interface VizelOutlineProps {
   /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
@@ -14,26 +18,18 @@ export interface VizelOutlineProps {
   /** Locale for translated UI strings */
   locale?: VizelLocale;
 }
-</script>
-
-<script setup lang="ts">
-import { buildVizelOutlineSpec, vizelEnLocale } from "@vizel/core";
-import { computed } from "vue";
-import { useVizelState } from "../composables/useVizelState.ts";
-import { useVizelContextSafe } from "./VizelContext.ts";
-import VizelOutlineItems from "./VizelOutlineItems.vue";
 
 const props = defineProps<VizelOutlineProps>();
 
 const contextEditor = useVizelContextSafe();
-const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
+const resolvedEditor = computed<Editor | null>(() => props.editor ?? contextEditor?.value ?? null);
 
-const updateCount = useVizelState(() => editor.value);
+const updateCount = useVizelState(() => resolvedEditor.value);
 
 const resolvedLocale = computed(() => props.locale ?? vizelEnLocale);
 const spec = computed(() => {
   void updateCount.value;
-  const e = editor.value;
+  const e = resolvedEditor.value;
   if (!e) return null;
   const resolvedPos = props.currentPos === undefined ? e.state.selection.from : props.currentPos;
   return buildVizelOutlineSpec(e, resolvedPos, resolvedLocale.value);
@@ -42,12 +38,12 @@ const spec = computed(() => {
 
 <template>
   <nav
-    v-if="editor && spec"
-    :class="['vizel-outline', props.class]"
+    v-if="resolvedEditor && spec"
+    :class="['vizel-outline', $props.class]"
     :role="spec.root.role"
     :aria-label="spec.root['aria-label']"
     data-vizel-outline=""
   >
-    <VizelOutlineItems v-if="spec.items.length > 0" :items="spec.items" :editor="editor" />
+    <VizelOutlineItems v-if="spec.items.length > 0" :items="spec.items" :editor="resolvedEditor" />
   </nav>
 </template>

--- a/packages/vue/src/components/VizelOutlineItems.vue
+++ b/packages/vue/src/components/VizelOutlineItems.vue
@@ -1,13 +1,11 @@
-<script lang="ts">
+<script setup lang="ts">
 import type { Editor, VizelOutlineItemSpec } from "@vizel/core";
 
 export interface VizelOutlineItemsProps {
   items: readonly VizelOutlineItemSpec[];
   editor: Editor;
 }
-</script>
 
-<script setup lang="ts">
 const props = defineProps<VizelOutlineItemsProps>();
 
 const onItemClick = (pos: number) => {

--- a/packages/vue/src/components/VizelToolbarOverflow.vue
+++ b/packages/vue/src/components/VizelToolbarOverflow.vue
@@ -8,7 +8,7 @@ import VizelToolbarDropdown from "./VizelToolbarDropdown.vue";
 
 export interface VizelToolbarOverflowProps {
   editor: Editor;
-  actions: VizelToolbarActionItem[];
+  actions: readonly VizelToolbarActionItem[];
   class?: string;
   /** Locale for translated UI strings */
   locale?: VizelLocale;


### PR DESCRIPTION
## Summary

Batch the remaining hostile-review action items that don't justify a standalone PR:

- **Vue `VizelOutline` / `VizelOutlineItems`**: collapse the dual-script split into a single `<script setup lang="ts">` block. The dual-script form was only needed for `defineComponent` exports; neither component is self-referential through `defineComponent`. `vue.md` says single `<script setup>` is the package convention.
- **Svelte `VizelColorPicker`** focus effect: wrap the "focus first swatch on mount" body in `untrack(...)` so a later `value` / `allColors` prop change does not yank `focusedIndex` back to the selected swatch mid-keyboard-navigation.
- **React / Vue / Svelte `VizelToolbarOverflow.actions`**: switch the array type to `readonly VizelToolbarActionItem[]` so the immutability-first convention (and `VizelBlockMenu.actions`'s own typing) is honored.
- **React `useLatest`**: tag with `@internal` so external consumers see the JSDoc-level signal that this is an internal escape hatch.
- **React `VizelIcon`**: drop the `as keyof typeof vizelDefaultIconIds` cast. The default-icon map is typed `Record<VizelIconName, string>`, so the index is already type-safe — the cast was a no-op flagged by the project's `as`-cast policy.
- **Svelte `createVizelEditor` JSDoc**: fix the example from `editor.current.commands.setContent(...)` to `editor.current?.commands.setContent(...)` so it compiles against the actual accessor type (`Editor | null`).

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:parity`