### PR TITLE
chore: align .claude/ artefacts with official Claude Code format

### DIFF
--- a/.claude/agents/cross-framework-reviewer.md
+++ b/.claude/agents/cross-framework-reviewer.md
@@ -2,75 +2,32 @@
 name: cross-framework-reviewer
 description: Verify component, hook, composable, and rune parity across @vizel/react, @vizel/vue, and @vizel/svelte. Use proactively after any change that touches more than one framework package, after introducing a new public API, and before opening a pull request that modifies any package under packages/.
 tools: Glob, Grep, Read, NotebookRead, BashOutput
+disallowedTools: Write, Edit, NotebookEdit
+color: blue
+model: haiku
 ---
 
 # Cross-Framework Reviewer
 
-This subagent verifies feature parity and API consistency across the three Vizel framework packages. It reads code only and reports findings; it never edits files.
+This subagent verifies feature parity and API consistency across the three Vizel framework packages. It reads code only and reports findings; it never edits files. The detailed parity contract lives in `.claude/rules/feature-manifest.md` and `packages/core/src/feature-manifest.ts`.
 
 ## Inputs
 
 - The list of changed paths (typically `git diff --name-only`).
-- The project rules under `.claude/rules/` (already loaded as project memory).
+- The project rules under `.claude/rules/` (already loaded on demand).
+- The feature manifest at `packages/core/src/feature-manifest.ts`.
 
 ## Process
 
 1. **Identify the changed feature.** Read each modified file under `packages/`.
 2. **Locate equivalents.** For each component, hook, composable, or rune, find the counterpart in the other two framework packages.
-3. **Verify parity.** Check the following:
-   - The component exists in all three frameworks.
-   - The props match in name and type, allowing `class` versus `className`.
-   - The hook, composable, and rune share an option interface defined in `@vizel/core`.
-   - The return shape matches the framework idiom: `Editor | null` (React), `ShallowRef<Editor | null>` (Vue), `{ get current(): Editor | null }` (Svelte).
-   - Shared types, constants, and utilities live in `@vizel/core`.
-4. **Run the six Parity Checks** (see next section).
-5. **Verify the demo apps.** Confirm that each demo under `apps/demo/{react,vue,svelte}/` exercises the new feature.
-6. **Verify the tests.** Confirm that `tests/ct/scenarios/` defines a shared scenario and that `tests/ct/{react,vue,svelte}/specs/` consumes it.
-
-## Parity Checks
-
-The six SSOT parity tables in `.claude/rules/cross-framework.md` are
-the contract. Run the following six checks against the changed
-surface. Any divergence outside Table 6 (Idiom Exception Catalog) is a
-defect.
-
-1. **Identifier parity.** Function name stems (hooks, composables,
-   runes) match across `packages/react/src/index.ts`,
-   `packages/vue/src/index.ts`, and `packages/svelte/src/index.ts`,
-   modulo the Category B prefix (`use*` in React and Vue, `create*`
-   for Svelte factories, `get*` for Svelte context getters). Diff the
-   three `index.ts` exports against the Identifier Parity Table.
-2. **Props parity.** For every component touched (or added), the prop
-   types match across frameworks by name and shape. The only allowed
-   shape differences are: `class` vs `className`; children prop type
-   (`ReactNode` vs default slot vs `Snippet`); imperative-ref shape
-   (`Ref<T>` vs `defineExpose` vs mutable ref prop). Cross-check the
-   per-component rows of the Props Parity Table.
-3. **Event payload parity.** Callback argument types match across
-   frameworks. The Vue counterpart may surface a callback prop as an
-   emitted event; the payload shape must still match the React/Svelte
-   callback signature, which itself must match the canonical signature
-   in `packages/core/src/types.ts`. Verify against the Event Payload
-   Table.
-4. **Idiom exception whitelist.** Differences outside the Idiom
-   Exception Catalog (Table 6 in `cross-framework.md`) are defects.
-   Flag any divergence that does not fall into Category B and propose
-   either bringing it back into parity or extending the catalog with a
-   documented justification.
-
-5. **CT spec parity.** Every `*.spec.{tsx,ts}` file must exist in all
-   three framework specs directories
-   (`tests/ct/{react,vue,svelte}/specs/`), modulo the idiom prefix
-   stripped from hook / composable / rune specs (`Use*` on React and
-   Vue, `Create*` / `Get*` on Svelte). Run `pnpm check:ct-parity` to
-   confirm; lefthook runs the same script on `pre-push` and the CI
-   `ct-parity` job blocks merge. The seven-pillar rules in
-   `.claude/rules/testing.md` gate review on this check.
-6. **Shared scenario usage.** For each spec touched, confirm it
-   imports its core assertions from `tests/ct/scenarios/`. A spec
-   that hand-rolls framework-specific assertions is a defect: lift
-   the assertions into the shared scenario so the other two
-   frameworks consume the same expectations.
+3. **Verify parity.** Confirm that:
+   - The feature has a `VizelFeatureDefinition` entry in the manifest.
+   - Every adapter exports the symbol declared in the manifest.
+   - The feature scenario folder under `tests/ct/scenarios/<feature-id>/` exists.
+   - Per-framework spec files under `tests/ct/{react,vue,svelte}/specs/` invoke the scenario.
+4. **Check that `pnpm check:parity` passes** by inspecting the relevant outputs.
+5. **Verify the demos.** Confirm that each demo under `apps/demo/{react,vue,svelte}/` exercises the new feature.
 
 ## Output
 
@@ -89,15 +46,14 @@ Report findings in the following format. Cite file paths in `path:line` form.
 
 ### Recommendations
 
