### PR TITLE
docs: add ADR-0001..0012 for v2 idiomatic-API breaking rebuild

### DIFF
--- a/docs/adr/ADR-0001-feature-parity-over-api-symmetry.md
+++ b/docs/adr/ADR-0001-feature-parity-over-api-symmetry.md
@@ -1,0 +1,57 @@
+# ADR-0001: Feature parity over API symmetry
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+Vizel v1 enforced API symmetry across React, Vue, and Svelte. Every component prop, hook or composable or rune name, return shape, and event payload had to mirror across packages. The intent was to ease cross-framework navigation. The result was the opposite: each framework lost its native idiom for the sake of a contract that no consumer ever asked to enforce.
+
+The audit of v1 confirms the harm:
+
+- Vue 3.5 uses `defineModel` in a single file. Every other component re-implements two-way binding via props + emit pairs.
+- Svelte 5 uses `Snippet` virtually nowhere. Render-prop semantics ship through component-constructor props, and events are forced to camelCase (`onClose`) instead of the Svelte 5 lowercase DOM-attribute convention.
+- React 19 over-uses `useImperativeHandle` to mirror Vue and Svelte ref patterns. Destructured-getter hooks (`const { current: editor } = useVizelEditor()`) sacrifice the React idiom of "the hook *is* the value".
+
+A symmetric API forces the same shape across three different runtime models. A native API lets each framework use what its 2025-era best practices already provide.
+
+## Decision
+
+Vizel v2 abandons API symmetry. The new contract has three binding mandates:
+
+- Vizel provides features to all three frameworks.
+- Each framework's API delivers that framework's best-in-class developer experience.
+- Feature parity is maintained across the three frameworks.
+
+Concretely:
+
+- The cross-framework rule that enforced symmetry retires (see [ADR-0006](./ADR-0006-retire-cross-framework-rule.md)).
+- The SSOT for parity becomes a typed feature manifest, verified in CI (see [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md)).
+- Each adapter expresses every feature in its framework's preferred shape (see [ADR-0004](./ADR-0004-per-framework-idiomatic-api.md)).
+
+## Consequences
+
+Positive:
+
+- Vue authors get `defineModel`, `defineExpose`, typed slots, `useId`, `useTemplateRef`, and generic SFCs.
+- Svelte authors get snippets, runes (`$state.raw`, `$bindable`), and lowercase events.
+- React authors get hooks-first state subscription, standard `forwardRef`, and selector-style re-render control.
+- Component size shrinks because logic that previously duplicated across frameworks moves into `@vizel/core` and `@vizel/headless`.
+
+Negative:
+
+- Documentation must be authored per framework instead of once with cross-links.
+- Cross-framework navigation requires a translation step the parity manifest provides.
+- The migration from v1 demands a guide that maps every old name to every new shape.
+
+Follow-up:
+
+- Implement the feature manifest before any adapter rewrite begins.
+- Write `docs/guide/migration-v1-to-v2.md` enumerating every breaking change with side-by-side code samples.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md`
+- Superseded: `.claude/rules/cross-framework.md`
+- Related: [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md), [ADR-0004](./ADR-0004-per-framework-idiomatic-api.md), [ADR-0005](./ADR-0005-v2-breaking-release.md), [ADR-0006](./ADR-0006-retire-cross-framework-rule.md)

--- a/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
+++ b/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
@@ -1,0 +1,45 @@
+# ADR-0002: Feature manifest as parity SSOT
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+[ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md) removes API symmetry as a binding rule but keeps feature parity. Parity requires a Single Source of Truth (SSOT) that lists every advertised feature and asserts that each adapter implements it.
+
+v1 expressed this contract in prose under `.claude/rules/cross-framework.md` (472 lines). Prose drifts. Reviewers must read the rules and compare them with code. CI cannot enforce the link.
+
+## Decision
+
+The parity SSOT moves into TypeScript as `packages/core/src/feature-manifest.ts`. The manifest is a frozen array of typed feature definitions:
+
+- Each entry carries an `id` (`"bubble-menu"`, `"slash-menu"`, etc.), a `category`, an optional spec builder reference, an optional controller factory reference, an ARIA contract, a keyboard map, and the list of test scenarios that cover it.
+- Each entry also declares the expected adapter symbol for React, Vue, and Svelte (component name, optional hook or composable or rune name).
+- The manifest is the authoritative parity contract. The TypeScript type system enforces structural integrity at compile time. A CI script (`scripts/check-parity.ts`) enforces cross-package coverage at build time.
+
+The CI script imports the manifest, then dynamically imports the declared symbol from each of `@vizel/react`, `@vizel/vue`, and `@vizel/svelte`. Missing entries fail the build. The script runs on `pre-push` and as a CI job before the test matrix.
+
+## Consequences
+
+Positive:
+
+- Parity drift cannot land. CI fails before the matrix tests even run.
+- The manifest doubles as documentation. New contributors find the feature catalogue in a single typed module.
+- The manifest drives test coverage: every entry links to scenario files under `tests/ct/scenarios/<feature-id>/`.
+
+Negative:
+
+- Adding a feature requires touching the manifest, every adapter, and the scenario folder. The cost is intentional; it prevents partial implementations from shipping.
+- Manifest schema changes require coordinated updates across all adapters in the same pull request.
+
+Follow-up:
+
+- Implement `feature-manifest.ts` in Phase 1.
+- Implement `scripts/check-parity.ts` and wire it into lefthook + CI.
+- Delete `.claude/rules/cross-framework.md` as part of the same pull request (see [ADR-0006](./ADR-0006-retire-cross-framework-rule.md)).
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (Phase 1, R2)
+- Related: [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md), [ADR-0006](./ADR-0006-retire-cross-framework-rule.md), [ADR-0012](./ADR-0012-playwright-ct-three-layer-rebuild.md)

--- a/docs/adr/ADR-0003-vizel-headless-package.md
+++ b/docs/adr/ADR-0003-vizel-headless-package.md
@@ -1,0 +1,59 @@
+# ADR-0003: `@vizel/headless` as a transitive package
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+v1 framework adapters re-implement the same UI primitives in three places: combobox keyboard navigation, popover positioning, dismissable layers (outside-click plus Escape), focus traps, and floating positioning. The audit counts 21 direct `document.addEventListener` calls inside framework components, every one of them banned by the architecture rule and propagated through copy-paste.
+
+The framework-neutral primitives must live in a single place so the adapters cannot re-implement them.
+
+## Decision
+
+Vizel v2 introduces a new package, `@vizel/headless`, that exports framework-neutral UI primitives:
+
+- `combobox/` — typeahead and roving tabindex for autocomplete-style menus.
+- `popover/` — positioning, dismissal, and portal target.
+- `dismissable/` — click-outside + Escape + focus return. Owns the listeners that used to land in framework components.
+- `focus-trap/` — focus boundary.
+- `floating/` — `@floating-ui/dom` wrapper.
+- `keyboard/` — list navigation, typeahead, roving tabindex helpers.
+
+Each primitive ships as `{ buildSpec, createController }`. The package depends only on pure DOM APIs; it imports no framework runtime.
+
+`@vizel/headless` is declared as a dependency (not a peer dependency) of every adapter package. Consumers do not declare it directly. From the consumer's perspective the package is transitive:
+
+```
+consumer/package.json
+└── "@vizel/react": "2.0.0"        ← only declared dep
+
+   @vizel/react@2.0.0
+   └── dependencies:
+       ├── @vizel/core: "2.0.0"
+       └── @vizel/headless: "2.0.0"  ← transitive, resolved by the package manager
+```
+
+## Consequences
+
+Positive:
+
+- The 21 `document.addEventListener` violations in adapter code collapse to zero. Listeners live in `dismissable/` and are mounted by the framework's lifecycle hook.
+- Each adapter shrinks: shared UI logic moves out of components.
+- Future support for additional frameworks (Solid, Qwik) becomes cheaper. The primitives already exist.
+
+Negative:
+
+- One more package to release in lockstep. Phase 5 publish coordinates `@vizel/core`, `@vizel/headless`, and the three adapters.
+- The primitives must be tree-shakeable. The package does not export barrel files; adapters import each primitive directly to keep bundle size low.
+
+Follow-up:
+
+- Phase 2 scaffolds the package and migrates the primitives one at a time.
+- Unit tests in `packages/headless/` cover each primitive before any adapter consumes it.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (Phase 2)
+- Related: [ADR-0007](./ADR-0007-component-size-and-controller-delegation.md), [ADR-0008](./ADR-0008-css-belongs-in-core.md)

--- a/docs/adr/ADR-0004-per-framework-idiomatic-api.md
+++ b/docs/adr/ADR-0004-per-framework-idiomatic-api.md
@@ -1,0 +1,64 @@
+# ADR-0004: Per-framework idiomatic API contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+[ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md) commits Vizel v2 to per-framework idiomatic APIs. This record names the specific idioms each adapter adopts.
+
+## Decision
+
+### `@vizel/react` (React 19)
+
+- Hooks-first. Components are functional. Refs use `React.Ref<HTMLElement>`; the custom `VizelEditorRef` retires.
+- `useVizelEditor(options): Editor | null` returns the editor directly. No destructured-getter wrappers.
+- `useVizelEditorState<T>(selector, { equalityFn? }): T` is the selector subscription primitive. Implementation uses `useSyncExternalStore` (see [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)).
+- Imperative APIs surface through `forwardRef`.
+- Render-props use React's standard pattern: `children` of type `(props) => ReactNode`, or named function props.
+
+### `@vizel/vue` (Vue 3.5)
+
+- SFCs with `<script setup lang="ts">`.
+- Two-way state surfaces via `defineModel<T>("name")`.
+- Imperative APIs surface via `defineExpose({...})`.
+- Scoped slots are typed with `defineSlots<...>()`.
+- ID generation uses `useId()` for SSR-safe ARIA identifiers.
+- Refs use `useTemplateRef<T>("name")`.
+- Generic SFCs use `<script setup lang="ts" generic="T">`.
+- The editor context binds through a typed `InjectionKey<ShallowRef<Editor | undefined>>`.
+
+### `@vizel/svelte` (Svelte 5)
+
+- Runes (`$state.raw`, `$derived`, `$effect`, `$bindable`) replace Svelte 4 idioms.
+- The editor lives in `$state.raw<Editor | null>`. Re-assignment triggers reactivity; field mutation does not, which matches Tiptap's mutable Editor instance.
+- Selector subscription uses `createSubscriber` from `svelte/reactivity` (see [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)).
+- Two-way state uses `$bindable()`.
+- Render-props use `{#snippet}` with `Snippet<[Ctx]>`-typed parameters.
+- All callback props use lowercase DOM-attribute names: `onclose`, `onselect`, `onsubmit`.
+- Imperative APIs surface via `bind:this` on the component plus Svelte 5's component-export pattern.
+- Context binds through typed `setVizelContext` / `getVizelContext` wrappers around `setContext` / `getContext`.
+
+## Consequences
+
+Positive:
+
+- Each adapter feels native. Reviewers familiar with the framework recognise the patterns immediately.
+- Adapter code shrinks because logic that previously simulated foreign idioms moves into Core and Headless.
+- Per-framework tooling (Volar for Vue, the Svelte language server, React DevTools) integrates correctly because the code follows the framework's expected shape.
+
+Negative:
+
+- The migration from v1 demands per-framework documentation and code-mod recipes.
+- Reviewers need familiarity with all three frameworks to assess cross-cutting changes. The feature manifest mitigates this by encoding parity in TypeScript.
+
+Follow-up:
+
+- Phase 3a, 3b, and 3c rewrite each adapter according to this contract.
+- Update `.claude/rules/packages/{react,vue,svelte}.md` to document the binding idioms.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R3)
+- Related: [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md), [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)

