### PR TITLE
docs: add v1-to-v2 migration guide and refresh demos

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -1,18 +1,19 @@
 import {
   createVizelFindReplaceExtension,
   type Editor,
-  getVizelEditorState,
   type JSONContent,
   setVizelMarkdown,
+  shallowEqualObject,
   useVizelAutoSave,
   useVizelComment,
-  useVizelState,
+  useVizelEditorState,
   useVizelThemeSafe,
   useVizelVersionHistory,
   Vizel,
   VizelFindReplace,
   type VizelMarkdownFlavor,
   VizelOutline,
+  VizelProvider,
   VizelSaveIndicator,
   VizelThemeProvider,
   vizelCommonMarkFlavor,
@@ -119,6 +120,31 @@ interface DemoFeatures {
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
 
+/**
+ * Read character and word counts via the v2 selector API.
+ *
+ * `useVizelEditorState` reads the editor from the surrounding
+ * `VizelProvider` and re-renders only when the selector slice changes
+ * (`shallowEqualObject`). See ADR-0009 for the first-party reactivity
+ * primitive that backs the hook.
+ */
+function StatsBar() {
+  const stats = useVizelEditorState(
+    (editor) => ({
+      characters: editor?.storage.characterCount?.characters() ?? 0,
+      words: editor?.storage.characterCount?.words() ?? 0,
+    }),
+    { equalityFn: shallowEqualObject }
+  );
+  return (
+    <>
+      <span className="status-item">{stats.characters} characters</span>
+      <span className="status-divider">·</span>
+      <span className="status-item">{stats.words} words</span>
+    </>
+  );
+}
+
 function AppContent() {
   // Feature toggles (all enabled by default).
   const [features, setFeatures] = useState<DemoFeatures>({
@@ -146,16 +172,6 @@ function AppContent() {
 
   // Store editor reference (useState for reactivity, unlike useRef)
   const [editor, setEditor] = useState<Editor | null>(null);
-
-  // Track editor state for character/word count (only when stats enabled).
-  // `useVizelEditorState` migrated to the selector-based API in Phase 3a-step1
-  // (ADR-0009). The demo subscribes through the lower-level
-  // `useVizelState` + `getVizelEditorState` pair until Phase 4 refactors the
-  // demo to use the context-driven selector hook.
-  const statsEditor = features.stats ? editor : null;
-  const editorTick = useVizelState(statsEditor);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: editorTick triggers recomputation on every transaction
-  const editorState = useMemo(() => getVizelEditorState(statsEditor), [statsEditor, editorTick]);
 
   // Auto-save functionality (only when autoSave enabled)
   const { status, lastSaved } = useVizelAutoSave(features.autoSave ? editor : null, {
@@ -324,313 +340,320 @@ function AppContent() {
         </div>
       </section>
 
-      <main className="main">
-        {features.outline && editor && (
-          <aside className="editor-aside" aria-label="Document outline">
-            <div className="editor-aside-panel">
-              <span className="editor-aside-title">Outline</span>
-              <VizelOutline editor={editor} />
-            </div>
-          </aside>
-        )}
-        <div className="editor-section">
-          <div className="editor-container">
-            <Vizel
-              initialMarkdown={getFlavorContent(flavor)}
-              autofocus="start"
-              className="editor-content"
-              showToolbar={features.toolbar}
-              flavor={flavor}
-              enableEmbed
-              extensions={findReplaceExtensions}
-              features={{
-                content: {
-                  mathematics: true,
-                  embed: true,
-                  details: true,
-                  diagram: true,
-                  wikiLink: true,
-                  callout: true,
-                  tableOfContents: true,
-                  superscript: true,
-                  subscript: true,
-                  image: {
-                    onUpload: mockUploadImage,
-                    maxFileSize: 10 * 1024 * 1024, // 10MB
-                    onValidationError: (error) => {
-                      alert(`Validation error: ${error.message}`);
-                    },
-                    onUploadError: (error) => {
-                      alert(`Upload failed: ${error.message}`);
+      <VizelProvider editor={editor}>
+        <main className="main">
+          {features.outline && editor && (
+            <aside className="editor-aside" aria-label="Document outline">
+              <div className="editor-aside-panel">
+                <span className="editor-aside-title">Outline</span>
+                <VizelOutline editor={editor} />
+              </div>
+            </aside>
+          )}
+          <div className="editor-section">
+            <div className="editor-container">
+              <Vizel
+                initialMarkdown={getFlavorContent(flavor)}
+                autofocus="start"
+                className="editor-content"
+                showToolbar={features.toolbar}
+                flavor={flavor}
+                enableEmbed
+                extensions={findReplaceExtensions}
+                features={{
+                  content: {
+                    mathematics: true,
+                    embed: true,
+                    details: true,
+                    diagram: true,
+                    wikiLink: true,
+                    callout: true,
+                    tableOfContents: true,
+                    superscript: true,
+                    subscript: true,
+                    image: {
+                      onUpload: mockUploadImage,
+                      maxFileSize: 10 * 1024 * 1024, // 10MB
+                      onValidationError: (error) => {
+                        alert(`Validation error: ${error.message}`);
+                      },
+                      onUploadError: (error) => {
+                        alert(`Upload failed: ${error.message}`);
+                      },
                     },
                   },
-                },
-                interaction: {
-                  typography: true,
-                  mention: { items: mockMentionItems },
-                },
-              }}
-              onCreate={({ editor: newEditor }) => {
-                setEditor(newEditor);
-                const json = newEditor.getJSON();
-                setJsonInput(JSON.stringify(json, null, 2));
-                setMarkdownInput(newEditor.getMarkdown());
-              }}
-              onUpdate={({ editor: updatedEditor }) => {
-                const json = updatedEditor.getJSON();
-                setJsonInput(JSON.stringify(json, null, 2));
-                setMarkdownInput(updatedEditor.getMarkdown());
-              }}
-            >
-              <VizelFindReplace editor={editor} />
-            </Vizel>
-            {(features.autoSave || features.stats) && (
-              <div className="status-bar">
-                {features.autoSave && (
-                  <>
-                    <VizelSaveIndicator status={status} lastSaved={lastSaved} />
-                    {features.stats && <span className="status-divider">·</span>}
-                  </>
-                )}
-                {features.stats && (
-                  <>
-                    <span className="status-item">{editorState.characterCount} characters</span>
-                    <span className="status-divider">·</span>
-                    <span className="status-item">{editorState.wordCount} words</span>
-                  </>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-        {showPanel && (
-          <div className="panel-section">
-            <div className="panel-container">
-              <div className="panel-tabs">
-                {features.syncPanel && (
-                  <button
-                    type="button"
-                    className="panel-tab"
-                    data-active={activeTab === "markdown"}
-                    onClick={() => setActiveTab("markdown")}
-                  >
-                    Markdown
-                  </button>
-                )}
-                {features.syncPanel && (
-                  <button
-                    type="button"
-                    className="panel-tab"
-                    data-active={activeTab === "json"}
-                    onClick={() => setActiveTab("json")}
-                  >
-                    JSON
-                  </button>
-                )}
-                {features.history && (
-                  <button
-                    type="button"
-                    className="panel-tab"
-                    data-active={activeTab === "history"}
-                    onClick={() => setActiveTab("history")}
-                  >
-                    History
-                  </button>
-                )}
-                {features.comments && (
-                  <button
-                    type="button"
-                    className="panel-tab"
-                    data-active={activeTab === "comments"}
-                    onClick={() => setActiveTab("comments")}
-                  >
-                    Comments
-                  </button>
-                )}
-              </div>
-              <div className="panel-content">
-                {activeTab === "markdown" && features.syncPanel && (
-                  <textarea
-                    className="panel-textarea"
-                    value={markdownInput}
-                    onChange={(e) => handleMarkdownChange(e.target.value)}
-                    placeholder="Edit Markdown here..."
-                  />
-                )}
-                {activeTab === "json" && features.syncPanel && (
-                  <textarea
-                    className="panel-textarea"
-                    value={jsonInput}
-                    onChange={(e) => handleJsonChange(e.target.value)}
-                    placeholder="Edit JSON here..."
-                  />
-                )}
-                {activeTab === "history" && (
-                  <div className="panel-list">
-                    <div className="panel-action-bar">
-                      <input
-                        type="text"
-                        placeholder="Version description..."
-                        value={versionDescription}
-                        onChange={(e) => setVersionDescription(e.target.value)}
-                        onKeyDown={(e) => e.key === "Enter" && handleSaveVersion()}
-                      />
-                      <button
-                        type="button"
-                        className="panel-action-btn"
-                        onClick={handleSaveVersion}
-                      >
-                        Save
-                      </button>
-                    </div>
-                    {versionHistory.snapshots.length === 0 ? (
-                      <div className="panel-list-empty">No versions saved yet</div>
-                    ) : (
-                      versionHistory.snapshots.map((snapshot) => (
-                        <div key={snapshot.id} className="panel-item">
-                          <div className="panel-item-header">
-                            <span className="panel-item-text">
-                              {snapshot.description || "Untitled"}
-                            </span>
-                            <span className="panel-item-meta">
-                              {new Date(snapshot.timestamp).toLocaleString()}
-                            </span>
-                          </div>
-                          <div className="panel-item-actions">
-                            <button
-                              type="button"
-                              className="panel-item-btn"
-                              onClick={() => versionHistory.restoreVersion(snapshot.id)}
-                            >
-                              Restore
-                            </button>
-                            <button
-                              type="button"
-                              className="panel-item-btn panel-item-btn--danger"
-                              onClick={() => versionHistory.deleteVersion(snapshot.id)}
-                            >
-                              Delete
-                            </button>
-                          </div>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                )}
-                {activeTab === "comments" && (
-                  <div className="panel-list">
-                    <div className="panel-action-bar">
-                      <input
-                        type="text"
-                        placeholder="Select text, then add a comment..."
-                        value={commentText}
-                        onChange={(e) => setCommentText(e.target.value)}
-                        onKeyDown={(e) => e.key === "Enter" && handleAddComment()}
-                      />
-                      <button type="button" className="panel-action-btn" onClick={handleAddComment}>
-                        Add
-                      </button>
-                    </div>
-                    {commentManager.comments.length === 0 ? (
-                      <div className="panel-list-empty">No comments yet</div>
-                    ) : (
-                      commentManager.comments.map((comment) => (
-                        // biome-ignore lint/a11y/useSemanticElements: Card contains nested interactive elements
-                        <div
-                          key={comment.id}
-                          className={`panel-item ${comment.resolved ? "panel-item-resolved" : ""}`}
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => commentManager.setActiveComment(comment.id)}
-                          onKeyDown={(e) =>
-                            e.key === "Enter" && commentManager.setActiveComment(comment.id)
-                          }
-                        >
-                          <div className="panel-item-header">
-                            <span className="panel-item-text">{comment.text}</span>
-                            <span className="panel-item-meta">
-                              {comment.author && `${comment.author} · `}
-                              {new Date(comment.createdAt).toLocaleString()}
-                            </span>
-                          </div>
-                          <div className="panel-item-actions">
-                            {comment.resolved ? (
-                              <button
-                                type="button"
-                                className="panel-item-btn"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  commentManager.reopenComment(comment.id);
-                                }}
-                              >
-                                Reopen
-                              </button>
-                            ) : (
-                              <button
-                                type="button"
-                                className="panel-item-btn"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  commentManager.resolveComment(comment.id);
-                                }}
-                              >
-                                Resolve
-                              </button>
-                            )}
-                            <button
-                              type="button"
-                              className="panel-item-btn panel-item-btn--danger"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                commentManager.removeComment(comment.id);
-                              }}
-                            >
-                              Remove
-                            </button>
-                          </div>
-                          {comment.replies.length > 0 && (
-                            <div className="panel-replies">
-                              {comment.replies.map((reply) => (
-                                <div key={reply.id} className="panel-reply">
-                                  <span className="panel-reply-meta">
-                                    {reply.author && `${reply.author} · `}
-                                    {new Date(reply.createdAt).toLocaleString()}
-                                  </span>
-                                  <div>{reply.text}</div>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                          <div className="panel-reply-input">
-                            <input
-                              placeholder="Reply..."
-                              value={replyTexts[comment.id] || ""}
-                              onChange={(e) =>
-                                setReplyTexts((prev) => ({ ...prev, [comment.id]: e.target.value }))
-                              }
-                              onKeyDown={(e) => e.key === "Enter" && handleReply(comment.id)}
-                              onClick={(e) => e.stopPropagation()}
-                            />
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleReply(comment.id);
-                              }}
-                            >
-                              Reply
-                            </button>
-                          </div>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                )}
-              </div>
+                  interaction: {
+                    typography: true,
+                    mention: { items: mockMentionItems },
+                  },
+                }}
+                onCreate={({ editor: newEditor }) => {
+                  setEditor(newEditor);
+                  const json = newEditor.getJSON();
+                  setJsonInput(JSON.stringify(json, null, 2));
+                  setMarkdownInput(newEditor.getMarkdown());
+                }}
+                onUpdate={({ editor: updatedEditor }) => {
+                  const json = updatedEditor.getJSON();
+                  setJsonInput(JSON.stringify(json, null, 2));
+                  setMarkdownInput(updatedEditor.getMarkdown());
+                }}
+              >
+                {/* `VizelFindReplace` lives inside the editor root so the
+                  Cmd/Ctrl+F shortcut binds to the surrounding container.
+                  The editor flows through the surrounding `VizelProvider`,
+                  so the explicit `editor` prop can be omitted. */}
+                <VizelFindReplace />
+              </Vizel>
+              {(features.autoSave || features.stats) && (
+                <div className="status-bar">
+                  {features.autoSave && (
+                    <>
+                      <VizelSaveIndicator status={status} lastSaved={lastSaved} />
+                      {features.stats && <span className="status-divider">·</span>}
+                    </>
+                  )}
+                  {features.stats && <StatsBar />}
+                </div>
+              )}
             </div>
           </div>
-        )}
-      </main>
+          {showPanel && (
+            <div className="panel-section">
+              <div className="panel-container">
+                <div className="panel-tabs">
+                  {features.syncPanel && (
+                    <button
+                      type="button"
+                      className="panel-tab"
+                      data-active={activeTab === "markdown"}
+                      onClick={() => setActiveTab("markdown")}
+                    >
+                      Markdown
+                    </button>
+                  )}
+                  {features.syncPanel && (
+                    <button
+                      type="button"
+                      className="panel-tab"
+                      data-active={activeTab === "json"}
+                      onClick={() => setActiveTab("json")}
+                    >
+                      JSON
+                    </button>
+                  )}
+                  {features.history && (
+                    <button
+                      type="button"
+                      className="panel-tab"
+                      data-active={activeTab === "history"}
+                      onClick={() => setActiveTab("history")}
+                    >
+                      History
+                    </button>
+                  )}
+                  {features.comments && (
+                    <button
+                      type="button"
+                      className="panel-tab"
+                      data-active={activeTab === "comments"}
+                      onClick={() => setActiveTab("comments")}
+                    >
+                      Comments
+                    </button>
+                  )}
+                </div>
+                <div className="panel-content">
+                  {activeTab === "markdown" && features.syncPanel && (
+                    <textarea
+                      className="panel-textarea"
+                      value={markdownInput}
+                      onChange={(e) => handleMarkdownChange(e.target.value)}
+                      placeholder="Edit Markdown here..."
+                    />
+                  )}
+                  {activeTab === "json" && features.syncPanel && (
+                    <textarea
+                      className="panel-textarea"
+                      value={jsonInput}
+                      onChange={(e) => handleJsonChange(e.target.value)}
+                      placeholder="Edit JSON here..."
+                    />
+                  )}
+                  {activeTab === "history" && (
+                    <div className="panel-list">
+                      <div className="panel-action-bar">
+                        <input
+                          type="text"
+                          placeholder="Version description..."
+                          value={versionDescription}
+                          onChange={(e) => setVersionDescription(e.target.value)}
+                          onKeyDown={(e) => e.key === "Enter" && handleSaveVersion()}
+                        />
+                        <button
+                          type="button"
+                          className="panel-action-btn"
+                          onClick={handleSaveVersion}
+                        >
+                          Save
+                        </button>
+                      </div>
+                      {versionHistory.snapshots.length === 0 ? (
+                        <div className="panel-list-empty">No versions saved yet</div>
+                      ) : (
+                        versionHistory.snapshots.map((snapshot) => (
+                          <div key={snapshot.id} className="panel-item">
+                            <div className="panel-item-header">
+                              <span className="panel-item-text">
+                                {snapshot.description || "Untitled"}
+                              </span>
+                              <span className="panel-item-meta">
+                                {new Date(snapshot.timestamp).toLocaleString()}
+                              </span>
+                            </div>
+                            <div className="panel-item-actions">
+                              <button
+                                type="button"
+                                className="panel-item-btn"
+                                onClick={() => versionHistory.restoreVersion(snapshot.id)}
+                              >
+                                Restore
+                              </button>
+                              <button
+                                type="button"
+                                className="panel-item-btn panel-item-btn--danger"
+                                onClick={() => versionHistory.deleteVersion(snapshot.id)}
+                              >
+                                Delete
+                              </button>
+                            </div>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  )}
+                  {activeTab === "comments" && (
+                    <div className="panel-list">
+                      <div className="panel-action-bar">
+                        <input
+                          type="text"
+                          placeholder="Select text, then add a comment..."
+                          value={commentText}
+                          onChange={(e) => setCommentText(e.target.value)}
+                          onKeyDown={(e) => e.key === "Enter" && handleAddComment()}
+                        />
+                        <button
+                          type="button"
+                          className="panel-action-btn"
+                          onClick={handleAddComment}
+                        >
+                          Add
+                        </button>
+                      </div>
+                      {commentManager.comments.length === 0 ? (
+                        <div className="panel-list-empty">No comments yet</div>
+                      ) : (
+                        commentManager.comments.map((comment) => (
+                          // biome-ignore lint/a11y/useSemanticElements: Card contains nested interactive elements
+                          <div
+                            key={comment.id}
+                            className={`panel-item ${comment.resolved ? "panel-item-resolved" : ""}`}
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => commentManager.setActiveComment(comment.id)}
+                            onKeyDown={(e) =>
+                              e.key === "Enter" && commentManager.setActiveComment(comment.id)
+                            }
+                          >
+                            <div className="panel-item-header">
+                              <span className="panel-item-text">{comment.text}</span>
+                              <span className="panel-item-meta">
+                                {comment.author && `${comment.author} · `}
+                                {new Date(comment.createdAt).toLocaleString()}
+                              </span>
+                            </div>
+                            <div className="panel-item-actions">
+                              {comment.resolved ? (
+                                <button
+                                  type="button"
+                                  className="panel-item-btn"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    commentManager.reopenComment(comment.id);
+                                  }}
+                                >
+                                  Reopen
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="panel-item-btn"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    commentManager.resolveComment(comment.id);
+                                  }}
+                                >
+                                  Resolve
+                                </button>
+                              )}
+                              <button
+                                type="button"
+                                className="panel-item-btn panel-item-btn--danger"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  commentManager.removeComment(comment.id);
+                                }}
+                              >
+                                Remove
+                              </button>
+                            </div>
+                            {comment.replies.length > 0 && (
+                              <div className="panel-replies">
+                                {comment.replies.map((reply) => (
+                                  <div key={reply.id} className="panel-reply">
+                                    <span className="panel-reply-meta">
+                                      {reply.author && `${reply.author} · `}
+                                      {new Date(reply.createdAt).toLocaleString()}
+                                    </span>
+                                    <div>{reply.text}</div>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                            <div className="panel-reply-input">
+                              <input
+                                placeholder="Reply..."
+                                value={replyTexts[comment.id] || ""}
+                                onChange={(e) =>
+                                  setReplyTexts((prev) => ({
+                                    ...prev,
+                                    [comment.id]: e.target.value,
+                                  }))
+                                }
+                                onKeyDown={(e) => e.key === "Enter" && handleReply(comment.id)}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleReply(comment.id);
+                                }}
+                              >
+                                Reply
+                              </button>
+                            </div>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </main>
+      </VizelProvider>
 
       <footer className="footer">
         <p>

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -266,6 +266,12 @@ function handleJsonChange(event: Event) {
           onCreate={handleCreate}
           onUpdate={handleUpdate}
         >
+          <!-- Svelte 5 snippet — the v2 render-prop idiom for Svelte
+               (ADR-0004). The snippet receives the bound editor; the
+               find-replace panel re-renders against it on every
+               transaction. Lowercase event props (`onclick`,
+               `onclose`, `onselect`) follow the DOM-attribute
+               convention. -->
           {#snippet children({ editor: snippetEditor })}
             {#if snippetEditor}
               <VizelFindReplace editor={snippetEditor} />

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -61,11 +61,13 @@ const replyTexts = ref<Record<string, string>>({});
 // Store editor reference from Vizel component
 const editorRef = shallowRef<Editor | null>(null);
 
-// Track editor state for character/word count (only when stats enabled).
-// `useVizelEditorState` migrated to the selector-based API in Phase 3b-step1
-// (ADR-0009). The demo subscribes through the lower-level
-// `useVizelState` + `getVizelEditorState` pair until Phase 4 refactors the
-// demo to use the context-driven selector composable.
+// Track editor state for character/word count.
+// The selector-based `useVizelEditorState(selector, { equalityFn? })`
+// reads the editor from the surrounding `VizelProvider`; in this demo
+// the editor lives in the same component, so we drive reactivity through
+// the lower-level `useVizelState` tick and read the snapshot with
+// `getVizelEditorState`. See `getting-started-vue.md` for the
+// provider-based selector pattern.
 const statsEditor = computed(() => (features.stats ? editorRef.value : null));
 const editorTick = useVizelState(() => statsEditor.value);
 const editorState = computed(() => {
@@ -271,6 +273,9 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
               @create="handleCreate"
               @update="handleUpdate"
             >
+              <!-- Vue scoped slot — the v2 render-prop idiom for Vue.
+                   The slot exposes the bound editor through its props
+                   so consumers can drop in any component that needs it. -->
               <template #default="{ editor: slotEditor }">
                 <VizelFindReplace v-if="slotEditor" :editor="slotEditor" />
               </template>

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,7 +137,7 @@ export default withMermaid({
     nav: [
       { text: "Guide", link: "/guide/" },
       { text: "API", link: "/api/" },
-      { text: "Migration", link: "/migration/v1-to-v2" },
+      { text: "Migration", link: "/guide/migration-v1-to-v2" },
       { text: "Demo", link: "/demo/" },
     ],
 
@@ -148,6 +148,14 @@ export default withMermaid({
           items: [
             { text: "What is Vizel?", link: "/guide/" },
             { text: "Getting Started", link: "/guide/getting-started" },
+          ],
+        },
+        {
+          text: "Per-framework Setup",
+          items: [
+            { text: "React", link: "/guide/getting-started-react" },
+            { text: "Vue", link: "/guide/getting-started-vue" },
+            { text: "Svelte", link: "/guide/getting-started-svelte" },
           ],
         },
         {
@@ -164,7 +172,10 @@ export default withMermaid({
         },
         {
           text: "Migration",
-          items: [{ text: "v1 to v2", link: "/migration/v1-to-v2" }],
+          items: [
+            { text: "v1 to v2 (guide)", link: "/guide/migration-v1-to-v2" },
+            { text: "v1 to v2 (reference)", link: "/migration/v1-to-v2" },
+          ],
         },
       ],
       "/migration/": [

--- a/docs/guide/getting-started-react.md
+++ b/docs/guide/getting-started-react.md
@@ -1,0 +1,181 @@
+# Getting Started — React
+
+`@vizel/react` ships React 19 components and hooks. Installing the package is enough to render Vizel — `@vizel/core` and `@vizel/headless` come along as transitive dependencies.
+
+This page covers the minimal setup. For a v1 codebase, read the [v1 to v2 migration guide](/guide/migration-v1-to-v2) first.
+
+## Installation
+
+```bash
+pnpm add @vizel/react
+# or
+npm install @vizel/react
+# or
+yarn add @vizel/react
+```
+
+::: info Peer requirements
+- React 19 and React DOM 19.
+- Any ESM-compatible bundler. The package is tested against Vite 8, Next.js 15, and esbuild.
+- Optional features (`lowlight`, `katex`, `mermaid`, `yjs`, `y-websocket`) install on demand when you enable the matching feature.
+:::
+
+## CSS
+
+Import the stylesheet once at the application entry point:
+
+```ts
+import "@vizel/react/styles.css";
+```
+
+The subpath resolves to `@vizel/core/styles.css` ([ADR-0008](/adr/ADR-0008-css-belongs-in-core)). The bundle ships under exactly two selectors — `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` — plus the `prefers-color-scheme: dark` fallback.
+
+## Minimal editor
+
+The `Vizel` component renders the editor, bubble menu, and slash menu in a single mount:
+
+```tsx
+import { Vizel } from "@vizel/react";
+import "@vizel/react/styles.css";
+
+export function App() {
+  return (
+    <Vizel
+      initialMarkdown="# Hello, Vizel"
+      placeholder="Type '/' for commands..."
+      onUpdate={({ editor }) => {
+        // The transaction has committed when this runs;
+        // `getMarkdown()` reflects the latest editor state.
+        console.log(editor.getMarkdown());
+      }}
+    />
+  );
+}
+```
+
+## Hook-driven editor
+
+`useVizelEditor` returns `Editor | null` directly. The editor stays `null` during the first render and until the async initialiser resolves.
+
+```tsx
+import { useVizelEditor, VizelEditor, VizelBubbleMenu } from "@vizel/react";
+import "@vizel/react/styles.css";
+
+export function Editor() {
+  // The hook is the value. No `{ current }` destructure.
+  const editor = useVizelEditor({
+    placeholder: "Type '/' for commands...",
+    features: {
+      content: { mathematics: true, diagram: true },
+      interaction: { typography: true },
+    },
+  });
+
+  return (
+    <div className="editor-container">
+      <VizelEditor editor={editor} />
+      {editor && <VizelBubbleMenu editor={editor} />}
+    </div>
+  );
+}
+```
+
+## Reading editor state
+
+`useVizelEditorState(selector, { equalityFn? })` subscribes to a slice of the editor state. The hook reads the editor from the surrounding `VizelProvider`; pass no editor argument. React re-renders only when the slice changes.
+
+```tsx
+import {
+  shallowEqualObject,
+  useVizelEditor,
+  useVizelEditorState,
+  VizelEditor,
+  VizelProvider,
+} from "@vizel/react";
+
+function StatusBar() {
+  // Selector observes character / word counts; equalityFn suppresses
+  // re-renders when both numbers stay the same.
+  const stats = useVizelEditorState(
+    (editor) => ({
+      characters: editor?.storage.characterCount?.characters() ?? 0,
+      words: editor?.storage.characterCount?.words() ?? 0,
+    }),
+    { equalityFn: shallowEqualObject },
+  );
+
+  return (
+    <div className="status-bar">
+      <span>{stats.characters} characters</span>
+      <span>{stats.words} words</span>
+    </div>
+  );
+}
+
+export function App() {
+  const editor = useVizelEditor();
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor editor={editor} />
+      <StatusBar />
+    </VizelProvider>
+  );
+}
+```
+
+## Two-way Markdown
+
+`useVizelMarkdown` returns a debounced `{ markdown, setMarkdown, isPending }` triple. Drive the editor from external state without bypassing Tiptap's transaction system:
+
+```tsx
+import { useVizelEditor, useVizelMarkdown, VizelEditor } from "@vizel/react";
+
+export function SplitView() {
+  const editor = useVizelEditor({ initialMarkdown: "# Hello" });
+  const { markdown, setMarkdown, isPending } = useVizelMarkdown(editor);
+
+  return (
+    <div className="split">
+      <VizelEditor editor={editor} />
+      <textarea value={markdown} onChange={(e) => setMarkdown(e.target.value)} />
+      {isPending && <span aria-live="polite">Syncing...</span>}
+    </div>
+  );
+}
+```
+
+## Theming
+
+Wrap the application in `VizelThemeProvider` to enable the dark / light / system toggle. `useVizelTheme()` exposes the resolved theme and the dedicated `resetToSystem()` method:
+
+```tsx
+import { useVizelTheme, VizelThemeProvider } from "@vizel/react";
+
+function ThemeToggle() {
+  // `theme` is VizelResolvedTheme ("light" | "dark") — never "system".
+  const { theme, setTheme, resetToSystem } = useVizelTheme();
+  return (
+    <fieldset>
+      <button onClick={() => setTheme("light")}>Light</button>
+      <button onClick={() => setTheme("dark")}>Dark</button>
+      <button onClick={resetToSystem}>System (currently {theme})</button>
+    </fieldset>
+  );
+}
+
+export function App() {
+  return (
+    <VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
+      <Editor />
+      <ThemeToggle />
+    </VizelThemeProvider>
+  );
+}
+```
+
+## Next steps
+
+- [Editor](/guide/editor) — options, features, lifecycle, auto-save.
+- [Theming](/guide/theming) — CSS variables and host-theme integration.
+- [SSR](/guide/ssr) — server rendering and static HTML generation.
+- [Migration v1 to v2](/guide/migration-v1-to-v2) — every breaking change in one place.

--- a/docs/guide/getting-started-svelte.md
+++ b/docs/guide/getting-started-svelte.md
@@ -1,0 +1,175 @@
+# Getting Started — Svelte
+
+`@vizel/svelte` ships Svelte 5 components and runes. Installing the package is enough to render Vizel — `@vizel/core` and `@vizel/headless` come along as transitive dependencies.
+
+This page covers the minimal setup. For a v1 codebase, read the [v1 to v2 migration guide](/guide/migration-v1-to-v2) first.
+
+## Installation
+
+```bash
+pnpm add @vizel/svelte
+# or
+npm install @vizel/svelte
+# or
+yarn add @vizel/svelte
+```
+
+::: info Peer requirements
+- Svelte 5 or newer. The package uses runes (`$state.raw`, `$derived`, `$effect`, `$bindable`) throughout.
+- Any ESM-compatible bundler. The package is tested against Vite 8 and SvelteKit.
+- Optional features (`lowlight`, `katex`, `mermaid`, `yjs`, `y-websocket`) install on demand when you enable the matching feature.
+:::
+
+## CSS
+
+Import the stylesheet once at the application entry point:
+
+```ts
+import "@vizel/svelte/styles.css";
+```
+
+The subpath resolves to `@vizel/core/styles.css` ([ADR-0008](/adr/ADR-0008-css-belongs-in-core)). The bundle ships under exactly two selectors — `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` — plus the `prefers-color-scheme: dark` fallback.
+
+## Minimal editor
+
+The `Vizel` component renders the editor, bubble menu, and slash menu in a single mount. `bind:markdown` provides two-way binding through Svelte 5's `$bindable()`:
+
+```svelte
+<script lang="ts">
+import { Vizel } from "@vizel/svelte";
+import "@vizel/svelte/styles.css";
+
+let markdown = $state("# Hello, Vizel");
+</script>
+
+<Vizel bind:markdown placeholder="Type '/' for commands..." />
+```
+
+## Rune-driven editor
+
+`createVizelEditor` returns `{ readonly current: Editor | null }`. Read `.current` inside `$derived`, `$effect`, or templates so the read registers as a reactive dependency. The first-party reactivity primitive uses `$state.raw` plus `createSubscriber` from `svelte/reactivity` ([ADR-0009](/adr/ADR-0009-first-party-editor-reactivity)).
+
+```svelte
+<script lang="ts">
+import {
+  createVizelEditor,
+  VizelBubbleMenu,
+  VizelEditor,
+} from "@vizel/svelte";
+import "@vizel/svelte/styles.css";
+
+const editor = createVizelEditor({
+  placeholder: "Type '/' for commands...",
+  features: {
+    content: { mathematics: true, diagram: true },
+    interaction: { typography: true },
+  },
+});
+</script>
+
+<div class="editor-container">
+  <VizelEditor editor={editor.current} />
+  {#if editor.current}
+    <VizelBubbleMenu editor={editor.current} />
+  {/if}
+</div>
+```
+
+## Reading editor state
+
+`createVizelEditorState(() => editor)` returns `{ readonly current: VizelEditorState }`. The rune hooks `editor.on('transaction')` once and registers the dependency through Svelte 5's compiler-driven tracking, so only the template expressions that read `.current` re-evaluate.
+
+```svelte
+<script lang="ts">
+import {
+  createVizelEditor,
+  createVizelEditorState,
+  VizelEditor,
+} from "@vizel/svelte";
+
+const editor = createVizelEditor();
+
+// Pass a getter that resolves the editor. The rune subscribes to
+// transactions and exposes the latest VizelEditorState through `.current`.
+const state = createVizelEditorState(() => editor.current);
+</script>
+
+<VizelEditor editor={editor.current} />
+<div class="status-bar">
+  <span>{state.current.characterCount} characters</span>
+  <span>{state.current.wordCount} words</span>
+</div>
+```
+
+::: info Selector contract per framework
+React (`useVizelEditorState(selector, { equalityFn? }): T`) and Vue (`useVizelEditorState(selector, { equalityFn? }): ComputedRef<T>`) ship a selector argument because their reactivity primitives recompute on every transaction. Svelte 5 tracks reads through the compiler, so the rune collapses to the getter form. [ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) records the per-framework primitive.
+:::
+
+## Two-way Markdown with `bind:markdown`
+
+The top-level `Vizel` component declares `markdown` as `$bindable()`. Pair it with a `$state` rune and consume both ends of the binding:
+
+```svelte
+<script lang="ts">
+import { Vizel } from "@vizel/svelte";
+
+let markdown = $state("# Hello");
+</script>
+
+<div class="split">
+  <Vizel bind:markdown />
+  <textarea bind:value={markdown}></textarea>
+</div>
+```
+
+## Theming
+
+Wrap the application in `VizelThemeProvider`. `getVizelTheme()` exposes the resolved theme through a `current` getter plus a dedicated `resetToSystem()` method:
+
+```svelte
+<!-- ThemeToggle.svelte -->
+<script lang="ts">
+import { getVizelTheme } from "@vizel/svelte";
+
+// `theme.current` is the resolved value ("light" | "dark").
+const theme = getVizelTheme();
+</script>
+
+<fieldset>
+  <button onclick={() => theme.setTheme("light")}>Light</button>
+  <button onclick={() => theme.setTheme("dark")}>Dark</button>
+  <button onclick={theme.resetToSystem}>System (currently {theme.current})</button>
+</fieldset>
+```
+
+```svelte
+<!-- App.svelte -->
+<script lang="ts">
+import { VizelThemeProvider } from "@vizel/svelte";
+import Editor from "./Editor.svelte";
+import ThemeToggle from "./ThemeToggle.svelte";
+</script>
+
+<VizelThemeProvider defaultTheme="system" storageKey="vizel-theme">
+  <Editor />
+  <ThemeToggle />
+</VizelThemeProvider>
+```
+
+## Event prop casing
+
+Svelte 5 uses lowercase DOM-attribute names for event props ([ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api)). React and Vue keep camelCase; Svelte does not:
+
+```svelte
+<!-- Svelte: lowercase. -->
+<VizelLinkEditor onclose={handleClose} />
+<VizelColorPicker onchange={handleChange} />
+<VizelSlashMenu onselect={handleSelect} />
+```
+
+## Next steps
+
+- [Editor](/guide/editor) — options, features, lifecycle, auto-save.
+- [Theming](/guide/theming) — CSS variables and host-theme integration.
+- [SSR](/guide/ssr) — server rendering and static HTML generation.
+- [Migration v1 to v2](/guide/migration-v1-to-v2) — every breaking change in one place.

--- a/docs/guide/getting-started-vue.md
+++ b/docs/guide/getting-started-vue.md
@@ -1,0 +1,184 @@
+# Getting Started — Vue
+
+`@vizel/vue` ships Vue 3.5 single-file components and composables. Installing the package is enough to render Vizel — `@vizel/core` and `@vizel/headless` come along as transitive dependencies.
+
+This page covers the minimal setup. For a v1 codebase, read the [v1 to v2 migration guide](/guide/migration-v1-to-v2) first.
+
+## Installation
+
+```bash
+pnpm add @vizel/vue
+# or
+npm install @vizel/vue
+# or
+yarn add @vizel/vue
+```
+
+::: info Peer requirements
+- Vue 3.5 or newer (`defineModel`, `useId`, `useTemplateRef` rely on 3.5 features).
+- Any ESM-compatible bundler. The package is tested against Vite 8 and Nuxt 3.
+- Optional features (`lowlight`, `katex`, `mermaid`, `yjs`, `y-websocket`) install on demand when you enable the matching feature.
+:::
+
+## CSS
+
+Import the stylesheet once at the application entry point:
+
+```ts
+import "@vizel/vue/styles.css";
+```
+
+The subpath resolves to `@vizel/core/styles.css` ([ADR-0008](/adr/ADR-0008-css-belongs-in-core)). The bundle ships under exactly two selectors — `:root, [data-vizel-theme="light"]` and `[data-vizel-theme="dark"]` — plus the `prefers-color-scheme: dark` fallback.
+
+## Minimal editor
+
+The `Vizel` component renders the editor, bubble menu, and slash menu in a single mount. Use `v-model:markdown` for two-way binding through Vue's `defineModel`:
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import { Vizel } from "@vizel/vue";
+import "@vizel/vue/styles.css";
+
+const markdown = ref("# Hello, Vizel");
+</script>
+
+<template>
+  <Vizel
+    v-model:markdown="markdown"
+    placeholder="Type '/' for commands..."
+  />
+</template>
+```
+
+## Composable-driven editor
+
+`useVizelEditor` returns a `ShallowRef<Editor | null>`. Read `.value` in script; templates auto-unwrap top-level refs. The first-party reactivity primitive uses `shallowRef` plus `onScopeDispose`-bound listeners ([ADR-0009](/adr/ADR-0009-first-party-editor-reactivity)).
+
+```vue
+<script setup lang="ts">
+import {
+  useVizelEditor,
+  VizelBubbleMenu,
+  VizelEditor,
+} from "@vizel/vue";
+import "@vizel/vue/styles.css";
+
+const editor = useVizelEditor({
+  placeholder: "Type '/' for commands...",
+  features: {
+    content: { mathematics: true, diagram: true },
+    interaction: { typography: true },
+  },
+});
+</script>
+
+<template>
+  <div class="editor-container">
+    <VizelEditor :editor="editor" />
+    <VizelBubbleMenu v-if="editor" :editor="editor" />
+  </div>
+</template>
+```
+
+## Reading editor state
+
+`useVizelEditorState(selector, { equalityFn? })` returns a `ComputedRef<T>`. The selector receives a typed snapshot (`{ editor, transaction }`); the composable re-evaluates on every transaction.
+
+```vue
+<script setup lang="ts">
+import {
+  shallowEqualObject,
+  useVizelEditor,
+  useVizelEditorState,
+  VizelEditor,
+  VizelProvider,
+} from "@vizel/vue";
+
+const editor = useVizelEditor();
+
+// The editor flows through <VizelProvider>; the composable injects it.
+const stats = useVizelEditorState(
+  ({ editor }) => ({
+    characters: editor?.storage.characterCount?.characters() ?? 0,
+    words: editor?.storage.characterCount?.words() ?? 0,
+  }),
+  { equalityFn: shallowEqualObject },
+);
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor :editor="editor" />
+    <div class="status-bar">
+      <span>{{ stats.characters }} characters</span>
+      <span>{{ stats.words }} words</span>
+    </div>
+  </VizelProvider>
+</template>
+```
+
+## Two-way Markdown with `v-model:markdown`
+
+The top-level `Vizel` component exposes `v-model:markdown` through `defineModel<string>("markdown")`. The same prop works in controlled mode:
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import { Vizel } from "@vizel/vue";
+
+const markdown = ref("# Hello");
+</script>
+
+<template>
+  <div class="split">
+    <Vizel v-model:markdown="markdown" />
+    <textarea v-model="markdown" />
+  </div>
+</template>
+```
+
+## Theming
+
+Wrap the application in `VizelThemeProvider`. `useVizelTheme()` exposes the resolved theme as a `ComputedRef<VizelResolvedTheme>` plus a dedicated `resetToSystem()` method:
+
+```vue
+<!-- ThemeToggle.vue -->
+<script setup lang="ts">
+import { useVizelTheme } from "@vizel/vue";
+
+// `theme` is a ComputedRef. Templates auto-unwrap; in script read `.value`.
+const { theme, setTheme, resetToSystem } = useVizelTheme();
+</script>
+
+<template>
+  <fieldset>
+    <button @click="setTheme('light')">Light</button>
+    <button @click="setTheme('dark')">Dark</button>
+    <button @click="resetToSystem">System (currently {{ theme }})</button>
+  </fieldset>
+</template>
+```
+
+```vue
+<!-- App.vue -->
+<script setup lang="ts">
+import { VizelThemeProvider } from "@vizel/vue";
+import Editor from "./Editor.vue";
+import ThemeToggle from "./ThemeToggle.vue";
+</script>
+
+<template>
+  <VizelThemeProvider default-theme="system" storage-key="vizel-theme">
+    <Editor />
+    <ThemeToggle />
+  </VizelThemeProvider>
+</template>
+```
+
+## Next steps
+
+- [Editor](/guide/editor) — options, features, lifecycle, auto-save.
+- [Theming](/guide/theming) — CSS variables and host-theme integration.
+- [SSR](/guide/ssr) — server rendering and static HTML generation.
+- [Migration v1 to v2](/guide/migration-v1-to-v2) — every breaking change in one place.

--- a/docs/guide/migration-v1-to-v2.md
+++ b/docs/guide/migration-v1-to-v2.md
@@ -1,0 +1,739 @@
+# Migration: v1 to v2
+
+Vizel v2 abandons the symmetric API contract that v1 enforced across React, Vue, and Svelte. Each adapter now delivers the framework's native idiom. Feature parity holds across the three packages, but the surface that exposes each feature differs.
+
+This guide enumerates every breaking change with side-by-side v1 / v2 code samples for all three frameworks. Apply the sections in order — later sections assume earlier ones are already resolved. The motivating Architecture Decision Records (ADRs) are linked inline.
+
+::: tip Why a clean break
+v2 ships no compatibility shim. The maintainer's directive prioritises a coherent surface over deprecation cycles. [ADR-0005](/adr/ADR-0005-v2-breaking-release) records the decision. v1.x stays on npm at its published versions and receives no further patches.
+:::
+
+## At a glance
+
+| Section | Change | ADR |
+|---------|--------|-----|
+| [1](#_1-the-cross-framework-symmetry-contract-retires) | Cross-framework symmetry retires; parity moves to a typed manifest | [ADR-0001](/adr/ADR-0001-feature-parity-over-api-symmetry), [ADR-0002](/adr/ADR-0002-feature-manifest-as-parity-ssot) |
+| [2](#_2-editor-lifecycle-returns-the-editor-directly) | Editor lifecycle hooks return the editor directly | [ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api), [ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) |
+| [3](#_3-usevizeleditorstate-becomes-a-selector-subscription) | `useVizelEditorState` becomes a selector subscription | [ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) |
+| [4](#_4-bubble-menu-slash-menu-and-mention-menu-adopt-render-prop-idioms) | Bubble menu, slash menu, and mention menu adopt render-prop idioms | [ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api) |
+| [5](#_5-link-editor-find-replace-and-color-picker-restructure) | Link editor, find-replace, and color picker restructure | [ADR-0007](/adr/ADR-0007-component-size-and-controller-delegation) |
+| [6](#_6-theme-provider-and-theme-hooks) | Theme provider exposes `resetToSystem`; theme hooks reshape | [ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api) |
+| [7](#_7-auto-save-shapes) | Auto-save composables adopt framework-native return shapes | [ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api) |
+| [8](#_8-vizel-headless-becomes-a-transitive-dependency) | `@vizel/headless` becomes a transitive dependency | [ADR-0003](/adr/ADR-0003-vizel-headless-package) |
+| [9](#_9-css-centralises-in-vizel-core) | CSS centralises in `@vizel/core`; adapters re-export | [ADR-0008](/adr/ADR-0008-css-belongs-in-core) |
+| [10](#_10-controllers-replace-direct-dom-listeners) | Controllers replace direct DOM listeners | [ADR-0007](/adr/ADR-0007-component-size-and-controller-delegation) |
+
+---
+
+## 1. The cross-framework symmetry contract retires
+
+v1 enforced API symmetry across the three adapters through `.claude/rules/cross-framework.md` (472 lines of prose). Every component prop, hook name, return shape, and event payload had to mirror across React, Vue, and Svelte. The contract prevented each framework from using its native idiom.
+
+v2 replaces the prose contract with a typed feature manifest at `packages/core/src/feature-manifest.ts`. The manifest lists every advertised feature and the symbol each adapter exports. CI runs `pnpm check:parity` against the manifest before any test executes.
+
+### What changes for consumers
+
+- Hook, composable, and rune signatures diverge per framework. Each adapter now reads like idiomatic React 19, Vue 3.5, or Svelte 5 code.
+- Component prop shapes diverge where the framework's slot or callback idiom differs. The feature set is identical.
+- Cross-framework navigation goes through the migration guide, the manifest, and the per-framework guides — not through a single symmetric reference.
+
+[ADR-0001](/adr/ADR-0001-feature-parity-over-api-symmetry) records the decision. [ADR-0002](/adr/ADR-0002-feature-manifest-as-parity-ssot) records the manifest design. [ADR-0006](/adr/ADR-0006-retire-cross-framework-rule) retires the prose rule.
+
+---
+
+## 2. Editor lifecycle returns the editor directly
+
+v1 returned a destructured-getter wrapper around the editor instance. The wrapper added indirection that React, Vue, and Svelte each absorbed differently. v2 returns the editor in the shape each framework already expects.
+
+[ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api) records the idiomatic API contract. [ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) records the first-party reactivity primitive each adapter now ships.
+
+### React: `useVizelEditor` returns `Editor | null`
+
+The hook *is* the value. Drop the `{ current }` destructure.
+
+#### Before (v1)
+
+```tsx
+import { useVizelEditor } from "@vizel/react";
+
+function Editor() {
+  // v1 wrapped the editor inside a getter object.
+  const { current: editor } = useVizelEditor({
+    placeholder: "Start typing...",
+  });
+
+  return <VizelEditor editor={editor} />;
+}
+```
+
+#### After (v2)
+
+```tsx
+import { useVizelEditor, VizelEditor } from "@vizel/react";
+
+function Editor() {
+  // v2 returns the editor directly. `Editor | null` matches the React
+  // idiom where the hook value flows straight into the component.
+  const editor = useVizelEditor({
+    placeholder: "Start typing...",
+  });
+
+  return <VizelEditor editor={editor} />;
+}
+```
+
+### Vue: `useVizelEditor` returns `ShallowRef<Editor | null>`
+
+The composable returns a `ShallowRef` so templates read `.value` once. The first-party reactivity primitive lives in `packages/vue/src/_reactivity.ts` and uses `shallowRef` plus `onScopeDispose`-bound listeners.
+
+#### Before (v1)
+
+```vue
+<script setup lang="ts">
+import { useVizelEditor } from "@vizel/vue";
+
+const { current: editor } = useVizelEditor({
+  placeholder: "Start typing...",
+});
+</script>
+
+<template>
+  <VizelEditor :editor="editor" />
+</template>
+```
+
+#### After (v2)
+
+```vue
+<script setup lang="ts">
+import { useVizelEditor, VizelEditor } from "@vizel/vue";
+
+// `editor` is a ShallowRef<Editor | null>. Read `.value` in script,
+// or pass the ref straight into templates — Vue unwraps top-level refs.
+const editor = useVizelEditor({
+  placeholder: "Start typing...",
+});
+</script>
+
+<template>
+  <VizelEditor :editor="editor" />
+</template>
+```
+
+### Svelte: `createVizelEditor` returns `{ readonly current: Editor | null }`
+
+The rune holds the editor in `$state.raw<Editor | null>` and exposes a `current` getter. Re-assignment triggers reactivity; field mutation does not, which matches Tiptap's mutable `Editor` instance.
+
+#### Before (v1)
+
+```svelte
+<script lang="ts">
+import { createVizelEditor, VizelEditor } from "@vizel/svelte";
+
+// v1 returned the same wrapper shape that React and Vue consumed.
+const { current: editor } = createVizelEditor({
+  placeholder: "Start typing...",
+});
+</script>
+
+<VizelEditor editor={editor} />
+```
+
+#### After (v2)
+
+```svelte
+<script lang="ts">
+import { createVizelEditor, VizelEditor } from "@vizel/svelte";
+
+// The rune returns a reactive accessor. Read `.current` inside templates
+// or reactive scopes ($derived, $effect) so the read registers as a
+// dependency.
+const editor = createVizelEditor({
+  placeholder: "Start typing...",
+});
+</script>
+
+<VizelEditor editor={editor.current} />
+```
+
+---
+
+## 3. `useVizelEditorState` becomes a selector subscription
+
+v1 derived a fixed-shape state record (`{ characterCount, wordCount, canUndo, ... }`) and re-rendered on every transaction. The shape forced every consumer through the same recompute path even when the consumer cared about a single boolean.
+
+v2 turns the hook into a selector subscription. The consumer picks the slice; the hook re-renders only when the slice changes. The hook reads the editor from the surrounding `VizelProvider` automatically — pass no editor argument.
+
+[ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) records the first-party reactivity contract. React uses `useSyncExternalStore`; Vue uses `shallowRef` plus `onScopeDispose`; Svelte uses `$state.raw` plus `createSubscriber`.
+
+### React
+
+#### Before (v1)
+
+```tsx
+import { useVizelEditorState } from "@vizel/react";
+
+function StatusBar({ editor }: { editor: Editor | null }) {
+  // v1: pass the editor, receive the full shape every render.
+  const { characterCount, wordCount } = useVizelEditorState(editor);
+
+  return (
+    <div>
+      <span>{characterCount} characters</span>
+      <span>{wordCount} words</span>
+    </div>
+  );
+}
+```
+
+#### After (v2)
+
+```tsx
+import { shallowEqualObject, useVizelEditorState } from "@vizel/react";
+
+function StatusBar() {
+  // Selector reads the slice; equalityFn suppresses re-renders when
+  // the slice is structurally unchanged. The editor comes from the
+  // surrounding <VizelProvider>; no argument is passed.
+  const stats = useVizelEditorState(
+    (editor) => ({
+      characterCount: editor?.storage.characterCount?.characters() ?? 0,
+      wordCount: editor?.storage.characterCount?.words() ?? 0,
+    }),
+    { equalityFn: shallowEqualObject },
+  );
+
+  return (
+    <div>
+      <span>{stats.characterCount} characters</span>
+      <span>{stats.wordCount} words</span>
+    </div>
+  );
+}
+```
+
+### Vue
+
+The Vue composable returns a `ComputedRef<T>` whose value re-evaluates on every transaction the selector observes.
+
+#### Before (v1)
+
+```vue
+<script setup lang="ts">
+import { useVizelEditorState } from "@vizel/vue";
+
+const props = defineProps<{ editor: Editor | null }>();
+const state = useVizelEditorState(() => props.editor);
+</script>
+
+<template>
+  <div>
+    <span>{{ state.characterCount }} characters</span>
+    <span>{{ state.wordCount }} words</span>
+  </div>
+</template>
+```
+
+#### After (v2)
+
+```vue
+<script setup lang="ts">
+import { shallowEqualObject, useVizelEditorState } from "@vizel/vue";
+
+// Selector receives a typed snapshot; the editor is injected from the
+// surrounding <VizelProvider>. The return is a ComputedRef<T>.
+const stats = useVizelEditorState(
+  ({ editor }) => ({
+    characterCount: editor?.storage.characterCount?.characters() ?? 0,
+    wordCount: editor?.storage.characterCount?.words() ?? 0,
+  }),
+  { equalityFn: shallowEqualObject },
+);
+</script>
+
+<template>
+  <div>
+    <span>{{ stats.characterCount }} characters</span>
+    <span>{{ stats.wordCount }} words</span>
+  </div>
+</template>
+```
+
+### Svelte
+
+The Svelte rune returns `{ readonly current: VizelEditorState }`. The implementation uses `$state.raw` plus the rune system; `createSubscriber` from `svelte/reactivity` hooks `editor.on('transaction')` once and registers the dependency through the compiler's tracking. The call site keeps the v1 getter form — reactivity flows through `.current` because Svelte 5 tracks reads, not selector arguments.
+
+#### Before (v1)
+
+```svelte
+<script lang="ts">
+import { createVizelEditorState } from "@vizel/svelte";
+
+let { editor }: { editor: Editor | null } = $props();
+// v1 returned an eager VizelEditorState object on every transaction.
+const state = createVizelEditorState(() => editor);
+</script>
+
+<div>
+  <span>{state.current.characterCount} characters</span>
+  <span>{state.current.wordCount} words</span>
+</div>
+```
+
+#### After (v2)
+
+```svelte
+<script lang="ts">
+import { createVizelEditorState } from "@vizel/svelte";
+
+let { editor }: { editor: Editor | null } = $props();
+
+// v2 keeps the getter form. Read the slice you care about inside the
+// template — the rune system only re-evaluates the bound expressions,
+// so React-style equalityFn knobs do not ship on the Svelte rune.
+const state = createVizelEditorState(() => editor);
+</script>
+
+<div>
+  <span>{state.current.characterCount} characters</span>
+  <span>{state.current.wordCount} words</span>
+</div>
+```
+
+::: info Why no `equalityFn` on Svelte
+React and Vue selectors recompute on every transaction; an `equalityFn` short-circuits the consequent re-render. Svelte 5's compiler tracks reads through the rune system, so only the bound expressions re-evaluate. The selector contract collapses into the template binding itself.
+:::
+
+---
+
+## 4. Bubble menu, slash menu, and mention menu adopt render-prop idioms
+
+v1 forced render customisation through a `renderItem` callback prop in every framework. v2 honours each framework's native render-prop idiom: React render-prop callback props (`bubbleMenuContent`, `toolbarContent`, `renderItem`), Vue scoped slots, Svelte snippets.
+
+The container's keyboard handling, ARIA wiring, and dismissal logic stay owned by the component. Consumers only swap the per-item or per-section markup.
+
+### React: callback render-props
+
+React 19 keeps `children` as `ReactNode` for layout composition. v2 exposes per-item rendering through a dedicated `renderItem` callback prop that receives a typed argument object (`{ item, isSelected, onClick }`), mirroring how `bubbleMenuContent` and `toolbarContent` already work on the top-level `Vizel` component.
+
+#### Before (v1)
+
+```tsx
+import { VizelSlashMenu } from "@vizel/react";
+
+<VizelSlashMenu
+  items={items}
+  onSelect={handleSelect}
+  // v1 separated the rendering state into a second positional argument.
+  renderItem={(item, state) => (
+    <div className={state.isSelected ? "active" : ""}>
+      <CustomIcon name={item.id} />
+      <span>{item.title}</span>
+    </div>
+  )}
+/>
+```
+
+#### After (v2)
+
+```tsx
+import { VizelSlashMenu } from "@vizel/react";
+
+<VizelSlashMenu
+  items={items}
+  onSelect={handleSelect}
+  // v2 collapses the arguments into a single typed object so the React
+  // signature mirrors Vue's scoped-slot props and Svelte's snippet args.
+  renderItem={({ item, isSelected, onClick }) => (
+    <button type="button" data-active={isSelected} onClick={onClick}>
+      <CustomIcon name={item.id} />
+      <span>{item.title}</span>
+    </button>
+  )}
+/>
+```
+
+### Vue: scoped slots
+
+#### Before (v1)
+
+```vue
+<script setup lang="ts">
+import { VizelSlashMenu } from "@vizel/vue";
+
+const renderItem = (item, state) => /* ... */;
+</script>
+
+<template>
+  <VizelSlashMenu
+    :items="items"
+    :render-item="renderItem"
+    @select="handleSelect"
+  />
+</template>
+```
+
+#### After (v2)
+
+```vue
+<script setup lang="ts">
+import { VizelSlashMenu } from "@vizel/vue";
+</script>
+
+<template>
+  <VizelSlashMenu :items="items" @select="handleSelect">
+    <template #item="{ item, isSelected, onClick }">
+      <!-- Scoped slot is the Vue-native render-prop equivalent. -->
+      <button type="button" :data-active="isSelected" @click="onClick">
+        <CustomIcon :name="item.id" />
+        <span>{{ item.title }}</span>
+      </button>
+    </template>
+  </VizelSlashMenu>
+</template>
+```
+
+### Svelte: snippets
+
+#### Before (v1)
+
+```svelte
+<script lang="ts">
+import { VizelSlashMenu } from "@vizel/svelte";
+</script>
+
+<VizelSlashMenu
+  items={items}
+  onSelect={handleSelect}
+  renderItem={(item, state) => /* awkward inline function */ ''}
+/>
+```
+
+#### After (v2)
+
+```svelte
+<script lang="ts">
+import { VizelSlashMenu } from "@vizel/svelte";
+</script>
+
+<VizelSlashMenu items={items} onselect={handleSelect}>
+  {#snippet item({ item, isSelected, onclick })}
+    <!-- Svelte 5 snippets read like template literals; lowercase
+         `onselect` / `onclick` follow the DOM attribute convention. -->
+    <button type="button" data-active={isSelected} {onclick}>
+      <CustomIcon name={item.id} />
+      <span>{item.title}</span>
+    </button>
+  {/snippet}
+</VizelSlashMenu>
+```
+
+The same shape applies to `VizelBubbleMenu` (children render the menu body) and `VizelMentionMenu` (per-item render seam).
+
+---
+
+## 5. Link editor, find-replace, and color picker restructure
+
+The three popover components shrank below the 120-line view-template budget that [ADR-0007](/adr/ADR-0007-component-size-and-controller-delegation) sets. Form state moved into Core; the framework code only renders the spec.
+
+### `VizelLinkEditor`
+
+- The `onClose` callback renames to `onclose` in Svelte (lowercase DOM-event convention) and becomes a `close` emit in Vue.
+- The embed toggle is now part of the form spec; consumers cannot inject a custom embed toggle.
+
+#### Before (v1)
+
+```tsx
+// React
+<VizelLinkEditor editor={editor} onClose={handleClose} enableEmbed />
+```
+
+```vue
+<!-- Vue -->
+<VizelLinkEditor :editor="editor" @close="handleClose" enable-embed />
+```
+
+```svelte
+<!-- Svelte -->
+<VizelLinkEditor editor={editor} onClose={handleClose} enableEmbed />
+```
+
+#### After (v2)
+
+```tsx
+// React: prop name unchanged.
+<VizelLinkEditor editor={editor} onClose={handleClose} enableEmbed />
+```
+
+```vue
+<!-- Vue: emit form unchanged. -->
+<VizelLinkEditor :editor="editor" @close="handleClose" enable-embed />
+```
+
+```svelte
+<!-- Svelte: lowercase event prop. -->
+<VizelLinkEditor editor={editor} onclose={handleClose} enableEmbed />
+```
+
+### `VizelFindReplace`
+
+The component now reads the editor from the surrounding provider when the `editor` prop is omitted. The find-replace extension still requires explicit registration:
+
+```ts
+import { createVizelFindReplaceExtension } from "@vizel/<framework>";
+
+const extensions = [createVizelFindReplaceExtension()];
+```
+
+The keyboard map (Cmd/Ctrl+F to open, Esc to close) now lives in the controller; consumers no longer wire global listeners.
+
+### `VizelColorPicker`
+
+- `onchange` (lowercase) in Svelte.
+- `recentColors` is a controlled prop; the component no longer reads `localStorage` internally.
+
+#### Svelte before / after
+
+```svelte
+<!-- v1 -->
+<VizelColorPicker
+  colors={colors}
+  value={color}
+  onChange={handleChange}
+/>
+
+<!-- v2 -->
+<VizelColorPicker
+  colors={colors}
+  value={color}
+  onchange={handleChange}
+/>
+```
+
+---
+
+## 6. Theme provider and theme hooks
+
+The theme APIs now expose a single resolved theme plus a dedicated `resetToSystem()` method. v1's overloaded `setTheme("system")` is gone — the type system rejects it. The `theme` field always carries a concrete `VizelResolvedTheme` (`"light" | "dark"`), never `"system"`.
+
+### React
+
+#### Before (v1)
+
+```tsx
+import { useVizelTheme } from "@vizel/react";
+
+function ThemeToggle() {
+  const { theme, setTheme } = useVizelTheme();
+  return (
+    <>
+      <button onClick={() => setTheme("light")}>Light</button>
+      <button onClick={() => setTheme("dark")}>Dark</button>
+      <button onClick={() => setTheme("system")}>System</button>
+    </>
+  );
+}
+```
+
+#### After (v2)
+
+```tsx
+import { useVizelTheme } from "@vizel/react";
+
+function ThemeToggle() {
+  // `theme` is `VizelResolvedTheme` ("light" | "dark"); `setTheme`
+  // accepts only concrete values. Switching back to the OS preference
+  // calls `resetToSystem`.
+  const { theme, setTheme, resetToSystem } = useVizelTheme();
+  return (
+    <>
+      <button onClick={() => setTheme("light")}>Light</button>
+      <button onClick={() => setTheme("dark")}>Dark</button>
+      <button onClick={resetToSystem}>System</button>
+    </>
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { useVizelTheme } from "@vizel/vue";
+
+// `theme` is a ComputedRef<VizelResolvedTheme>. Read `theme.value` in
+// script, or `{{ theme }}` in templates (Vue auto-unwraps refs).
+const { theme, setTheme, resetToSystem } = useVizelTheme();
+</script>
+
+<template>
+  <button @click="setTheme('light')">Light</button>
+  <button @click="setTheme('dark')">Dark</button>
+  <button @click="resetToSystem">System</button>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+import { getVizelTheme } from "@vizel/svelte";
+
+// `theme.current` is the resolved value; `setTheme` and
+// `resetToSystem` mirror React and Vue.
+const theme = getVizelTheme();
+</script>
+
+<button onclick={() => theme.setTheme("light")}>Light</button>
+<button onclick={() => theme.setTheme("dark")}>Dark</button>
+<button onclick={theme.resetToSystem}>System</button>
+```
+
+`VizelThemeProvider` props stay the same: `defaultTheme`, `storageKey`, `targetSelector`, `disableTransitionOnChange`.
+
+---
+
+## 7. Auto-save shapes
+
+The auto-save composable still accepts the same options (`debounceMs`, `storage`, `key`, `onSave`, `onError`). The return shape adopts each framework's native primitive type.
+
+| Framework | v1 return shape | v2 return shape |
+|-----------|----------------|-----------------|
+| React | `{ status, hasUnsavedChanges, lastSaved, error, save, restore }` (snapshot on render) | Same — React snapshots on every render, no change |
+| Vue | Eager object | Per-field `ComputedRef` (read `.value` in script, auto-unwrapped in templates) |
+| Svelte | Eager object | Rune-getter object (`status`, `lastSaved` etc. are getters) |
+
+### Vue change
+
+```vue
+<script setup lang="ts">
+import { useVizelAutoSave, useVizelEditor } from "@vizel/vue";
+
+const editor = useVizelEditor();
+
+// v2 returns { status: ComputedRef, hasUnsavedChanges: ComputedRef, ... }.
+// Read `.value` in script; templates auto-unwrap.
+const { status, lastSaved, save, restore } = useVizelAutoSave(
+  () => editor.value,
+  { debounceMs: 2000, storage: "localStorage", key: "vizel-demo" },
+);
+</script>
+
+<template>
+  <VizelSaveIndicator :status="status" :last-saved="lastSaved" />
+</template>
+```
+
+### Svelte change
+
+```svelte
+<script lang="ts">
+import { createVizelAutoSave, createVizelEditor } from "@vizel/svelte";
+
+const editor = createVizelEditor();
+
+// v2 returns { readonly status, readonly lastSaved, save, restore, ... }.
+// Read the getters directly inside templates.
+const autoSave = createVizelAutoSave(() => editor.current, {
+  debounceMs: 2000,
+  storage: "localStorage",
+  key: "vizel-demo",
+});
+</script>
+
+<VizelSaveIndicator status={autoSave.status} lastSaved={autoSave.lastSaved} />
+```
+
+---
+
+## 8. `@vizel/headless` becomes a transitive dependency
+
+v2 introduces `@vizel/headless`, a framework-neutral package that hosts the dismissable layer, popover positioning, combobox keyboard map, focus trap, and floating positioning. Each adapter package declares `@vizel/headless` as a *dependency* (not a peer dependency) so consumers never import from it directly.
+
+[ADR-0003](/adr/ADR-0003-vizel-headless-package) records the package decision.
+
+### Consumer impact
+
+- Add no entry for `@vizel/headless` to `package.json`. The framework adapter pulls it in transitively.
+- Tree-shake-friendly: each primitive is exported from its own subpath; framework adapters import only the primitives they need.
+- 21 v1 violations of "no `document.addEventListener` inside framework components" collapse to zero because the listeners now live in `dismissable/` controllers under `@vizel/headless`.
+
+If your build tool surfaces transitive dependencies during dedup (pnpm's `pnpm.overrides`, npm's `overrides`), pin `@vizel/headless` alongside the framework package to keep major versions aligned.
+
+---
+
+## 9. CSS centralises in `@vizel/core`
+
+v1 shipped CSS per adapter. Each `@vizel/<framework>/styles.css` duplicated the token catalogue. A token edit required three coordinated changes.
+
+v2 keeps the consumer import unchanged but resolves it to a single source. Every adapter's `package.json` declares an `exports."./styles.css"` entry that re-exports `@vizel/core/styles.css`.
+
+[ADR-0008](/adr/ADR-0008-css-belongs-in-core) records the decision.
+
+### Consumer impact
+
+The import statement does not change:
+
+```ts
+// All three frameworks — unchanged from v1.
+import "@vizel/react/styles.css";
+import "@vizel/vue/styles.css";
+import "@vizel/svelte/styles.css";
+```
+
+The CSS now ships under exactly two top-level selectors plus the `prefers-color-scheme: dark` fallback:
+
+- `:root, [data-vizel-theme="light"]`
+- `[data-vizel-theme="dark"]`
+- `@media (prefers-color-scheme: dark)` fallback for unset themes
+
+Host-environment selectors (`.dark`, `.light`, `[data-theme="*"]`) remain banned. Integrate host theming by setting `data-vizel-theme` on a wrapper element. Vizel never reads host theme attributes.
+
+If you wrote v1 overrides that targeted `[data-theme="dark"]` directly inside Vizel, switch them to `[data-vizel-theme="dark"]`. The host-theme bridge lives in your application code now.
+
+---
+
+## 10. Controllers replace direct DOM listeners
+
+[ADR-0007](/adr/ADR-0007-component-size-and-controller-delegation) bans `document.addEventListener`, `window.addEventListener`, `MutationObserver`, and `ResizeObserver` calls inside `packages/{react,vue,svelte}/src/`. CI fails the build when the grep check finds one.
+
+### Consumer impact
+
+The consumer-facing API does not change — the controllers run inside the components. The contract matters if you extend Vizel with a custom bubble-menu replacement or a custom popover:
+
+- Import the relevant controller from `@vizel/core/controllers/` or `@vizel/headless/`.
+- Mount it inside the framework's lifecycle hook (`useEffect`, `onMounted`, `$effect`).
+- Unmount it in the cleanup return.
+
+Example with the `dismissable` controller from `@vizel/headless`:
+
+```ts
+import { createDismissableController } from "@vizel/headless/dismissable";
+
+// Inside a React useEffect, Vue onMounted, or Svelte $effect:
+const controller = createDismissableController({
+  onDismiss: closeMenu,
+});
+controller.mount(menuElement);
+// Cleanup:
+return () => controller.unmount();
+```
+
+The controller owns the outside-click listener, the Escape-key handler, and the focus return. The framework code stays inside the 120-line view-template budget [ADR-0007](/adr/ADR-0007-component-size-and-controller-delegation) records.
+
+---
+
+## Reading order
+
+After applying the migration:
+
+1. Read the per-framework getting-started page that matches your codebase: [React](/guide/getting-started-react), [Vue](/guide/getting-started-vue), or [Svelte](/guide/getting-started-svelte).
+2. Read [ADR-0001](/adr/ADR-0001-feature-parity-over-api-symmetry) for the parity-over-symmetry rationale.
+3. Read [ADR-0004](/adr/ADR-0004-per-framework-idiomatic-api) for the per-framework idiom contract.
+4. Read [ADR-0009](/adr/ADR-0009-first-party-editor-reactivity) for the reactivity primitive details.
+
+---
+
+## Need help?
+
+Open an issue at [github.com/seijikohara/vizel/issues](https://github.com/seijikohara/vizel/issues). Attach the v1 snippet, the v2 form you tried, and the error or behaviour you observe. A resolved `VizelError` (`code`, `context`, `cause`) speeds the diagnosis.


### PR DESCRIPTION
## Summary

- Add `docs/guide/migration-v1-to-v2.md` as the dominant v2 migration artefact. The guide covers the editor lifecycle, the selector-form `useVizelEditorState`, render-prop idioms for bubble / slash / mention menus, the link editor, find-replace, color picker, theme provider, auto-save, the `@vizel/headless` transitive dependency, CSS centralisation, and controller delegation. Each breaking change carries side-by-side React, Vue, and Svelte samples and cross-links the motivating ADRs (ADR-0001, 0002, 0003, 0004, 0007, 0008, 0009).
- Add per-framework getting-started pages (`getting-started-react.md`, `getting-started-vue.md`, `getting-started-svelte.md`) that walk through installation, the single CSS import, the idiomatic minimal editor, the selector hook, two-way Markdown, and theming for each framework.
- Wire the new pages into the VitePress sidebar (`docs/.vitepress/config.mts`) and point the top Migration nav link at the new guide.
- Refresh the React demo to drive character / word counts through the v2 selector API (`useVizelEditorState` + `shallowEqualObject`) inside a `VizelProvider`. Annotate the Vue and Svelte demos so the v2 idiom (scoped slots, snippets, lowercase events) is explicit in the source.

## Test Plan

- [x] `pnpm install` — installed dependencies cleanly.
- [x] `pnpm typecheck` — 8 of 9 packages pass (`packages/core`, `headless`, `react`, `vue`, `svelte`; demos skipped — they ship no typecheck script).
- [x] `pnpm lint` — `Checked 600 files in 1429ms. No fixes applied.`
- [x] `pnpm check:nolet` — `No-let check passed.`
- [x] `pnpm check:parity` — `Cross-framework parity check passed.`
- [x] `pnpm check:feature-parity` — `Feature manifest parity check passed (23 features × 3 frameworks).`
- [x] `pnpm check:scenarios` — `Scenario parity check passed (23 features × 1 scenario folder).`
- [x] `pnpm docs:build` — completed cleanly; `docs/.vitepress/dist/guide/migration-v1-to-v2.html` and the three `getting-started-*.html` pages exist.

## Notes

- New `migration-v1-to-v2.md` is intended as the migration *guide* (per-feature surface walkthrough); the existing `migration/v1-to-v2.md` (v1.x → 2.0 feature options / error API reference) stays in place and the sidebar links both.
- React demo gains a small `StatsBar` sub-component that consumes `useVizelEditorState(selector, { equalityFn })` inside a surrounding `VizelProvider`. Vue's selector composable also reads from a surrounding provider; the Vue demo keeps the legacy `useVizelState` + `getVizelEditorState` pair because the demo cannot host a child component in the same SFC file without expanding the task scope past `App.vue`. The migration guide and per-framework getting-started page document the provider-based selector pattern.
- Svelte's `createVizelEditorState` retains the v1 getter signature in code; the migration guide and the Svelte getting-started page explain why no `equalityFn` knob ships (Svelte 5 tracks reads through the compiler).
