### PR TITLE
feat(headless): scaffold @vizel/headless with the dismissable primitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Cross-framework parity
         run: pnpm check:parity
 
+      - name: Feature manifest parity
+        run: pnpm check:feature-parity
+
       - name: No-let check
         run: pnpm check:nolet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Feature manifest parity
         run: pnpm check:feature-parity
 
+      - name: Scenario foundation parity
+        run: pnpm check:scenarios
+
       - name: No-let check
         run: pnpm check:nolet
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,6 +55,9 @@ pre-push:
     feature-parity:
       run: pnpm check:feature-parity
 
+    scenarios:
+      run: pnpm check:scenarios
+
     ct-parity:
       run: pnpm check:ct-parity
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,6 +52,9 @@ pre-push:
     parity:
       run: pnpm check:parity
 
+    feature-parity:
+      run: pnpm check:feature-parity
+
     ct-parity:
       run: pnpm check:ct-parity
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check": "biome check --error-on-warnings .",
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
+    "check:feature-parity": "tsx scripts/check-feature-parity.ts",
     "check:ct-parity": "tsx scripts/check-ct-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "check:nolet": "tsx scripts/check-no-let.ts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check:fix": "biome check --write .",
     "check:parity": "tsx scripts/check-cross-framework-parity.ts",
     "check:feature-parity": "tsx scripts/check-feature-parity.ts",
+    "check:scenarios": "tsx tests/ct/parity/check-scenarios.ts",
     "check:ct-parity": "tsx scripts/check-ct-parity.ts",
     "check:ssr": "tsx scripts/check-ssr-safety.ts",
     "check:nolet": "tsx scripts/check-no-let.ts",

