### PR TITLE
feat(react): add useVizelEditorState backed by useSyncExternalStore

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,11 +1,12 @@
 import {
   createVizelFindReplaceExtension,
   type Editor,
+  getVizelEditorState,
   type JSONContent,
   setVizelMarkdown,
   useVizelAutoSave,
   useVizelComment,
-  useVizelEditorState,
+  useVizelState,
   useVizelThemeSafe,
   useVizelVersionHistory,
   Vizel,
@@ -146,8 +147,15 @@ function AppContent() {
   // Store editor reference (useState for reactivity, unlike useRef)
   const [editor, setEditor] = useState<Editor | null>(null);
 
-  // Track editor state for character/word count (only when stats enabled)
-  const editorState = useVizelEditorState(features.stats ? editor : null);
+  // Track editor state for character/word count (only when stats enabled).
+  // `useVizelEditorState` migrated to the selector-based API in Phase 3a-step1
+  // (ADR-0009). The demo subscribes through the lower-level
+  // `useVizelState` + `getVizelEditorState` pair until Phase 4 refactors the
+  // demo to use the context-driven selector hook.
+  const statsEditor = features.stats ? editor : null;
+  const editorTick = useVizelState(statsEditor);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: editorTick triggers recomputation on every transaction
+  const editorState = useMemo(() => getVizelEditorState(statsEditor), [statsEditor, editorTick]);
 
   // Auto-save functionality (only when autoSave enabled)
   const { status, lastSaved } = useVizelAutoSave(features.autoSave ? editor : null, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -572,6 +572,9 @@ export {
   resolveVizelGridNavigation,
   resolveVizelListNavigation,
   setVizelMarkdown,
+  // Shallow-equality helpers used by selector-based reactivity layers.
+  shallowEqualArray,
+  shallowEqualObject,
   shouldFlipSubmenu,
   // Text highlight utilities
   splitVizelTextByMatches,

--- a/packages/core/src/utils/equality.ts
+++ b/packages/core/src/utils/equality.ts
@@ -1,0 +1,67 @@
+/**
+ * Shallow-equality helpers tailored for selector-result memoisation.
+ *
+ * Selector subscriptions in Vizel's reactivity layers (React's
+ * `useSyncExternalStore`-backed `useVizelEditorState`, Vue's
+ * `computed` short-circuit, Svelte's `createSubscriber` snapshot)
+ * compare consecutive snapshots to decide whether to notify
+ * subscribers. The default `Object.is` comparison misses structurally
+ * equal but freshly allocated arrays and objects. The helpers below
+ * provide the two shallow-equality shapes selectors most commonly
+ * need without pulling in `react`, `vue`, or `svelte`.
+ *
+ * The helpers live in `@vizel/core` so the reactivity layer of every
+ * framework adapter can consume them. Framework packages re-export
+ * the helpers under their own import paths to keep consumer imports
+ * idiomatic.
+ */
+
+/**
+ * Return `true` when two arrays carry identical references in the
+ * same order and the same length.
+ *
+ * The comparison runs in O(n) on the shared length; selectors that
+ * return short arrays (typical in toolbar / bubble-menu state slices)
+ * stay cheap to compare.
+ *
+ * @example
+ * ```ts
+ * shallowEqualArray([a, b], [a, b]); // true
+ * shallowEqualArray([a, b], [a, c]); // false
+ * ```
+ */
+export function shallowEqualArray<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => Object.is(value, b[index]));
+}
+
+/**
+ * Return `true` when two plain objects share the same own
+ * enumerable string keys and identical references for every value.
+ *
+ * The comparison treats `null` as a valid input and short-circuits on
+ * reference equality, so callers may pass `null` whenever a selector
+ * legitimately returns absence.
+ *
+ * @example
+ * ```ts
+ * shallowEqualObject({ a: 1, b: 2 }, { a: 1, b: 2 }); // true
+ * shallowEqualObject({ a: 1 }, { a: 1, b: 2 });       // false
+ * ```
+ */
+export function shallowEqualObject<T extends Record<string, unknown>>(
+  a: T | null,
+  b: T | null
+): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.hasOwn(b, key)) return false;
+    if (!Object.is(a[key], b[key])) return false;
+  }
+  return true;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -47,6 +47,8 @@ export {
   type VizelResolveFeaturesOptions,
   vizelDefaultEditorProps,
 } from "./editorHelpers.ts";
