### PR TITLE
fix(react,vue,svelte): re-register BubbleMenu plugin on shouldShow toggle

### DIFF
--- a/packages/react/src/components/VizelBubbleMenu.tsx
+++ b/packages/react/src/components/VizelBubbleMenu.tsx
@@ -83,6 +83,16 @@ export function VizelBubbleMenu({
     shouldShowRef.current = shouldShow;
   }, [shouldShow]);
 
+  // Re-register the plugin when `shouldShow` toggles between `undefined`
+  // and a function: if the prop transitions from `undefined` → defined,
+  // the wrapper has to be installed once. If it transitions from
+  // defined → `undefined`, the previously installed wrapper would keep
+  // calling `shouldShowRef.current?.(...) ?? false` (always `false`) and
+  // hide the menu forever. Comparing presence (not identity) so identity
+  // changes of a continuously-defined callback still flow through the
+  // ref without re-registering.
+  const hasShouldShow = shouldShow !== undefined;
+
   useEffect(() => {
     if (!(editor && menuRef.current)) {
       return;
@@ -93,7 +103,7 @@ export function VizelBubbleMenu({
       editor,
       element: menuRef.current,
       updateDelay,
-      ...(shouldShowRef.current && {
+      ...(hasShouldShow && {
         shouldShow: ({ editor: e, from, to }) =>
           shouldShowRef.current?.({ editor: e, from, to }) ?? false,
       }),
@@ -116,7 +126,7 @@ export function VizelBubbleMenu({
       editor.unregisterPlugin(pluginKey);
       escapeController.unmount();
     };
-  }, [editor, pluginKey, updateDelay]);
+  }, [editor, pluginKey, updateDelay, hasShouldShow]);
 
   if (!editor) {
     return null;

--- a/packages/svelte/src/components/VizelBubbleMenu.svelte
+++ b/packages/svelte/src/components/VizelBubbleMenu.svelte
@@ -26,7 +26,6 @@ export interface VizelBubbleMenuProps {
 
 <script lang="ts">
 import { BubbleMenuPlugin, createVizelBubbleMenuEscapeController } from "@vizel/core";
-import { untrack } from "svelte";
 import VizelBubbleMenuDefault from "./VizelBubbleMenuDefault.svelte";
 import { getVizelContextSafe } from "./VizelContext.js";
 
@@ -53,17 +52,21 @@ $effect(() => {
   const currentEditor = editor;
   const currentPluginKey = pluginKey;
 
-  // Capture `shouldShow` without tracking so value updates flow through the
-  // wrapper closure (read lazily, outside any reactive context) without
-  // re-registering the plugin. Matches the React `shouldShowRef` pattern.
-  const initialShouldShow = untrack(() => shouldShow);
+  // Track `shouldShow` *presence* (not identity) so the effect re-runs when
+  // the prop toggles between `undefined` and a function. An identity-stable
+  // change of a continuously-defined `shouldShow` still flows through the
+  // wrapper closure without re-registering the plugin (the wrapper reads
+  // `shouldShow` lazily at fire time). The previous shape captured presence
+  // via `untrack(...)`, so toggling from `undefined` → defined silently
+  // skipped the wrapper and the reverse pinned the bubble menu hidden.
+  const hasShouldShow = shouldShow !== undefined;
 
   const plugin = BubbleMenuPlugin({
     pluginKey: currentPluginKey,
     editor: currentEditor,
     element: menuElement,
     updateDelay,
-    ...(initialShouldShow && {
+    ...(hasShouldShow && {
       shouldShow: ({ editor: e, from, to }) =>
         shouldShow?.({ editor: e as Editor, from, to }) ?? false,
     }),

--- a/packages/vue/src/components/VizelBubbleMenu.vue
+++ b/packages/vue/src/components/VizelBubbleMenu.vue
@@ -44,8 +44,16 @@ const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
 // `oldElement` check + a separate `onBeforeUnmount`) double-registered the
 // ProseMirror plugin on the first editor-resolve because the initial early
 // return left `oldElement` permanently undefined.
+// Track `shouldShow` *presence* (not identity) so the watcher re-registers
+// the plugin when the prop toggles between `undefined` and a function. An
+// identity-stable change of a continuously-defined `shouldShow` flows
+// through `props.shouldShow?.(...)` inside the wrapper without re-firing.
+// The previous shape registered the conditional `...(props.shouldShow && {...})`
+// spread once at plugin construction — toggling from `undefined` → defined
+// silently skipped the wrapper, and the reverse pinned the bubble menu
+// hidden.
 watch(
-  [editor, menuRef],
+  [editor, menuRef, () => props.shouldShow !== undefined],
   ([editorValue, element], _old, onCleanup) => {
     if (!(editorValue && element)) return;
 
@@ -54,7 +62,7 @@ watch(
       editor: editorValue,
       element,
       updateDelay: props.updateDelay,
-      ...(props.shouldShow && {
+      ...(props.shouldShow !== undefined && {
         shouldShow: ({ editor: e, from, to }) =>
           props.shouldShow?.({ editor: e as Editor, from, to }) ?? false,
       }),


### PR DESCRIPTION
## Summary

`VizelBubbleMenu` wired the consumer's `shouldShow` callback through a ref / reactive-prop closure so identity changes flowed without re-registering the underlying ProseMirror plugin. The outer guard, `...(shouldShow && { shouldShow: ... })`, was evaluated **once** at plugin construction, which left two transitions broken:

- `shouldShow` `undefined` → defined: the wrapper field was never installed, so the new callback never ran. Tiptap silently kept its default predicate.
- `shouldShow` defined → `undefined`: the previously installed wrapper kept calling `shouldShow?.(...) ?? false` (always `false`), pinning the bubble menu hidden until the parent unmounted.

Switch the guard to a presence check (`shouldShow !== undefined`) that flows into the effect / watch dependency list, so the plugin re-registers exactly when the prop crosses the `undefined` boundary. Identity changes of a continuously-defined callback still flow through the closure without re-registering.

Same fix in React, Vue, and Svelte — the bug existed identically in all three. Drop Svelte's `untrack` import that became unused after the change.

Found by a hostile React review during Round 11; verified the Vue and Svelte siblings shared the same shape before fixing.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Manual: render `<VizelBubbleMenu />` without `shouldShow`, then toggle the prop to a function — bubble menu predicate should switch on. Toggle back to `undefined` — bubble menu should fall back to Tiptap's default selection-based show.