### PR TITLE
fix(demo): hold Svelte flavor in $state.raw to stop mount effect loop

### DIFF
--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -90,9 +90,16 @@ const commentManager = createVizelComment(() => (features.comments ? editorRef :
 // Find & Replace extension
 const findReplaceExtensions = [createVizelFindReplaceExtension()];
 
-// Swap content when flavor changes
+// Swap content when flavor changes. `$state.raw` holds the flavor object
+// by reference without deep-proxying it: a plain `$state(flavor)` wraps the
+// object in a reactive Proxy, so `flavor !== prevFlavor` compares the raw
+// derived value against a Proxy and is always true, and the
+// `prevFlavor = flavor` write re-proxies on every run. That re-marks the
+// `prevFlavor` this effect reads as dirty and re-triggers the effect
+// forever (effect_update_depth_exceeded), which aborts the initial render
+// before the editor mounts.
 // svelte-ignore state_referenced_locally
-let prevFlavor = $state(flavor);
+let prevFlavor = $state.raw(flavor);
 $effect(() => {
   if (flavor !== prevFlavor && editorRef) {
     setVizelMarkdown(editorRef, getFlavorContent(flavor), { transformDiagrams: true });


### PR DESCRIPTION
## Summary

- Fix a crash that left the Svelte demo editor unmounted. The page rendered the chrome and an empty editor shell, and the console threw Svelte's `effect_update_depth_exceeded`.
- Root cause: the flavor-swap effect tracked the previous flavor with `let prevFlavor = $state(flavor)`. Svelte 5 deep-proxies an object passed to `$state`, so `prevFlavor` became a reactive Proxy while `flavor` (the derived value) stayed the raw object. The guard `flavor !== prevFlavor` then compared a raw object against a Proxy and was always true, and `prevFlavor = flavor` re-proxied the object on every run — re-marking the `prevFlavor` the effect reads as dirty and re-triggering the effect without end. The churn ran regardless of `editorRef`, so it aborted the initial render before the editor mounted.
- Fix: hold the reference with `$state.raw`, which stores the flavor object without proxying it. The identity comparison and the write-back then operate on the same raw reference, so an unchanged flavor is a no-op and the effect fires only when the selected flavor actually changes.
- The React and Vue demos were unaffected; their equivalent tracking uses a plain variable rather than a deep-proxying reactive store.

## Why CI did not catch this

The Playwright Component Tests mount individual package components with their own harnesses. The bug lived in the demo `App.svelte` flavor-swap wiring, which no component test exercises.

## Test Plan

- [x] Browser verification (Chrome DevTools): the Svelte demo editor mounts with all features enabled (84 blocks, 17843 characters, console clean apart from the pre-existing KaTeX font 404s).
- [x] Flavor switching (GFM → Obsidian) reloads content (84 → 89 blocks) without re-triggering the loop.
- [x] Slash menu renders 23 commands across 6 groups; bubble menu renders the full formatting toolbar — both matching the React and Vue demos.
- [x] `pnpm typecheck`.
- [x] `pnpm lint` (Biome) on the changed file.
