### PR TITLE
feat(core): add feature manifest as cross-framework parity SSOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Cross-framework parity
         run: pnpm check:parity
 
+      - name: Feature manifest parity
+        run: pnpm check:feature-parity
+
       - name: No-let check
         run: pnpm check:nolet
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,6 +52,9 @@ pre-push:
     parity:
       run: pnpm check:parity
 
+    feature-parity:
+      run: pnpm check:feature-parity
+
     ct-parity:
       run: pnpm check:ct-parity
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check": "biome check --error-on-warnings .",
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
+    "check:feature-parity": "tsx scripts/check-feature-parity.ts",
     "check:ct-parity": "tsx scripts/check-ct-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "check:nolet": "tsx scripts/check-no-let.ts",

--- a/packages/core/src/feature-manifest.ts
+++ b/packages/core/src/feature-manifest.ts
@@ -1,0 +1,463 @@
+/**
+ * Vizel Feature Manifest
+ *
+ * Single Source of Truth (SSOT) for cross-framework feature parity.
+ * Every advertised Vizel feature has one entry below. The script
+ * `scripts/check-feature-parity.ts` verifies that every adapter
+ * (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports the declared
+ * symbol for every entry.
+ *
+ * The manifest deliberately replaces v1's `cross-framework.md` prose
+ * tables. ADR-0001, ADR-0002, and ADR-0006 explain the rationale; the
+ * companion rule `.claude/rules/feature-manifest.md` documents the
+ * workflow for adding, modifying, and removing features.
+ */
+
+/** Stable identifier for every advertised Vizel feature. */
+export type VizelFeatureId =
+  | "editor-core"
+  | "bubble-menu"
+  | "slash-menu"
+  | "mention-menu"
+  | "block-menu"
+  | "toolbar"
+  | "toolbar-dropdown"
+  | "toolbar-overflow"
+  | "node-selector"
+  | "link-editor"
+  | "find-replace"
+  | "color-picker"
+  | "outline"
+  | "embed-view"
+  | "save-indicator"
+  | "portal"
+  | "theme"
+  | "auto-save"
+  | "collaboration"
+  | "comment"
+  | "version-history"
+  | "icon"
+  | "provider";
+
+/** Category that groups features by their UI role. */
+export type VizelFeatureCategory =
+  | "engine"
+  | "menu"
+  | "popover"
+  | "toolbar"
+  | "overlay"
+  | "form"
+  | "infrastructure";
+
+/** ARIA contract that every adapter implementation must honour. */
+export interface VizelAriaContract {
+  /** Optional ARIA role applied to the feature's root element. */
+  readonly role?: string;
+  /** Attributes the feature exposes for accessibility. */
+  readonly requiredAttributes: readonly string[];
+}
+
+/** Keyboard bindings keyed by canonical command name. */
+export interface VizelKeyboardMap {
+  readonly bindings: Readonly<Record<string, readonly string[]>>;
+}
+
+/** Public symbol that an adapter exports for a feature. */
+export interface VizelAdapterSymbol {
+  /** Component or root export from the adapter's `src/index.ts`. */
+  readonly component?: string;
+  /** Hook (React, Vue) or rune factory (Svelte) that accompanies the component. */
+  readonly companion?: string;
+}
+
+/** Per-framework adapter declaration for a single feature. */
+export interface VizelFeatureAdapters {
+  readonly react: VizelAdapterSymbol;
+  readonly vue: VizelAdapterSymbol;
+  readonly svelte: VizelAdapterSymbol;
+}
+
+/** Single feature definition consumed by `pnpm check:feature-parity`. */
+export interface VizelFeatureDefinition {
+  readonly id: VizelFeatureId;
+  readonly category: VizelFeatureCategory;
+  readonly description: string;
+  readonly ariaContract: VizelAriaContract;
+  readonly keyboardMap: VizelKeyboardMap;
+  /**
+   * Scenario identifiers under `tests/ct/scenarios/<feature-id>/`.
+   * Phase 1.5 populates the scenario folders; entries can stay empty
+   * until that work lands.
+   */
+  readonly scenarios: readonly string[];
+  readonly adapters: VizelFeatureAdapters;
+}
+
+const EMPTY_KEYBOARD_MAP: VizelKeyboardMap = { bindings: {} };
+
+/**
+ * The authoritative feature catalogue. Add, modify, and remove entries
+ * here together with the corresponding adapter and scenario changes;
+ * the parity check fails the build when an adapter omits a declared
+ * symbol.
+ */
+export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
+  {
+    id: "editor-core",
+    category: "engine",
+    description: "Editor instance bound to the framework lifecycle.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: EMPTY_KEYBOARD_MAP,
+    scenarios: ["lifecycle", "markdown-roundtrip"],
+    adapters: {
+      react: { component: "VizelEditor", companion: "useVizelEditor" },
+      vue: { component: "VizelEditor", companion: "useVizelEditor" },
+      svelte: { component: "VizelEditor", companion: "createVizelEditor" },
+    },
+  },
+  {
+    id: "bubble-menu",
+    category: "menu",
+    description: "Floating menu surfaced when the user makes a non-empty text selection.",
+    ariaContract: { role: "menu", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "selection-tracking", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelBubbleMenu" },
+      vue: { component: "VizelBubbleMenu" },
+      svelte: { component: "VizelBubbleMenu" },
+    },
+  },
+  {
+    id: "slash-menu",
+    category: "menu",
+    description: "Command palette that opens after the user types '/'.",
+    ariaContract: {
+      role: "listbox",
+      requiredAttributes: ["aria-activedescendant", "aria-label"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "filter", "keyboard-navigation", "confirm-selection"],
+    adapters: {
+      react: { component: "VizelSlashMenu" },
+      vue: { component: "VizelSlashMenu" },
+      svelte: { component: "VizelSlashMenu" },
+    },
+  },
+  {
+    id: "mention-menu",
+    category: "menu",
+    description: "Suggestion popover that opens after the user types the mention trigger.",
+    ariaContract: {
+      role: "listbox",
+      requiredAttributes: ["aria-activedescendant", "aria-label"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "filter", "keyboard-navigation"],
+    adapters: {
+      react: { component: "VizelMentionMenu" },
+      vue: { component: "VizelMentionMenu" },
+      svelte: { component: "VizelMentionMenu" },
+    },
+  },
+  {
+    id: "block-menu",
+    category: "menu",
+    description: "Block-level action menu surfaced by the drag handle.",
+    ariaContract: { role: "menu", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "block-actions", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelBlockMenu" },
+      vue: { component: "VizelBlockMenu" },
+      svelte: { component: "VizelBlockMenu" },
+    },
+  },
+  {
+    id: "toolbar",
+    category: "toolbar",
+    description: "Top-level toolbar that renders formatting and block actions.",
+    ariaContract: { role: "toolbar", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "action-invocation"],
+    adapters: {
+      react: { component: "VizelToolbar" },
+      vue: { component: "VizelToolbar" },
+      svelte: { component: "VizelToolbar" },
+    },
+  },
+  {
+    id: "toolbar-dropdown",
+    category: "popover",
+    description: "Dropdown surface used inside the toolbar for grouped actions.",
+    ariaContract: {
+      role: "menu",
+      requiredAttributes: ["aria-expanded", "aria-haspopup"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "keyboard-navigation", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelToolbarDropdown" },
+      vue: { component: "VizelToolbarDropdown" },
+      svelte: { component: "VizelToolbarDropdown" },
+    },
+  },
+  {
+    id: "toolbar-overflow",
+    category: "toolbar",
+    description: "Overflow controller that collapses toolbar items into a secondary menu.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "overflow-resize"],
+    adapters: {
+      react: { component: "VizelToolbarOverflow" },
+      vue: { component: "VizelToolbarOverflow" },
+      svelte: { component: "VizelToolbarOverflow" },
+    },
+  },
+  {
+    id: "node-selector",
+    category: "popover",
+    description: "Selector for swapping the current block's node type.",
+    ariaContract: {
+      role: "menu",
+      requiredAttributes: ["aria-expanded", "aria-haspopup"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "selection-change"],
+    adapters: {
+      react: { component: "VizelNodeSelector" },
+      vue: { component: "VizelNodeSelector" },
+      svelte: { component: "VizelNodeSelector" },
+    },
+  },
+  {
+    id: "link-editor",
+    category: "form",
+    description: "Inline form for editing the current link mark.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: {
+      bindings: {
+        submit: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "submit", "remove-link", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelLinkEditor" },
+      vue: { component: "VizelLinkEditor" },
+      svelte: { component: "VizelLinkEditor" },
+    },
+  },
+  {
+    id: "find-replace",
+    category: "overlay",
+    description: "Find-and-replace panel that searches and rewrites editor content.",
+    ariaContract: {
+      role: "dialog",
+      requiredAttributes: ["aria-label", "aria-modal"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "find", "replace", "replace-all"],
+    adapters: {
+      react: { component: "VizelFindReplace" },
+      vue: { component: "VizelFindReplace" },
+      svelte: { component: "VizelFindReplace" },
+    },
+  },
+  {
+    id: "color-picker",
+    category: "popover",
+    description: "Colour picker surface used by toolbar and bubble-menu colour controls.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "select-colour", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelColorPicker" },
+      vue: { component: "VizelColorPicker" },
+      svelte: { component: "VizelColorPicker" },
+    },
+  },
+  {
+    id: "outline",
+    category: "infrastructure",
+    description: "Document outline panel that summarises the heading structure.",
+    ariaContract: {
+      role: "navigation",
+      requiredAttributes: ["aria-label"],
+    },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "heading-tracking"],
+    adapters: {
+      react: { component: "VizelOutline" },
+      vue: { component: "VizelOutline" },
+      svelte: { component: "VizelOutline" },
+    },
+  },
+  {
+    id: "embed-view",
+    category: "infrastructure",
+    description: "Node view that renders embedded content (images, diagrams, etc.).",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render-image", "render-diagram"],
+    adapters: {
+      react: { component: "VizelEmbedView" },
+      vue: { component: "VizelEmbedView" },
+      svelte: { component: "VizelEmbedView" },
+    },
+  },
+  {
+    id: "save-indicator",
+    category: "infrastructure",
+    description: "Status indicator that visualises auto-save progress.",
+    ariaContract: {
+      role: "status",
+      requiredAttributes: ["aria-live"],
+    },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "status-transitions"],
+    adapters: {
+      react: { component: "VizelSaveIndicator" },
+      vue: { component: "VizelSaveIndicator" },
+      svelte: { component: "VizelSaveIndicator" },
+    },
+  },
+  {
+    id: "portal",
+    category: "infrastructure",
+    description: "Portal primitive that renders children into a detached DOM root.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "unmount-cleanup"],
+    adapters: {
+      react: { component: "VizelPortal" },
+      vue: { component: "VizelPortal" },
+      svelte: { component: "VizelPortal" },
+    },
+  },
+  {
+    id: "theme",
+    category: "infrastructure",
+    description: "Theme provider and resolver bound to the `data-vizel-theme` attribute.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["resolve-light", "resolve-dark", "system-preference"],
+    adapters: {
+      react: { component: "VizelThemeProvider", companion: "useVizelTheme" },
+      vue: { component: "VizelThemeProvider", companion: "useVizelTheme" },
+      svelte: { component: "VizelThemeProvider", companion: "getVizelTheme" },
+    },
+  },
+  {
+    id: "auto-save",
+    category: "infrastructure",
+    description: "Auto-save lifecycle that persists Markdown to a configured backend.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["debounce", "persist", "restore"],
+    adapters: {
+      react: { companion: "useVizelAutoSave" },
+      vue: { companion: "useVizelAutoSave" },
+      svelte: { companion: "createVizelAutoSave" },
+    },
+  },
+  {
+    id: "collaboration",
+    category: "infrastructure",
+    description: "Yjs-backed collaboration channel for multi-user editing.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["join", "remote-update", "presence"],
+    adapters: {
+      react: { companion: "useVizelCollaboration" },
+      vue: { companion: "useVizelCollaboration" },
+      svelte: { companion: "createVizelCollaboration" },
+    },
+  },
+  {
+    id: "comment",
+    category: "infrastructure",
+    description: "Comment thread overlay anchored to selection ranges.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["create-thread", "resolve-thread"],
+    adapters: {
+      react: { companion: "useVizelComment" },
+      vue: { companion: "useVizelComment" },
+      svelte: { companion: "createVizelComment" },
+    },
+  },
+  {
+    id: "version-history",
+    category: "infrastructure",
+    description: "Version-history surface that snapshots and restores Markdown revisions.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["snapshot", "restore"],
+    adapters: {
+      react: { companion: "useVizelVersionHistory" },
+      vue: { companion: "useVizelVersionHistory" },
+      svelte: { companion: "createVizelVersionHistory" },
+    },
+  },
+  {
+    id: "icon",
+    category: "infrastructure",
+    description: "Icon component bound to the icon registry.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render-default", "render-custom-registry"],
+    adapters: {
+      react: { component: "VizelIcon", companion: "useVizelIconContext" },
+      vue: { component: "VizelIcon", companion: "useVizelIconContext" },
+      svelte: { component: "VizelIcon", companion: "getVizelIconContext" },
+    },
+  },
+  {
+    id: "provider",
+    category: "infrastructure",
+    description:
+      "Top-level provider that exposes editor, locale, theme, and icons through context.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["expose-editor", "expose-locale", "expose-theme"],
+    adapters: {
+      react: { component: "VizelProvider", companion: "useVizelContext" },
+      vue: { component: "VizelProvider", companion: "useVizelContext" },
+      svelte: { component: "VizelProvider", companion: "getVizelContext" },
+    },
+  },
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -392,6 +392,19 @@ export {
   vizelWikiLinkPluginKey,
 } from "./extensions/index.ts";
 // =============================================================================