-- [ ] Add `onOpenChange` to the Vue component at `packages/vue/src/components/BubbleMenu.vue`.
-- [ ] Add a `createVizel<Feature>` rune at `packages/svelte/src/runes/<feature>.svelte.ts`.
-- [ ] Update demos at `apps/demo/{react,vue,svelte}/` to exercise the feature.
-- [ ] Add a shared scenario at `tests/ct/scenarios/<feature>.scenario.ts`.
-- [ ] Confirm `pnpm check:ct-parity` exits 0 after adding the per-framework specs.
+- [ ] Add the missing adapter symbol declared in the manifest.
+- [ ] Add the scenario file at `tests/ct/scenarios/<feature-id>/`.
+- [ ] Confirm `pnpm check:parity` exits 0 after adding the per-framework symbols.
 ```
 
 ## Constraints
 
-- Report findings only. Do not modify files.
-- Defer general code-style or rule enforcement to the `lint-instructions` skill.
+- Report findings only; the `disallowedTools` frontmatter prevents accidental edits.
+- Defer general code-style enforcement to the `lint-instructions` skill.
 - Defer commit-message validation to the lefthook `commit-msg` hook.
+- The manifest in `packages/core/src/feature-manifest.ts` is the authoritative parity contract; any divergence cited as an exception requires an ADR under `docs/adr/`.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,97 +1,34 @@
 # Architecture
 
-This file is the single source of truth (SSOT) for Vizel's package-layering
-rules. It loads at startup with the same priority as `CLAUDE.md`. The
-cross-framework rules in `.claude/rules/cross-framework.md` defer to this
-file — if they conflict, this file wins.
+This rule states the binding architecture invariants for Vizel v2.0.0. The detailed rationale for each invariant lives in `docs/adr/`. Read the relevant ADR before changing a binding rule.
 
-## Product Identity
+## Product identity
 
-Vizel is a **block-based visual Markdown editor** built on Tiptap. The product:
+Vizel is a block-based visual Markdown editor built on Tiptap. The product:
 
-- Edits content as Tiptap nodes (block-level structure) but Markdown is the
-  source of truth on save and load. Tiptap's internal HTML is an editing-time
-  representation, not a persisted format.
-- Targets a Notion-like authoring experience: slash menu, drag handle,
-  mentions, block menu, embeds, find-and-replace, version history, comments,
-  collaboration.
+- Edits content as Tiptap nodes (block-level structure) but Markdown is the source of truth on save and load. Tiptap's internal HTML is an editing-time representation, not a persisted format.
+- Targets a Notion-like authoring experience: slash menu, drag handle, mentions, block menu, embeds, find-and-replace, version history, comments, collaboration.
 - Ships React, Vue, and Svelte adapters around the same Tiptap configuration.
 
-## Core Concepts (binding)
+## Binding invariants
 
-1. **`@vizel/core` is framework-agnostic.**
-   A facade over Tiptap. It never imports React, Vue, or Svelte runtimes or
-   types. It exposes three categories of API and nothing else:
-   - **Tiptap extensions** and configuration helpers.
-   - **Pure builders** that produce framework-neutral specs (DOM shape + ARIA
-     wiring + derived state). These are deterministic functions of their inputs
-     with no side effects.
-   - **Controller factories** that own DOM side effects behind a
-     `{ mount(target), unmount() }` interface. Framework components must never
-     call `document.addEventListener` directly — they pass an element into a
-     controller and let it own the listener.
-
-   The concrete directory layout for these three categories appears in
-   `.claude/rules/packages/core.md` under "Four-Layer Structure".
-
-2. **Framework packages are thin adapters.**
-   `@vizel/react`, `@vizel/vue`, and `@vizel/svelte` only:
-   - Bind the editor to the framework lifecycle (mount, update, unmount).
-   - Convert framework-idiomatic props / refs / snippets to the Core spec or
-     controller shape and back.
-
-   They do not implement ARIA wiring, keyboard navigation, dismissal logic,
-   focus management, or state derivation. Those live in Core. Each
-   framework-side component file should fit within ~120 lines of view code; if
-   it grows past that, the excess is logic that belongs in Core.
-
-3. **UI components ship as Core specs + framework renderers.**
-   Every menu, popover, and form (`VizelSlashMenu`, `VizelMentionMenu`,
-   `VizelBlockMenu`, `VizelToolbarDropdown`, `VizelNodeSelector`,
-   `VizelLinkEditor`, `VizelFindReplace`, `VizelColorPicker`,
-   `VizelBubbleMenu`, ...) declares its DOM scaffolding as a typed spec in
-   `packages/core/src/builders/`. The framework component is a thin
-   transformer that maps the spec to native template syntax. ARIA attributes,
-   identifiers, and section/item structure live in the spec — frameworks do
-   not duplicate them.
+1. **`@vizel/core` stays framework-agnostic.** Core never imports React, Vue, or Svelte runtimes or types. It exposes Tiptap extensions, pure spec builders, controller factories (`{ mount, unmount, update }`), the feature manifest, and the single CSS catalogue.
+2. **`@vizel/headless` provides framework-neutral primitives.** Combobox, popover, dismissable, focus-trap, floating, and keyboard helpers live here. Consumers do not depend on this package directly; adapter packages declare it as a dependency. See [ADR-0003](../../docs/adr/ADR-0003-vizel-headless-package.md).
+3. **Adapter packages are thin transformers.** Each adapter expresses every feature in its framework's native idiom. See [ADR-0004](../../docs/adr/ADR-0004-per-framework-idiomatic-api.md). Component files stay at or under 120 view-template lines; logic that overflows moves into Core or Headless. See [ADR-0007](../../docs/adr/ADR-0007-component-size-and-controller-delegation.md).
+4. **Editor reactivity is first-party in every adapter.** React uses `useSyncExternalStore`; Vue uses `shallowRef` + `onScopeDispose`-bound listeners; Svelte uses `$state.raw` + `createSubscriber`. `@tiptap/react` and `@tiptap/vue-3` are not depended on. See [ADR-0009](../../docs/adr/ADR-0009-first-party-editor-reactivity.md).
+5. **Feature parity is enforced by the feature manifest.** The SSOT is `packages/core/src/feature-manifest.ts`; `pnpm check:parity` verifies coverage. API symmetry across frameworks is explicitly NOT a goal. See [ADR-0001](../../docs/adr/ADR-0001-feature-parity-over-api-symmetry.md) and [ADR-0002](../../docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md).
 
 ## Consumer-facing invariants
 
-These hold across every framework package:
-
-- **Import surface.** Installing one of `@vizel/react`, `@vizel/vue`, or
-  `@vizel/svelte` is sufficient to render Vizel. Consumers never need to
-  `import` from `@vizel/core` for normal use; framework packages re-export the
-  symbols a consumer is expected to touch (types, locale, error class, action
-  helpers).
-- **Style surface.** A single CSS entry per framework package (e.g.
-  `@vizel/react/styles.css`). No hand-mounting of additional stylesheets is
-  required to make any built-in component render correctly. The CSS ships
-  the entire token catalog under exactly two selectors —
-  `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` —
-  plus the `(prefers-color-scheme: dark)` fallback for unset themes.
-  Vizel never writes host-environment selectors (`.dark`, `.light`,
-  `[data-theme="*"]`); host theming belongs to the host theme library
-  and stays decoupled from Vizel.
-- **Symmetric API.** Component props, hook / composable / rune names, return
-  shapes, and event payloads mirror each other across the three frameworks,
-  modulo idiomatic naming (`useFoo` in React and Vue, `createFoo` in Svelte).
-  Any divergence requires a rationale comment in the diverging package.
-- **Loud errors at boundaries.** Misuse — conflicting props, invalid
-  editor configuration, missing context — surfaces as a typed
-  `VizelError` carrying a stable `code` from `VizelErrorCode`.
-  Configuration mistakes throw; runtime / input errors flow through
-  `emitVizelError` and the consumer-supplied `onError` callback.
-  `console.warn` and `console.error` are banned inside
-  `packages/core/src/`; the only allowed `console.error` lives inside
-  `emitVizelError`.
-- **SSR safe.** All Core utilities guard `document` / `window` access and
-  produce no DOM side effects until a framework lifecycle hook (`onMount`,
-  `useEffect`, Vue `onMounted`) runs.
+- **Import surface.** Installing one of `@vizel/react`, `@vizel/vue`, or `@vizel/svelte` is sufficient. `@vizel/core` and `@vizel/headless` are transitive dependencies.
+- **Style surface.** A single CSS entry per adapter (e.g. `@vizel/react/styles.css`) resolves to `@vizel/core/styles.css`. The CSS ships under two selectors — `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` — plus the `prefers-color-scheme: dark` fallback. Host theming integrates by setting `data-vizel-theme`. See [ADR-0008](../../docs/adr/ADR-0008-css-belongs-in-core.md).
+- **Loud errors at boundaries.** Misuse surfaces as a typed `VizelError` carrying a stable `VizelErrorCode`. Configuration mistakes throw; runtime input errors flow through `emitVizelError` and the consumer-supplied `onError` callback. `console.warn` and `console.error` are banned in `packages/core/src/` except inside `emitVizelError`.
+- **SSR safe.** All Core utilities guard `document` / `window` access. Adapter components mount DOM-touching controllers only inside the framework's lifecycle hook (`useEffect`, `onMounted`, `$effect`).
 
 ## When to deviate
 
-These rules are binding. If a feature seems to require deviation, add a brief
-exception (file path, rationale, expiry condition) to the relevant package
-rule under `.claude/rules/packages/` in the same pull request that introduces
-the deviation. Drift without an exception entry is a review-blocker.
+These invariants are binding. If a feature seems to require deviation, write an ADR under `docs/adr/` in the same pull request that introduces the deviation. Drift without an ADR is a review-blocker.
+
+## Decision records
+
+See `docs/adr/README.md` for the full ADR index covering API parity, feature manifest, headless package, per-framework idiom, breaking-release policy, CSS centralisation, first-party reactivity, `.claude/` format, technical-writing style, and the Playwright CT three-layer rebuild.

--- a/.claude/rules/cross-framework.md
+++ b/.claude/rules/cross-framework.md
@@ -4,6 +4,20 @@ paths:
   - "packages/core/src/types.ts"
 ---
 
+> **DEPRECATED — scheduled for removal in Phase 1.**
+>
+> This rule encodes v1's API-symmetry contract. v2.0.0 replaces it with the
+> typed feature manifest at `packages/core/src/feature-manifest.ts` plus the
+> per-framework idiomatic API contract. The new contract is documented in:
+>
+> - [ADR-0001](../../docs/adr/ADR-0001-feature-parity-over-api-symmetry.md) — feature parity over API symmetry
+> - [ADR-0002](../../docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md) — feature manifest as parity SSOT
+> - [ADR-0004](../../docs/adr/ADR-0004-per-framework-idiomatic-api.md) — per-framework idiomatic API contract
+> - [ADR-0006](../../docs/adr/ADR-0006-retire-cross-framework-rule.md) — retire this file
+>
+> Phase 1 lands the manifest and deletes this file in the same pull request.
+> Until then, the tables below describe v1 behaviour for reference only.
+
 # Cross-Framework Consistency
 
 The React, Vue, and Svelte packages must maintain feature parity and consistent APIs.

--- a/.claude/rules/feature-manifest.md
+++ b/.claude/rules/feature-manifest.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "packages/core/src/feature-manifest.ts"
+  - "packages/{react,vue,svelte}/**/*"
+  - "tests/ct/scenarios/**"
+  - "tests/ct/parity/**"
+---
+
+# Feature Manifest
+
+Vizel v2 expresses cross-framework feature parity as TypeScript, not prose. The Single Source of Truth (SSOT) is `packages/core/src/feature-manifest.ts`. The full rationale lives in [ADR-0002](../../docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md).
+
+> **Status as of 2026-05-28**: this rule documents the target contract. The manifest file lands in Phase 1 alongside `scripts/check-parity.ts`. Until then, treat this rule as the design specification for that work.
+
+## What the manifest contains
+
+Each feature entry exports a `VizelFeatureDefinition`:
+
+- `id` — stable kebab-case identifier (`"bubble-menu"`, `"slash-menu"`, …).
+- `category` — `"menu" | "popover" | "form" | "overlay" | "extension"`.
+- `specBuilder` — optional reference to the pure spec builder in `@vizel/core/builders/`.
+- `controllerFactory` — optional reference to the controller in `@vizel/core/controllers/` or `@vizel/headless/`.
+- `ariaContract` — declared role, labelling, and state attributes.
+- `keyboardMap` — key → command bindings.
+- `scenarios` — array of scenario IDs under `tests/ct/scenarios/<feature-id>/`.
+- `adapters` — declared adapter symbols for React, Vue, and Svelte (component name, optional hook or composable or rune name).
+
+## Workflow: add a feature
+
+1. Append a `VizelFeatureDefinition` entry to `VIZEL_FEATURE_MANIFEST` in `packages/core/src/feature-manifest.ts`.
+2. Implement the feature in each adapter under `packages/{react,vue,svelte}/src/`.
+3. Create the scenario folder at `tests/ct/scenarios/<feature-id>/` with a typed scenario interface.
+4. Create per-framework spec files under `tests/ct/{react,vue,svelte}/specs/` that invoke the scenario.
+5. Run `pnpm check:parity` locally; the same script runs in `pre-push` and CI.
+
+## Workflow: modify a feature
+
+1. Update the manifest entry (props, ARIA, keyboard map, scenarios) in the same pull request as the adapter changes.
+2. Update all three adapters in the same pull request. The parity check fails the build if any adapter drifts.
+3. Update scenarios under `tests/ct/scenarios/<feature-id>/` to match the new behaviour.
+
+## Workflow: remove a feature
+
+1. Delete the manifest entry.
+2. Delete the adapter implementations.
+3. Delete the scenario folder.
+4. Note the removal in `docs/guide/migration-v1-to-v2.md` (or the next major release's migration guide).
+
+## CI verification
+
+- `pnpm check:parity` — TypeScript-level check: every manifest entry exports a matching symbol from each adapter.
+- `pnpm test:ct:parity` — Playwright-level check: every manifest entry has a scenario that runs across every framework.
+- `pnpm test:ct:scenarios` — scenarios compile without errors.
+
+The lefthook `pre-push` hook runs `pnpm check:parity`. The CI matrix runs all three.

--- a/.claude/rules/packages/headless.md
+++ b/.claude/rules/packages/headless.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "packages/headless/**/*"
+---
+
+# `@vizel/headless` Package
+
+`@vizel/headless` provides framework-neutral UI primitives that every adapter consumes. The rationale lives in [ADR-0003](../../../docs/adr/ADR-0003-vizel-headless-package.md).
+
+> **Status as of 2026-05-28**: this rule documents the target contract. The package scaffolds in Phase 2. Until then, treat this rule as the design specification.
+
+## What the package contains
+
+| Primitive | Purpose |
+|-----------|---------|
+| `combobox/` | Typeahead and roving tabindex for autocomplete-style menus |
+| `popover/` | Positioning, dismissal, and portal target |
+| `dismissable/` | Click-outside + Escape + focus return |
+| `focus-trap/` | Focus boundary |
+| `floating/` | `@floating-ui/dom` wrapper for positioning strategies |
+| `keyboard/` | List navigation, typeahead, roving tabindex helpers |
+
+Each primitive exports `{ buildSpec, createController }`. The spec is a pure function; the controller owns DOM side effects behind `{ mount(target), unmount(), update(args) }`.
+
+## Dependency direction
+
+- `@vizel/headless` depends on `@floating-ui/dom` (positioning) and standard DOM APIs only.
+- `@vizel/headless` never imports React, Vue, or Svelte runtimes.
+- The three adapter packages depend on `@vizel/headless`. Consumers do not depend on it directly; the package is transitive.
+
+## Authoring constraints
+
+- Tree-shakeable exports: import each primitive directly. Do not re-export everything from a single barrel.
+- Every primitive ships with unit tests under `packages/headless/__tests__/`.
+- Every primitive guards SSR (`typeof document === "undefined"`) so adapters can import the module at build time without DOM access.
+
+## CSS
+
+`@vizel/headless` ships no CSS. The single CSS catalogue lives in `@vizel/core/styles.css` (see [ADR-0008](../../../docs/adr/ADR-0008-css-belongs-in-core.md)).
+
+## Migration target
+
+The 21 `document.addEventListener` calls that currently live inside adapter components migrate into the `dismissable/` primitive during Phase 2. Adapter components consume the primitive thereafter; they never attach global listeners directly.

--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -1,0 +1,71 @@
+---
+paths:
+  - "**/*.{ts,tsx,vue,svelte,scss,css}"
+  - "**/*.md"
+  - "**/*.{json,yml,yaml}"
+---
+
+# Technical Writing Style
+
+Every authored sentence in this repository follows a single technical-writing standard. The standard covers source-code comments, JSDoc, README files, design documents, ADRs, the migration guide, demo descriptions, commit messages, pull-request bodies, and rule files under `.claude/rules/**`.
+
+The full rationale lives in [ADR-0011](../../docs/adr/ADR-0011-technical-writing-style.md).
+
+## Binding principles
+
+- Write one idea per sentence. Remove filler words.
+- Avoid ambiguous pronouns (`it`, `this`, `that`). Name the noun instead.
+- Define abbreviations at first use, e.g. `Application Programming Interface (API)`.
+- Use the active voice. Write "The function throws ValidationError", not "ValidationError is thrown by the function".
+- Use the present tense in comments and docstrings.
+- Make the subject explicit.
+- Start function and class docstrings with a verb in the infinitive form: "Return the merged Markdown".
+- Comments explain *why*, not *what*. Skip self-evident comments. Reference the cause — a constraint, a past bug, an external standard — when relevant. Do not narrate the code.
+- Commit messages and pull-request titles follow Conventional Commits (`<type>(<scope>): <description>`). The subject is imperative, lower-case, has no trailing period, and stays at or under 72 characters.
+- Markdown documents use a hierarchical heading structure. Avoid passive constructions.
+
+## Mechanical enforcement
+
+- Biome enforces line length and formatting.
+- Lefthook's `commit-msg` hook enforces Conventional Commits.
+- CI runs the same lint job.
+
+## Semantic enforcement
+
+Reviewers cite this rule when they request changes for passive voice, narrative comments, ambiguous pronouns, or undefined abbreviations. The rule itself is the checklist.
+
+## Examples
+
+### Comments
+
+```ts
+// Bad: narrates the code.
+// Increment the counter.
+counter += 1;
+
+// Good: explains why.
+// Tiptap re-emits the transaction synchronously when the selection
+// collapses; bump the counter so useSyncExternalStore re-runs the
+// selector even though the editor identity has not changed.
+counter += 1;
+```
+
+### Commit subjects
+
+```
+feat(react): add useVizelEditorState selector subscription
+fix(svelte): re-attach createSubscriber after editor reassignment
+docs: add ADR-0001 for feature parity over API symmetry
+```
+
+### Function docstrings
+
+```ts
+/**
+ * Return the editor's current Markdown serialisation.
+ *
+ * The Markdown reflects the latest committed transaction; calls made
+ * during a transaction read the pre-transaction state.
+ */
+function getMarkdown(editor: Editor): string { /* ... */ }
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Bash(pnpm install)",

