### PR TITLE
fix(react,vue,svelte,core): drop duplicate id from VizelLinkEditor embed toggle

### DIFF
--- a/packages/core/src/styles/embed.scss
+++ b/packages/core/src/styles/embed.scss
@@ -235,20 +235,24 @@
 .vizel-link-editor-embed-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
   padding: 0.375rem 0;
   font-size: 0.75rem;
   color: v("muted-foreground");
+
+  // Nested label wraps the checkbox + caption so framework adapters
+  // can avoid `for`/`id` pairs (see `VizelLinkEditor.{tsx,vue,svelte}`).
+  .vizel-link-editor-embed-toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    user-select: none;
+  }
 
   input[type="checkbox"] {
     width: 14px;
     height: 14px;
     cursor: pointer;
-  }
-
-  label {
-    cursor: pointer;
-    user-select: none;
   }
 }
 

--- a/packages/react/src/components/VizelLinkEditor.tsx
+++ b/packages/react/src/components/VizelLinkEditor.tsx
@@ -173,13 +173,21 @@ export function VizelLinkEditor({
       </div>
       {viewState.showEmbedToggle && (
         <div className="vizel-link-editor-embed-toggle">
-          <input
-            type="checkbox"
-            id="vizel-embed-toggle"
-            checked={asEmbed}
-            onChange={(e) => setAsEmbed(e.target.checked)}
-          />
-          <label htmlFor="vizel-embed-toggle">{labels.embedAsRichContent}</label>
+          {/*
+            Wrap the input in the label so the click target is the same as
+            an `htmlFor`/`id` pair without needing a globally-unique DOM id.
+            Two link editors on one page (the bubble-menu instance plus a
+            custom toolbar instance) used to share `id="vizel-embed-toggle"`,
+            triggering the wrong checkbox under WCAG 4.1.1.
+          */}
+          <label className="vizel-link-editor-embed-toggle-label">
+            <input
+              type="checkbox"
+              checked={asEmbed}
+              onChange={(e) => setAsEmbed(e.target.checked)}
+            />
+            <span>{labels.embedAsRichContent}</span>
+          </label>
         </div>
       )}
     </form>

--- a/packages/svelte/src/components/VizelLinkEditor.svelte
+++ b/packages/svelte/src/components/VizelLinkEditor.svelte
@@ -160,12 +160,16 @@ function handleVisit() {
   </div>
   {#if viewState.showEmbedToggle}
     <div class="vizel-link-editor-embed-toggle">
-      <input
-        id="vizel-embed-toggle"
-        type="checkbox"
-        bind:checked={asEmbed}
-      />
-      <label for="vizel-embed-toggle">{labels.embedAsRichContent}</label>
+      <!--
+        Wrap the input in the label so the click target is the same as
+        a `for`/`id` pair without needing a globally-unique DOM id. Two
+        link editors on one page used to share `id="vizel-embed-toggle"`,
+        triggering the wrong checkbox under WCAG 4.1.1.
+      -->
+      <label class="vizel-link-editor-embed-toggle-label">
+        <input type="checkbox" bind:checked={asEmbed} />
+        <span>{labels.embedAsRichContent}</span>
+      </label>
     </div>
   {/if}
 </form>

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -164,12 +164,17 @@ function handleVisit() {
       </button>
     </div>
     <div v-if="viewState.showEmbedToggle" class="vizel-link-editor-embed-toggle">
-      <input
-        id="vizel-embed-toggle"
-        v-model="asEmbed"
-        type="checkbox"
-      />
-      <label for="vizel-embed-toggle">{{ labels.embedAsRichContent }}</label>
+      <!--
+        Wrap the input in the label so the click target is the same as
+        an `for`/`id` pair without needing a globally-unique DOM id.
+        Two link editors on one page used to share
+        `id="vizel-embed-toggle"`, triggering the wrong checkbox under
+        WCAG 4.1.1.
+      -->
+      <label class="vizel-link-editor-embed-toggle-label">
+        <input v-model="asEmbed" type="checkbox" />
+        <span>{{ labels.embedAsRichContent }}</span>
+      </label>
     </div>
   </form>
 </template>


### PR DESCRIPTION
## Summary

The link editor's embed toggle paired a hard-coded `id="vizel-embed-toggle"` on the checkbox with a matching `<label htmlFor>` / `for` reference. Two link editors on the same page (e.g. the bubble-menu instance plus a custom toolbar-driven instance, or React 19 strict-mode double-mount) produced duplicate DOM ids; clicking the label toggled whichever input the user agent matched first, and assistive tech announced both controls under the same accessible name. WCAG 4.1.1 (Parsing) flags this whenever duplicates occur.

Drop the `id`/`for` pair across all three frameworks and wrap the input inside the label so the click target stays identical without needing a globally-unique DOM id. Tweak `embed.scss` so the existing layout still holds: the gap moves from the outer container onto the new `.vizel-link-editor-embed-toggle-label` wrapper.

Found by a hostile React review during Round 12; verified Vue and Svelte siblings shared the same shape before fixing.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Manual: open two `<VizelLinkEditor>` instances on one page (or just trigger the bubble-menu link editor twice in React 19 strict mode) — embed checkbox should toggle independently per instance.