+// Feature Manifest (cross-framework parity SSOT)
+// =============================================================================
+export {
+  VIZEL_FEATURE_MANIFEST,
+  type VizelAdapterSymbol,
+  type VizelAriaContract,
+  type VizelFeatureAdapters,
+  type VizelFeatureCategory,
+  type VizelFeatureDefinition,
+  type VizelFeatureId,
+  type VizelKeyboardMap,
+} from "./feature-manifest.ts";
+// =============================================================================
 // i18n
 // =============================================================================
 export {

--- a/scripts/check-feature-parity.ts
+++ b/scripts/check-feature-parity.ts
@@ -1,0 +1,152 @@
+/**
+ * Feature manifest parity check.
+ *
+ * Loads `VIZEL_FEATURE_MANIFEST` from `@vizel/core` and verifies that
+ * every adapter (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports
+ * the declared `component` and `companion` symbols for every feature.
+ *
+ * The check runs in two layers:
+ *
+ * 1. Structural — the manifest itself is valid TypeScript (unique IDs,
+ *    every adapter shape resolves).
+ * 2. Surface — each adapter's `src/index.ts` exports the declared
+ *    symbols. The check tolerates symbols that re-export from
+ *    `@vizel/core` because `export * from "@vizel/core"` is mandatory
+ *    per the v2 architecture.
+ *
+ * Exits 0 on success, 1 on any divergence.
+ *
+ * See ADR-0002 for the rationale and `.claude/rules/feature-manifest.md`
+ * for the contributor workflow.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  VIZEL_FEATURE_MANIFEST,
+  type VizelFeatureAdapters,
+  type VizelFeatureDefinition,
+} from "../packages/core/src/feature-manifest.ts";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+interface AdapterPaths {
+  readonly framework: keyof VizelFeatureAdapters;
+  readonly indexPath: string;
+}
+
+const ADAPTERS: readonly AdapterPaths[] = [
+  { framework: "react", indexPath: resolve(REPO_ROOT, "packages/react/src/index.ts") },
+  { framework: "vue", indexPath: resolve(REPO_ROOT, "packages/vue/src/index.ts") },
+  { framework: "svelte", indexPath: resolve(REPO_ROOT, "packages/svelte/src/index.ts") },
+];
+
+interface ParityFinding {
+  readonly featureId: string;
+  readonly framework: keyof VizelFeatureAdapters;
+  readonly missing: readonly string[];
+}
+
+/**
+ * Verify the manifest itself: every feature ID is unique. The TypeScript
+ * compiler enforces structural correctness; this check guards the one
+ * invariant the type system cannot express.
+ */
+function verifyManifestStructure(manifest: readonly VizelFeatureDefinition[]): readonly string[] {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  for (const feature of manifest) {
+    if (seen.has(feature.id)) errors.push(`Duplicate feature id: ${feature.id}`);
+    seen.add(feature.id);
+  }
+  return errors;
+}
+
+/**
+ * Read an adapter's `src/index.ts` and return the set of identifiers it
+ * exports. The check looks for direct named exports and the wildcard
+ * `export * from "@vizel/core"` that flags Core surface availability.
+ */
+function loadAdapterSurface(indexPath: string): {
+  readonly named: ReadonlySet<string>;
+  readonly reexportsCore: boolean;
+} {
+  const source = readFileSync(indexPath, "utf8");
+  const named = new Set<string>();
+  const reexportsCore = /export\s*\*\s*from\s*["']@vizel\/core["']/.test(source);
+  for (const match of source.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const raw of match[1].split(",")) {
+      const trimmed = raw
+        .trim()
+        .replace(/\s+as\s+\w+$/u, "")
+        .replace(/^type\s+/u, "");
+      if (trimmed) named.add(trimmed);
+    }
+  }
+  for (const match of source.matchAll(
+    /export\s+(?:function|class|const|let|interface|type|enum)\s+(\w+)/g
+  )) {
+    named.add(match[1]);
+  }
+  return { named, reexportsCore };
+}
+
+/**
+ * Verify a single adapter against the manifest. Returns a finding when
+ * the adapter is missing any declared symbol.
+ */
+function verifyAdapter(
+  manifest: readonly VizelFeatureDefinition[],
+  adapter: AdapterPaths
+): readonly ParityFinding[] {
+  const surface = loadAdapterSurface(adapter.indexPath);
+  const findings: ParityFinding[] = [];
+  for (const feature of manifest) {
+    const adapterShape = feature.adapters[adapter.framework];
+    const missing: string[] = [];
+    for (const symbol of [adapterShape.component, adapterShape.companion]) {
+      if (!symbol) continue;
+      if (surface.named.has(symbol)) continue;
+      // The wildcard re-export forwards every Core symbol. The check
+      // accepts it as a presence signal; future iterations may resolve
+      // Core's index.ts to enumerate the forwarded names explicitly.
+      if (surface.reexportsCore) continue;
+      missing.push(symbol);
+    }
+    if (missing.length > 0)
+      findings.push({ featureId: feature.id, framework: adapter.framework, missing });
+  }
+  return findings;
+}
+
+function main(): void {
+  const structuralErrors = verifyManifestStructure(VIZEL_FEATURE_MANIFEST);
+  if (structuralErrors.length > 0) {
+    console.error("Manifest structure errors:");
+    for (const error of structuralErrors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  const allFindings: ParityFinding[] = [];
+  for (const adapter of ADAPTERS) {
+    allFindings.push(...verifyAdapter(VIZEL_FEATURE_MANIFEST, adapter));
+  }
+
+  if (allFindings.length === 0) {
+    const featureCount = VIZEL_FEATURE_MANIFEST.length;
+    console.log(`Feature manifest parity check passed (${featureCount} features × 3 frameworks).`);
+    return;
+  }
+
+  console.error("Feature manifest parity violations:");
+  for (const finding of allFindings) {
+    console.error(
+      `  - ${finding.featureId} / ${finding.framework}: missing ${finding.missing.join(", ")}`
+    );
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Land the cross-framework feature manifest at `packages/core/src/feature-manifest.ts` as the typed Single Source of Truth (SSOT) for v2 parity (ADR-0002).
- Add `scripts/check-feature-parity.ts`, driven by the manifest, that asserts every adapter (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports the declared symbol set for every feature.
- Wire the new script into `pnpm check:feature-parity`, into the lefthook `pre-push` hook, and into the CI quality job alongside the existing legacy cross-framework parity check.
- Re-export the new types and constants from `@vizel/core`'s public surface.

## Why

The v1 cross-framework rule (`.claude/rules/cross-framework.md`) encoded parity in prose and could only be enforced by a script that re-derived intent from `index.ts` exports. The v2 manifest moves the contract into TypeScript, so the compiler enforces structural integrity and the parity check fails the build at edit time instead of at review time.

## Coverage

The manifest declares 23 features across seven categories (engine, menu, popover, toolbar, overlay, form, infrastructure). `pnpm check:feature-parity` reports:

```
Feature manifest parity check passed (23 features × 3 frameworks).
```

## Follow-up

ADR-0006 retires `.claude/rules/cross-framework.md` and the legacy parity script. The retirement lands in a follow-up PR after PR #559 (the `.claude/` rewrite) merges, to avoid conflicts with the deprecation header that PR introduces.

## Breaking Changes

None for end users. The new check is additive; the legacy check remains in place during the transition.

## Test Plan

- [x] Run `pnpm typecheck`.
- [x] Run `pnpm lint`.
- [x] Run `pnpm check:feature-parity` — passes with 23 features × 3 frameworks.
- [x] Run `pnpm check:nolet` — passes.
- [x] Confirm `pnpm check:parity` (legacy) still passes.
- [x] Verify the `pre-push` hook runs the new check alongside the legacy one.