--- a/.claude/skills/lint-instructions/SKILL.md
+++ b/.claude/skills/lint-instructions/SKILL.md
@@ -1,133 +1,31 @@
 ---
 name: lint-instructions
-description: Detect and fix violations of the project rules under .claude/rules/. Use before committing changes, after implementing a feature, or when the user asks to check rule compliance.
+description: Detect and fix violations of the project rules under `.claude/rules/`.
+when_to_use: Use before committing changes, after implementing a feature, during pull-request preparation, or when the user asks to check rule compliance.
+paths:
+  - "packages/**"
+  - "apps/**"
+  - "tests/**"
+  - "docs/**"
+disable-model-invocation: true
 ---
 
 # Instruction Linter
 
-This skill validates code against the project rules in `.claude/rules/`.
+This skill validates code against the project rules in `.claude/rules/`. The skill is manual-only: the maintainer invokes it explicitly when ready for a compliance pass.
 
-## When to Use
-
-- Before committing changes.
-- After implementing a feature.
-- During pull request preparation.
-- When the user asks to check rule compliance.
-
-## Process
-
-### 1. Load the Rules
-
-Each rule under `.claude/rules/` declares a `paths:` frontmatter that scopes its automatic loading. This skill performs full compliance checks across the project, so it reads every rule file explicitly regardless of the current file scope.
-
-Read all rule files:
-
-- `.claude/rules/code-style.md`
-- `.claude/rules/cross-framework.md`
-- `.claude/rules/git.md`
-- `.claude/rules/testing.md`
-- `.claude/rules/demo.md`
-- `.claude/rules/packages/core.md`
-- `.claude/rules/packages/react.md`
-- `.claude/rules/packages/vue.md`
-- `.claude/rules/packages/svelte.md`
-
-### 2. Identify Changed Files
-
-```bash
-git diff --name-only HEAD~1
-```
-
-### 3. Apply the Relevant Rules
-
-| Changed Path | Apply These Rules |
-|--------------|-------------------|
-| `packages/core/**` | `code-style.md`, `cross-framework.md`, `packages/core.md` |
-| `packages/react/**` | `code-style.md`, `cross-framework.md`, `packages/react.md` |
-| `packages/vue/**` | `code-style.md`, `cross-framework.md`, `packages/vue.md` |
-| `packages/svelte/**` | `code-style.md`, `cross-framework.md`, `packages/svelte.md` |
-| `apps/demo/**` | `code-style.md`, `demo.md` |
-| `tests/ct/**` | `code-style.md`, `testing.md` |
-| Commit message | `git.md` |
-
-### 4. Verify Each Category
-
-For each applicable rule file, verify the following.
-
-#### Code Style (`code-style.md`)
-
-- [ ] Exports use `function` declarations.
-- [ ] Callbacks use arrow functions.
-- [ ] Public APIs prefer `satisfies` over type annotations.
-- [ ] Type guards replace `as` casts.
-- [ ] Public APIs include JSDoc.
-
-#### Cross-Framework (`cross-framework.md`)
-
-- [ ] Each component exists in all three framework packages.
-- [ ] Props match across frameworks (allowing `class` versus `className`).
-- [ ] Hooks, composables, and runes share an option interface defined in `@vizel/core`.
-- [ ] Each framework package re-exports the full `@vizel/core` surface via `export * from "@vizel/core"` in its `src/index.ts` (Section 6 of the v2 redesign — verified by `pnpm check:parity`).
-
-#### Core Package (`packages/core.md`)
-
-- [ ] No framework runtime dependencies.
-- [ ] Shared types and constants live here.
-- [ ] No usage of `@tiptap/starter-kit`.
-
-#### Framework Packages (`packages/{react,vue,svelte}.md`)
-
-- [ ] Idiomatic naming (hooks vs composables vs runes).
-- [ ] Correct context API usage.
-- [ ] No duplication of `@vizel/core` logic.
-
-#### Git (`git.md`)
-
-- [ ] The commit subject follows Conventional Commits.
-- [ ] The subject uses the imperative mood.
-- [ ] The subject is 72 characters or fewer.
-
-### 5. Report
-
-Use this format:
-
-```markdown
-## Instruction Compliance Report
-
-### ✅ Passing
-- <rule>: <description>
-
-### ❌ Violations
-- <rule>: <file:line> — <issue>
-  - **Fix**: <suggested fix>
-
-### ⚠️ Warnings
-- <rule>: <potential issue>
-```
-
-### 6. Apply Fixes
-
-For each fixable violation:
-
-1. Show the violation.
-2. Propose the fix.
-3. Apply the fix after the user confirms.
-
-## Quick Checks
+## Quick checks
 
 | Command | Purpose |
 |---------|---------|
 | `pnpm check` | Auto-fix Biome violations (formatting, imports, exports, naming) |
 | `pnpm typecheck` | Verify type safety |
