### PR TITLE
refactor(react): close idiom gaps against ADR-0004 and ADR-0001

### DIFF
--- a/packages/react/src/_reactivity.ts
+++ b/packages/react/src/_reactivity.ts
@@ -127,6 +127,14 @@ export interface UseVizelEditorStateOptions<T> {
    * the shapes that selectors typically return.
    */
   readonly equalityFn?: (a: T, b: T) => boolean;
+  /**
+   * Editor instance to subscribe to. Defaults to the editor resolved
+   * from the surrounding `VizelProvider`. A component that already
+   * receives the editor as a prop passes it here so the selector
+   * subscribes to that exact instance even when no provider wraps the
+   * component (for example, a standalone `<VizelToolbar editor={...} />`).
+   */
+  readonly editor?: Editor | null;
 }
 
 /**
@@ -134,7 +142,10 @@ export interface UseVizelEditorStateOptions<T> {
  *
  * The hook reads the editor instance from the surrounding `VizelProvider`
  * (or returns `null` while no provider is mounted, mirroring
- * {@link useVizelContextSafe}). It then wraps a per-editor store inside
+ * {@link useVizelContextSafe}). Pass `options.editor` to subscribe to an
+ * explicit instance instead — a component that receives the editor as a
+ * prop uses it so the selector still tracks state when no provider wraps
+ * the component. The hook then wraps a per-editor store inside
  * `useSyncExternalStore` so React re-runs the selector on every
  * transaction. The hook short-circuits via the supplied `equalityFn`
  * (defaulting to `Object.is`), preventing re-renders when the slice is
@@ -165,7 +176,14 @@ export function useVizelEditorState<T>(
   selector: (editor: Editor | null) => T,
   options?: UseVizelEditorStateOptions<T>
 ): T {
-  const editor = useVizelContextSafe();
+  const contextEditor = useVizelContextSafe();
+  // The explicit override wins so a component holding the editor as a
+  // prop subscribes to that instance; otherwise the hook tracks the
+  // provider's editor. `undefined` means "no override supplied"; an
+  // explicit `null` (editor still initializing) falls back to context so
+  // a parent that passes `editor={null}` before mount does not lose the
+  // provider's eventual instance.
+  const editor = options?.editor ?? contextEditor;
 
   // Pin the latest selector / equality predicate inside refs so the
   // snapshot reader closure never goes stale across renders. The

--- a/packages/react/src/components/Vizel.tsx
+++ b/packages/react/src/components/Vizel.tsx
@@ -9,8 +9,8 @@ import {
   type VizelLocale,
   type VizelMarkdownFlavor,
 } from "@vizel/core";
-import type { ReactNode, Ref } from "react";
-import { useEffect, useImperativeHandle, useMemo } from "react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo } from "react";
 import { useLatest } from "../hooks/useLatest.ts";
 import { useVizelEditor } from "../hooks/useVizelEditor.ts";
 import { VizelBlockMenu } from "./VizelBlockMenu.tsx";
@@ -20,8 +20,6 @@ import { VizelEditor } from "./VizelEditor.tsx";
 import { VizelToolbar } from "./VizelToolbar.tsx";
 
 export interface VizelProps {
-  /** Ref to access editor instance */
-  ref?: Ref<VizelRef>;
   /** Initial content in JSON format */
   initialContent?: JSONContent;
   /**
@@ -117,16 +115,15 @@ export interface VizelProps {
   onError?: (error: VizelError) => void;
 }
 
-export interface VizelRef {
-  /** The underlying Tiptap editor instance */
-  editor: Editor | null;
-}
-
 /**
  * Vizel - All-in-one editor component
  *
  * A complete editor component that includes VizelEditor and VizelBubbleMenu.
  * This is the recommended way to use Vizel for most use cases.
+ *
+ * To read or drive the underlying Tiptap editor, lift it into state from
+ * `onCreate` or render a descendant that calls `useVizelContext`. The
+ * component intentionally does not expose the editor through a ref (ADR-0004).
  *
  * @example
  * ```tsx
@@ -139,20 +136,19 @@ export interface VizelRef {
  *
  * @example
  * ```tsx
- * import { Vizel, type VizelRef } from '@vizel/react';
- * import { useRef } from 'react';
+ * import { type Editor, Vizel } from '@vizel/react';
+ * import { useState } from 'react';
  *
  * function App() {
- *   const vizelRef = useRef<VizelRef>(null);
+ *   const [editor, setEditor] = useState<Editor | null>(null);
  *
  *   const handleSave = () => {
- *     const content = vizelRef.current?.editor?.getJSON();
- *     console.log(content);
+ *     console.log(editor?.getJSON());
  *   };
  *
  *   return (
  *     <>
- *       <Vizel ref={vizelRef} onUpdate={({ editor }) => console.log(editor.getJSON())} />
+ *       <Vizel onCreate={({ editor: created }) => setEditor(created)} />
  *       <button onClick={handleSave}>Save</button>
  *     </>
  *   );
@@ -160,7 +156,6 @@ export interface VizelRef {
  * ```
  */
 export function Vizel({
-  ref,
   initialContent,
   initialMarkdown,
   transformDiagramsOnImport = true,
@@ -250,15 +245,6 @@ export function Vizel({
       transformDiagrams: transformDiagramsOnImport,
     });
   }, [markdown, editor, transformDiagramsOnImport]);