+// Shallow-equality helpers used by selector-based reactivity layers.
+export { shallowEqualArray, shallowEqualObject } from "./equality.ts";
 // Error handling utilities
 export {
   createVizelError,

--- a/packages/react/src/_reactivity.ts
+++ b/packages/react/src/_reactivity.ts
@@ -1,0 +1,223 @@
+"use client";
+
+/**
+ * First-party React reactivity primitive for the Vizel editor.
+ *
+ * The module replaces v1's reliance on `@tiptap/react` for selector
+ * subscriptions. ADR-0009 mandates a first-party implementation in every
+ * adapter so the SSR boundary, the selector contract, and the cleanup
+ * behaviour stay under Vizel's control. The React implementation wraps a
+ * monotonic version counter inside `useSyncExternalStore`, which React's
+ * official guidance recommends for editor-style external stores that must
+ * stay tearing-safe under concurrent rendering.
+ *
+ * The module exposes one public hook (`useVizelEditorState`) plus two
+ * equality helpers re-exported from `@vizel/core`. Consumers select the
+ * slice they care about and optionally supply an equality function to
+ * suppress re-renders when the slice is structurally unchanged.
+ *
+ * Phase 3a-step1 lands this primitive. Later steps migrate every
+ * framework component to consume it; `useVizelEditor` itself moves onto
+ * the same store in Phase 3a-step4.
+ */
+
+import { type Editor, shallowEqualArray, shallowEqualObject } from "@vizel/core";
+import { useMemo, useRef, useSyncExternalStore } from "react";
+import { useVizelContextSafe } from "./components/VizelContext.tsx";
+
+/**
+ * Shape returned by {@link createEditorStore} — a `useSyncExternalStore`
+ * adapter pinned to a single editor instance.
+ *
+ * The store does not surface the editor itself. The version counter
+ * (returned by `getSnapshot`) increments on every transaction, which
+ * forces React to invoke the selector against the latest editor state
+ * without changing the snapshot's referential identity contract.
+ */
+export interface VizelReactEditorStore {
+  /**
+   * Attach a transaction listener and return the cleanup. The store
+   * subscribes to both `transaction` and `selectionUpdate` so menus
+   * driven by selection changes (the bubble menu, the toolbar's active
+   * state) react without forcing every consumer to track both events.
+   */
+  subscribe(onChange: () => void): () => void;
+  /**
+   * Read the current version counter. The counter increments by one on
+   * every notification with 32-bit wrap-around so it never grows
+   * unbounded over long editing sessions.
+   */
+  getSnapshot(): number;
+  /**
+   * SSR snapshot — always zero. React calls `getServerSnapshot` during
+   * server rendering, where the editor has not yet mounted. Returning a
+   * stable value avoids hydration mismatches.
+   */
+  getServerSnapshot(): number;
+}
+
+/**
+ * Build a {@link VizelReactEditorStore} for the supplied editor.
+ *
+ * The factory is an internal building block consumed by
+ * {@link useVizelEditorState} and, in later Phase 3a steps, by the
+ * `useVizelEditor` hook itself. The factory is intentionally
+ * framework-agnostic at the function-signature level — it only depends
+ * on Tiptap's `Editor.on` / `Editor.off` event surface — so the test
+ * suite can exercise it without rendering React.
+ *
+ * @internal
+ */
+export function createEditorStore(editor: Editor | null): VizelReactEditorStore {
+  // Closure-shared mutable state. A typed object keeps the binding
+  // const-safe at the file scope and survives `Find Usages` better than
+  // a free `let` would (see `.claude/rules/code-style.md`).
+  const state = { version: 0 };
+
+  const bumpVersion = (): void => {
+    // 32-bit wrap-around stops the counter from drifting toward
+    // unsafe-integer territory on long editing sessions. The actual
+    // numeric value is opaque to consumers; only the change matters.
+    state.version = (state.version + 1) | 0;
+  };
+
+  return {
+    subscribe(onChange) {
+      if (editor === null) {
+        // SSR snapshot already returns zero and never changes, so React
+        // never calls `subscribe` outside the browser. Guard anyway in
+        // case a consumer triggers a manual re-render with `editor: null`.
+        return () => {
+          /* no-op cleanup when the editor is still initializing */
+        };
+      }
+      const handler = (): void => {
+        bumpVersion();
+        onChange();
+      };
+      // Tiptap exposes a single `transaction` event for document /
+      // selection / metadata updates. The bubble menu, the toolbar, and
+      // the find-replace panel all depend on the selection signal, so
+      // the store subscribes to `selectionUpdate` too for consumers that
+      // would otherwise miss pure-cursor moves.
+      editor.on("transaction", handler);
+      editor.on("selectionUpdate", handler);
+      return () => {
+        editor.off("transaction", handler);
+        editor.off("selectionUpdate", handler);
+      };
+    },
+    getSnapshot() {
+      return state.version;
+    },
+    getServerSnapshot() {
+      return 0;
+    },
+  };
+}
+
+/**
+ * Options accepted by {@link useVizelEditorState}.
+ */
+export interface UseVizelEditorStateOptions<T> {
+  /**
+   * Equality predicate the hook applies to consecutive selector
+   * results. `Object.is` is the default; the bundled
+   * {@link shallowEqualArray} and {@link shallowEqualObject} cover
+   * the shapes that selectors typically return.
+   */
+  readonly equalityFn?: (a: T, b: T) => boolean;
+}
+
+/**
+ * Subscribe to a slice of the editor's state.
+ *
+ * The hook reads the editor instance from the surrounding `VizelProvider`
+ * (or returns `null` while no provider is mounted, mirroring
+ * {@link useVizelContextSafe}). It then wraps a per-editor store inside
+ * `useSyncExternalStore` so React re-runs the selector on every
+ * transaction. The hook short-circuits via the supplied `equalityFn`
+ * (defaulting to `Object.is`), preventing re-renders when the slice is
+ * structurally unchanged.
+ *
+ * Tearing-safety under React 19 concurrent rendering is the load-bearing
+ * reason for `useSyncExternalStore` here: React routes every snapshot
+ * read through the official store contract, so two concurrently
+ * scheduled trees never observe inconsistent editor state.
+ *
+ * @example
+ * ```tsx
+ * const isBold = useVizelEditorState((editor) => editor?.isActive("bold") ?? false);
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const marks = useVizelEditorState(
+ *   (editor) => ({
+ *     bold: editor?.isActive("bold") ?? false,
+ *     italic: editor?.isActive("italic") ?? false,
+ *   }),
+ *   { equalityFn: shallowEqualObject },
+ * );
+ * ```
+ */
+export function useVizelEditorState<T>(
+  selector: (editor: Editor | null) => T,
+  options?: UseVizelEditorStateOptions<T>
+): T {
+  const editor = useVizelContextSafe();
+
+  // Pin the latest selector / equality predicate inside refs so the
+  // snapshot reader closure never goes stale across renders. The
+  // closures handed to `useSyncExternalStore` must stay referentially
+  // stable; capturing the parameters directly would force React to
+  // re-subscribe on every render that supplies a fresh inline selector.
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+  const equalityRef = useRef<(a: T, b: T) => boolean>(options?.equalityFn ?? Object.is);
+  equalityRef.current = options?.equalityFn ?? Object.is;
+
+  // Build the store and the snapshot reader once per editor instance.
+  // The closure-shared `cache` slot keeps the previous selector result
+  // available so `equalityFn` short-circuits never break the
+  // referential-stability contract `useSyncExternalStore` requires.
+  const readers = useMemo(() => {
+    const store = createEditorStore(editor);
+    // The cache is a discriminated union so the `cached` branch carries
+    // a typed value without an `as` cast or non-null assertion.
+    type SnapshotCache = { kind: "empty" } | { kind: "cached"; value: T };
+    const cache: { current: SnapshotCache } = { current: { kind: "empty" } };
+
+    const getClientSnapshot = (): T => {
+      // `getSnapshot` runs each time React reads from the store. The
+      // selector executes against the live editor; the cached previous
+      // value short-circuits when `equalityFn` declares the slice
+      // unchanged so consumers can rely on `Object.is` against the
+      // hook's return value.
+      const next = selectorRef.current(editor);
+      const previous = cache.current;
+      if (previous.kind === "cached" && equalityRef.current(previous.value, next)) {
+        return previous.value;
+      }
+      cache.current = { kind: "cached", value: next };
+      return next;
+    };
+
+    const getServerSnapshot = (): T =>
+      // React calls `getServerSnapshot` during server rendering, where
+      // the editor has not yet mounted. The selector receives `null` so
+      // the consumer's selector observes the same absence shape as the
+      // first browser render before mount completes.
+      selectorRef.current(null);
+
+    return { subscribe: store.subscribe, getClientSnapshot, getServerSnapshot };
+  }, [editor]);
+
+  return useSyncExternalStore(
+    readers.subscribe,
+    readers.getClientSnapshot,
+    readers.getServerSnapshot
+  );
+}
+
+export { shallowEqualArray, shallowEqualObject };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,7 +18,13 @@ initVizelIconRenderer();
 // the framework package and import every shared symbol from one place.
 // biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
 export * from "@vizel/core";
-
+// First-party `useSyncExternalStore`-backed reactivity primitive.
+// ADR-0009 mandates that every adapter implements editor reactivity
+// natively; React's adapter holds the implementation in `_reactivity.ts`
+// and re-exports the consumer-facing surface here. The shallow-equality
+// helpers re-export from `@vizel/core` so the cross-framework parity
+// check can resolve them back to a single source.
+export { shallowEqualArray, shallowEqualObject, useVizelEditorState } from "./_reactivity.ts";
 // Components
 export {
   useVizelContext,
@@ -105,7 +111,6 @@ export {
   type VizelToolbarOverflowProps,
   type VizelToolbarProps,
 } from "./components/index.ts";
-
 // Hooks
 export {
   createVizelMentionMenuRenderer,
@@ -121,7 +126,6 @@ export {
   useVizelCollaboration,
   useVizelComment,
   useVizelEditor,
-  useVizelEditorState,
   useVizelMarkdown,
   useVizelState,
   useVizelTheme,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -17,6 +17,12 @@ initVizelIconRenderer();
 // biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
 export * from "@vizel/core";
 
+// Explicit re-export so the cross-framework literal parity check picks
+// up the shallow-equality helpers from Core. The wildcard above already
+// forwards them; the named declaration keeps `scripts/check-cross-
+// framework-parity.ts`'s same-name literal scan happy.
+export { shallowEqualArray, shallowEqualObject } from "@vizel/core";
+
 // Components
 export {
   getVizelContext,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -17,6 +17,12 @@ initVizelIconRenderer();
 // biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
 export * from "@vizel/core";
 
+// Explicit re-export so the cross-framework literal parity check picks
+// up the shallow-equality helpers from Core. The wildcard above already
+// forwards them; the named declaration keeps `scripts/check-cross-
+// framework-parity.ts`'s same-name literal scan happy.
+export { shallowEqualArray, shallowEqualObject } from "@vizel/core";
+
 // Components
 export {
   provideVizelIcons,


### PR DESCRIPTION
## Summary

- Lands the new `packages/react/src/_reactivity.ts` module that ships a `useSyncExternalStore`-backed editor store and a selector-driven `useVizelEditorState<T>(selector, { equalityFn? })` hook per ADR-0009.
- Adds the shallow-equality helpers (`shallowEqualArray`, `shallowEqualObject`) to `@vizel/core` so every framework adapter consumes the same predicates; React re-exports them through `_reactivity.ts`, Vue and Svelte expose them through an explicit named re-export plus the existing `export * from "@vizel/core"` wildcard.
- Switches `@vizel/react`'s public `useVizelEditorState` over to the new selector-based implementation; the legacy `packages/react/src/hooks/useVizelEditorState.ts` file stays for internal use only so the surrounding hook surface keeps working alongside the new module.
- Updates the React demo so its stats display continues to work; the demo migrates to the v2 selector idiom in Phase 4.

## Breaking Changes

- The public `useVizelEditorState` from `@vizel/react` now takes `(selector, options?)` instead of `(editor)` and returns the selector result instead of `VizelEditorState`. Consumers that need the full editor state can call `useVizelEditorState((editor) => getVizelEditorState(editor))` or stay on the lower-level `useVizelState` + `getVizelEditorState` pair (the demo demonstrates the latter).

## Test Plan

- [x] Run `pnpm install`.
- [x] Run `pnpm typecheck`.
- [x] Run `pnpm lint`.
- [x] Run `pnpm check:nolet`.
- [x] Run `pnpm check:parity`.
- [x] Run `pnpm check:feature-parity`.
- [x] Run `pnpm check:scenarios`.