+| `pnpm check:parity` | Verify cross-framework feature parity against the manifest |
 | `pnpm build` | Verify the build succeeds |
 
-## Common Violations
+## Supporting files
 
-| Violation | Rule | Fix |
-|-----------|------|-----|
-| `export const fn = () => {}` | `code-style.md` | Use `export function fn() {}` |
-| `data as Type` | `code-style.md` | Add a type guard function |
-| Type defined inside a framework package | `cross-framework.md` | Move the type to `@vizel/core` |
-| Component missing in one framework | `cross-framework.md` | Add the equivalent component |
-| `default export` | Biome | Use a named export |
-| Framework `src/index.ts` missing `export * from "@vizel/core"` | `cross-framework.md` | Add the mirror re-export so consumers do not need a direct `@vizel/core` dependency |
+- [`reference.md`](./reference.md) — full process, rule taxonomy, report format, common violations.
+- [`examples.md`](./examples.md) — concrete invocation patterns.
+
+The reference and examples files load on demand. The skill picks them up when running a full compliance pass or when the user requests detail.

--- a/.claude/skills/lint-instructions/examples.md
+++ b/.claude/skills/lint-instructions/examples.md
@@ -1,0 +1,27 @@
+# Lint-Instructions Skill Examples
+
+Concrete invocation patterns for the `lint-instructions` skill.
+
+## Run before opening a pull request
+
+The skill enumerates every rule that matches the changed files, then reports passes, violations, and warnings. Run it once the implementation is feature-complete and before requesting review.
+
+## Verify writing style across documentation changes
+
+When the change scope is `docs/**`, the skill loads `writing.md` and `git.md`. The skill checks active voice, present tense, ambiguous pronouns, and Conventional Commits.
+
+## Verify cross-framework parity after adding a feature
+
+When the change touches `packages/{react,vue,svelte}/`, the skill loads `feature-manifest.md` plus the per-framework rule. The skill confirms the manifest carries the new feature, every adapter exports the declared symbol, and the scenario folder exists.
+
+## Verify code style after refactoring
+
+When the change touches `packages/**` or `apps/**`, the skill loads `code-style.md`. The skill confirms `function` declarations, `satisfies` over annotations, type guards instead of `as` casts, and JSDoc on public APIs.
+
+## Drive the report into action
+
+The report sections (`Passing`, `Violations`, `Warnings`) map directly onto the work to do:
+
+- For each violation, apply the suggested fix or escalate.
+- For each warning, decide whether the case is genuine or a false positive; document the call in the pull-request body when accepting a warning.
+- For each passing item, no action; the skill keeps the entry visible to reassure the reviewer that the rule was actively checked.