-
-  // Expose editor instance via ref
-  useImperativeHandle(
-    ref,
-    () => ({
-      editor,
-    }),
-    [editor]
-  );
 
   // Memoize so child components that compare prop identity (toolbar / bubble
   // menu / block menu) don't see a fresh `localeProps` object on every render.

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -4,11 +4,12 @@ import {
   filterVizelBubbleMenuActions,
   formatVizelTooltip,
   groupVizelBubbleMenuActions,
+  shallowEqualObject,
   type VizelBubbleMenuAction,
   type VizelLocale,
 } from "@vizel/core";
 import { useMemo, useState } from "react";
-import { useVizelState } from "../hooks/useVizelState.ts";
+import { useVizelEditorState } from "../_reactivity.ts";
 import { VizelBubbleMenuButton } from "./VizelBubbleMenuButton.tsx";
 import { VizelBubbleMenuColorPicker } from "./VizelBubbleMenuColorPicker.tsx";
 import { VizelBubbleMenuDivider } from "./VizelBubbleMenuDivider.tsx";
@@ -39,19 +40,29 @@ export function VizelBubbleMenuDefault({
   enableEmbed,
   locale,
 }: VizelBubbleMenuDefaultProps) {
-  // Subscribe to editor state changes so isActive() reflects the latest state.
-  useVizelState(editor);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
 
-  const { markGroups, linkAction } = useMemo(() => {
+  const { markGroups, linkAction, allActions } = useMemo(() => {
     const all = filterVizelBubbleMenuActions(createVizelBubbleMenuActions(locale), editor);
     const link = all.find((a) => a.id === "link");
     const marks = all.filter((a) => a.id !== "link");
     return {
       markGroups: groupVizelBubbleMenuActions(marks),
       linkAction: link,
+      allActions: all,
     };
   }, [locale, editor]);
+
+  // Read each action's active flag through a selector slice keyed by
+  // action id. `shallowEqualObject` suppresses a re-render unless one of
+  // the marks toggles, replacing the coarse `useVizelState` tick that
+  // re-rendered on every transaction (ADR-0004). The explicit `editor`
+  // keeps the subscription working when the bubble menu renders outside a
+  // `VizelProvider`.
+  const activeById = useVizelEditorState((current) => buildActiveById(allActions, current), {
+    editor,
+    equalityFn: shallowEqualObject,
+  });
 
   if (showLinkEditor) {
     return (
@@ -69,7 +80,7 @@ export function VizelBubbleMenuDefault({
       key={action.id}
       action={action.id}
       onClick={() => action.run(editor)}
-      isActive={action.isActive(editor)}
+      isActive={activeById[action.id] ?? false}
       title={formatVizelTooltip(action.label, action.shortcut)}
     >
       <VizelIcon name={action.icon} />
@@ -93,7 +104,7 @@ export function VizelBubbleMenuDefault({
           <VizelBubbleMenuButton
             action={linkAction.id}
             onClick={() => setShowLinkEditor(true)}
-            isActive={linkAction.isActive(editor)}
+            isActive={activeById[linkAction.id] ?? false}
             title={formatVizelTooltip(linkAction.label, linkAction.shortcut)}
           >
             <VizelIcon name={linkAction.icon} />
@@ -113,4 +124,17 @@ export function VizelBubbleMenuDefault({
       />
     </div>
   );
+}
+
+/**
+ * Project each action's active flag into a plain record keyed by action
+ * id. The record is the selector slice: `shallowEqualObject` compares it
+ * field by field, so the bubble menu re-renders only when a mark toggles.
+ */
+function buildActiveById(
+  actions: readonly VizelBubbleMenuAction[],
+  editor: Editor | null
+): Record<string, boolean> {
+  if (editor === null) return {};
+  return Object.fromEntries(actions.map((action) => [action.id, action.isActive(editor)]));
 }

--- a/packages/react/src/components/VizelContext.tsx
+++ b/packages/react/src/components/VizelContext.tsx
@@ -7,8 +7,8 @@ import { createContext, type ReactNode, useContext } from "react";
  *
  * The context value is the editor itself (or `null` while it is still
  * initializing). The wrapping `{ editor }` object was removed in v2.0 so the
- * public hook surface (`useVizelContext`) returns the editor directly — see
- * the Section 4 return-type table in `cross-framework.md`.
+ * public hook surface (`useVizelContext`) returns the editor directly,
+ * matching the React idiom that "the hook is the value" (ADR-0004).
  *
  * A `symbol` sentinel disambiguates "no provider mounted" from "provider
  * mounted but the editor is still `null`" without requiring a wrapper object.

--- a/packages/react/src/components/VizelEditor.tsx
+++ b/packages/react/src/components/VizelEditor.tsx
@@ -1,28 +1,23 @@
 import { type Editor, mountVizelEditorView } from "@vizel/core";
 import type { ReactNode, Ref } from "react";
-import { useEffect, useImperativeHandle, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelEditorProps {
-  /** Ref to access editor container */
-  ref?: Ref<VizelEditorRef>;
+  /**
+   * Forwarded ref to the editable container element.
+   *
+   * The ref resolves to the rendered `<div>`. React 19 treats `ref` as a
+   * regular prop, so the consumer passes a standard `Ref<HTMLDivElement>` and
+   * reads the element directly. To reach the editor instance, call
+   * `useVizelEditor` or `useVizelContext` rather than routing the editor
+   * through this ref (ADR-0004).
+   */
+  ref?: Ref<HTMLDivElement>;
   /** Editor instance. Falls back to the editor from `VizelProvider` / `Vizel` context if omitted. */
   editor?: Editor | null;
   /** Optional className for the editor container */
   className?: string;
-}
-
-export interface VizelEditorRef {
-  /** The container DOM element */
-  container: HTMLDivElement | null;
-  /**
-   * The Tiptap editor instance that this component is rendering.
-   *
-   * Mirrors whichever editor was resolved (explicit prop or context).
-   * Lets callers skip the extra round-trip through `useVizelContext` or
-   * lifting state when they only need imperative access to the editor.
-   */
-  editor: Editor | null;
 }
 
 /**
@@ -40,28 +35,32 @@ export interface VizelEditorRef {
  * // Or directly with editor prop
  * <VizelEditor editor={editor} className="prose" />
  *
- * // With ref to access container DOM
- * const editorRef = useRef<VizelEditorRef>(null);
- * <VizelEditor ref={editorRef} editor={editor} />
- * // editorRef.current?.container gives you the container element
+ * // With a ref to read the container DOM element
+ * const containerRef = useRef<HTMLDivElement>(null);
+ * <VizelEditor ref={containerRef} editor={editor} />
  * ```
  */
 export function VizelEditor({ ref, editor: editorProp, className }: VizelEditorProps): ReactNode {
   const contextEditor = useVizelContextSafe();
   const editor = editorProp ?? contextEditor;
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Keep a private container ref the mount effect can read. The forwarded
+  // `ref` may be a callback or an object ref, so the component cannot read
+  // `.current` off it directly; the callback ref below fans the node out to
+  // both targets.
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Expose container ref and editor instance via imperative handle. The
-  // editor moves into the dependency list so consumers that read
-  // `ref.current?.editor` after the editor resolves see the live value
-  // instead of the `null` snapshot captured at first mount.
-  useImperativeHandle(
-    ref,
-    () => ({
-      container: containerRef.current,
-      editor: editor ?? null,
-    }),
-    [editor]
+  const setContainer = useCallback(
+    (node: HTMLDivElement | null): void => {
+      containerRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+        return;
+      }
+      if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref]
   );
 
   useEffect(() => {
@@ -74,5 +73,5 @@ export function VizelEditor({ ref, editor: editorProp, className }: VizelEditorP
     return null;
   }
 
-  return <div ref={containerRef} className={className} data-vizel-content="" />;
+  return <div ref={setContainer} className={className} data-vizel-content="" />;
 }

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -3,7 +3,6 @@ import {
   type Editor,
   getVizelFindReplaceState,
   resolveVizelFindReplaceLabels,
-  type VizelFindReplaceState,
   type VizelLocale,
 } from "@vizel/core";
 import {
@@ -15,6 +14,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useVizelEditorState } from "../_reactivity.ts";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelFindReplaceProps {
@@ -50,25 +50,20 @@ export function VizelFindReplace({
   const [findText, setFindText] = useState("");
   const [replaceText, setReplaceText] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
-  const [state, setState] = useState<VizelFindReplaceState | null>(null);
   const findInputRef = useRef<HTMLInputElement>(null);
 
-  // Subscribe to plugin state changes
-  useEffect(() => {
-    if (!editor) return;
-
-    const updateState = () => {
-      const pluginState = getVizelFindReplaceState(editor.state);
-      setState(pluginState);
-    };
-
-    updateState();
-    editor.on("transaction", updateState);
-
-    return () => {
-      editor.off("transaction", updateState);
-    };
-  }, [editor]);
+  // Read the Find & Replace plugin state through the flagship
+  // `useVizelEditorState` primitive (ADR-0004), replacing the hand-rolled
+  // `editor.on("transaction")` subscription. The plugin's `apply` returns
+  // the same state reference on transactions that leave the find state
+  // unchanged, so the default `Object.is` equality re-renders the panel
+  // only when the query, matches, or open state actually change. The
+  // explicit `editor` keeps the subscription bound to the prop instance
+  // when the panel renders outside a `VizelProvider`.
+  const state = useVizelEditorState(
+    (current) => (current === null ? null : getVizelFindReplaceState(current.state)),
+    { editor }
+  );
 
   // Focus input when panel opens
   useEffect(() => {

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -31,7 +31,7 @@ export interface VizelMentionMenuProps {
   /**
    * Custom render function for items. Receives the item, the selection
    * state, and a click handler that selects the item. Mirrors the
-   * `renderItem` seam on `VizelSlashMenu` (cross-framework Table 6).
+   * `renderItem` seam on `VizelSlashMenu`.
    */
   renderItem?: (props: {
     item: VizelMentionItem;

--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useVizelState } from "../hooks/useVizelState.ts";
+import { useVizelEditorState } from "../_reactivity.ts";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -43,7 +43,6 @@ export function VizelNodeSelector({
   const editor = editorProp ?? contextEditor;
   const effectiveNodeTypes =
     nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes);
-  useVizelState(editor);
 
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -51,12 +50,31 @@ export function VizelNodeSelector({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
+  // Track only which node type is active through the flagship
+  // `useVizelEditorState` primitive (ADR-0004). The trigger label and
+  // every row's `aria-selected` derive from the active node type, so a
+  // string slice dedupes through the hook's `Object.is` cache: cursor
+  // moves within the same block type do not re-render, replacing the
+  // coarse `useVizelState` tick.
+  const activeNodeName = useVizelEditorState(
+    (current) =>
+      current === null
+        ? null
+        : (effectiveNodeTypes.find((type) => type.isActive(current))?.name ?? null),
+    { editor }
+  );
+
+  // `activeNodeName` joins the dependency list as a reactive stand-in for
+  // the editor's active-block state: it changes when the caret enters a
+  // block of a different type, so the spec rebuilds with the new active
+  // highlight even though the `editor` identity stays stable.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `activeNodeName` is the reactive trigger for re-reading the editor's active block, which `buildVizelNodeSelectorSpec` reads off the live editor.
   const spec = useMemo(
     () =>
       editor
         ? buildVizelNodeSelectorSpec(editor, effectiveNodeTypes, isOpen, focusedIndex, locale)
         : null,
-    [editor, effectiveNodeTypes, isOpen, focusedIndex, locale]
+    [editor, effectiveNodeTypes, isOpen, focusedIndex, locale, activeNodeName]
   );
 
   useEffect(() => {

--- a/packages/react/src/components/VizelOutline.tsx
+++ b/packages/react/src/components/VizelOutline.tsx
@@ -5,7 +5,8 @@ import {
   type VizelOutlineItemSpec,
   vizelEnLocale,
 } from "@vizel/core";
-import { useVizelState } from "../hooks/useVizelState.ts";
+import { useMemo } from "react";
+import { useVizelEditorState } from "../_reactivity.ts";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 
 export interface VizelOutlineProps {
@@ -33,15 +34,35 @@ export function VizelOutline({
 }: VizelOutlineProps) {
   const contextEditor = useVizelContextSafe();
   const editor = editorProp ?? contextEditor;
-  // Subscribe to editor transactions so the outline re-renders on doc /
-  // selection changes. The numeric tick itself is intentionally unused.
-  useVizelState(editor);
-
-  if (!editor) return null;
-
   const resolvedLocale = locale ?? vizelEnLocale;
-  const resolvedPos = currentPos === undefined ? editor.state.selection.from : currentPos;
-  const spec = buildVizelOutlineSpec(editor, resolvedPos, resolvedLocale);
+
+  // Gate re-renders on a doc-and-selection signature read through the
+  // flagship `useVizelEditorState` primitive (ADR-0004), replacing the
+  // coarse `useVizelState` tick. The signature changes whenever a
+  // heading is edited or the caret moves, which is exactly when the
+  // outline's entries or active highlight must update; transactions that
+  // leave both unchanged short-circuit through the default `Object.is`
+  // equality. `buildVizelOutlineSpec` returns a nested spec, so a
+  // selector that returned the spec object directly could not be
+  // memoised by a shallow comparator — deriving a primitive signature
+  // keeps the subscription stable.
+  const signature = useVizelEditorState(
+    (current) => (current === null ? null : buildVizelOutlineSignature(current)),
+    { editor }
+  );
+
+  // `signature` joins the dependency list as a reactive stand-in for the
+  // editor's mutable doc / selection state: it changes with every heading
+  // edit or caret move, so the memo rebuilds the spec from the live editor
+  // even though the `editor` identity stays stable.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `signature` is the reactive trigger for re-reading the editor's doc/selection, which `buildVizelOutlineSpec` reads off the live editor.
+  const spec = useMemo(() => {
+    if (!editor) return null;
+    const resolvedPos = currentPos === undefined ? editor.state.selection.from : currentPos;
+    return buildVizelOutlineSpec(editor, resolvedPos, resolvedLocale);
+  }, [editor, currentPos, resolvedLocale, signature]);
+
+  if (!(editor && spec)) return null;
 
   return (
     <nav
@@ -53,6 +74,29 @@ export function VizelOutline({
       {spec.items.length > 0 ? renderItems(spec.items, editor) : null}
     </nav>
   );
+}
+
+/**
+ * Derive a primitive signature from the editor's headings and caret
+ * position. The signature changes whenever a heading's level, position,
+ * or text changes, or the caret moves — the exact inputs the outline
+ * renders — so `useVizelEditorState` re-renders the component only when
+ * the outline would visibly differ. The signature stays a string so the
+ * hook's `Object.is` cache short-circuits transactions that leave the
+ * outline unchanged (such as edits inside a non-heading paragraph that
+ * do not shift heading positions).
+ */
+function buildVizelOutlineSignature(editor: Editor): string {
+  const parts: string[] = [];
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === "heading") {
+      const rawLevel = (node.attrs as { level?: number }).level;
+      const level = typeof rawLevel === "number" ? rawLevel : 1;
+      parts.push(`${level}:${pos}:${node.textContent}`);
+    }
+    return node.type.name !== "heading";
+  });
+  return `${editor.state.selection.from}|${parts.join("\n")}`;
 }
 
 function renderItems(items: readonly VizelOutlineItemSpec[], editor: Editor) {

--- a/packages/react/src/components/VizelToolbarDefault.tsx
+++ b/packages/react/src/components/VizelToolbarDefault.tsx
@@ -4,12 +4,13 @@ import {
   formatVizelTooltip,
   groupVizelToolbarActions,
   isVizelToolbarDropdownAction,
+  shallowEqualObject,
   type VizelLocale,
   type VizelToolbarActionItem,
   vizelDefaultToolbarActions,
 } from "@vizel/core";
-import { Fragment } from "react";
-import { useVizelState } from "../hooks/useVizelState.ts";
+import { Fragment, useMemo } from "react";
+import { useVizelEditorState } from "../_reactivity.ts";
 import { VizelIcon } from "./VizelIcon.tsx";
 import { VizelToolbarButton } from "./VizelToolbarButton.tsx";
 import { VizelToolbarDivider } from "./VizelToolbarDivider.tsx";
@@ -42,12 +43,26 @@ export function VizelToolbarDefault({
   actions,
   locale,
 }: VizelToolbarDefaultProps) {
-  // Subscribe to editor state changes to update active/enabled states
-  useVizelState(editor);
+  const { groups, buttonActions } = useMemo(() => {
+    const effectiveActions: readonly VizelToolbarActionItem[] =
+      actions ?? (locale ? createVizelToolbarActions(locale) : vizelDefaultToolbarActions);
+    return {
+      groups: groupVizelToolbarActions(effectiveActions),
+      // Dropdown actions own their own active/disabled rendering, so the
+      // selector slice only tracks the plain button actions.
+      buttonActions: effectiveActions.filter((action) => !isVizelToolbarDropdownAction(action)),
+    };
+  }, [actions, locale]);
 
-  const effectiveActions: readonly VizelToolbarActionItem[] =
-    actions ?? (locale ? createVizelToolbarActions(locale) : vizelDefaultToolbarActions);
-  const groups = groupVizelToolbarActions(effectiveActions);
+  // Read each button's active/enabled flags through a selector slice.
+  // `shallowEqualObject` re-renders the toolbar only when one of those
+  // flags flips, replacing the coarse `useVizelState` full-tick re-render
+  // (ADR-0004). The explicit `editor` keeps the subscription bound when
+  // the toolbar renders without a surrounding `VizelProvider`.
+  const stateById = useVizelEditorState((current) => buildButtonStateById(buttonActions, current), {
+    editor,
+    equalityFn: shallowEqualObject,
+  });
 
   return (
     <div className={`vizel-toolbar-content ${className ?? ""}`} data-vizel-toolbar="">
@@ -62,8 +77,8 @@ export function VizelToolbarDefault({
                 key={action.id}
                 action={action.id}
                 onClick={() => action.run(editor)}
-                isActive={action.isActive(editor)}
-                disabled={!action.isEnabled(editor)}
+                isActive={stateById[`${action.id}:active`] ?? false}
+                disabled={!(stateById[`${action.id}:enabled`] ?? true)}
                 title={formatVizelTooltip(action.label, action.shortcut)}
               >
                 <VizelIcon name={action.icon} />
@@ -73,5 +88,27 @@ export function VizelToolbarDefault({
         </Fragment>
       ))}
     </div>
+  );
+}
+
+/**
+ * Project each button action's active and enabled flags into a flat
+ * record. The keys carry an `:active` / `:enabled` suffix so the slice
+ * stays a single shallow-compared object rather than a nested map.
+ */
+function buildButtonStateById(
+  actions: readonly VizelToolbarActionItem[],
+  editor: Editor | null
+): Record<string, boolean> {
+  if (editor === null) return {};
+  return Object.fromEntries(
+    actions.flatMap((action) =>
+      isVizelToolbarDropdownAction(action)
+        ? []
+        : [
+            [`${action.id}:active`, action.isActive(editor)],
+            [`${action.id}:enabled`, action.isEnabled(editor)],
+          ]
+    )
   );
 }

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,5 +1,5 @@
 // Vizel all-in-one component
-export { Vizel, type VizelProps, type VizelRef } from "./Vizel.tsx";
+export { Vizel, type VizelProps } from "./Vizel.tsx";
 // VizelBlockMenu component
 export { VizelBlockMenu, type VizelBlockMenuProps } from "./VizelBlockMenu.tsx";
 // VizelBubbleMenu components
@@ -24,7 +24,7 @@ export {
 export { VizelColorPicker, type VizelColorPickerProps } from "./VizelColorPicker.tsx";
 export { useVizelContext, useVizelContextSafe } from "./VizelContext.tsx";
 // Editor components
-export { VizelEditor, type VizelEditorProps, type VizelEditorRef } from "./VizelEditor.tsx";
+export { VizelEditor, type VizelEditorProps } from "./VizelEditor.tsx";
 // VizelEmbedView component
 export { VizelEmbedView, type VizelEmbedViewProps } from "./VizelEmbedView.tsx";
 // VizelFindReplace component

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,8 +22,9 @@ export * from "@vizel/core";
 // ADR-0009 mandates that every adapter implements editor reactivity
 // natively; React's adapter holds the implementation in `_reactivity.ts`
 // and re-exports the consumer-facing surface here. The shallow-equality
-// helpers re-export from `@vizel/core` so the cross-framework parity
-// check can resolve them back to a single source.
+// helpers re-export from `@vizel/core` so the feature manifest
+// (verified by `pnpm check:feature-parity`) resolves them to a single
+// source across frameworks.
 export {
   shallowEqualArray,
   shallowEqualObject,
@@ -57,7 +58,6 @@ export {
   // Editor components
   VizelEditor,
   type VizelEditorProps,
-  type VizelEditorRef,
   // EmbedView
   VizelEmbedView,
   type VizelEmbedViewProps,
@@ -87,7 +87,6 @@ export {
   type VizelProps,
   VizelProvider,
   type VizelProviderProps,
-  type VizelRef,
   // SaveIndicator
   VizelSaveIndicator,
   type VizelSaveIndicatorProps,


### PR DESCRIPTION
## Summary

Phase B1 of the v2 idiomatic-API closure (ADR-0004 / ADR-0001) — the React adapter.

- **Retire the custom `VizelEditorRef` and `VizelRef` types** (breaking; v2 is unreleased). `<VizelEditor>`'s `ref` is now a standard `Ref<HTMLDivElement>` exposing the container element; the editor is reached via `useVizelEditor` / `useVizelContext`. Removed the `useImperativeHandle` plumbing and the JSDoc example that taught the `ref.current?.editor` anti-pattern. `VizelSlashMenuRef` / `VizelMentionMenuRef` stay — their behavioral `onKeyDown` handle is what Tiptap's suggestion plugin calls synchronously.
- **Adopt the `useVizelEditorState` selector inside the built-in components** (it was exported but used by zero components). `VizelBubbleMenuDefault`, `VizelToolbarDefault`, `VizelNodeSelector`, `VizelOutline`, and `VizelFindReplace` now subscribe through the selector instead of the coarse `useVizelState` tick or a hand-rolled `editor.on('transaction')`. `useVizelState` stays exported for cross-framework parity and coarse subscription.
- **Add an optional `editor` override** to `useVizelEditorState` options so a component that receives the editor as a prop subscribes to that instance even outside a `VizelProvider` (e.g. a standalone `<VizelToolbar editor={...} />`).
- **Drop stale references** to the retired `cross-framework.md` / literal parity checker in component comments.

## Breaking Changes

- Removes `VizelEditorRef` and `VizelRef` from `@vizel/react`. v2.0.0 is unreleased, so there is no migration burden. Read the editor via `useVizelEditor` / `useVizelContext`; read the container via a standard `Ref<HTMLDivElement>` on `<VizelEditor>`.

## Test Plan

- [x] `pnpm typecheck`, `pnpm lint`.
- [x] `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS), `pnpm check:ssr`, `pnpm check:nolet`, `pnpm check:ct-parity`, `pnpm check:scenarios`.
- [x] `pnpm test:ct:react --project=chromium` → 283 passed.
- [x] Browser smoke of the React demo: editor mounts, bubble-menu active states track selection, toolbar, node selector, outline, and find/replace all work.