--- a/docs/adr/ADR-0005-v2-breaking-release.md
+++ b/docs/adr/ADR-0005-v2-breaking-release.md
@@ -1,0 +1,47 @@
+# ADR-0005: v2.0.0 as a breaking release
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+Vizel v1 is published on npm. v1 consumers depend on the symmetric API, the legacy `VizelEditorRef` type, the per-feature state hooks, and the v1 CSS surface. Carrying any of these forward into v2 would compromise every other v2 decision.
+
+The maintainer's directive is explicit: "後方互換性は一切放棄". v2 is a clean break.
+
+## Decision
+
+Vizel v2.0.0 is a breaking release. The repository declares it as such across every package. No compatibility shim ships.
+
+Concretely:
+
+- Every `package.json` under `packages/` bumps to `2.0.0`.
+- The v1 surface (`VizelEditorRef`, per-feature state hooks, symmetric prop names, camelCase Svelte events) is removed, not deprecated.
+- `docs/guide/migration-v1-to-v2.md` is the single migration artefact. It enumerates every breaking change and provides side-by-side code samples per framework.
+- v1.x continues to exist on npm at its published versions. v2.0.0 publishes under the default `latest` dist-tag. v1 receives no further patches.
+- Publishing v2.0.0 requires explicit maintainer approval. The release pipeline never auto-publishes.
+
+## Consequences
+
+Positive:
+
+- Every other ADR can make optimal choices unconstrained by compatibility.
+- The codebase shrinks because the deprecated paths disappear.
+- The mental model simplifies: one supported version, one set of idioms.
+
+Negative:
+
+- v1 consumers must read the migration guide and rewrite call sites. The guide must cover every breaking change.
+- Until the guide lands, early-adopter feedback risks being dominated by "how do I migrate" questions. Phase 4 prioritises the guide before publish (Phase 5).
+
+Follow-up:
+
+- Phase 4 writes `docs/guide/migration-v1-to-v2.md` covering every breaking change identified across ADR-0001 through ADR-0009.
+- Phase 5 coordinates the v2.0.0 publish across `@vizel/core`, `@vizel/headless`, `@vizel/react`, `@vizel/vue`, and `@vizel/svelte`.
+- The release-notes commit explicitly states that v1 receives no further patches.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md`
+- Related: every other ADR in this directory.

--- a/docs/adr/ADR-0006-retire-cross-framework-rule.md
+++ b/docs/adr/ADR-0006-retire-cross-framework-rule.md
@@ -1,0 +1,43 @@
+# ADR-0006: Retire `cross-framework.md`
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+`.claude/rules/cross-framework.md` (472 lines) was v1's SSOT for cross-framework consistency. It enforced API symmetry through prose tables: identical component names, identical props, identical hook signatures, identical event payloads across React, Vue, and Svelte.
+
+[ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md) drops the symmetry requirement. [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md) moves the parity SSOT into TypeScript. `cross-framework.md` has no remaining purpose.
+
+## Decision
+
+Delete `.claude/rules/cross-framework.md`. Replace it with `.claude/rules/feature-manifest.md`, which describes how to add, modify, and verify entries in `packages/core/src/feature-manifest.ts`.
+
+The deletion lands in the same pull request that introduces the feature manifest (Phase 1). The new `feature-manifest.md` includes:
+
+- The schema for `VizelFeatureDefinition`.
+- The workflow for adding a feature (manifest entry → adapter implementations → scenarios → parity check).
+- The workflow for modifying a feature (update manifest → coordinated adapter changes → scenario updates).
+- The CI verification commands (`pnpm check:parity`, `pnpm test:ct:parity`).
+
+## Consequences
+
+Positive:
+
+- The 472-line prose rule retires. Reviewers no longer read three documents to verify a single change.
+- The parity contract becomes type-checked. The TypeScript compiler enforces structural integrity at edit time, not at review time.
+
+Negative:
+
+- The deletion is a hard break for anyone who linked to `cross-framework.md` in prior discussions. The replacement `feature-manifest.md` covers the same intent in a different shape.
+
+Follow-up:
+
+- Phase 1 lands the deletion alongside the manifest.
+- ADR-0005's migration guide notes the rule retirement for anyone navigating from v1 documentation.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (Phase 1)
+- Related: [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md), [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md), [ADR-0010](./ADR-0010-claude-config-official-format.md)

--- a/docs/adr/ADR-0007-component-size-and-controller-delegation.md
+++ b/docs/adr/ADR-0007-component-size-and-controller-delegation.md
@@ -1,0 +1,44 @@
+# ADR-0007: 120-line component size rule and controller delegation
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+The v1 audit shows that 65 percent of framework components exceed 120 view-template lines. `VizelBubbleMenu.vue` reaches 200+ lines. `VizelLinkEditor.tsx` reaches 195+. Every overflow case contains the same pattern: framework code that should delegate to a controller re-implements DOM listeners, ARIA wiring, keyboard maps, dismiss logic, and focus management inline.
+
+The architecture rule already forbids direct `document.addEventListener` calls in framework components. The rule went unenforced: 21 violations remain across the three adapters.
+
+## Decision
+
+v2 introduces two binding constraints:
+
+1. **Every adapter component file stays at or under 120 view-template lines.** "View-template lines" means JSX, template, or `.svelte` markup lines; `<script>` declarations count separately. CI fails the build when any component exceeds the limit. The limit applies to the file's view block, not its supporting hooks or composables.
+2. **Adapter components delegate all global side effects to a controller.** A "controller" comes from `@vizel/core/controllers/` or `@vizel/headless/`. Controllers expose `{ mount(target), unmount(), update(args) }`. Adapter code passes an element into a controller and lets the controller own the listener, the positioning, and the focus return.
+
+Direct calls to `document.addEventListener`, `window.addEventListener`, `MutationObserver`, or `ResizeObserver` inside `packages/{react,vue,svelte}/src/` are forbidden. CI enforces the rule with `grep`.
+
+## Consequences
+
+Positive:
+
+- Adapter files become readable in a single screen. New contributors orient in seconds.
+- Listener cleanup centralises. Memory leaks become a controller bug, not a framework bug.
+- Cross-framework parity becomes easier because the controllers do the heavy lifting once.
+
+Negative:
+
+- Logic that previously lived in `<script>` blocks must move into Core. Phase 3 sub-phases carry this cost up front.
+- The 120-line audit script fails the build immediately on overflow. Authors must split files or extract logic instead of letting overflow accumulate.
+
+Follow-up:
+
+- Phase 2 lands the headless controllers that absorb the 21 violations.
+- Phase 3a, 3b, and 3c rewrite each adapter against the size rule.
+- CI adds a `view-lines` check that runs on every pull request.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R3, R4)
+- Related: [ADR-0003](./ADR-0003-vizel-headless-package.md), [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)

--- a/docs/adr/ADR-0008-css-belongs-in-core.md
+++ b/docs/adr/ADR-0008-css-belongs-in-core.md
@@ -1,0 +1,50 @@
+# ADR-0008: CSS belongs in `@vizel/core`; adapters re-export
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+v1 ships CSS per adapter. Each adapter exports `styles.css` independently. The three files duplicate the same token catalogue and component rules, which means a token change requires three coordinated edits.
+
+The maintainer's directive: "CSSのスタイリングなどは各フレームワークのパッケージではなく共通のパッケージで管理したい".
+
+## Decision
+
+The CSS source of truth lives in `@vizel/core/styles.css`. Every adapter package declares an `exports."./styles.css"` entry in its `package.json` that resolves to the Core file. Consumers continue to write a single import:
+
+```ts
+import "@vizel/react/styles.css";   // resolves to @vizel/core/styles.css
+```
+
+The CSS catalogue ships under exactly two top-level selectors plus the `prefers-color-scheme: dark` fallback for unset themes:
+
+- `:root, [data-vizel-theme="light"]`
+- `[data-vizel-theme="dark"]`
+- `@media (prefers-color-scheme: dark)` fallback
+
+Host-environment selectors (`.dark`, `.light`, `[data-theme="*"]`) remain banned. Host theming integrates by setting `data-vizel-theme` on a wrapper element; Vizel never reads host theme attributes.
+
+## Consequences
+
+Positive:
+
+- A token edit touches one file. The three adapter packages stay in lockstep automatically.
+- Bundle size drops because consumers no longer pay for three near-identical stylesheets.
+- The CSS catalogue documents itself: the variables, components, and themes live where the engine lives.
+
+Negative:
+
+- Adapter packages must keep their `exports."./styles.css"` re-export pointing at the Core file. A package-manager hoisting failure could break the resolution; the build verifies that `@vizel/{react,vue,svelte}/styles.css` resolves to a file that contains the Core sentinel comment.
+- Authors adding component CSS must do so in `@vizel/core`, not in their adapter package.
+
+Follow-up:
+
+- Phase 1 (or earlier) updates each adapter's `package.json` exports to point at Core.
+- Phase 2 (headless extraction) keeps CSS in Core; the headless package ships no CSS of its own.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R6)
+- Related: [ADR-0003](./ADR-0003-vizel-headless-package.md)

--- a/docs/adr/ADR-0009-first-party-editor-reactivity.md
+++ b/docs/adr/ADR-0009-first-party-editor-reactivity.md
@@ -1,0 +1,50 @@
+# ADR-0009: First-party editor reactivity in every adapter
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+Tiptap ships official framework integrations for React (`@tiptap/react`) and Vue (`@tiptap/vue-3`). Both packages export `useEditor` and `useEditorState({ editor, selector, equalityFn? })`. No official Svelte integration exists; the community option `svelte-tiptap` targets Tiptap v2 and Svelte 4.
+
+Two options exist for v2:
+
+- Depend on `@tiptap/react` and `@tiptap/vue-3` for React and Vue; implement Svelte natively.
+- Implement reactivity natively in every adapter.
+
+The maintainer's directive: "3FW 全て Vizel 独自実装".
+
+## Decision
+
+Vizel v2 implements editor reactivity natively in every adapter. The only Tiptap runtime dependencies live in `@vizel/core` and are `@tiptap/core`, `@tiptap/pm`, and the per-feature `@tiptap/extension-*` packages. `@tiptap/react` and `@tiptap/vue-3` are not depended on anywhere in the repository.
+
+Per-adapter implementation:
+
+- **React 19**: `packages/react/src/_reactivity.ts` provides a `useSyncExternalStore`-backed editor store. `subscribe` attaches `editor.on('transaction')` and returns a cleanup. `getSnapshot` returns a monotonic version counter so the selector re-evaluates. `getServerSnapshot` returns `null` for SSR safety. `useVizelEditor` and `useVizelEditorState(selector, { equalityFn? })` share this store.
+- **Vue 3.5**: `packages/vue/src/_reactivity.ts` holds the editor in `shallowRef<Editor | undefined>` and re-assigns on transaction. The transaction listener attaches inside the composable and detaches in `onScopeDispose`. The composable users cannot leak listeners.
+- **Svelte 5**: `packages/svelte/src/runes/createVizelEditor.ts` holds the editor in `$state.raw<Editor | null>`. Selector subscription uses `createSubscriber` from `svelte/reactivity`, which hooks `editor.on('transaction')` once and registers dependencies through the rune system. `editor.state(selector)` returns a getter that re-runs the selector on every transaction.
+
+## Consequences
+
+Positive:
+
+- Reactivity semantics stay under Vizel's control. SSR boundaries, selector semantics, and cleanup behave identically across adapters because Vizel writes the same contract three times.
+- The Tiptap dependency surface shrinks. The runtime closure no longer pulls in two framework integrations the project does not consume.
+- The Svelte implementation is no longer the divergent case. Every adapter follows the same "first-party reactivity" pattern.
+
+Negative:
+
+- Vizel must track Tiptap's React and Vue integrations for performance improvements (e.g., `shouldRerenderOnTransaction: false` semantics) and port them into `_reactivity.ts`. The maintenance cost is real.
+- Tearing-safety under React 19 concurrent rendering depends on getting the `useSyncExternalStore` contract right. Phase 3a's tests cover transaction interleaving explicitly.
+
+Follow-up:
+
+- Phase 3a and 3b implement `_reactivity.ts` in their respective adapters. Phase 3c relies on `createSubscriber`.
+- A quarterly review of Tiptap's React and Vue changelogs identifies performance work to port.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R3, Phase 3)
+- External: [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore), [`svelte/reactivity` `createSubscriber`](https://svelte.dev/docs/svelte/svelte-reactivity)
+- Related: [ADR-0004](./ADR-0004-per-framework-idiomatic-api.md), [ADR-0007](./ADR-0007-component-size-and-controller-delegation.md)

--- a/docs/adr/ADR-0010-claude-config-official-format.md
+++ b/docs/adr/ADR-0010-claude-config-official-format.md
@@ -1,0 +1,53 @@
+# ADR-0010: `.claude/` artefacts follow Anthropic's official reference
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+The `.claude/` directory contains skills, subagents, rules, and settings that drive how Claude Code interacts with this repository. v1's artefacts mix official conventions with bespoke patterns:
+
+- Skills declare `description` but omit `when_to_use` and `paths:`.
+- The subagent declares `name`, `description`, `tools` but omits `disallowedTools`, `color`, `model`, and `memory`.
+- Rule files use the official auto-discovery mechanism (`paths:`) but several files omit the frontmatter.
+- The custom skill `lint-instructions` enumerates rule contents that the auto-discovery mechanism would surface naturally.
+
+The maintainer's directive: "`.claude/` 配下も対象にしてください。公式リファレンスに沿った適切な形式でなければなりません".
+
+## Decision
+
+Every file under `.claude/` conforms to the latest official Claude Code specification. Bespoke conventions remain only when a documented exception applies.
+
+Concrete rules:
+
+- **Skills** (`.claude/skills/<name>/SKILL.md`) carry `name`, `description`, `when_to_use`, and `paths:` (when path-scoped). Supporting files use the documented structure (`reference.md`, `examples.md`, `scripts/`). The combined `description` + `when_to_use` fits within 1,536 characters. Manual-only skills declare `disable-model-invocation: true`.
+- **Subagents** (`.claude/agents/<name>.md`) declare `name`, `description`, `tools` (or omit for inherit-all), and SHOULD declare `disallowedTools`, `model`, `color`, `memory`, and `isolation` when the use case calls for them. The system-prompt body stays task-specific and concise (≤80 lines). Detailed reference defers to `.claude/rules/*.md`.
+- **Rules** (`.claude/rules/**/*.md`) carry `paths:` frontmatter for path-scoped rules. Always-on rules omit `paths:` and load with the same priority as `CLAUDE.md`. `CLAUDE.md` lists the rules in a table but never duplicates rule content.
+- **Settings** (`.claude/settings.json`, `.claude/settings.local.json`) declare `$schema`. Claude-Code-aware hooks live under `.claude/settings.json` `hooks`. Project-wide git hooks remain in `lefthook.yml`. The split is explicit and documented in this ADR.
+- **Slash commands**: absent. Vizel uses skills, which the official guidance prefers for new authoring.
+
+## Consequences
+
+Positive:
+
+- `.claude/` artefacts work the same way for every contributor and on every machine. No bespoke loader is required.
+- Path-scoped rules and skills load only when relevant, which reduces context cost on unrelated edits.
+- The subagent frontmatter unlocks read-only enforcement (`disallowedTools`), cumulative learning (`memory`), and isolation (`isolation: worktree`).
+
+Negative:
+
+- Existing skill bodies must split into `SKILL.md` + `reference.md` + `examples.md`. The migration is a Phase 0b task.
+- Hooks are split between `.claude/settings.json` (Claude-Code-aware) and `lefthook.yml` (git-aware). Contributors must know which file owns which hook. This ADR records the split.
+
+Follow-up:
+
+- Phase 0b rewrites every `.claude/` artefact to match this ADR.
+- `CLAUDE.md` becomes a slim index that references rules, skills, subagents, and settings tables.
+- The new `.claude/rules/writing.md` (see [ADR-0011](./ADR-0011-technical-writing-style.md)) carries `paths:` covering all source and documentation files.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R7, Phase 0b)
+- External: [Claude Code Skills reference](https://docs.anthropic.com/), [Claude Code Subagents reference](https://docs.anthropic.com/)
+- Related: [ADR-0011](./ADR-0011-technical-writing-style.md)

--- a/docs/adr/ADR-0011-technical-writing-style.md
+++ b/docs/adr/ADR-0011-technical-writing-style.md
@@ -1,0 +1,57 @@
+# ADR-0011: Technical-writing style governs every artefact
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+v1 artefacts drift in tone. Some source comments narrate the code instead of the rationale. Some doc pages slip into passive voice. Some commit messages use past tense and end with periods. The global `~/.claude/CLAUDE.md` already prescribes a single technical-writing standard, but the repository never codified it.
+
+The maintainer's directive: "全ファイルの文章はテクニカルライティングの文体としてください。各種ドキュメントファイルからソースコードのコメントまで含みます".
+
+## Decision
+
+Vizel adopts a single technical-writing standard for every authored artefact: source-code comments, JSDoc, README files, design documents, ADRs, migration guides, demo descriptions, commit messages, pull-request bodies, and rule files under `.claude/rules/**`.
+
+The standard codifies into `.claude/rules/writing.md` with `paths:` frontmatter that auto-loads the rule whenever any source, test, or doc file is edited.
+
+Binding principles:
+
+- One idea per sentence. Remove filler words.
+- Avoid ambiguous pronouns (`it`, `this`, `that`); name the noun.
+- Define abbreviations at first use, e.g. `Application Programming Interface (API)`.
+- Use the active voice ("The function throws ValidationError" instead of "ValidationError is thrown by the function").
+- Use the present tense in comments and docstrings.
+- Make the subject explicit.
+- Start function or class docstrings with a verb in the infinitive form ("Return the merged Markdown").
+- Comments explain *why*, not *what*. Skip self-evident comments. Reference the cause (a constraint, a past bug, an external standard) when relevant; do not narrate the code.
+- Commit messages and pull-request titles follow Conventional Commits (`<type>(<scope>): <description>`); the subject is imperative, lower-case, no trailing period, ≤72 characters.
+- Markdown documents use a hierarchical heading structure and avoid passive constructions.
+
+Mechanical enforcement runs through Biome (line length, formatting), lefthook (`commit-msg` Conventional Commits check), and CI (lint job). Semantic enforcement happens at code review; reviewers cite the rule when they request changes.
+
+## Consequences
+
+Positive:
+
+- Documentation tone stabilises. Reviewers gain a concrete reference instead of an implicit standard.
+- New contributors find the writing rules in the same place they find the architecture rules.
+- The `paths:` frontmatter on `.claude/rules/writing.md` keeps the rule in Claude Code's context whenever an editable file is open, which prevents drift during long sessions.
+
+Negative:
+
+- Existing artefacts that violate the rules must be updated. The migration to v2 absorbs most of these updates because Phase 3 rewrites adapter code wholesale; older docs are revisited in Phase 4.
+- Reviewers need to spot semantic violations the formatter cannot catch (passive voice, narrative comments, ambiguous pronouns). The rule itself serves as the checklist.
+
+Follow-up:
+
+- Phase 0b writes `.claude/rules/writing.md`.
+- Phase 4 rewrites `docs/guide/` and `docs/api/` against the rule.
+- The migration guide notes that v2 doc tone tightens; v1 doc passages do not carry over verbatim.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R8)
+- External: `~/.claude/CLAUDE.md` (the global standard this ADR codifies for Vizel)
+- Related: [ADR-0010](./ADR-0010-claude-config-official-format.md)

--- a/docs/adr/ADR-0012-playwright-ct-three-layer-rebuild.md
+++ b/docs/adr/ADR-0012-playwright-ct-three-layer-rebuild.md
@@ -1,0 +1,45 @@
+# ADR-0012: Playwright Component Tests rebuilt in three layers
+
+- **Status**: Accepted
+- **Date**: 2026-05-28
+- **Targets**: v2.0.0
+
+## Context
+
+The v1 Playwright Component Tests (CT) layout shares 32 `.scenario.ts` files across React, Vue, and Svelte. The shared scenarios bake in API-symmetry assumptions: identical event names, identical prop shapes, identical ref patterns. [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md) drops symmetry, so the v1 scenario contract no longer fits.
+
+Patching the v1 scenarios to handle per-framework variation would erode the value of "shared" scenarios while keeping the maintenance cost. A clean rebuild is cheaper than a series of compromises.
+
+## Decision
+
+Rebuild the Playwright CT in three layers:
+
+- **`tests/ct/scenarios/<feature-id>/`** — framework-neutral assertions driven by `VIZEL_FEATURE_MANIFEST`. Each scenario describes *what* a feature must deliver: DOM nodes, ARIA attributes, keyboard interactions, Markdown round-trip outputs, focus transitions. Per-framework spec files call into these scenarios via a framework-specific mount helper and an interaction helper. Scenario assertions live at the rendered-DOM level, not the API-shape level.
+- **`tests/ct/<framework>/<feature-id>.spec.{tsx,ts}`** — framework-idiomatic harness. The harness mounts the component using the framework's idiomatic API (`v-model` for Vue, `bind:markdown` for Svelte, hooks plus refs for React) and runs the shared scenario. The harness also asserts API-shape correctness for that framework (e.g. `defineModel<string>("markdown")` round-trips, Svelte's `onclose` fires, React's selector subscription skips re-renders on irrelevant transactions).
+- **`tests/ct/parity/<feature-id>.parity.ts`** — manifest-driven parity check. Reads `VIZEL_FEATURE_MANIFEST`, asserts every entry has scenario coverage on every framework, fails CI on drift.
+
+The v1 `tests/ct/scenarios/*.scenario.ts` files are removed, not migrated. The v1 file list serves only as a behavioural reference for which DOM/ARIA outcomes the v2 scenarios must cover.
+
+## Consequences
+
+Positive:
+
+- Per-framework spec files own the framework-idiomatic harness. Shared scenarios focus on what a feature must deliver, not how each framework calls into it.
+- Parity stays observable. The `parity/` layer fails CI if a framework omits a feature.
+- Adapter rewrites in Phase 3 plug into the scenarios cleanly because the scenarios assert rendered behaviour, not API shape.
+
+Negative:
+
+- Existing v1 spec files do not migrate as-is. Phase 3a, 3b, and 3c rewrite each adapter's spec layer against the new scenarios.
+- The CT directory grows a third layer. The rule file `.claude/rules/testing.md` is rewritten to explain the three-layer split.
+
+Follow-up:
+
+- Phase 1.5 lands the scenario foundation before any adapter rewrite consumes it.
+- Phase 3a, 3b, and 3c rewrite each adapter's spec files against the scenarios.
+- Phase 5 adds a CI job for `pnpm test:ct:parity`.
+
+## References
+
+- Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R9, Phase 1.5)
+- Related: [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md), [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,53 @@
+# Architecture Decision Records
+
+This directory records the architectural decisions that shape Vizel v2.0.0. Each record documents the context that motivated the decision, the decision itself, and the consequences that follow.
+
+## Conventions
+
+- Records use the `ADR-NNNN-kebab-case-title.md` naming pattern. `NNNN` is a four-digit number that increases monotonically.
+- Status values are `Proposed`, `Accepted`, `Superseded`, or `Deprecated`. A superseded record links forward to the record that replaces it.
+- Records describe one decision each. Bundle related decisions into separate records and cross-link.
+- Records remain immutable after acceptance. Subsequent changes land as new records that supersede earlier ones.
+
+## Index
+
+| ID | Title | Status |
+|----|-------|--------|
+| [ADR-0001](./ADR-0001-feature-parity-over-api-symmetry.md) | Feature parity over API symmetry | Accepted |
+| [ADR-0002](./ADR-0002-feature-manifest-as-parity-ssot.md) | Feature manifest as parity SSOT | Accepted |
+| [ADR-0003](./ADR-0003-vizel-headless-package.md) | `@vizel/headless` as a transitive package | Accepted |
+| [ADR-0004](./ADR-0004-per-framework-idiomatic-api.md) | Per-framework idiomatic API contract | Accepted |
+| [ADR-0005](./ADR-0005-v2-breaking-release.md) | v2.0.0 as a breaking release | Accepted |
+| [ADR-0006](./ADR-0006-retire-cross-framework-rule.md) | Retire `cross-framework.md` | Accepted |
+| [ADR-0007](./ADR-0007-component-size-and-controller-delegation.md) | 120-line component size rule and controller delegation | Accepted |
+| [ADR-0008](./ADR-0008-css-belongs-in-core.md) | CSS belongs in `@vizel/core`; adapters re-export | Accepted |
+| [ADR-0009](./ADR-0009-first-party-editor-reactivity.md) | First-party editor reactivity in every adapter | Accepted |
+| [ADR-0010](./ADR-0010-claude-config-official-format.md) | `.claude/` artefacts follow Anthropic's official reference | Accepted |
+| [ADR-0011](./ADR-0011-technical-writing-style.md) | Technical-writing style governs every artefact | Accepted |
+| [ADR-0012](./ADR-0012-playwright-ct-three-layer-rebuild.md) | Playwright Component Tests rebuilt in three layers | Accepted |
+
+## Template
+
+```markdown
+# ADR-NNNN: Title in sentence case
+
+- **Status**: Proposed | Accepted | Superseded | Deprecated
+- **Date**: YYYY-MM-DD
+- **Targets**: vN.M (release that adopts the decision)
+
+## Context
+
+Describe the problem, the constraints, and the prior state. State the forces in play.
+
+## Decision
+
+State the decision in the active voice. One paragraph, then bullets that enumerate the binding rules.
+
+## Consequences
+
+List the trade-offs the decision accepts. Separate positive and negative outcomes. Identify follow-up work and risks.
+
+## References
+
+Link to the plan, related ADRs, external standards, and prior discussions.
+```


### PR DESCRIPTION
## Summary

- Land the twelve architecture decision records that govern the v2.0.0 rewrite.
- Establish the binding contract for every subsequent phase (0b through 5).
- Cover the major decisions: feature parity over symmetry, feature-manifest SSOT, `@vizel/headless` extraction, per-framework idiomatic API, breaking release policy, cross-framework rule retirement, component-size rule, CSS centralisation, first-party reactivity, `.claude/` official format compliance, technical-writing style, and the Playwright CT three-layer rebuild.

## Records added

| ID | Title |
|----|-------|
| ADR-0001 | Feature parity over API symmetry |
| ADR-0002 | Feature manifest as parity SSOT |
| ADR-0003 | `@vizel/headless` as a transitive package |
| ADR-0004 | Per-framework idiomatic API contract |
| ADR-0005 | v2.0.0 as a breaking release |
| ADR-0006 | Retire `cross-framework.md` |
| ADR-0007 | 120-line component size rule and controller delegation |
| ADR-0008 | CSS belongs in `@vizel/core`; adapters re-export |
| ADR-0009 | First-party editor reactivity in every adapter |
| ADR-0010 | `.claude/` artefacts follow Anthropic's official reference |
| ADR-0011 | Technical-writing style governs every artefact |
| ADR-0012 | Playwright Component Tests rebuilt in three layers |

## Breaking Changes

None in this pull request. The ADRs document the upcoming breaking changes that subsequent phases implement. The implementation work lands in follow-up pull requests per phase.

## Test Plan

- [x] Run `pnpm lint`.
- [x] No source changes; typecheck and CT remain unaffected.
- [x] Verify ADR Markdown renders correctly under VitePress (covered in Phase 4 docs rewrite).