--- a/.claude/skills/lint-instructions/reference.md
+++ b/.claude/skills/lint-instructions/reference.md
@@ -1,0 +1,120 @@
+# Lint-Instructions Skill Reference
+
+This document holds the long-form reference for the `lint-instructions` skill. The skill's `SKILL.md` keeps the trigger short; this file expands the process, the rule taxonomy, and the report format.
+
+## Process
+
+### 1. Load the rules
+
+Each rule under `.claude/rules/` declares a `paths:` frontmatter that scopes its automatic loading. This skill performs full compliance checks across the project, so it reads every rule file explicitly regardless of the current file scope.
+
+Read every file under `.claude/rules/` and `.claude/rules/packages/`. The skill considers a rule applicable when the changed path matches the rule's `paths:` patterns or when the rule has no `paths:` (always-on rules).
+
+### 2. Identify changed files
+
+```bash
+git diff --name-only HEAD~1
+```
+
+### 3. Apply the relevant rules
+
+| Changed path | Apply these rules |
+|--------------|-------------------|
+| `packages/core/**` | `code-style.md`, `writing.md`, `feature-manifest.md`, `packages/core.md` |
+| `packages/headless/**` | `code-style.md`, `writing.md`, `packages/headless.md` |
+| `packages/react/**` | `code-style.md`, `writing.md`, `feature-manifest.md`, `packages/react.md` |
+| `packages/vue/**` | `code-style.md`, `writing.md`, `feature-manifest.md`, `packages/vue.md` |
+| `packages/svelte/**` | `code-style.md`, `writing.md`, `feature-manifest.md`, `packages/svelte.md` |
+| `apps/demo/**` | `code-style.md`, `writing.md`, `demo.md` |
+| `tests/ct/**` | `code-style.md`, `writing.md`, `testing.md` |
+| `docs/**` | `writing.md` |
+| Commit message | `git.md` |
+
+### 4. Verify each category
+
+#### Code style (`code-style.md`)
+
+- Exports use `function` declarations where applicable.
+- Callbacks use arrow functions.
+- Public APIs prefer `satisfies` over type annotations.
+- Type guards replace `as` casts.
+- Public APIs include JSDoc.
+
+#### Writing (`writing.md`)
+
+- One idea per sentence; no filler.
+- Active voice; present tense in comments and docstrings.
+- Explicit subjects; no ambiguous pronouns (`it`, `this`, `that`).
+- Abbreviations defined at first use.
+- Function docstrings start with an infinitive verb.
+- Comments explain *why*, not *what*.
+
+#### Feature manifest (`feature-manifest.md`)
+
+- Every new feature has a `VizelFeatureDefinition` entry in `packages/core/src/feature-manifest.ts`.
+- Every adapter implements the symbol declared in the manifest.
+- The scenario folder under `tests/ct/scenarios/<feature-id>/` exists.
+
+#### Core package (`packages/core.md`)
+
+- No framework runtime dependencies.
+- Shared types and constants live here.
+
+#### Framework packages (`packages/{react,vue,svelte}.md`)
+
+- Idiomatic naming (hooks vs composables vs runes).
+- Correct context API usage.
+- No duplication of `@vizel/core` logic.
+- No direct `document.addEventListener` calls; controllers from `@vizel/core` or `@vizel/headless` own global listeners.
+
+#### Git (`git.md`)
+
+- The commit subject follows Conventional Commits.
+- The subject uses the imperative mood, lower case, no trailing period.
+- The subject stays at or under 72 characters.
+
+### 5. Report
+
+```markdown
+## Instruction Compliance Report
+
+### ✅ Passing
+- <rule>: <description>
+
+### ❌ Violations
+- <rule>: <file:line> — <issue>
+  - **Fix**: <suggested fix>
+
+### ⚠️ Warnings
+- <rule>: <potential issue>
+```
+
+### 6. Apply fixes
+
+For each fixable violation:
+
+1. Show the violation.
+2. Propose the fix.
+3. Apply the fix after the user confirms.
+
+## Quick checks
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm check` | Auto-fix Biome violations (formatting, imports, exports, naming) |
+| `pnpm typecheck` | Verify type safety |
+| `pnpm check:parity` | Verify cross-framework feature parity against the manifest |
+| `pnpm build` | Verify the build succeeds |
+
+## Common violations
+
+| Violation | Rule | Fix |
+|-----------|------|-----|
+| `export const fn = () => {}` | `code-style.md` | Use `export function fn() {}` |
+| `data as Type` | `code-style.md` | Add a type guard function |
+| Type defined inside a framework package | `feature-manifest.md` / `packages/core.md` | Move the type to `@vizel/core` |
+| Component missing in one framework | `feature-manifest.md` | Add the equivalent component and update the manifest |
+| `default export` | Biome | Use a named export |
+| `document.addEventListener` in framework component | `packages/{react,vue,svelte}.md` | Delegate to a controller from `@vizel/core` or `@vizel/headless` |
+| Passive voice in a comment | `writing.md` | Rewrite in the active voice |
+| Component file over 120 view-template lines | `packages/{react,vue,svelte}.md` | Split or extract logic into Core / Headless |

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,26 +1,23 @@
 ---
 name: test
-description: Run E2E tests for React, Vue, and Svelte. Use when testing components, verifying changes, or before committing.
+description: Run Playwright Component Tests for React, Vue, and Svelte, and audit test coverage.
+when_to_use: Use after implementing or modifying components, before committing changes, when verifying cross-framework compatibility, when the user asks to run tests, or when the user asks about test coverage.
+paths:
+  - "tests/**"
+  - "**/playwright-ct.config.ts"
+argument-hint: "[framework]"
 ---
 
 # Test Runner
 
-This skill runs Playwright Component Tests across the React, Vue, and Svelte frameworks. It also audits test coverage on request.
+This skill runs Playwright Component Tests across React, Vue, and Svelte, drives the Markdown round-trip and SSR smoke suites, and audits coverage on request.
 
-## When to Use
-
-- After implementing or modifying components.
-- Before committing changes.
-- When verifying cross-framework compatibility.
-- When the user asks to run tests.
-- When the user asks about test coverage.
-
-## Quick Commands
+## Quick commands
 
 | Command | Description |
 |---------|-------------|
-| `pnpm test:ct` | Run all framework tests in parallel |
-| `pnpm test:ct:seq` | Run all framework tests sequentially |
+| `pnpm test:ct` | Run every framework in parallel |
+| `pnpm test:ct:seq` | Run every framework sequentially |
 | `pnpm test:ct:react` | Run React tests only |
 | `pnpm test:ct:vue` | Run Vue tests only |
 | `pnpm test:ct:svelte` | Run Svelte tests only |
@@ -28,318 +25,21 @@ This skill runs Playwright Component Tests across the React, Vue, and Svelte fra
 | `pnpm test:ssr` | Run the SSR static-HTML smoke test (Pillar 4) |
 | `pnpm check:ct-parity` | Verify CT spec parity across frameworks (Pillar 1) |
 
-
-## Section 14 Pillars
-
-The seven-pillar testing rules in `.claude/rules/testing.md` govern
-the broader test surface. This skill drives all pillars that ship
-runnable suites today.
-
-| Pillar | Status | How to run |
-|--------|--------|------------|
-| 1. Framework parity | shipped | `pnpm check:ct-parity` |
-| 2. Behavior tests | shipped | `pnpm test:ct` (and variants above) |
-| 3. Markdown round-trip | shipped | `pnpm test:md-roundtrip` |
-| 4. SSR | shipped | `pnpm test:ssr` |
-| 5. Accessibility | not yet | follow-up; `tests/a11y/` not yet created |
-| 6. Visual regression | not yet | follow-up; CI-only suite not yet created |
-| 7. Coverage discipline | shipped | reviewed at PR time against the Pillar 7 matrix |
-
-### Run the full local matrix
-
-```bash
-pnpm check:ct-parity   # Pillar 1
-pnpm test:ct           # Pillar 2
-pnpm test:md-roundtrip # Pillar 3
-pnpm test:ssr          # Pillar 4
-```
-
-### CT spec parity
-
-`pnpm check:ct-parity` lints `tests/ct/{react,vue,svelte}/specs/`
-for matching spec filenames, modulo the `Use*` / `Create*` / `Get*`
-idiom prefix. A non-zero exit means a spec exists in one or two
-frameworks but not all three.
-
-```bash
-pnpm check:ct-parity
-# CT spec parity check (react=33, vue=33, svelte=33)
-# CT spec parity check passed.
-```
-
-### Markdown round-trip
-
-`pnpm test:md-roundtrip` drives `generateVizelStaticHtml` against
-every sample in `tests/markdown-roundtrip/samples/index.ts` and
-asserts the round-tripped Markdown matches the input. Add a new
-sample by appending to the relevant `<flavor>Samples` array.
-
-### SSR static HTML smoke test
-
-`pnpm test:ssr` runs `scripts/test-static-html.ts`. The script
-boots the Core SSR path in Node, renders fixed Markdown samples,
-and asserts the produced HTML contains the expected DOM markers.
-Add a case by appending a `StaticHtmlCase` entry to the same
-script.
-
-### Accessibility (NOT YET SHIPPED)
-
-`tests/a11y/` will run `@axe-core/playwright` against every
-component. The directory and dependency are tracked as follow-up
-work; the test skill will gain a `pnpm test:a11y` command once
-the suite lands.
-
-### Visual regression (NOT YET SHIPPED)
-
-A CI-only visual snapshot suite covering ~20 essential views is
-planned. Local execution is intentionally skipped to avoid
-OS-level rendering noise. The test skill will gain a
-`pnpm test:visual` (CI-only) command once the suite lands.
-
-## Process
-
-### 1. Determine Test Scope
-
-Pick the test scope based on the changed paths.
-
-| Changed Path | Tests to Run |
-|--------------|--------------|
-| `packages/core/**` | All frameworks |
-| `packages/react/**` | React only |
-| `packages/vue/**` | Vue only |
-| `packages/svelte/**` | Svelte only |
-| `tests/ct/scenarios/**` | All frameworks |
-| `tests/ct/react/**` | React only |
-| `tests/ct/vue/**` | Vue only |
-| `tests/ct/svelte/**` | Svelte only |
-
-### 2. Run Tests
-
-#### All Frameworks (Parallel)
-
-```bash
-pnpm test:ct
-```
-
-> Parallel runs can hit timeouts when all browsers run together. Use `--project=chromium` for a faster, more reliable parallel run.
-
-#### All Frameworks (Sequential)
-
-```bash
-pnpm test:ct:seq
-```
-
-#### Single Framework
-
-```bash
-pnpm test:ct:react
-pnpm test:ct:vue
-pnpm test:ct:svelte
-```
-
-#### Specific Browser
-
-```bash
-pnpm test:ct:react --project=chromium
-pnpm test:ct:react --project=firefox
-pnpm test:ct:react --project=webkit
-```
-
-#### Specific Test File
-
-```bash
-pnpm test:ct:react tests/ct/react/specs/Editor.spec.tsx
-```
-
-#### Headed Mode (Visible Browser)
-
-```bash
-pnpm test:ct:react --headed
-```
-
-### 3. Analyze Results
-
-#### Success Output
-
-```
-Running X tests using Y workers
-
-  ✓ ComponentName › test description (XXms)
-  ...
-
-  X passed (Y.Zs)
-```
-
-#### Failure Output
-
-```
-  ✗ ComponentName › test description (XXms)
-    Error: expect(locator).toBeVisible()
-    Locator: ...
-    Expected: visible
-    Received: hidden
-```
-
-### 4. Report Format
-
-```markdown
-## Test Results
-
-### Summary
-- **React**: ✅ X passed / ❌ Y failed
-- **Vue**: ✅ X passed / ❌ Y failed
-- **Svelte**: ✅ X passed / ❌ Y failed
-
-### Failures (if any)
-
-| Framework | Test | Error |
-|-----------|------|-------|
-| React | ComponentName › test | Error message |
-
-### Next Steps
-- [ ] Fix failing tests.
-- [ ] Re-run the affected suite.
-```
-
-## Coverage Audit
-
-When the user asks about coverage, verify that every component and every hook, composable, or rune has a corresponding test.
-
-### 1. List Implementations
-
-```bash
-# React
-ls packages/react/src/components/*.tsx | xargs -I {} basename {} .tsx
-ls packages/react/src/hooks/*.ts | xargs -I {} basename {} .ts
-
-# Vue
-ls packages/vue/src/components/*.vue | xargs -I {} basename {} .vue
-ls packages/vue/src/composables/*.ts | xargs -I {} basename {} .ts
-
-# Svelte
-ls packages/svelte/src/components/*.svelte | xargs -I {} basename {} .svelte
-ls packages/svelte/src/runes/*.ts | xargs -I {} basename {} .ts
-```
-
-### 2. List Test Specs
-
-```bash
-ls tests/ct/react/specs/*.tsx tests/ct/vue/specs/*.ts tests/ct/svelte/specs/*.ts | xargs -I {} basename {}
-```
-
-### 3. Classify Coverage
-
-| Status | Meaning |
-|--------|---------|
-| ✅ Direct | Has a dedicated spec file |
-| ✅ Indirect | Tested through a parent component |
-| ⚠️ Style-only | Pure styling component; may not require a spec |
-| ❌ Missing | Requires a spec |
-
-### 4. Coverage Report Format
-
-```markdown
-## Test Coverage Report
-
-### Components
-
-| Component | React | Vue | Svelte | Status |
-|-----------|:-----:|:---:|:------:|--------|
-| EditorRoot | ✅ | ✅ | ✅ | Direct |
-| BubbleMenu | ✅ | ✅ | ✅ | Direct |
-| SlashMenu | ✅ | ✅ | ✅ | Direct |
-
-### Hooks / Composables / Runes
-
-| Function | React | Vue | Svelte | Status |
-|----------|:-----:|:---:|:------:|--------|
-| useVizelEditor | ✅ | ✅ | ✅ | Indirect |
-| useVizelEditorState | ❌ | ❌ | ❌ | Missing |
-
-### Summary
-- Components: X/Y covered (Z%).
-- Hooks/Composables/Runes: X/Y covered (Z%).
-
-### Recommendations
-- [ ] Add tests for missing items.
-- [ ] Decide whether style-only components require tests.
-```
-
-## Troubleshooting
-
-### Browser Not Installed
-
-```bash
-pnpm exec playwright install chromium
-# or install all browsers
-pnpm exec playwright install
-```
-
-### Test Timeout
-
-Increase the timeout for the affected test:
-
-```typescript
-test("slow test", async ({ mount, page }) => {
-  test.setTimeout(30000); // 30 seconds
-  // ...
-});
-```
-
-### Parallel Execution Timeout
-
-Parallel runs across all frameworks and all browsers can fail with messages like:
-
-```
-browserContext.newPage: Test timeout of 10000ms exceeded
-```
-
-Mitigation:
-
-1. Use a single browser: `pnpm test:ct --project=chromium`.
-2. Use sequential execution: `pnpm test:ct:seq`.
-3. Reduce the worker count in the config (currently 50% CPU).
-
-### Element Not Found
-
-Check whether the element renders to `document.body` (a portal):
-
-```typescript
-// Inside the mount target.
-const element = component.locator(".selector");
-
-// Rendered to document.body.
-const popup = page.locator(".selector");
-```
-
-## Common Patterns
-
-### Run Tests for Changed Files
-
-```bash
-# List changed files.
-git diff --name-only HEAD~1
-
-# Run the relevant suite.
-pnpm test:ct:react  # if React files changed
-```
-
-### Pre-commit Verification
-
-```bash
-# Quick parallel check with a single browser.
-pnpm test:ct --project=chromium
-
-# Or a sequential check with a single browser.
-pnpm test:ct:seq --project=chromium
-```
-
-### Full CI-like Verification
-
-```bash
-# All frameworks in parallel, all browsers.
-pnpm test:ct
-
-# All frameworks sequentially, all browsers (more stable).
-pnpm test:ct:seq
-```
+## Scope routing
+
+| Argument | Action |
+|----------|--------|
+| (none) | Run `pnpm test:ct` for every framework. |
+| `react` | Run `pnpm test:ct:react`. |
+| `vue` | Run `pnpm test:ct:vue`. |
+| `svelte` | Run `pnpm test:ct:svelte`. |
+| `parity` | Run `pnpm check:ct-parity`. |
+| `roundtrip` | Run `pnpm test:md-roundtrip`. |
+| `ssr` | Run `pnpm test:ssr`. |
+
+## Supporting files
+
+- [`reference.md`](./reference.md) — full process, pillar matrix, failure analysis, troubleshooting.
+- [`examples.md`](./examples.md) — concrete invocation patterns.
+
+The reference and examples files load on demand. The skill picks them up when the user asks for details or hits an unfamiliar failure mode.

--- a/.claude/skills/test/examples.md
+++ b/.claude/skills/test/examples.md
@@ -1,0 +1,65 @@
+# Test Skill Examples
+
+Concrete invocation patterns for the `test` skill.
+
+## Run every framework in parallel
+
+```bash
+pnpm test:ct
+```
+
+Best for the default verification pass. Falls back to `--project=chromium` when the matrix flakes.
+
+## Run a single framework
+
+```bash
+pnpm test:ct:react
+pnpm test:ct:vue
+pnpm test:ct:svelte
+```
+
+Use this when the change scope is limited to one adapter (e.g. `packages/react/**`).
+
+## Run a single spec file
+
+```bash
+pnpm test:ct:react tests/ct/react/specs/Editor.spec.tsx
+```
+
+Use this when iterating on a failing test. Combine with `--headed` to see the browser.
+
+## Reproduce a flaky CI failure locally
+
+```bash
+pnpm test:ct:seq --project=chromium
+```
+
+Sequential execution on a single browser surfaces races that parallel runs hide.
+
+## Verify Markdown round-trip after touching `packages/core/src/markdown/`
+
+```bash
+pnpm test:md-roundtrip
+```
+
+Add a new flavour-specific sample to `tests/markdown-roundtrip/samples/<flavour>.ts` to extend coverage.
+
+## Verify SSR after touching `@vizel/core` SSR helpers
+
+```bash
+pnpm test:ssr
+```
+
+Append a `StaticHtmlCase` to `scripts/test-static-html.ts` to cover a new SSR scenario.
+
+## Verify framework parity after adding a component
+
+```bash
+pnpm check:ct-parity
+```
+
+The script fails when a spec file exists in one framework but not all three. Lefthook also runs this on `pre-push`.
+
+## Audit coverage before opening a pull request
+
+Run the coverage workflow in `reference.md` and produce the coverage report. The reviewer reads the same report when evaluating the change.

--- a/.claude/skills/test/reference.md
+++ b/.claude/skills/test/reference.md
@@ -1,0 +1,259 @@
+# Test Skill Reference
+
+This document holds the long-form reference for the `test` skill. The skill's `SKILL.md` keeps the trigger short; this file expands the process, the seven testing pillars, and the failure analysis flow.
+
+## Seven testing pillars
+
+The pillars come from `.claude/rules/testing.md`. The skill drives every pillar that ships a runnable suite today.
+
+| Pillar | Status | How to run |
+|--------|--------|------------|
+| 1. Framework parity | shipped | `pnpm check:ct-parity` |
+| 2. Behaviour tests | shipped | `pnpm test:ct` (and the per-framework variants) |
+| 3. Markdown round-trip | shipped | `pnpm test:md-roundtrip` |
+| 4. SSR static-HTML smoke | shipped | `pnpm test:ssr` |
+| 5. Accessibility | not yet | `tests/a11y/` is tracked as follow-up |
+| 6. Visual regression | not yet | CI-only suite tracked as follow-up |
+| 7. Coverage discipline | shipped | reviewed at PR time against the Pillar 7 matrix |
+
+### Full local matrix
+
+```bash
+pnpm check:ct-parity   # Pillar 1
+pnpm test:ct           # Pillar 2
+pnpm test:md-roundtrip # Pillar 3
+pnpm test:ssr          # Pillar 4
+```
+
+### CT spec parity
+
+`pnpm check:ct-parity` confirms that every `*.spec.{tsx,ts}` file exists across `tests/ct/{react,vue,svelte}/specs/`, modulo the idiom prefix (`Use*` on React and Vue, `Create*` / `Get*` on Svelte). A non-zero exit means a spec exists in one or two frameworks but not all three.
+
+### Markdown round-trip
+
+`pnpm test:md-roundtrip` drives `generateVizelStaticHtml` against every sample in `tests/markdown-roundtrip/samples/index.ts` and asserts the round-tripped Markdown matches the input. Append a new sample to the relevant `<flavor>Samples` array to extend coverage.
+
+### SSR static-HTML smoke
+
+`pnpm test:ssr` runs `scripts/test-static-html.ts`. The script boots the Core SSR path in Node, renders fixed Markdown samples, and asserts the produced HTML contains the expected DOM markers. Append a `StaticHtmlCase` entry to the same script to cover a new case.
+
+### Accessibility (planned)
+
+`tests/a11y/` will run `@axe-core/playwright` against every component. The directory and dependency are tracked as follow-up work. The skill will gain a `pnpm test:a11y` command once the suite lands.
+
+### Visual regression (planned)
+
+A CI-only visual-snapshot suite covering ~20 essential views is planned. Local execution stays skipped to avoid OS-level rendering noise. The skill will gain a `pnpm test:visual` (CI-only) command once the suite lands.
+
+## Process
+
+### 1. Determine test scope
+
+Pick the test scope based on the changed paths.
+
+| Changed path | Tests to run |
+|--------------|--------------|
+| `packages/core/**` | All frameworks |
+| `packages/react/**` | React only |
+| `packages/vue/**` | Vue only |
+| `packages/svelte/**` | Svelte only |
+| `tests/ct/scenarios/**` | All frameworks |
+| `tests/ct/react/**` | React only |
+| `tests/ct/vue/**` | Vue only |
+| `tests/ct/svelte/**` | Svelte only |
+
+### 2. Run tests
+
+#### All frameworks (parallel)
+
+```bash
+pnpm test:ct
+```
+
+Parallel runs across all frameworks and all browsers can hit timeouts. Use `--project=chromium` for a faster, more reliable parallel run when investigating a failure.
+
+#### All frameworks (sequential)
+
+```bash
+pnpm test:ct:seq
+```
+
+#### Single framework
+
+```bash
+pnpm test:ct:react
+pnpm test:ct:vue
+pnpm test:ct:svelte
+```
+
+#### Specific browser
+
+```bash
+pnpm test:ct:react --project=chromium
+pnpm test:ct:react --project=firefox
+pnpm test:ct:react --project=webkit
+```
+
+#### Specific test file
+
+```bash
+pnpm test:ct:react tests/ct/react/specs/Editor.spec.tsx
+```
+
+#### Headed mode (visible browser)
+
+```bash
+pnpm test:ct:react --headed
+```
+
+### 3. Analyse results
+
+Successful output:
+
+```
+Running X tests using Y workers
+
+  ✓ ComponentName › test description (XXms)
+  ...
+
+  X passed (Y.Zs)
+```
+
+Failure output:
+
+```
+  ✗ ComponentName › test description (XXms)
+    Error: expect(locator).toBeVisible()
+    Locator: ...
+    Expected: visible
+    Received: hidden
+```
+
+### 4. Report
+
+```markdown
+## Test Results
+
+### Summary
+- **React**: ✅ X passed / ❌ Y failed
+- **Vue**: ✅ X passed / ❌ Y failed
+- **Svelte**: ✅ X passed / ❌ Y failed
+
+### Failures
+
+| Framework | Test | Error |
+|-----------|------|-------|
+| React | ComponentName › test | Error message |
+
+### Next steps
+- [ ] Fix the failing tests.
+- [ ] Re-run the affected suite.
+```
+
+## Coverage audit
+
+When the user asks about coverage, verify that every component and every hook, composable, or rune has a corresponding test.
+
+### 1. List implementations
+
+```bash
+# React
+ls packages/react/src/components/*.tsx | xargs -I {} basename {} .tsx
+ls packages/react/src/hooks/*.ts | xargs -I {} basename {} .ts
+
+# Vue
+ls packages/vue/src/components/*.vue | xargs -I {} basename {} .vue
+ls packages/vue/src/composables/*.ts | xargs -I {} basename {} .ts
+
+# Svelte
+ls packages/svelte/src/components/*.svelte | xargs -I {} basename {} .svelte
+ls packages/svelte/src/runes/*.ts | xargs -I {} basename {} .ts
+```
+
+### 2. List test specs
+
+```bash
+ls tests/ct/react/specs/*.tsx tests/ct/vue/specs/*.ts tests/ct/svelte/specs/*.ts | xargs -I {} basename {}
+```
+
+### 3. Classify coverage
+
+| Status | Meaning |
+|--------|---------|
+| ✅ Direct | Has a dedicated spec file |
+| ✅ Indirect | Tested through a parent component |
+| ⚠️ Style-only | Pure styling component; may not require a spec |
+| ❌ Missing | Requires a spec |
+
+### 4. Coverage report format
+
+```markdown
+## Test Coverage Report
+
+### Components
+
+| Component | React | Vue | Svelte | Status |
+|-----------|:-----:|:---:|:------:|--------|
+| EditorRoot | ✅ | ✅ | ✅ | Direct |
+| BubbleMenu | ✅ | ✅ | ✅ | Direct |
+
+### Hooks / Composables / Runes
+
+| Function | React | Vue | Svelte | Status |
+|----------|:-----:|:---:|:------:|--------|
+| useVizelEditor | ✅ | ✅ | ✅ | Indirect |
+
+### Summary
+- Components: X/Y covered (Z%).
+- Hooks/Composables/Runes: X/Y covered (Z%).
+
+### Recommendations
+- [ ] Add tests for the missing items.
+```
+
+## Troubleshooting
+
+### Browser not installed
+
+```bash
+pnpm exec playwright install chromium
+# Install every browser:
+pnpm exec playwright install
+```
+
+### Test timeout
+
+Increase the timeout for the affected test:
+
+```ts
+test("slow test", async ({ mount, page }) => {
+  test.setTimeout(30000); // 30 seconds.
+  // ...
+});
+```
+
+### Parallel execution timeout
+
+Parallel runs across all frameworks and all browsers can fail with messages like:
+
+```
+browserContext.newPage: Test timeout of 10000ms exceeded
+```
+
+Mitigations:
+
+1. Use a single browser: `pnpm test:ct --project=chromium`.
+2. Run sequentially: `pnpm test:ct:seq`.
+3. Reduce the worker count in the config (currently 50% CPU).
+
+### Element not found
+
+Check whether the element renders to `document.body` (a portal):
+
+```ts
+// Inside the mount target.
+const element = component.locator(".selector");
+
+// Rendered to document.body.
+const popup = page.locator(".selector");
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,22 +46,44 @@ Use Node.js LTS and pnpm. Invoke scripts with `pnpm <script>` and external binar
 | `pnpm deps:check` | List outdated dependencies (read-only) |
 | `pnpm deps:update` | Bump dependencies via `taze major -r -w` and run `pnpm install` |
 
+## Architecture Decision Records
+
+The v2.0.0 design records live under `docs/adr/`. Read the relevant ADR before changing a binding rule.
+
+| ID | Title |
+|----|-------|
+| [ADR-0001](./docs/adr/ADR-0001-feature-parity-over-api-symmetry.md) | Feature parity over API symmetry |
+| [ADR-0002](./docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md) | Feature manifest as parity SSOT |
+| [ADR-0003](./docs/adr/ADR-0003-vizel-headless-package.md) | `@vizel/headless` as a transitive package |
+| [ADR-0004](./docs/adr/ADR-0004-per-framework-idiomatic-api.md) | Per-framework idiomatic API contract |
+| [ADR-0005](./docs/adr/ADR-0005-v2-breaking-release.md) | v2.0.0 as a breaking release |
+| [ADR-0006](./docs/adr/ADR-0006-retire-cross-framework-rule.md) | Retire `cross-framework.md` |
+| [ADR-0007](./docs/adr/ADR-0007-component-size-and-controller-delegation.md) | 120-line component size and controller delegation |
+| [ADR-0008](./docs/adr/ADR-0008-css-belongs-in-core.md) | CSS belongs in `@vizel/core` |
+| [ADR-0009](./docs/adr/ADR-0009-first-party-editor-reactivity.md) | First-party editor reactivity in every adapter |
+| [ADR-0010](./docs/adr/ADR-0010-claude-config-official-format.md) | `.claude/` artefacts follow Anthropic's official reference |
+| [ADR-0011](./docs/adr/ADR-0011-technical-writing-style.md) | Technical-writing style governs every artefact |
+| [ADR-0012](./docs/adr/ADR-0012-playwright-ct-three-layer-rebuild.md) | Playwright Component Tests rebuilt in three layers |
+
 ## Project Rules
 
 Each rule under `.claude/rules/` is the single source of truth (SSOT) for its topic. Claude Code auto-discovers `.claude/rules/**/*.md` and loads each rule on demand: rules with a `paths:` frontmatter load when Claude reads a file matching the pattern; rules without `paths:` load at startup with the same priority as this file.
 
 | Rule | Loads When | Topic |
 |------|------------|-------|
-| `.claude/rules/architecture.md` | Always (project-wide layering invariants) | Core / framework adapter / UI-skeleton layering and consumer-facing invariants |
+| `.claude/rules/architecture.md` | Always (project-wide invariants) | Binding architecture invariants and ADR index |
 | `.claude/rules/code-style.md` | Editing source under `packages/`, `apps/`, or `tests/` | TypeScript style, function declarations, type safety |
-| `.claude/rules/cross-framework.md` | Editing under `packages/{react,vue,svelte}/` or `packages/core/src/types.ts` | Component, hook, composable, and rune parity |
+| `.claude/rules/writing.md` | Editing any source, test, or documentation file | Technical-writing principles for prose, comments, docstrings, commits |
+| `.claude/rules/feature-manifest.md` | Editing the manifest, any adapter, or any CT scenario | Feature manifest schema and parity workflow |
+| `.claude/rules/cross-framework.md` | Editing under `packages/{react,vue,svelte}/` (deprecated, removed in Phase 1) | v1 API-symmetry contract; superseded by the feature manifest |
 | `.claude/rules/git.md` | Always (commit messages, branches, hooks) | Conventional Commits, branch naming, lefthook |
 | `.claude/rules/testing.md` | Editing under `tests/` or any `playwright-ct.config.ts` | Playwright CT structure and best practices |
 | `.claude/rules/demo.md` | Editing under `apps/demo/` | Demo content, dependencies, and CSS |
-| `.claude/rules/packages/core.md` | Editing under `packages/core/` (`*.ts` / `*.scss`) | `@vizel/core` centralization and extension catalog |
-| `.claude/rules/packages/react.md` | Editing under `packages/react/` (`*.{ts,tsx}`) | React 19 components, hooks, and context |
-| `.claude/rules/packages/vue.md` | Editing under `packages/vue/` (`*.{ts,vue}`) | Vue 3 SFC components, composables, and provide/inject |
-| `.claude/rules/packages/svelte.md` | Editing under `packages/svelte/` (`*.{ts,svelte,svelte.ts}`) | Svelte 5 components, runes, and snippets |
+| `.claude/rules/packages/core.md` | Editing under `packages/core/` (`*.ts` / `*.scss`) | `@vizel/core` centralisation and extension catalog |
+| `.claude/rules/packages/headless.md` | Editing under `packages/headless/` | Framework-neutral UI primitives |
+| `.claude/rules/packages/react.md` | Editing under `packages/react/` (`*.{ts,tsx}`) | React 19 components and hooks |
+| `.claude/rules/packages/vue.md` | Editing under `packages/vue/` (`*.{ts,vue}`) | Vue 3 SFC components and composables |
+| `.claude/rules/packages/svelte.md` | Editing under `packages/svelte/` (`*.{ts,svelte,svelte.ts}`) | Svelte 5 components and runes |
 
 ## Skills
 


### PR DESCRIPTION
## Summary

- Align every artefact under `.claude/` with Anthropic's official Claude Code reference (ADR-0010).
- Skills (`test`, `lint-instructions`) gain `description`, `when_to_use`, `paths`, and `argument-hint` frontmatter, plus supporting `reference.md` and `examples.md` files per the official skill structure.
- The `cross-framework-reviewer` subagent gains `disallowedTools`, `color`, and `model` frontmatter, and a slimmer system prompt that defers detail to the feature-manifest rule.
- New rule files: `writing.md` (ADR-0011 technical-writing style), `feature-manifest.md` (ADR-0002 parity SSOT design), and `packages/headless.md` (ADR-0003 headless primitives).
- `architecture.md` trims to the binding invariants plus the ADR index.
- `cross-framework.md` gains a deprecation header; the file deletes in Phase 1 alongside the manifest landing.
- `settings.json` sets `attribution.commit` and `attribution.pr` to empty strings so commits and PRs ship without AI signature lines.
- `CLAUDE.md` gains an ADR table and lists the three new rules.

## Breaking Changes

None for end users. The changes affect only `.claude/` artefacts and the project's CLAUDE.md index.

## Test Plan

- [x] Run `pnpm lint`.
- [x] Verify `pre-push` runs the full typecheck and CT parity matrix.
- [x] `.claude/skills/*/SKILL.md` carries `description`, `when_to_use`, and `paths:` per the official spec.
- [x] `.claude/agents/cross-framework-reviewer.md` carries `disallowedTools`, `color`, and `model` frontmatter.
- [x] `cross-framework.md` shows the deprecation header; deletion lands in Phase 1.
- [x] `CLAUDE.md` lists `writing.md`, `feature-manifest.md`, and `packages/headless.md`.