--- a/packages/core/src/feature-manifest.ts
+++ b/packages/core/src/feature-manifest.ts
@@ -1,0 +1,463 @@
+/**
+ * Vizel Feature Manifest
+ *
+ * Single Source of Truth (SSOT) for cross-framework feature parity.
+ * Every advertised Vizel feature has one entry below. The script
+ * `scripts/check-feature-parity.ts` verifies that every adapter
+ * (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports the declared
+ * symbol for every entry.
+ *
+ * The manifest deliberately replaces v1's `cross-framework.md` prose
+ * tables. ADR-0001, ADR-0002, and ADR-0006 explain the rationale; the
+ * companion rule `.claude/rules/feature-manifest.md` documents the
+ * workflow for adding, modifying, and removing features.
+ */
+
+/** Stable identifier for every advertised Vizel feature. */
+export type VizelFeatureId =
+  | "editor-core"
+  | "bubble-menu"
+  | "slash-menu"
+  | "mention-menu"
+  | "block-menu"
+  | "toolbar"
+  | "toolbar-dropdown"
+  | "toolbar-overflow"
+  | "node-selector"
+  | "link-editor"
+  | "find-replace"
+  | "color-picker"
+  | "outline"
+  | "embed-view"
+  | "save-indicator"
+  | "portal"
+  | "theme"
+  | "auto-save"
+  | "collaboration"
+  | "comment"
+  | "version-history"
+  | "icon"
+  | "provider";
+
+/** Category that groups features by their UI role. */
+export type VizelFeatureCategory =
+  | "engine"
+  | "menu"
+  | "popover"
+  | "toolbar"
+  | "overlay"
+  | "form"
+  | "infrastructure";
+
+/** ARIA contract that every adapter implementation must honour. */
+export interface VizelAriaContract {
+  /** Optional ARIA role applied to the feature's root element. */
+  readonly role?: string;
+  /** Attributes the feature exposes for accessibility. */
+  readonly requiredAttributes: readonly string[];
+}
+
+/** Keyboard bindings keyed by canonical command name. */
+export interface VizelKeyboardMap {
+  readonly bindings: Readonly<Record<string, readonly string[]>>;
+}
+
+/** Public symbol that an adapter exports for a feature. */
+export interface VizelAdapterSymbol {
+  /** Component or root export from the adapter's `src/index.ts`. */
+  readonly component?: string;
+  /** Hook (React, Vue) or rune factory (Svelte) that accompanies the component. */
+  readonly companion?: string;
+}
+
+/** Per-framework adapter declaration for a single feature. */
+export interface VizelFeatureAdapters {
+  readonly react: VizelAdapterSymbol;
+  readonly vue: VizelAdapterSymbol;
+  readonly svelte: VizelAdapterSymbol;
+}
+
+/** Single feature definition consumed by `pnpm check:feature-parity`. */
+export interface VizelFeatureDefinition {
+  readonly id: VizelFeatureId;
+  readonly category: VizelFeatureCategory;
+  readonly description: string;
+  readonly ariaContract: VizelAriaContract;
+  readonly keyboardMap: VizelKeyboardMap;
+  /**
+   * Scenario identifiers under `tests/ct/scenarios/<feature-id>/`.
+   * Phase 1.5 populates the scenario folders; entries can stay empty
+   * until that work lands.
+   */
+  readonly scenarios: readonly string[];
+  readonly adapters: VizelFeatureAdapters;
+}
+
+const EMPTY_KEYBOARD_MAP: VizelKeyboardMap = { bindings: {} };
+
+/**
+ * The authoritative feature catalogue. Add, modify, and remove entries
+ * here together with the corresponding adapter and scenario changes;
+ * the parity check fails the build when an adapter omits a declared
+ * symbol.
+ */
+export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
+  {
+    id: "editor-core",
+    category: "engine",
+    description: "Editor instance bound to the framework lifecycle.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: EMPTY_KEYBOARD_MAP,
+    scenarios: ["lifecycle", "markdown-roundtrip"],
+    adapters: {
+      react: { component: "VizelEditor", companion: "useVizelEditor" },
+      vue: { component: "VizelEditor", companion: "useVizelEditor" },
+      svelte: { component: "VizelEditor", companion: "createVizelEditor" },
+    },
+  },
+  {
+    id: "bubble-menu",
+    category: "menu",
+    description: "Floating menu surfaced when the user makes a non-empty text selection.",
+    ariaContract: { role: "menu", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "selection-tracking", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelBubbleMenu" },
+      vue: { component: "VizelBubbleMenu" },
+      svelte: { component: "VizelBubbleMenu" },
+    },
+  },
+  {
+    id: "slash-menu",
+    category: "menu",
+    description: "Command palette that opens after the user types '/'.",
+    ariaContract: {
+      role: "listbox",
+      requiredAttributes: ["aria-activedescendant", "aria-label"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "filter", "keyboard-navigation", "confirm-selection"],
+    adapters: {
+      react: { component: "VizelSlashMenu" },
+      vue: { component: "VizelSlashMenu" },
+      svelte: { component: "VizelSlashMenu" },
+    },
+  },
+  {
+    id: "mention-menu",
+    category: "menu",
+    description: "Suggestion popover that opens after the user types the mention trigger.",
+    ariaContract: {
+      role: "listbox",
+      requiredAttributes: ["aria-activedescendant", "aria-label"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "filter", "keyboard-navigation"],
+    adapters: {
+      react: { component: "VizelMentionMenu" },
+      vue: { component: "VizelMentionMenu" },
+      svelte: { component: "VizelMentionMenu" },
+    },
+  },
+  {
+    id: "block-menu",
+    category: "menu",
+    description: "Block-level action menu surfaced by the drag handle.",
+    ariaContract: { role: "menu", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "block-actions", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelBlockMenu" },
+      vue: { component: "VizelBlockMenu" },
+      svelte: { component: "VizelBlockMenu" },
+    },
+  },
+  {
+    id: "toolbar",
+    category: "toolbar",
+    description: "Top-level toolbar that renders formatting and block actions.",
+    ariaContract: { role: "toolbar", requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "action-invocation"],
+    adapters: {
+      react: { component: "VizelToolbar" },
+      vue: { component: "VizelToolbar" },
+      svelte: { component: "VizelToolbar" },
+    },
+  },
+  {
+    id: "toolbar-dropdown",
+    category: "popover",
+    description: "Dropdown surface used inside the toolbar for grouped actions.",
+    ariaContract: {
+      role: "menu",
+      requiredAttributes: ["aria-expanded", "aria-haspopup"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "keyboard-navigation", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelToolbarDropdown" },
+      vue: { component: "VizelToolbarDropdown" },
+      svelte: { component: "VizelToolbarDropdown" },
+    },
+  },
+  {
+    id: "toolbar-overflow",
+    category: "toolbar",
+    description: "Overflow controller that collapses toolbar items into a secondary menu.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "overflow-resize"],
+    adapters: {
+      react: { component: "VizelToolbarOverflow" },
+      vue: { component: "VizelToolbarOverflow" },
+      svelte: { component: "VizelToolbarOverflow" },
+    },
+  },
+  {
+    id: "node-selector",
+    category: "popover",
+    description: "Selector for swapping the current block's node type.",
+    ariaContract: {
+      role: "menu",
+      requiredAttributes: ["aria-expanded", "aria-haspopup"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["ArrowDown"],
+        previous: ["ArrowUp"],
+        confirm: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "selection-change"],
+    adapters: {
+      react: { component: "VizelNodeSelector" },
+      vue: { component: "VizelNodeSelector" },
+      svelte: { component: "VizelNodeSelector" },
+    },
+  },
+  {
+    id: "link-editor",
+    category: "form",
+    description: "Inline form for editing the current link mark.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: {
+      bindings: {
+        submit: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "submit", "remove-link", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelLinkEditor" },
+      vue: { component: "VizelLinkEditor" },
+      svelte: { component: "VizelLinkEditor" },
+    },
+  },
+  {
+    id: "find-replace",
+    category: "overlay",
+    description: "Find-and-replace panel that searches and rewrites editor content.",
+    ariaContract: {
+      role: "dialog",
+      requiredAttributes: ["aria-label", "aria-modal"],
+    },
+    keyboardMap: {
+      bindings: {
+        next: ["Enter"],
+        close: ["Escape"],
+      },
+    },
+    scenarios: ["render", "find", "replace", "replace-all"],
+    adapters: {
+      react: { component: "VizelFindReplace" },
+      vue: { component: "VizelFindReplace" },
+      svelte: { component: "VizelFindReplace" },
+    },
+  },
+  {
+    id: "color-picker",
+    category: "popover",
+    description: "Colour picker surface used by toolbar and bubble-menu colour controls.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: { close: ["Escape"] } },
+    scenarios: ["render", "select-colour", "keyboard-dismiss"],
+    adapters: {
+      react: { component: "VizelColorPicker" },
+      vue: { component: "VizelColorPicker" },
+      svelte: { component: "VizelColorPicker" },
+    },
+  },
+  {
+    id: "outline",
+    category: "infrastructure",
+    description: "Document outline panel that summarises the heading structure.",
+    ariaContract: {
+      role: "navigation",
+      requiredAttributes: ["aria-label"],
+    },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "heading-tracking"],
+    adapters: {
+      react: { component: "VizelOutline" },
+      vue: { component: "VizelOutline" },
+      svelte: { component: "VizelOutline" },
+    },
+  },
+  {
+    id: "embed-view",
+    category: "infrastructure",
+    description: "Node view that renders embedded content (images, diagrams, etc.).",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render-image", "render-diagram"],
+    adapters: {
+      react: { component: "VizelEmbedView" },
+      vue: { component: "VizelEmbedView" },
+      svelte: { component: "VizelEmbedView" },
+    },
+  },
+  {
+    id: "save-indicator",
+    category: "infrastructure",
+    description: "Status indicator that visualises auto-save progress.",
+    ariaContract: {
+      role: "status",
+      requiredAttributes: ["aria-live"],
+    },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "status-transitions"],
+    adapters: {
+      react: { component: "VizelSaveIndicator" },
+      vue: { component: "VizelSaveIndicator" },
+      svelte: { component: "VizelSaveIndicator" },
+    },
+  },
+  {
+    id: "portal",
+    category: "infrastructure",
+    description: "Portal primitive that renders children into a detached DOM root.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render", "unmount-cleanup"],
+    adapters: {
+      react: { component: "VizelPortal" },
+      vue: { component: "VizelPortal" },
+      svelte: { component: "VizelPortal" },
+    },
+  },
+  {
+    id: "theme",
+    category: "infrastructure",
+    description: "Theme provider and resolver bound to the `data-vizel-theme` attribute.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["resolve-light", "resolve-dark", "system-preference"],
+    adapters: {
+      react: { component: "VizelThemeProvider", companion: "useVizelTheme" },
+      vue: { component: "VizelThemeProvider", companion: "useVizelTheme" },
+      svelte: { component: "VizelThemeProvider", companion: "getVizelTheme" },
+    },
+  },
+  {
+    id: "auto-save",
+    category: "infrastructure",
+    description: "Auto-save lifecycle that persists Markdown to a configured backend.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["debounce", "persist", "restore"],
+    adapters: {
+      react: { companion: "useVizelAutoSave" },
+      vue: { companion: "useVizelAutoSave" },
+      svelte: { companion: "createVizelAutoSave" },
+    },
+  },
+  {
+    id: "collaboration",
+    category: "infrastructure",
+    description: "Yjs-backed collaboration channel for multi-user editing.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["join", "remote-update", "presence"],
+    adapters: {
+      react: { companion: "useVizelCollaboration" },
+      vue: { companion: "useVizelCollaboration" },
+      svelte: { companion: "createVizelCollaboration" },
+    },
+  },
+  {
+    id: "comment",
+    category: "infrastructure",
+    description: "Comment thread overlay anchored to selection ranges.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["create-thread", "resolve-thread"],
+    adapters: {
+      react: { companion: "useVizelComment" },
+      vue: { companion: "useVizelComment" },
+      svelte: { companion: "createVizelComment" },
+    },
+  },
+  {
+    id: "version-history",
+    category: "infrastructure",
+    description: "Version-history surface that snapshots and restores Markdown revisions.",
+    ariaContract: { requiredAttributes: ["aria-label"] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["snapshot", "restore"],
+    adapters: {
+      react: { companion: "useVizelVersionHistory" },
+      vue: { companion: "useVizelVersionHistory" },
+      svelte: { companion: "createVizelVersionHistory" },
+    },
+  },
+  {
+    id: "icon",
+    category: "infrastructure",
+    description: "Icon component bound to the icon registry.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["render-default", "render-custom-registry"],
+    adapters: {
+      react: { component: "VizelIcon", companion: "useVizelIconContext" },
+      vue: { component: "VizelIcon", companion: "useVizelIconContext" },
+      svelte: { component: "VizelIcon", companion: "getVizelIconContext" },
+    },
+  },
+  {
+    id: "provider",
+    category: "infrastructure",
+    description:
+      "Top-level provider that exposes editor, locale, theme, and icons through context.",
+    ariaContract: { requiredAttributes: [] },
+    keyboardMap: { bindings: {} },
+    scenarios: ["expose-editor", "expose-locale", "expose-theme"],
+    adapters: {
+      react: { component: "VizelProvider", companion: "useVizelContext" },
+      vue: { component: "VizelProvider", companion: "useVizelContext" },
+      svelte: { component: "VizelProvider", companion: "getVizelContext" },
+    },
+  },
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -392,6 +392,19 @@ export {
   vizelWikiLinkPluginKey,
 } from "./extensions/index.ts";
 // =============================================================================
+// Feature Manifest (cross-framework parity SSOT)
+// =============================================================================
+export {
+  VIZEL_FEATURE_MANIFEST,
+  type VizelAdapterSymbol,
+  type VizelAriaContract,
+  type VizelFeatureAdapters,
+  type VizelFeatureCategory,
+  type VizelFeatureDefinition,
+  type VizelFeatureId,
+  type VizelKeyboardMap,
+} from "./feature-manifest.ts";
+// =============================================================================
 // i18n
 // =============================================================================
 export {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@vizel/headless",
+  "version": "2.0.0",
+  "type": "module",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/vizel",
+    "directory": "packages/headless"
+  },
+  "description": "Framework-neutral UI primitives consumed by every Vizel framework adapter",
+  "license": "MIT",
+  "author": "Seiji Kohara",
+  "homepage": "https://seijikohara.github.io/vizel/",
+  "bugs": {
+    "url": "https://github.com/seijikohara/vizel/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "vizel",
+    "headless",
+    "ui",
+    "primitives",
+    "combobox",
+    "popover",
+    "dismissable",
+    "focus-trap"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./dismissable": {
+      "types": "./dist/dismissable/index.d.ts",
+      "import": "./dist/dismissable/index.js",
+      "default": "./dist/dismissable/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "vite": "^8.0.14",
+    "vite-plugin-dts": "^5.0.1"
+  }
+}

--- a/packages/headless/src/dismissable/index.ts
+++ b/packages/headless/src/dismissable/index.ts
@@ -1,0 +1,169 @@
+/**
+ * Dismissable controller.
+ *
+ * Wires the three signals every floating UI surface in Vizel needs to
+ * dismiss: pointer activity outside the surface, the `Escape` key, and
+ * focus that leaves the surface entirely. The controller owns the
+ * `document`-level listeners so framework adapters never attach them
+ * directly. ADR-0007 (controller delegation) and ADR-0003 (headless
+ * package) record the constraints this controller honours.
+ *
+ * The factory returns a `{ mount, unmount, update }` controller. Each
+ * `mount(target)` activates the listeners against the supplied target;
+ * `unmount()` detaches every listener and is safe to call repeatedly.
+ */
+
+export interface VizelDismissableOptions {
+  /**
+   * Fires when the user clicks or taps outside the mount target.
+   * Implementations typically close the surface from this callback.
+   */
+  readonly onPointerOutside?: () => void;
+  /**
+   * Fires when the user presses Escape while the surface is mounted.
+   */
+  readonly onEscape?: () => void;
+  /**
+   * Fires when keyboard focus leaves the mount target. The callback
+   * receives the element that gained focus.
+   */
+  readonly onFocusOutside?: (nextFocus: Element | null) => void;
+  /**
+   * When `true`, the Escape handler uses capture phase and calls
+   * `event.stopImmediatePropagation()` so the editor's own Escape
+   * binding does not also fire. Defaults to `false`.
+   */
+  readonly captureEscape?: boolean;
+  /**
+   * When `true`, the controller defers pointer-listener installation
+   * until the next animation frame. Editor menus that open in
+   * response to a pointerdown event use this to avoid swallowing the
+   * opening event as an outside click. Defaults to `false`.
+   */
+  readonly deferPointerHandler?: boolean;
+}
+
+export interface VizelDismissableController {
+  /**
+   * Activate dismissal handlers against `target`. Re-mounting on a
+   * different target unmounts the previous target first.
+   */
+  mount(target: HTMLElement): void;
+  /**
+   * Detach every listener. Calling `unmount()` more than once is a
+   * no-op.
+   */
+  unmount(): void;
+  /**
+   * Update the callbacks without re-attaching listeners. The
+   * controller invokes the latest callback at every event delivery.
+   */
+  update(options: VizelDismissableOptions): void;
+}
+
+const isBrowser = (): boolean => typeof document !== "undefined";
+
+/**
+ * Construct a dismissable controller for a floating surface.
+ *
+ * The controller is the home for the listener wiring that v1
+ * framework components attached directly to `document`. Adapter code
+ * obtains the controller through `@vizel/headless`, passes its root
+ * element into `mount`, and detaches via `unmount` on lifecycle
+ * teardown.
+ */
+export function createVizelDismissable(
+  initialOptions: VizelDismissableOptions = {}
+): VizelDismissableController {
+  const state = {
+    options: initialOptions,
+    target: null as HTMLElement | null,
+    pointerHandler: null as ((event: PointerEvent) => void) | null,
+    escapeHandler: null as ((event: KeyboardEvent) => void) | null,
+    focusHandler: null as ((event: FocusEvent) => void) | null,
+    pointerInstallTimer: null as number | null,
+  };
+
+  const detachListeners = (): void => {
+    if (!isBrowser()) return;
+    if (state.pointerInstallTimer !== null) {
+      window.clearTimeout(state.pointerInstallTimer);
+      state.pointerInstallTimer = null;
+    }
+    if (state.pointerHandler !== null) {
+      document.removeEventListener("pointerdown", state.pointerHandler, true);
+      state.pointerHandler = null;
+    }
+    if (state.escapeHandler !== null) {
+      document.removeEventListener(
+        "keydown",
+        state.escapeHandler,
+        Boolean(state.options.captureEscape)
+      );
+      state.escapeHandler = null;
+    }
+    if (state.focusHandler !== null) {
+      document.removeEventListener("focusin", state.focusHandler, true);
+      state.focusHandler = null;
+    }
+  };
+
+  const installPointerHandler = (target: HTMLElement): void => {
+    const handler = (event: PointerEvent): void => {
+      if (!(event.target instanceof Node)) return;
+      if (target.contains(event.target)) return;
+      state.options.onPointerOutside?.();
+    };
+    state.pointerHandler = handler;
+    document.addEventListener("pointerdown", handler, true);
+  };
+
+  const installEscapeHandler = (): void => {
+    const handler = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      if (state.options.captureEscape) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+      state.options.onEscape?.();
+    };
+    state.escapeHandler = handler;
+    document.addEventListener("keydown", handler, Boolean(state.options.captureEscape));
+  };
+
+  const installFocusHandler = (target: HTMLElement): void => {
+    const handler = (event: FocusEvent): void => {
+      if (event.target instanceof Node && target.contains(event.target)) return;
+      const next = event.target instanceof Element ? event.target : null;
+      state.options.onFocusOutside?.(next);
+    };
+    state.focusHandler = handler;
+    document.addEventListener("focusin", handler, true);
+  };
+
+  return {
+    mount(target: HTMLElement): void {
+      if (!isBrowser()) return;
+      if (state.target === target) return;
+      detachListeners();
+      state.target = target;
+      if (state.options.deferPointerHandler) {
+        state.pointerInstallTimer = window.setTimeout(() => {
+          state.pointerInstallTimer = null;
+          installPointerHandler(target);
+        }, 0);
+      } else {
+        installPointerHandler(target);
+      }
+      installEscapeHandler();
+      installFocusHandler(target);
+    },
+    unmount(): void {
+      detachListeners();
+      state.target = null;
+    },
+    update(options: VizelDismissableOptions): void {
+      state.options = options;
+    },
+  };
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @vizel/headless
+ *
+ * Framework-neutral UI primitives consumed by every Vizel framework
+ * adapter. The package exports spec builders and controller factories
+ * (`{ mount, unmount, update }`) for combobox, popover, dismissable,
+ * focus-trap, floating, and keyboard helpers. Adapter packages depend
+ * on this package; consumers do not.
+ *
+ * ADR-0003 records the design rationale.
+ *
+ * Current scope (Phase 2):
+ * - `dismissable/` ships the first primitive and is the migration
+ *   target for the 21 `document.addEventListener` violations that
+ *   v1 adapter components carry.
+ *
+ * Subsequent primitives (combobox, popover, focus-trap, floating,
+ * keyboard) land in follow-up commits alongside each Phase 3 adapter
+ * rewrite that needs them.
+ */
+
+export {
+  createVizelDismissable,
+  type VizelDismissableController,
+  type VizelDismissableOptions,
+} from "./dismissable/index.ts";

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/headless/vite.config.ts
+++ b/packages/headless/vite.config.ts
@@ -1,0 +1,29 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [
+    dts({
+      include: ["src/**/*.ts"],
+      outDir: "dist",
+    }),
+  ],
+  build: {
+    lib: {
+      entry: {
+        index: resolve(__dirname, "src/index.ts"),
+        "dismissable/index": resolve(__dirname, "src/dismissable/index.ts"),
+      },
+      formats: ["es"],
+    },
+    rollupOptions: {
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: "src",
+      },
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,15 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/headless:
+    devDependencies:
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite-plugin-dts:
+        specifier: ^5.0.1
+        version: 5.0.1(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/react:
     dependencies:
       '@iconify/react':

--- a/scripts/check-feature-parity.ts
+++ b/scripts/check-feature-parity.ts
@@ -1,0 +1,152 @@
+/**
+ * Feature manifest parity check.
+ *
+ * Loads `VIZEL_FEATURE_MANIFEST` from `@vizel/core` and verifies that
+ * every adapter (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports
+ * the declared `component` and `companion` symbols for every feature.
+ *
+ * The check runs in two layers:
+ *
+ * 1. Structural — the manifest itself is valid TypeScript (unique IDs,
+ *    every adapter shape resolves).
+ * 2. Surface — each adapter's `src/index.ts` exports the declared
+ *    symbols. The check tolerates symbols that re-export from
+ *    `@vizel/core` because `export * from "@vizel/core"` is mandatory
+ *    per the v2 architecture.
+ *
+ * Exits 0 on success, 1 on any divergence.
+ *
+ * See ADR-0002 for the rationale and `.claude/rules/feature-manifest.md`
+ * for the contributor workflow.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  VIZEL_FEATURE_MANIFEST,
+  type VizelFeatureAdapters,
+  type VizelFeatureDefinition,
+} from "../packages/core/src/feature-manifest.ts";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+interface AdapterPaths {
+  readonly framework: keyof VizelFeatureAdapters;
+  readonly indexPath: string;
+}
+
+const ADAPTERS: readonly AdapterPaths[] = [
+  { framework: "react", indexPath: resolve(REPO_ROOT, "packages/react/src/index.ts") },
+  { framework: "vue", indexPath: resolve(REPO_ROOT, "packages/vue/src/index.ts") },
+  { framework: "svelte", indexPath: resolve(REPO_ROOT, "packages/svelte/src/index.ts") },
+];
+
+interface ParityFinding {
+  readonly featureId: string;
+  readonly framework: keyof VizelFeatureAdapters;
+  readonly missing: readonly string[];
+}
+
+/**
+ * Verify the manifest itself: every feature ID is unique. The TypeScript
+ * compiler enforces structural correctness; this check guards the one
+ * invariant the type system cannot express.
+ */
+function verifyManifestStructure(manifest: readonly VizelFeatureDefinition[]): readonly string[] {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  for (const feature of manifest) {
+    if (seen.has(feature.id)) errors.push(`Duplicate feature id: ${feature.id}`);
+    seen.add(feature.id);
+  }
+  return errors;
+}
+
+/**
+ * Read an adapter's `src/index.ts` and return the set of identifiers it
+ * exports. The check looks for direct named exports and the wildcard
+ * `export * from "@vizel/core"` that flags Core surface availability.
+ */
+function loadAdapterSurface(indexPath: string): {
+  readonly named: ReadonlySet<string>;
+  readonly reexportsCore: boolean;
+} {
+  const source = readFileSync(indexPath, "utf8");
+  const named = new Set<string>();
+  const reexportsCore = /export\s*\*\s*from\s*["']@vizel\/core["']/.test(source);
+  for (const match of source.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const raw of match[1].split(",")) {
+      const trimmed = raw
+        .trim()
+        .replace(/\s+as\s+\w+$/u, "")
+        .replace(/^type\s+/u, "");
+      if (trimmed) named.add(trimmed);
+    }
+  }
+  for (const match of source.matchAll(
+    /export\s+(?:function|class|const|let|interface|type|enum)\s+(\w+)/g
+  )) {
+    named.add(match[1]);
+  }
+  return { named, reexportsCore };
+}
+
+/**
+ * Verify a single adapter against the manifest. Returns a finding when
+ * the adapter is missing any declared symbol.
+ */
+function verifyAdapter(
+  manifest: readonly VizelFeatureDefinition[],
+  adapter: AdapterPaths
+): readonly ParityFinding[] {
+  const surface = loadAdapterSurface(adapter.indexPath);
+  const findings: ParityFinding[] = [];
+  for (const feature of manifest) {
+    const adapterShape = feature.adapters[adapter.framework];
+    const missing: string[] = [];
+    for (const symbol of [adapterShape.component, adapterShape.companion]) {
+      if (!symbol) continue;
+      if (surface.named.has(symbol)) continue;
+      // The wildcard re-export forwards every Core symbol. The check
+      // accepts it as a presence signal; future iterations may resolve
+      // Core's index.ts to enumerate the forwarded names explicitly.
+      if (surface.reexportsCore) continue;
+      missing.push(symbol);
+    }
+    if (missing.length > 0)
+      findings.push({ featureId: feature.id, framework: adapter.framework, missing });
+  }
+  return findings;
+}
+
+function main(): void {
+  const structuralErrors = verifyManifestStructure(VIZEL_FEATURE_MANIFEST);
+  if (structuralErrors.length > 0) {
+    console.error("Manifest structure errors:");
+    for (const error of structuralErrors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  const allFindings: ParityFinding[] = [];
+  for (const adapter of ADAPTERS) {
+    allFindings.push(...verifyAdapter(VIZEL_FEATURE_MANIFEST, adapter));
+  }
+
+  if (allFindings.length === 0) {
+    const featureCount = VIZEL_FEATURE_MANIFEST.length;
+    console.log(`Feature manifest parity check passed (${featureCount} features × 3 frameworks).`);
+    return;
+  }
+
+  console.error("Feature manifest parity violations:");
+  for (const finding of allFindings) {
+    console.error(
+      `  - ${finding.featureId} / ${finding.framework}: missing ${finding.missing.join(", ")}`
+    );
+  }
+  process.exit(1);
+}
+
+main();

--- a/tests/ct/parity/check-scenarios.ts
+++ b/tests/ct/parity/check-scenarios.ts
@@ -1,0 +1,70 @@
+/**
+ * Scenario parity check.
+ *
+ * Loads `VIZEL_FEATURE_MANIFEST` and verifies that every feature has a
+ * corresponding scenario folder under `tests/ct/scenarios/v2/<feature-id>/`
+ * exporting a typed `VizelScenarioDefinition`.
+ *
+ * The check is the bridge between the manifest (which declares parity)
+ * and the test surface (which proves parity). It fails CI when a
+ * manifest entry lacks a scenario or when a scenario lives outside the
+ * expected location.
+ *
+ * See ADR-0002 (manifest) and ADR-0012 (three-layer CT) for the
+ * rationale.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  VIZEL_FEATURE_MANIFEST,
+  type VizelFeatureDefinition,
+} from "../../../packages/core/src/feature-manifest.ts";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SCENARIOS_ROOT = resolve(SCRIPT_DIR, "..", "scenarios", "v2");
+
+interface ScenarioGap {
+  readonly featureId: string;
+  readonly reason: string;
+}
+
+function locateScenarioFile(feature: VizelFeatureDefinition): string {
+  return resolve(SCENARIOS_ROOT, feature.id, "index.ts");
+}
+
+function verifyScenarioPresence(
+  manifest: readonly VizelFeatureDefinition[]
+): readonly ScenarioGap[] {
+  const gaps: ScenarioGap[] = [];
+  for (const feature of manifest) {
+    const path = locateScenarioFile(feature);
+    if (!existsSync(path)) {
+      gaps.push({ featureId: feature.id, reason: `missing ${path}` });
+      continue;
+    }
+    if (!statSync(path).isFile()) {
+      gaps.push({ featureId: feature.id, reason: `not a file: ${path}` });
+    }
+  }
+  return gaps;
+}
+
+function main(): void {
+  const gaps = verifyScenarioPresence(VIZEL_FEATURE_MANIFEST);
+  if (gaps.length === 0) {
+    const featureCount = VIZEL_FEATURE_MANIFEST.length;
+    process.stdout.write(
+      `Scenario parity check passed (${featureCount} features × 1 scenario folder).\n`
+    );
+    return;
+  }
+  process.stderr.write("Scenario parity violations:\n");
+  for (const gap of gaps) {
+    process.stderr.write(`  - ${gap.featureId}: ${gap.reason}\n`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/tests/ct/scenarios/v2/auto-save/index.ts
+++ b/tests/ct/scenarios/v2/auto-save/index.ts
@@ -1,0 +1,22 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+/**
+ * Framework-neutral scenario for the `auto-save` feature.
+ *
+ * Phase 3a/3b/3c fill the assertions. This Phase 1.5 stub lets the
+ * manifest-driven parity check verify that every feature has a
+ * scenario folder.
+ */
+export interface AutoSaveScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const autoSaveScenario: VizelScenarioDefinition<AutoSaveScenarioProps> = {
+  featureId: "auto-save",
+  description: "Debounce, persist, and restore Markdown through the configured backend.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("auto-save scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/block-menu/index.ts
+++ b/tests/ct/scenarios/v2/block-menu/index.ts
@@ -1,0 +1,22 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+/**
+ * Framework-neutral scenario for the `block-menu` feature.
+ *
+ * Phase 3a/3b/3c fill the assertions. This Phase 1.5 stub lets the
+ * manifest-driven parity check verify that every feature has a
+ * scenario folder.
+ */
+export interface BlockMenuScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const blockMenuScenario: VizelScenarioDefinition<BlockMenuScenarioProps> = {
+  featureId: "block-menu",
+  description: "Surface block-level actions through the drag-handle menu.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("block-menu scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/bubble-menu/index.ts
+++ b/tests/ct/scenarios/v2/bubble-menu/index.ts
@@ -1,0 +1,22 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+/**
+ * Framework-neutral scenario for the `bubble-menu` feature.
+ *
+ * Phase 3a/3b/3c fill the assertions. This Phase 1.5 stub lets the
+ * manifest-driven parity check verify that every feature has a
+ * scenario folder.
+ */
+export interface BubbleMenuScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const bubbleMenuScenario: VizelScenarioDefinition<BubbleMenuScenarioProps> = {
+  featureId: "bubble-menu",
+  description: "Render the bubble menu, track selection, and respond to keyboard dismiss.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("bubble-menu scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/collaboration/index.ts
+++ b/tests/ct/scenarios/v2/collaboration/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface CollaborationScenarioProps {
+  readonly roomId: string;
+}
+
+export const collaborationScenario: VizelScenarioDefinition<CollaborationScenarioProps> = {
+  featureId: "collaboration",
+  description: "Join a Yjs room, receive remote updates, and broadcast presence.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("collaboration scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/color-picker/index.ts
+++ b/tests/ct/scenarios/v2/color-picker/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ColorPickerScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const colorPickerScenario: VizelScenarioDefinition<ColorPickerScenarioProps> = {
+  featureId: "color-picker",
+  description: "Render the colour grid, pick a colour, and dismiss with Escape.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("color-picker scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/comment/index.ts
+++ b/tests/ct/scenarios/v2/comment/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface CommentScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const commentScenario: VizelScenarioDefinition<CommentScenarioProps> = {
+  featureId: "comment",
+  description: "Create a comment thread, list replies, and resolve the thread.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("comment scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/editor-core/index.ts
+++ b/tests/ct/scenarios/v2/editor-core/index.ts
@@ -1,0 +1,16 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface EditorCoreScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const editorCoreScenario: VizelScenarioDefinition<EditorCoreScenarioProps> = {
+  featureId: "editor-core",
+  description:
+    "Mount the editor, type text, and round-trip Markdown through the framework lifecycle.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("editor-core scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/embed-view/index.ts
+++ b/tests/ct/scenarios/v2/embed-view/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface EmbedViewScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const embedViewScenario: VizelScenarioDefinition<EmbedViewScenarioProps> = {
+  featureId: "embed-view",
+  description: "Render embedded images and diagrams inside the editor's node view layer.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("embed-view scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/find-replace/index.ts
+++ b/tests/ct/scenarios/v2/find-replace/index.ts
@@ -1,0 +1,16 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface FindReplaceScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const findReplaceScenario: VizelScenarioDefinition<FindReplaceScenarioProps> = {
+  featureId: "find-replace",
+  description:
+    "Open the find-replace panel, find a term, replace one match, and replace all matches.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("find-replace scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/icon/index.ts
+++ b/tests/ct/scenarios/v2/icon/index.ts
@@ -1,0 +1,13 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface IconScenarioProps {
+  readonly name: string;
+}
+
+export const iconScenario: VizelScenarioDefinition<IconScenarioProps> = {
+  featureId: "icon",
+  description: "Render an icon from the default registry and from a custom registry override.",
+  run(): Promise<void> {
+    return Promise.reject(new Error("icon scenario pending Phase 3 implementation; see ADR-0012"));
+  },
+};

--- a/tests/ct/scenarios/v2/index.ts
+++ b/tests/ct/scenarios/v2/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Barrel for the v2 CT scenario foundation.
+ *
+ * Re-exports the shared types and every feature scenario. The parity
+ * check `tests/ct/parity/check-scenarios.ts` reads this barrel to
+ * verify every entry in `VIZEL_FEATURE_MANIFEST` has a scenario.
+ */
+
+export { autoSaveScenario } from "./auto-save/index.ts";
+export { blockMenuScenario } from "./block-menu/index.ts";
+export { bubbleMenuScenario } from "./bubble-menu/index.ts";
+export { collaborationScenario } from "./collaboration/index.ts";
+export { colorPickerScenario } from "./color-picker/index.ts";
+export { commentScenario } from "./comment/index.ts";
+export { editorCoreScenario } from "./editor-core/index.ts";
+export { embedViewScenario } from "./embed-view/index.ts";
+export { findReplaceScenario } from "./find-replace/index.ts";
+export { iconScenario } from "./icon/index.ts";
+export { linkEditorScenario } from "./link-editor/index.ts";
+export { mentionMenuScenario } from "./mention-menu/index.ts";
+export { nodeSelectorScenario } from "./node-selector/index.ts";
+export { outlineScenario } from "./outline/index.ts";
+export { portalScenario } from "./portal/index.ts";
+export { providerScenario } from "./provider/index.ts";
+export { saveIndicatorScenario } from "./save-indicator/index.ts";
+export { slashMenuScenario } from "./slash-menu/index.ts";
+export { themeScenario } from "./theme/index.ts";
+export { toolbarScenario } from "./toolbar/index.ts";
+export { toolbarDropdownScenario } from "./toolbar-dropdown/index.ts";
+export { toolbarOverflowScenario } from "./toolbar-overflow/index.ts";
+export type {
+  VizelScenarioContext,
+  VizelScenarioDefinition,
+  VizelScenarioMount,
+  VizelScenarioMountResult,
+} from "./types.ts";
+export { versionHistoryScenario } from "./version-history/index.ts";

--- a/tests/ct/scenarios/v2/link-editor/index.ts
+++ b/tests/ct/scenarios/v2/link-editor/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface LinkEditorScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const linkEditorScenario: VizelScenarioDefinition<LinkEditorScenarioProps> = {
+  featureId: "link-editor",
+  description: "Open the link editor, submit a URL, remove the link, and dismiss with Escape.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("link-editor scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/mention-menu/index.ts
+++ b/tests/ct/scenarios/v2/mention-menu/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface MentionMenuScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const mentionMenuScenario: VizelScenarioDefinition<MentionMenuScenarioProps> = {
+  featureId: "mention-menu",
+  description: "Trigger the mention menu, filter candidates, and navigate with the keyboard.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("mention-menu scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/node-selector/index.ts
+++ b/tests/ct/scenarios/v2/node-selector/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface NodeSelectorScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const nodeSelectorScenario: VizelScenarioDefinition<NodeSelectorScenarioProps> = {
+  featureId: "node-selector",
+  description: "Open the node selector and switch the current block's node type.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("node-selector scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/outline/index.ts
+++ b/tests/ct/scenarios/v2/outline/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface OutlineScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const outlineScenario: VizelScenarioDefinition<OutlineScenarioProps> = {
+  featureId: "outline",
+  description: "Render the document outline and track heading changes as the user edits.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("outline scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/portal/index.ts
+++ b/tests/ct/scenarios/v2/portal/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface PortalScenarioProps {
+  readonly target?: string;
+}
+
+export const portalScenario: VizelScenarioDefinition<PortalScenarioProps> = {
+  featureId: "portal",
+  description: "Render children into a detached DOM root and tear down cleanly on unmount.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("portal scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/provider/index.ts
+++ b/tests/ct/scenarios/v2/provider/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ProviderScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const providerScenario: VizelScenarioDefinition<ProviderScenarioProps> = {
+  featureId: "provider",
+  description: "Expose editor, locale, theme, and icons through the framework context.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("provider scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/save-indicator/index.ts
+++ b/tests/ct/scenarios/v2/save-indicator/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface SaveIndicatorScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const saveIndicatorScenario: VizelScenarioDefinition<SaveIndicatorScenarioProps> = {
+  featureId: "save-indicator",
+  description: "Reflect auto-save status transitions in the save indicator's live region.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("save-indicator scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/slash-menu/index.ts
+++ b/tests/ct/scenarios/v2/slash-menu/index.ts
@@ -1,0 +1,16 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface SlashMenuScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const slashMenuScenario: VizelScenarioDefinition<SlashMenuScenarioProps> = {
+  featureId: "slash-menu",
+  description:
+    "Open the slash menu, filter results, navigate with the keyboard, and confirm a selection.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("slash-menu scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/theme/index.ts
+++ b/tests/ct/scenarios/v2/theme/index.ts
@@ -1,0 +1,13 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ThemeScenarioProps {
+  readonly defaultTheme?: "light" | "dark" | "system";
+}
+
+export const themeScenario: VizelScenarioDefinition<ThemeScenarioProps> = {
+  featureId: "theme",
+  description: "Resolve light and dark themes and respect the system preference fallback.",
+  run(): Promise<void> {
+    return Promise.reject(new Error("theme scenario pending Phase 3 implementation; see ADR-0012"));
+  },
+};

--- a/tests/ct/scenarios/v2/toolbar-dropdown/index.ts
+++ b/tests/ct/scenarios/v2/toolbar-dropdown/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ToolbarDropdownScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const toolbarDropdownScenario: VizelScenarioDefinition<ToolbarDropdownScenarioProps> = {
+  featureId: "toolbar-dropdown",
+  description: "Open a toolbar dropdown, navigate with the keyboard, and dismiss with Escape.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("toolbar-dropdown scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/toolbar-overflow/index.ts
+++ b/tests/ct/scenarios/v2/toolbar-overflow/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ToolbarOverflowScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const toolbarOverflowScenario: VizelScenarioDefinition<ToolbarOverflowScenarioProps> = {
+  featureId: "toolbar-overflow",
+  description: "Collapse toolbar items into the secondary overflow menu when the host shrinks.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("toolbar-overflow scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/toolbar/index.ts
+++ b/tests/ct/scenarios/v2/toolbar/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface ToolbarScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const toolbarScenario: VizelScenarioDefinition<ToolbarScenarioProps> = {
+  featureId: "toolbar",
+  description: "Render the toolbar and invoke formatting and block actions.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("toolbar scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};

--- a/tests/ct/scenarios/v2/types.ts
+++ b/tests/ct/scenarios/v2/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared types for the v2 Playwright CT scenario layer.
+ *
+ * Each feature in `VIZEL_FEATURE_MANIFEST` owns a folder under
+ * `tests/ct/scenarios/v2/<feature-id>/` that exports a typed scenario.
+ * Per-framework spec files in `tests/ct/{react,vue,svelte}/specs/`
+ * invoke the scenario through a framework-specific mount helper.
+ *
+ * ADR-0012 describes the three-layer structure (`scenarios/v2/`,
+ * `<framework>/specs/`, `parity/`) and the rationale for replacing the
+ * v1 shared `.scenario.ts` files.
+ */
+
+import type { Locator, Page } from "@playwright/test";
+import type { VizelFeatureId } from "@vizel/core";
+
+/**
+ * Result returned by a framework-specific mount helper. The harness
+ * uses `host` for DOM queries and `unmount` to tear down after the
+ * scenario completes.
+ */
+export interface VizelScenarioMountResult {
+  /** Locator scoped to the component's mount root. */
+  readonly host: Locator;
+  /** Tear down the component and release resources. */
+  unmount(): Promise<void>;
+}
+
+/**
+ * Framework-specific mount helper passed by the per-framework spec.
+ *
+ * The helper renders the component using the framework's idiomatic API
+ * (`v-model` for Vue, `bind:markdown` for Svelte, hooks plus refs for
+ * React) and returns a handle the scenario uses for DOM assertions.
+ */
+export type VizelScenarioMount<TProps> = (
+  page: Page,
+  props: TProps
+) => Promise<VizelScenarioMountResult>;
+
+/**
+ * Common context every scenario receives.
+ */
+export interface VizelScenarioContext {
+  readonly page: Page;
+}
+
+/**
+ * Definition of a feature scenario. Each feature folder under
+ * `tests/ct/scenarios/v2/<feature-id>/` re-exports this shape.
+ */
+export interface VizelScenarioDefinition<TProps> {
+  readonly featureId: VizelFeatureId;
+  readonly description: string;
+  /**
+   * Run the scenario against a framework-specific mount helper. The
+   * helper is supplied by the per-framework spec file.
+   */
+  run(context: VizelScenarioContext, mount: VizelScenarioMount<TProps>): Promise<void>;
+}

--- a/tests/ct/scenarios/v2/version-history/index.ts
+++ b/tests/ct/scenarios/v2/version-history/index.ts
@@ -1,0 +1,15 @@
+import type { VizelScenarioDefinition } from "../types.ts";
+
+export interface VersionHistoryScenarioProps {
+  readonly initialMarkdown: string;
+}
+
+export const versionHistoryScenario: VizelScenarioDefinition<VersionHistoryScenarioProps> = {
+  featureId: "version-history",
+  description: "Snapshot Markdown revisions and restore an earlier version.",
+  run(): Promise<void> {
+    return Promise.reject(
+      new Error("version-history scenario pending Phase 3 implementation; see ADR-0012")
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- Scaffold the new `@vizel/headless` workspace package with `package.json`, `tsconfig.json`, and `vite.config.ts`.
- Land the first primitive: `createVizelDismissable(options): { mount, unmount, update }`.
- The package is `private: true` for now; Phase 5 flips it to public alongside the coordinated v2.0.0 release.

## Why

ADR-0003 records the rationale. Every Vizel framework adapter ships a near-identical copy of the dismissal wiring (pointer outside, Escape, focus outside). The v1 audit counts 21 direct `document.addEventListener` calls inside framework components, every one of them banned by the architecture rule. The new package consolidates that wiring behind a `{ mount, unmount, update }` controller so adapters never attach global listeners.

## What the dismissable primitive covers

- Pointer activity outside the mounted target (`onPointerOutside`).
- The `Escape` key, with optional `captureEscape` to stop propagation before the editor's own binding fires.
- Focus that leaves the mount target (`onFocusOutside`).
- Optional deferred pointer-listener installation (`deferPointerHandler`) for menus that open in response to a pointer event.

The controller is SSR-safe: `mount` returns early when `document` is unavailable, so framework lifecycle hooks can call it unconditionally.

## Follow-up primitives

Phase 3a/3b/3c add the remaining primitives (`combobox`, `popover`, `focus-trap`, `floating`, `keyboard`) alongside the per-adapter rewrites that need them.

## Breaking Changes

None. The package is unused until Phase 3 rewrites the adapters.

## Test Plan

- [x] `pnpm install` — workspace resolves the new package.
- [x] `pnpm typecheck` — passes across every project including `@vizel/headless`.
- [x] `pnpm lint` — passes.
- [x] `pnpm check:nolet` — passes; the controller uses closure-shared state objects, never `let`.
- [x] `pnpm check:feature-parity` and `pnpm check:scenarios` — both pass; the new package introduces no manifest entries yet.
