### PR TITLE
refactor(vue): close idiom gaps against ADR-0004 and ADR-0001

### DIFF
--- a/packages/vue/src/components/Vizel.vue
+++ b/packages/vue/src/components/Vizel.vue
@@ -14,7 +14,7 @@ import {
   type VizelLocale,
   type VizelMarkdownFlavor,
 } from "@vizel/core";
-import { computed, provide, useSlots, watch } from "vue";
+import { computed, provide, watch } from "vue";
 import { useVizelEditor } from "../composables/useVizelEditor.ts";
 import VizelBlockMenu from "./VizelBlockMenu.vue";
 import VizelBubbleMenu from "./VizelBubbleMenu.vue";
@@ -28,6 +28,20 @@ import VizelToolbar from "./VizelToolbar.vue";
  */
 export interface VizelRef {
   /** The underlying Tiptap editor instance */
+  editor: Editor | null;
+}
+
+/**
+ * Props passed to every `Vizel` scoped slot (`toolbar`, `bubble-menu`,
+ * and the default content slot).
+ *
+ * The default slot can render before the editor finishes async
+ * initialization, so `editor` is nullable. The `toolbar` and
+ * `bubble-menu` slots only render once the editor exists, but they share
+ * the same type for a single consumer-facing contract.
+ */
+export interface VizelSlotProps {
+  /** The underlying Tiptap editor instance, or `null` before initialization */
   editor: Editor | null;
 }
 
@@ -110,7 +124,14 @@ const emit = defineEmits<{
  */
 const markdown = defineModel<string>("markdown");
 
-const slots = useSlots();
+const slots = defineSlots<{
+  /** Replace the toolbar content. Receives the resolved editor. */
+  toolbar?: (props: VizelSlotProps) => unknown;
+  /** Replace the bubble-menu content. Receives the resolved editor. */
+  "bubble-menu"?: (props: VizelSlotProps) => unknown;
+  /** Render extra content inside the editor root. Receives the resolved editor. */
+  default?: (props: VizelSlotProps) => unknown;
+}>();
 
 const editor = useVizelEditor({
   ...(props.initialContent !== undefined && { initialContent: props.initialContent }),

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -16,7 +16,16 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  useTemplateRef,
+  watch,
+} from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -61,8 +70,7 @@ const effectiveNodeTypes = computed(
 const menuState = shallowRef<BlockMenuState | null>(null);
 const showTurnInto = ref(false);
 const submenuFlipped = ref(false);
-const menuRef = ref<HTMLDivElement | null>(null);
-const submenuRef = ref<HTMLDivElement | null>(null);
+const menuRef = useTemplateRef<HTMLDivElement>("menuRef");
 
 const turnIntoOptions = computed(() =>
   menuState.value ? getVizelTurnIntoOptions(menuState.value.editor, effectiveNodeTypes.value) : []
@@ -257,7 +265,6 @@ onBeforeUnmount(() => {
     <!-- Turn into submenu -->
     <div
       v-if="showTurnInto && spec.submenu.sections.length > 0"
-      ref="submenuRef"
       :class="['vizel-block-menu-submenu', { 'vizel-block-menu-submenu--left': submenuFlipped }]"
       :role="spec.submenu.root.role"
       :aria-label="spec.submenu.root['aria-label']"

--- a/packages/vue/src/components/VizelBubbleMenu.vue
+++ b/packages/vue/src/components/VizelBubbleMenu.vue
@@ -5,7 +5,7 @@ import {
   type Editor,
   type VizelLocale,
 } from "@vizel/core";
-import { computed, ref, useSlots, watch } from "vue";
+import { computed, useTemplateRef, watch } from "vue";
 import VizelBubbleMenuDefault from "./VizelBubbleMenuDefault.vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
@@ -34,8 +34,14 @@ const props = withDefaults(defineProps<VizelBubbleMenuProps>(), {
   updateDelay: 100,
 });
 
-const slots = useSlots();
-const menuRef = ref<HTMLElement | null>(null);
+// The default slot replaces the built-in formatting menu wholesale; the
+// consumer supplies its own buttons and reads the editor from the
+// surrounding `VizelProvider` / `Vizel` context, so the slot passes no
+// props. Typing it keeps `slots.default` discoverable under Volar.
+const slots = defineSlots<{
+  default?: () => unknown;
+}>();
+const menuRef = useTemplateRef<HTMLElement>("menuRef");
 const contextEditor = useVizelContextSafe();
 const editor = computed(() => props.editor ?? contextEditor?.value ?? null);
 

--- a/packages/vue/src/components/VizelBubbleMenuColorPicker.vue
+++ b/packages/vue/src/components/VizelBubbleMenuColorPicker.vue
@@ -9,7 +9,7 @@ import {
   type VizelLocale,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import VizelColorPicker from "./VizelColorPicker.vue";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -37,7 +37,7 @@ const props = withDefaults(defineProps<VizelBubbleMenuColorPickerProps>(), {
 
 const isOpen = ref(false);
 const recentColors = ref<string[]>([]);
-const containerRef = ref<HTMLDivElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
 
 const colorPalette = computed(() => {
   return props.colors ?? (props.type === "textColor" ? VIZEL_TEXT_COLORS : VIZEL_HIGHLIGHT_COLORS);
@@ -61,10 +61,19 @@ watch(isOpen, (open) => {
   }
 });
 
-function handleColorChange(color: string) {
-  applyVizelColorToEditor(props.editor, props.type, color);
-  isOpen.value = false;
-}
+// Bridge `VizelColorPicker`'s `v-model:value` to the editor. The getter
+// reflects the current text/highlight color; the setter applies the
+// chosen color through the Core command and closes the dropdown. A
+// writable computed is required because the bound source (`currentColor`)
+// is a read-only computed that derives from editor attributes.
+const selectedColor = computed<string | undefined>({
+  get: () => currentColor.value,
+  set: (color) => {
+    if (color === undefined) return;
+    applyVizelColorToEditor(props.editor, props.type, color);
+    isOpen.value = false;
+  },
+});
 
 // Pointer-outside dismissal routes through `createVizelDismissable` so this
 // component never attaches the listener directly. ADR-0007 delegates the
@@ -127,8 +136,8 @@ function getTriggerStyle() {
 
     <div v-if="isOpen" class="vizel-color-picker-dropdown">
       <VizelColorPicker
+        v-model:value="selectedColor"
         :colors="colorPalette"
-        :value="currentColor"
         :label="isTextColor ? (props.locale?.colorPicker?.textColorPalette ?? 'Text color palette') : (props.locale?.colorPicker?.highlightPalette ?? 'Highlight color palette')"
         :allow-custom-color="props.allowCustomColor"
         :recent-colors="recentColors"
@@ -138,7 +147,6 @@ function getTriggerStyle() {
         :hex-placeholder="props.locale?.colorPicker?.hexPlaceholder ?? '#000000'"
         :apply-title="props.locale?.colorPicker?.apply ?? 'Apply'"
         :apply-aria-label="props.locale?.colorPicker?.applyAriaLabel ?? 'Apply custom color'"
-        @change="handleColorChange"
       />
     </div>
   </div>

--- a/packages/vue/src/components/VizelColorPicker.vue
+++ b/packages/vue/src/components/VizelColorPicker.vue
@@ -10,8 +10,6 @@ import VizelIcon from "./VizelIcon.vue";
 export interface VizelColorPickerProps {
   /** Color palette to display */
   colors: readonly VizelColorDefinition[];
-  /** Currently selected color */
-  value?: string;
   /** Label for accessibility */
   label?: string;
   /** Custom class name */
@@ -46,19 +44,22 @@ const props = withDefaults(defineProps<VizelColorPickerProps>(), {
   applyAriaLabel: "Apply custom color",
 });
 
-const emit = defineEmits<{
-  /** Emitted when the selected color changes */
-  change: [color: string];
-}>();
+/**
+ * Selected color, exposed as a two-way binding (`v-model:value`).
+ * Selecting a swatch or applying a valid HEX value writes the new color
+ * back to the parent through the model, replacing the v1 `change` emit.
+ * The model accepts `undefined` so callers can bind a source that has no
+ * color yet (e.g. an editor attribute that is unset).
+ */
+const value = defineModel<string | undefined>("value");
 
-const currentValue = computed(() => props.value);
+const currentValue = computed(() => value.value);
 
 const GRID_COLUMNS = 4;
 
 const inputValue = ref("");
 const focusedIndex = ref(-1);
 const swatchRefs = ref<(HTMLButtonElement | null)[]>([]);
-const inputRef = ref<HTMLInputElement | null>(null);
 
 // Build flat list of all selectable colors for keyboard navigation
 const allColors = computed(() => [
@@ -97,7 +98,7 @@ function isNoneValue(color: string): boolean {
 
 // Handle swatch selection
 function handleSelect(color: string) {
-  emit("change", color);
+  value.value = color;
   inputValue.value = "";
 }
 
@@ -105,7 +106,7 @@ function handleSelect(color: string) {
 function handleInputSubmit() {
   const normalized = normalizeVizelHexColor(inputValue.value);
   if (isVizelValidHexColor(normalized)) {
-    emit("change", normalized);
+    value.value = normalized;
     inputValue.value = "";
   }
 }
@@ -251,7 +252,6 @@ const previewColor = computed(() =>
         aria-hidden="true"
       />
       <input
-        ref="inputRef"
         type="text"
         class="vizel-color-picker-input"
         :placeholder="props.hexPlaceholder"

--- a/packages/vue/src/components/VizelEditor.vue
+++ b/packages/vue/src/components/VizelEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type Editor, mountVizelEditorView } from "@vizel/core";
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
 export interface VizelEditorProps {
@@ -25,7 +25,7 @@ export interface VizelEditorRef {
 
 const props = defineProps<VizelEditorProps>();
 
-const containerRef = ref<HTMLDivElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
 const contextEditor = useVizelContextSafe();
 const resolvedEditor = computed(() => props.editor ?? contextEditor?.value ?? null);
 

--- a/packages/vue/src/components/VizelEmbedView.vue
+++ b/packages/vue/src/components/VizelEmbedView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { loadVizelEmbedScripts, resolveVizelEmbedView, type VizelEmbedData } from "@vizel/core";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, useTemplateRef, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelEmbedViewProps {
@@ -14,7 +14,7 @@ export interface VizelEmbedViewProps {
 
 const props = defineProps<VizelEmbedViewProps>();
 
-const containerRef = ref<HTMLDivElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
 
 const view = computed(() => resolveVizelEmbedView(props.data));
 

--- a/packages/vue/src/components/VizelFindReplace.vue
+++ b/packages/vue/src/components/VizelFindReplace.vue
@@ -7,7 +7,7 @@ import {
   type VizelFindReplaceState,
   type VizelLocale,
 } from "@vizel/core";
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
 export interface VizelFindReplaceProps {
@@ -36,7 +36,7 @@ const findText = ref("");
 const replaceText = ref("");
 const caseSensitive = ref(false);
 const state = ref<VizelFindReplaceState | null>(null);
-const findInputRef = ref<HTMLInputElement | null>(null);
+const findInputRef = useTemplateRef<HTMLInputElement>("findInputRef");
 
 const labels = computed(() => resolveVizelFindReplaceLabels(props.locale?.findReplace));
 const view = computed(() => buildVizelFindReplaceSpec(state.value, labels.value.noResults));

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -7,7 +7,7 @@ import {
   type VizelLocale,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -38,8 +38,8 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const formRef = ref<HTMLFormElement | null>(null);
-const inputRef = ref<HTMLInputElement | null>(null);
+const formRef = useTemplateRef<HTMLFormElement>("formRef");
+const inputRef = useTemplateRef<HTMLInputElement>("inputRef");
 
 const labels = computed(() => resolveVizelLinkEditorLabels(props.locale));
 const initialState = computed(() =>

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -18,10 +18,35 @@ export interface VizelMentionMenuProps {
   locale?: VizelLocale;
 }
 
+/**
+ * Props passed to the `#item` scoped slot.
+ *
+ * The callback prop uses the lowercase `onclick` name to stay consistent
+ * with `VizelSlashMenu`'s `#item` slot and the Svelte adapter's
+ * `renderItem` snippet (ADR-0004). Slot props are plain object keys, not
+ * DOM event bindings, so the name is a deliberate contract rather than a
+ * native listener.
+ */
+export interface VizelMentionMenuItemSlotProps {
+  /** The mention item to render */
+  item: VizelMentionItem;
+  /** Whether the item is the active keyboard selection */
+  isSelected: boolean;
+  /** Invoke the item's selection */
+  onclick: () => void;
+}
+
 const props = defineProps<VizelMentionMenuProps>();
 
 const emit = defineEmits<{
   select: [item: VizelMentionItem];
+}>();
+
+defineSlots<{
+  /** Replace the default no-results markup shown when no item matches. */
+  empty?: () => unknown;
+  /** Replace the per-item markup; the container, keyboard, and ARIA wiring stay owned by VizelMentionMenu. */
+  item?: (props: VizelMentionMenuItemSlotProps) => unknown;
 }>();
 
 const selectedIndex = ref(0);

--- a/packages/vue/src/components/VizelNodeSelector.vue
+++ b/packages/vue/src/components/VizelNodeSelector.vue
@@ -8,7 +8,7 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useVizelState } from "../composables/useVizelState.ts";
 import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
@@ -38,9 +38,9 @@ const editorStateVersion = useVizelState(() => resolvedEditor.value);
 
 const isOpen = ref(false);
 const focusedIndex = ref(0);
-const containerRef = ref<HTMLDivElement | null>(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
-const triggerRef = ref<HTMLButtonElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
+const dropdownRef = useTemplateRef<HTMLDivElement>("dropdownRef");
+const triggerRef = useTemplateRef<HTMLButtonElement>("triggerRef");
 
 const spec = computed(() => {
   void editorStateVersion.value;

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -5,7 +5,7 @@ import {
   resolveVizelListNavigation,
   type VizelSlashCommandItem,
 } from "@vizel/core";
-import { computed, nextTick, ref, useSlots, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.vue";
 import VizelSlashMenuItem from "./VizelSlashMenuItem.vue";
 
@@ -34,6 +34,24 @@ export interface VizelSlashMenuProps {
   groupOrder?: string[];
 }
 
+/**
+ * Props passed to the `#item` scoped slot.
+ *
+ * The callback prop uses the lowercase `onclick` name to stay consistent
+ * with `VizelMentionMenu`'s `#item` slot and the Svelte adapter's
+ * `renderItem` snippet (ADR-0004). Slot props are plain object keys, not
+ * DOM event bindings, so the name is a deliberate contract rather than a
+ * native listener.
+ */
+export interface VizelSlashMenuItemSlotProps {
+  /** The slash command item to render */
+  item: VizelSlashCommandItem;
+  /** Whether the item is the active keyboard selection */
+  isSelected: boolean;
+  /** Invoke the item's command */
+  onclick: () => void;
+}
+
 const props = withDefaults(defineProps<VizelSlashMenuProps>(), {
   showGroups: true,
 });
@@ -42,7 +60,12 @@ const emit = defineEmits<{
   select: [item: VizelSlashCommandItem];
 }>();
 
-const slots = useSlots();
+const slots = defineSlots<{
+  /** Replace the default empty-state markup shown when no item matches. */
+  empty?: () => unknown;
+  /** Replace the per-item markup; the container, keyboard, and ARIA wiring stay owned by VizelSlashMenu. */
+  item?: (props: VizelSlashMenuItemSlotProps) => unknown;
+}>();
 const selectedIndex = ref(0);
 const itemRefs = ref<(HTMLElement | null)[]>([]);
 
@@ -140,7 +163,7 @@ defineExpose({
               name="item"
               :item="slot.data.item"
               :is-selected="slot.data.isSelected"
-              :on-click="() => selectItem(slot.index)"
+              :onclick="() => selectItem(slot.index)"
             />
             <VizelSlashMenuItem
               v-else
@@ -162,7 +185,7 @@ defineExpose({
               name="item"
               :item="slot.data.item"
               :is-selected="slot.data.isSelected"
-              :on-click="() => selectItem(slot.index)"
+              :onclick="() => selectItem(slot.index)"
             />
             <VizelSlashMenuItem
               v-else

--- a/packages/vue/src/components/VizelSlashMenuEmpty.vue
+++ b/packages/vue/src/components/VizelSlashMenuEmpty.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useSlots } from "vue";
-
 export interface VizelSlashMenuEmptyProps {
   /** Custom class name */
   class?: string;
@@ -8,7 +6,12 @@ export interface VizelSlashMenuEmptyProps {
 
 defineProps<VizelSlashMenuEmptyProps>();
 
-const slots = useSlots();
+// The default slot replaces the built-in "No results" text. It passes no
+// props, so consumers supply static markup. Typing keeps `slots.default`
+// discoverable under Volar.
+const slots = defineSlots<{
+  default?: () => unknown;
+}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/VizelToolbar.vue
+++ b/packages/vue/src/components/VizelToolbar.vue
@@ -15,9 +15,23 @@ export interface VizelToolbarProps {
   locale?: VizelLocale;
 }
 
+/**
+ * Props passed to the default scoped slot. The slot only renders once the
+ * editor resolves, so `editor` is non-null.
+ */
+export interface VizelToolbarSlotProps {
+  /** The resolved Tiptap editor instance */
+  editor: Editor;
+}
+
 const props = withDefaults(defineProps<VizelToolbarProps>(), {
   showDefaultToolbar: true,
 });
+
+defineSlots<{
+  /** Replace the default toolbar buttons. Receives the resolved editor. */
+  default?: (props: VizelToolbarSlotProps) => unknown;
+}>();
 
 const contextEditor = useVizelContextSafe();
 const editor = computed(() => props.editor ?? contextEditor?.value ?? null);

--- a/packages/vue/src/components/VizelToolbarDropdown.vue
+++ b/packages/vue/src/components/VizelToolbarDropdown.vue
@@ -6,7 +6,7 @@ import {
   resolveVizelListNavigation,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelToolbarDropdownProps {
@@ -19,8 +19,8 @@ const props = defineProps<VizelToolbarDropdownProps>();
 
 const isOpen = ref(false);
 const focusedIndex = ref(0);
-const containerRef = ref<HTMLDivElement | null>(null);
-const triggerRef = ref<HTMLButtonElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
+const triggerRef = useTemplateRef<HTMLButtonElement>("triggerRef");
 
 const spec = computed(() =>
   buildVizelToolbarDropdownSpec(props.dropdown, props.editor, isOpen.value, focusedIndex.value)

--- a/packages/vue/src/components/VizelToolbarOverflow.vue
+++ b/packages/vue/src/components/VizelToolbarOverflow.vue
@@ -2,7 +2,7 @@
 import type { Editor, VizelLocale, VizelToolbarActionItem } from "@vizel/core";
 import { formatVizelTooltip, isVizelToolbarDropdownAction, vizelEnLocale } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 import VizelToolbarButton from "./VizelToolbarButton.vue";
 import VizelToolbarDropdown from "./VizelToolbarDropdown.vue";
@@ -18,8 +18,8 @@ export interface VizelToolbarOverflowProps {
 const props = defineProps<VizelToolbarOverflowProps>();
 
 const isOpen = ref(false);
-const containerRef = ref<HTMLDivElement | null>(null);
-const triggerRef = ref<HTMLButtonElement | null>(null);
+const containerRef = useTemplateRef<HTMLDivElement>("containerRef");
+const triggerRef = useTemplateRef<HTMLButtonElement>("triggerRef");
 
 function close() {
   isOpen.value = false;

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -1,5 +1,10 @@
 // Vizel all-in-one component
-export { default as Vizel, type VizelProps, type VizelRef } from "./Vizel.vue";
+export {
+  default as Vizel,
+  type VizelProps,
+  type VizelRef,
+  type VizelSlotProps,
+} from "./Vizel.vue";
 // VizelBlockMenu component
 export {
   default as VizelBlockMenu,
@@ -56,6 +61,7 @@ export {
 // VizelMentionMenu component
 export {
   default as VizelMentionMenu,
+  type VizelMentionMenuItemSlotProps,
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
 } from "./VizelMentionMenu.vue";
@@ -80,6 +86,7 @@ export {
 // VizelSlashMenu components
 export {
   default as VizelSlashMenu,
+  type VizelSlashMenuItemSlotProps,
   type VizelSlashMenuProps,
   type VizelSlashMenuRef,
 } from "./VizelSlashMenu.vue";
@@ -97,7 +104,11 @@ export {
   type VizelThemeProviderProps,
 } from "./VizelThemeProvider.vue";
 // VizelToolbar components
-export { default as VizelToolbar, type VizelToolbarProps } from "./VizelToolbar.vue";
+export {
+  default as VizelToolbar,
+  type VizelToolbarProps,
+  type VizelToolbarSlotProps,
+} from "./VizelToolbar.vue";
 export {
   default as VizelToolbarButton,
   type VizelToolbarButtonProps,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -20,8 +20,8 @@ export * from "@vizel/core";
 // ADR-0009 mandates that every adapter implements editor reactivity
 // natively; Vue's adapter holds the implementation in `_reactivity.ts`
 // and re-exports the consumer-facing surface here. The shallow-equality
-// helpers re-export from `@vizel/core` so the cross-framework parity
-// check can resolve them back to a single source.
+// helpers re-export from `@vizel/core` so the feature-manifest parity
+// check resolves them back to a single source.
 export {
   shallowEqualArray,
   shallowEqualObject,
@@ -73,6 +73,7 @@ export {
   type VizelLinkEditorProps,
   // MentionMenu
   VizelMentionMenu,
+  type VizelMentionMenuItemSlotProps,
   type VizelMentionMenuProps,
   type VizelMentionMenuRef,
   // NodeSelector
@@ -97,8 +98,10 @@ export {
   type VizelSlashMenuEmptyProps,
   VizelSlashMenuItem,
   type VizelSlashMenuItemProps,
+  type VizelSlashMenuItemSlotProps,
   type VizelSlashMenuProps,
   type VizelSlashMenuRef,
+  type VizelSlotProps,
   VizelThemeProvider,
   type VizelThemeProviderProps,
   // Toolbar
@@ -114,6 +117,7 @@ export {
   VizelToolbarOverflow,
   type VizelToolbarOverflowProps,
   type VizelToolbarProps,
+  type VizelToolbarSlotProps,
 } from "./components/index.ts";
 
 // Composables

--- a/tests/ct/vue/specs/ColorPickerFixture.vue
+++ b/tests/ct/vue/specs/ColorPickerFixture.vue
@@ -32,24 +32,19 @@ const selectedColor = ref(props.value ?? "");
 const colorPalette = computed(() => {
   return props.colors ?? (props.useHighlightColors ? VIZEL_HIGHLIGHT_COLORS : VIZEL_TEXT_COLORS);
 });
-
-function handleChange(color: string) {
-  selectedColor.value = color;
-}
 </script>
 
 <template>
   <div>
     <VizelColorPicker
+      v-model:value="selectedColor"
       :colors="colorPalette"
-      :value="selectedColor"
       :label="props.label"
       :class="props.class"
       :allow-custom-color="props.allowCustomColor ?? true"
       :recent-colors="props.recentColors"
       :show-recent-colors="props.showRecentColors ?? true"
       :none-values="props.noneValues"
-      @change="handleChange"
     />
     <div data-testid="selected-color">{{ selectedColor }}</div>
   </div>


### PR DESCRIPTION
## Summary

Phase B2 of the v2 idiomatic-API closure (ADR-0004 / ADR-0001) — the Vue 3.5 adapter.

- **Type every scoped slot with `defineSlots<...>()`** (previously zero uses; all slots were untyped). `Vizel`, `VizelToolbar`, `VizelBubbleMenu`, `VizelSlashMenu`, `VizelMentionMenu`, and `VizelSlashMenuEmpty` now declare typed slots; the slot-prop types are exported for consumers.
- **Migrate string template refs to `useTemplateRef<T>()`** across the adapter (the pre-3.5 `ref="x"` pattern is retired; two dead refs were removed rather than migrated).
- **`VizelColorPicker` two-way state via `defineModel<string | undefined>("value")`** instead of a `value` prop + `change` emit; `VizelBubbleMenuColorPicker` consumes it with `v-model:value`.
- **Unify the suggestion-menu slot-prop casing on `onclick`** (the slash menu used kebab `:on-click`, which Vue camelCases to `onClick`; the mention menu and the Svelte snippet already use `onclick`).
- Drop a stale reference to the retired cross-framework parity script in a comment.

The editor-context `InjectionKey<ShallowRef<Editor | null>>`, `_reactivity.ts`, and the data-derived ARIA ids (no `useId` needed) are intentionally unchanged.

## Breaking Changes

- `VizelColorPicker` now uses `v-model:value` instead of `:value` + `@change`. v2.0.0 is unreleased.

## Test Plan

- [x] `pnpm typecheck`, `pnpm lint`.
- [x] `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS), and the other check scripts.
- [x] `pnpm test:ct:vue --project=chromium` → 283 passed.
- [x] Browser (Vue demo): editor mounts (no console errors); selecting text opens the bubble menu; the Text Color picker opens (23 swatches) and applying `Gray` writes `color: rgb(107,114,128)` onto the selection — the `defineModel` two-way binding works end to end.
