### PR TITLE
refactor(svelte): close idiom gaps against ADR-0004 and ADR-0001

### DIFF
--- a/.claude/rules/packages/svelte.md
+++ b/.claude/rules/packages/svelte.md
@@ -8,7 +8,7 @@ paths:
 
 `@vizel/svelte` provides Svelte 5 components and runes. The package wraps `@vizel/core` and adds Svelte-specific code only.
 
-See `cross-framework.md` for component, rune, and props parity requirements.
+Feature parity across React, Vue, and Svelte is enforced by the feature manifest (`packages/core/src/feature-manifest.ts`); run `pnpm check:feature-parity`. ADR-0004 governs the Svelte-idiomatic API surface. API symmetry across frameworks is NOT a goal.
 
 ## Svelte 5 Runes
 
@@ -158,19 +158,38 @@ editor.current?.commands.setContent(content);
 
 ### `createVizelEditorState`
 
-`createVizelEditorState` tracks editor state changes.
+`createVizelEditorState` projects a slice of editor state through a
+selector and re-evaluates it on every transaction. Two call forms
+resolve the editor:
 
 ```typescript
-const updateCount = createVizelEditorState(() => editor.current);
-// Read updateCount.current to trigger reactivity.
+// Context form: reads the editor from <Vizel> / <VizelProvider>.
+const characters = createVizelEditorState(
+  ({ editor }) => editor?.storage.characterCount?.characters() ?? 0,
+);
+
+// Explicit-source form: pass `() => Editor | null` to subscribe to an
+// editor held OUTSIDE the provider tree (for example, a status bar).
+const stats = createVizelEditorState(
+  () => editorRef,
+  ({ editor }) => getVizelEditorState(editor),
+);
+// Read stats.current to trigger reactivity.
 ```
+
+The explicit-source getter mirrors the source `createVizelState`,
+`createVizelAutoSave`, and `createVizelComment` already accept, and
+parallels React's `useVizelEditorState` `options.editor` override.
 
 ### Rune Conventions
 
 - Place runes in `*.svelte.ts` files.
 - Return an object with a `current` getter: `{ get current() { return editor; } }`.
 - Use `$effect` for lifecycle management (the Svelte 5 pattern).
-- Initialize state with `$state<Editor | null>(null)`.
+- Hold the editor in `$state.raw<Editor | null>(null)`. The Tiptap
+  `Editor` is an opaque, mutable class instance, so the rune tracks its
+  identity (re-assignment), not field mutation. ADR-0004 mandates
+  `$state.raw` here, mirroring React `useState` and Vue `shallowRef`.
 
 ```typescript
 $effect(() => {
@@ -213,7 +232,10 @@ the page and corrupt sessions when more than one suggestion is open.
 
 ## Context
 
-- `VizelProvider` calls `setContext()`.
+- `<VizelProvider>` and `<Vizel>` publish the editor through the typed
+  `setVizelContext(accessor)` wrapper (ADR-0004), not a raw `setContext`
+  call. The theme and icon providers use the matching
+  `setVizelThemeContext` / `setVizelIconContext` wrappers.
 - Consumers call `getVizelContext()` for required access or `getVizelContextSafe()` for optional access.
 
 `getVizelContext()` returns a reactive accessor (`{ readonly current: Editor | null }`). Keep the accessor bound and read `.current` inside reactive scopes so the read registers as a dependency.

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -2,8 +2,8 @@
 import {
   createVizelAutoSave,
   createVizelComment,
+  createVizelEditorState,
   createVizelFindReplaceExtension,
-  createVizelState,
   createVizelVersionHistory,
   type Editor,
   getVizelEditorState,
@@ -60,14 +60,14 @@ let replyTexts = $state<Record<string, string>>({});
 let editorRef: Editor | null = $state(null);
 
 // Track editor state for character/word count (only when stats enabled).
-// The v2 selector-style `createVizelEditorState` reads the editor from
-// `<VizelProvider>` context, so the top-level demo uses `createVizelState`
-// + `getVizelEditorState` to drive the status bar that sits outside `<Vizel>`.
-const editorVersion = createVizelState(() => (features.stats ? editorRef : null));
-const editorState = $derived.by(() => {
-  void editorVersion.version;
-  return getVizelEditorState(features.stats ? editorRef : null);
-});
+// The status bar sits OUTSIDE `<Vizel>`, so it passes an explicit editor
+// getter to `createVizelEditorState`; the selector projects each snapshot
+// onto the full `VizelEditorState`. The rune re-runs on every transaction
+// and short-circuits when the projection is unchanged.
+const editorState = createVizelEditorState(
+  () => (features.stats ? editorRef : null),
+  ({ editor }) => getVizelEditorState(editor)
+);
 
 // Auto-save functionality (only when autoSave enabled)
 const autoSave = createVizelAutoSave(() => (features.autoSave ? editorRef : null), {
@@ -302,9 +302,9 @@ function handleJsonChange(event: Event) {
               {/if}
             {/if}
             {#if features.stats}
-              <span class="status-item">{editorState.characterCount} characters</span>
+              <span class="status-item">{editorState.current.characterCount} characters</span>
               <span class="status-divider">·</span>
-              <span class="status-item">{editorState.wordCount} words</span>
+              <span class="status-item">{editorState.current.wordCount} words</span>
             {/if}
           </div>
         {/if}

--- a/packages/svelte/src/components/Vizel.svelte
+++ b/packages/svelte/src/components/Vizel.svelte
@@ -99,11 +99,10 @@ export interface VizelProps {
 // A complete editor component that includes EditorContent and BubbleMenu.
 // This is the recommended way to use Vizel for most use cases.
 import { getVizelMarkdown, setVizelMarkdown } from "@vizel/core";
-import { setContext } from "svelte";
 import { createVizelEditor } from "../runes/createVizelEditor.svelte.js";
 import VizelBlockMenu from "./VizelBlockMenu.svelte";
 import VizelBubbleMenu from "./VizelBubbleMenu.svelte";
-import { type VizelContextAccessor, VIZEL_CONTEXT_KEY } from "./VizelContext.js";
+import { type VizelContextAccessor, setVizelContext } from "./VizelContext.js";
 import VizelEditor from "./VizelEditor.svelte";
 import VizelToolbar from "./VizelToolbar.svelte";
 
@@ -194,7 +193,7 @@ const editorState = createVizelEditor({
 
 const editor = $derived(editorState.current);
 
-// Expose the editor through the same context key VizelProvider uses, so
+// Expose the editor through the same context VizelProvider uses, so
 // nested components (and the built-in toolbar / bubble menu / block menu)
 // can resolve it via getVizelContext() without an explicit `editor` prop.
 const accessor: VizelContextAccessor = {
@@ -202,7 +201,7 @@ const accessor: VizelContextAccessor = {
     return editorState.current;
   },
 };
-setContext(VIZEL_CONTEXT_KEY, accessor);
+setVizelContext(accessor);
 
 // Watch for external markdown changes (bind:markdown). `wrappedOnUpdate`
 // compares the editor's markdown against the bound prop and skips the

--- a/packages/svelte/src/components/VizelContext.ts
+++ b/packages/svelte/src/components/VizelContext.ts
@@ -1,5 +1,5 @@
 import { type Editor, VizelError } from "@vizel/core";
-import { getContext } from "svelte";
+import { getContext, setContext } from "svelte";
 
 export const VIZEL_CONTEXT_KEY = Symbol("vizel-editor");
 
@@ -15,6 +15,24 @@ export const VIZEL_CONTEXT_KEY = Symbol("vizel-editor");
 export interface VizelContextAccessor {
   /** The currently provided editor instance, or `null` when not ready. */
   readonly current: Editor | null;
+}
+
+/**
+ * Publish the editor accessor to descendants through Svelte context.
+ *
+ * Call this typed wrapper instead of `setContext(VIZEL_CONTEXT_KEY, ...)`
+ * so the key and the {@link VizelContextAccessor} value type stay paired
+ * at every call site. ADR-0004 names `setVizelContext` / `getVizelContext`
+ * as the Svelte context idiom; `<Vizel>` and `<VizelProvider>` both
+ * publish the editor through this function.
+ *
+ * @param accessor - Reactive accessor whose `current` getter returns the
+ *   live editor instance, or `null` before mount.
+ * @returns The accessor, so a caller can publish and reuse it in one
+ *   expression.
+ */
+export function setVizelContext(accessor: VizelContextAccessor): VizelContextAccessor {
+  return setContext(VIZEL_CONTEXT_KEY, accessor);
 }
 
 /**

--- a/packages/svelte/src/components/VizelIconContext.ts
+++ b/packages/svelte/src/components/VizelIconContext.ts
@@ -1,7 +1,24 @@
 import type { VizelIconContextValue } from "@vizel/core";
-import { getContext } from "svelte";
+import { getContext, setContext } from "svelte";
 
 export const VIZEL_ICON_CONTEXT_KEY = Symbol("vizel-icon-context");
+
+/**
+ * Publish custom icon mappings to descendants through Svelte context.
+ *
+ * Call this typed wrapper instead of `setContext(VIZEL_ICON_CONTEXT_KEY,
+ * ...)` so the key and the `VizelIconContextValue` value type stay paired.
+ * {@link getVizelIconContext} reads the same context. The wrapper mirrors
+ * the editor context's `setVizelContext` idiom (ADR-0004).
+ *
+ * @param value - Reactive icon-context value whose `customIcons` getter
+ *   returns the active icon overrides.
+ * @returns The value, so a caller can publish and reuse it in one
+ *   expression.
+ */
+export function setVizelIconContext(value: VizelIconContextValue): VizelIconContextValue {
+  return setContext(VIZEL_ICON_CONTEXT_KEY, value);
+}
 
 /**
  * Get custom icon mappings from parent context.

--- a/packages/svelte/src/components/VizelIconProvider.svelte
+++ b/packages/svelte/src/components/VizelIconProvider.svelte
@@ -30,14 +30,13 @@ export interface VizelIconProviderProps {
 </script>
 
 <script lang="ts">
-  import { setContext } from "svelte";
-  import type { VizelIconContextValue } from "@vizel/core";
-  import { VIZEL_ICON_CONTEXT_KEY } from "./VizelIconContext.js";
+  import { setVizelIconContext } from "./VizelIconContext.js";
 
   const { icons, children }: VizelIconProviderProps = $props();
 
-  // Use getter to maintain reactivity when icons prop changes
-  setContext<VizelIconContextValue>(VIZEL_ICON_CONTEXT_KEY, {
+  // Expose `customIcons` through a getter so descendants observe the latest
+  // `icons` prop instead of the value captured at mount.
+  setVizelIconContext({
     get customIcons() { return icons; },
   });
 </script>

--- a/packages/svelte/src/components/VizelProvider.svelte
+++ b/packages/svelte/src/components/VizelProvider.svelte
@@ -13,8 +13,7 @@ export interface VizelProviderProps {
 </script>
 
 <script lang="ts">
-import { setContext } from "svelte";
-import { type VizelContextAccessor, VIZEL_CONTEXT_KEY } from "./VizelContext.js";
+import { type VizelContextAccessor, setVizelContext } from "./VizelContext.js";
 
 let { editor, class: className, children }: VizelProviderProps = $props();
 
@@ -27,7 +26,7 @@ const accessor: VizelContextAccessor = {
     return editor;
   },
 };
-setContext(VIZEL_CONTEXT_KEY, accessor);
+setVizelContext(accessor);
 
 // Always emit the `vizel-root` class so consumers get the CSS variable scope
 // for free (.vizel-root { --vizel-* }). Matches the React provider behavior.

--- a/packages/svelte/src/components/VizelThemeContext.ts
+++ b/packages/svelte/src/components/VizelThemeContext.ts
@@ -1,3 +1,6 @@
+import type { VizelThemeState } from "@vizel/core";
+import { setContext } from "svelte";
+
 /**
  * Context key for VizelThemeProvider (internal use only).
  *
@@ -6,3 +9,21 @@
  * provider component.
  */
 export const VIZEL_THEME_CONTEXT_KEY = Symbol("VizelThemeContext");
+
+/**
+ * Publish the theme state to descendants through Svelte context.
+ *
+ * Call this typed wrapper instead of `setContext(VIZEL_THEME_CONTEXT_KEY,
+ * ...)` so the key and the `VizelThemeState` value type stay paired.
+ * `getVizelTheme` reads the same context. The wrapper mirrors the editor
+ * context's `setVizelContext` idiom (ADR-0004) so no provider calls
+ * `setContext` with a raw key.
+ *
+ * @param state - Reactive theme state exposing `theme`, `resolvedTheme`,
+ *   `systemTheme`, and `setTheme`.
+ * @returns The state, so a caller can publish and reuse it in one
+ *   expression.
+ */
+export function setVizelThemeContext(state: VizelThemeState): VizelThemeState {
+  return setContext(VIZEL_THEME_CONTEXT_KEY, state);
+}

--- a/packages/svelte/src/components/VizelThemeProvider.svelte
+++ b/packages/svelte/src/components/VizelThemeProvider.svelte
@@ -22,8 +22,7 @@ export interface VizelThemeProviderProps extends VizelThemeProviderOptions {
     type VizelTheme,
     type VizelThemeState,
   } from "@vizel/core";
-  import { setContext } from "svelte";
-  import { VIZEL_THEME_CONTEXT_KEY } from "./VizelThemeContext.js";
+  import { setVizelThemeContext } from "./VizelThemeContext.js";
 
   let {
     children,
@@ -59,7 +58,7 @@ export interface VizelThemeProviderProps extends VizelThemeProviderOptions {
     setTheme,
   };
 
-  setContext(VIZEL_THEME_CONTEXT_KEY, themeState);
+  setVizelThemeContext(themeState);
 
   // Apply theme when resolved theme changes
   $effect(() => {

--- a/packages/svelte/src/components/index.ts
+++ b/packages/svelte/src/components/index.ts
@@ -42,7 +42,12 @@ export {
 // ============================================================================
 // Vizel Context
 // ============================================================================
-export { getVizelContext, getVizelContextSafe } from "./VizelContext.js";
+export {
+  getVizelContext,
+  getVizelContextSafe,
+  setVizelContext,
+  type VizelContextAccessor,
+} from "./VizelContext.js";
 // ============================================================================
 // Vizel Editor components
 // ============================================================================
@@ -69,7 +74,7 @@ export {
 // Vizel Icon component
 // ============================================================================
 export { default as VizelIcon, type VizelIconProps } from "./VizelIcon.svelte";
-export { getVizelIconContext } from "./VizelIconContext.js";
+export { getVizelIconContext, setVizelIconContext } from "./VizelIconContext.js";
 export {
   default as VizelIconProvider,
   type VizelIconProviderProps,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -28,6 +28,8 @@ export {
   getVizelContext,
   getVizelContextSafe,
   getVizelIconContext,
+  setVizelContext,
+  setVizelIconContext,
   // Vizel all-in-one
   Vizel,
   // BlockMenu
@@ -47,6 +49,7 @@ export {
   // ColorPicker
   VizelColorPicker,
   type VizelColorPickerProps,
+  type VizelContextAccessor,
   // Editor components
   VizelEditor,
   type VizelEditorProps,

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -85,7 +85,13 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
   // Store image upload options for event handler
   const imageOptions = typeof features?.content?.image === "object" ? features.content.image : {};
 
-  let editor = $state<Editor | null>(null);
+  // Hold the editor in `$state.raw`: the Tiptap `Editor` is an opaque,
+  // mutable class instance, so deep proxying buys nothing and the rune
+  // tracks identity, not field mutation. Re-assignment on create triggers
+  // reactivity; in-place edits do not, which matches Tiptap's transaction
+  // model. ADR-0004 mandates this idiom, mirroring React `useState` and
+  // Vue `shallowRef`.
+  let editor = $state.raw<Editor | null>(null);
 
   // Create editor on mount and cleanup on destroy (async - optional deps loaded dynamically)
   $effect(() => {

--- a/packages/svelte/src/runes/createVizelEditorState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditorState.svelte.ts
@@ -35,13 +35,28 @@ export interface CreateVizelEditorStateOptions<T> {
 }
 
 /**
+ * Reactive editor source: a getter returning the editor to subscribe to,
+ * re-evaluated on every read so a `$state`-backed editor reference (for
+ * example, `() => editorRef`) drives the subscription.
+ */
+export type VizelEditorStateSource = () => Editor | null | undefined;
+
+/**
  * Selector-style editor-state rune. Returns the projection of the
  * latest editor snapshot through `selector`, re-evaluated on every
  * Tiptap `transaction` and `selectionUpdate`.
  *
+ * Two call forms resolve the editor:
+ * - `createVizelEditorState(selector, options?)` reads the editor from
+ *   {@link getVizelContextSafe}, so a consumer under `<Vizel>` or
+ *   `<VizelProvider>` never threads the editor through props.
+ * - `createVizelEditorState(getEditor, selector, options?)` subscribes to
+ *   the editor the getter returns, so a status bar rendered OUTSIDE the
+ *   provider tree still tracks state. The getter mirrors the source
+ *   `createVizelState`, `createVizelAutoSave`, and `createVizelComment`
+ *   already accept, and parallels React's `options.editor` override.
+ *
  * Behavior:
- * - Resolves the editor from {@link getVizelContextSafe}, so consumers
- *   never thread the editor instance manually through props.
  * - Subscribes through `createSubscriber` so the listeners attach
  *   exactly once per consumer effect and detach when every consumer
  *   tears down. The teardown closure detaches `transaction` and
@@ -68,16 +83,58 @@ export interface CreateVizelEditorStateOptions<T> {
  *
  * <span>{characters.current} characters</span>
  * ```
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   // Subscribe to an explicit editor held outside the provider tree.
+ *   const stats = createVizelEditorState(
+ *     () => editorRef,
+ *     ({ editor }) => getVizelEditorState(editor),
+ *   );
+ * </script>
+ *
+ * <span>{stats.current.characterCount} characters</span>
+ * ```
  */
 export function createVizelEditorState<T>(
   selector: (snapshot: VizelEditorStateSnapshot) => T,
-  options: CreateVizelEditorStateOptions<T> = {}
+  options?: CreateVizelEditorStateOptions<T>
+): { readonly current: T };
+export function createVizelEditorState<T>(
+  getEditor: VizelEditorStateSource,
+  selector: (snapshot: VizelEditorStateSnapshot) => T,
+  options?: CreateVizelEditorStateOptions<T>
+): { readonly current: T };
+export function createVizelEditorState<T>(
+  selectorOrGetEditor: ((snapshot: VizelEditorStateSnapshot) => T) | VizelEditorStateSource,
+  selectorOrOptions?:
+    | ((snapshot: VizelEditorStateSnapshot) => T)
+    | CreateVizelEditorStateOptions<T>,
+  maybeOptions?: CreateVizelEditorStateOptions<T>
 ): { readonly current: T } {
+  // Disambiguate the two call forms by the second argument's type. A
+  // function in that slot means the call passed `(getEditor, selector)`;
+  // anything else means `(selector, options)`.
+  const hasExplicitSource = typeof selectorOrOptions === "function";
+  const selector = (hasExplicitSource ? selectorOrOptions : selectorOrGetEditor) as (
+    snapshot: VizelEditorStateSnapshot
+  ) => T;
+  const options = (hasExplicitSource ? maybeOptions : selectorOrOptions) ?? {};
+  const explicitSource = hasExplicitSource ? (selectorOrGetEditor as VizelEditorStateSource) : null;
+
   const equalityFn = options.equalityFn ?? Object.is;
-  // The accessor is `null` outside a `<VizelProvider>`; the rune still
-  // returns a working `{ current }` so consumers can mount before the
-  // provider does without crashing.
-  const accessor = getVizelContextSafe();
+  // Read context only for the context-sourced form. `getVizelContextSafe`
+  // calls `getContext`, which must run during rune init, so the call
+  // happens here rather than inside the `$derived`. The accessor is
+  // `null` outside a provider; the rune still returns a working
+  // `{ current }` so consumers can mount before the provider does
+  // without crashing.
+  const accessor = explicitSource ? null : getVizelContextSafe();
+  // Uniform editor resolver: the explicit getter when supplied, otherwise
+  // the provider accessor. Reading inside the `$derived` registers the
+  // dependency so the selector re-runs when either source changes.
+  const getEditor: VizelEditorStateSource = explicitSource ?? (() => accessor?.current ?? null);
 
   // Latest transaction observed by the listener, paired with the
   // editor that produced it. The `editor` pairing prevents a stale
@@ -134,10 +191,10 @@ export function createVizelEditorState<T>(
   };
 
   const current = $derived.by(() => {
-    // Register dependency on the editor accessor first so swapping a
-    // `<VizelProvider editor>` value re-runs the selector even before
-    // the first transaction lands.
-    const editor = accessor?.current ?? null;
+    // Register dependency on the editor source first so swapping the
+    // provider's editor (or the explicit getter's reference) re-runs the
+    // selector even before the first transaction lands.
+    const editor = getEditor() ?? null;
     if (editor) {
       // Calling `subscribe()` inside a tracking scope registers the
       // dependency on the subscription's version counter and triggers

--- a/packages/svelte/src/runes/getVizelTheme.ts
+++ b/packages/svelte/src/runes/getVizelTheme.ts
@@ -7,15 +7,14 @@ import { VIZEL_THEME_CONTEXT_KEY } from "../components/VizelThemeContext.js";
  *
  * The flat `{ current, setTheme }` shape parallels the React hook's
  * `{ theme, setTheme }` and the Vue composable's
- * `{ theme: ComputedRef<…>, setTheme }`. The scalar field is renamed
- * to `current` here so it lines up with every other Svelte rune
- * accessor (`editor.current`, `state.current`, etc.) — the rename is
- * documented as Table 6's "Hook scalar field" idiom exception in
- * `.claude/rules/cross-framework.md`. `current` is the currently
- * applied (resolved) theme so a toggle is a one-liner. `setTheme`
- * accepts only concrete `VizelResolvedTheme` values because entering
- * "system" mode is the provider's `defaultTheme` concern, not a
- * runtime toggle.
+ * `{ theme: ComputedRef<…>, setTheme }`. The scalar field is named
+ * `current` here so it lines up with every other Svelte rune accessor
+ * (`editor.current`, `state.current`, etc.); ADR-0004 favours each
+ * adapter's native idiom over a shared field name across frameworks.
+ * `current` is the currently applied (resolved) theme so a toggle is a
+ * one-liner. `setTheme` accepts only concrete `VizelResolvedTheme`
+ * values because entering "system" mode is the provider's
+ * `defaultTheme` concern, not a runtime toggle.
  */
 export interface GetVizelThemeResult {
   /** Currently applied theme (resolved from the user's preference). */
@@ -30,6 +29,25 @@ export interface GetVizelThemeResult {
    */
   resetToSystem: () => void;
 }
+
+/**
+ * Project a provider `VizelThemeState` onto the public result shape.
+ *
+ * `getVizelTheme` and `getVizelThemeSafe` return identical shapes; the
+ * helper keeps the projection in one place. `current` reads the resolved
+ * theme through a getter so the value stays reactive. `setTheme` is
+ * re-wrapped so the parameter type is physically narrowed to
+ * `VizelResolvedTheme`: `context.setTheme` accepts the wider `VizelTheme`
+ * (including `"system"`), and contravariant assignment would let an
+ * `as VizelTheme` cast slip through; the wrapper closes that hole.
+ */
+const toVizelThemeResult = (context: VizelThemeState): GetVizelThemeResult => ({
+  get current() {
+    return context.resolvedTheme;
+  },
+  setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
+  resetToSystem: () => context.setTheme("system"),
+});
 
 /**
  * Get the editor theme and a setter from context.
@@ -57,23 +75,7 @@ export function getVizelTheme(): GetVizelThemeResult {
     );
   }
 
-  // Surface the resolved theme through the public `current` field. The
-  // underlying `VizelThemeState` keeps `theme` (user setting) and
-  // `resolvedTheme` (applied) separate; v2 collapses both into a single
-  // observable so the toggle pattern stays a one-liner.
-  //
-  // `setTheme` is re-wrapped so the parameter type is physically narrowed
-  // to `VizelResolvedTheme`. The underlying `context.setTheme` accepts the
-  // wider `VizelTheme` (including "system"), and contravariant assignment
-  // would let an `as VizelTheme` cast slip through; the wrapper closes
-  // that hole.
-  return {
-    get current() {
-      return context.resolvedTheme;
-    },
-    setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
-    resetToSystem: () => context.setTheme("system"),
-  };
+  return toVizelThemeResult(context);
 }
 
 /**
@@ -85,11 +87,5 @@ export function getVizelTheme(): GetVizelThemeResult {
 export function getVizelThemeSafe(): GetVizelThemeResult | null {
   const context = getContext<VizelThemeState | undefined>(VIZEL_THEME_CONTEXT_KEY);
   if (!context) return null;
-  return {
-    get current() {
-      return context.resolvedTheme;
-    },
-    setTheme: (next: VizelResolvedTheme) => context.setTheme(next),
-    resetToSystem: () => context.setTheme("system"),
-  };
+  return toVizelThemeResult(context);
 }


### PR DESCRIPTION
## Summary

Phase B3 of the v2 idiomatic-API closure (ADR-0004 / ADR-0001) — the Svelte 5 adapter.

- **Hold the editor in `$state.raw<Editor | null>`** in `createVizelEditor.svelte.ts` (was plain `$state`). ADR-0004 mandates `$state.raw` for the opaque, mutable Tiptap `Editor`; this matches React (`useState`) and Vue (`shallowRef`).
- **Route context through typed `setVizelContext`** (the counterpart to `getVizelContext`, which was the only half present). `Vizel`/`VizelProvider` now publish the editor through `setVizelContext`; the theme and icon providers gain matching `setVizelThemeContext` / `setVizelIconContext` wrappers, so no provider calls a raw `setContext`.
- **`createVizelEditorState` gains an explicit-source overload** — `createVizelEditorState(() => editor, selector, options?)` — so a status bar outside `<Vizel>` can use the selector rune directly. The demo status bar drops its `createVizelState` + `getVizelEditorState` workaround for the single-call form. `createVizelState` stays exported for cross-framework parity.
- Reword the dangling `cross-framework.md` reference in `getVizelTheme.ts`, de-duplicate the shared theme-result body, and update `.claude/rules/packages/svelte.md` to document `$state.raw`, `setVizelContext`, and both `createVizelEditorState` call forms.

## Breaking Changes

- None for consumers of the documented API; the new `createVizelEditorState` getter form is additive. v2.0.0 is unreleased.

## Test Plan

- [x] `pnpm typecheck` (svelte-check, 0 errors), `pnpm lint`.
- [x] `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS), and the other check scripts.
- [x] `pnpm test:ct:svelte --project=chromium` → 283 passed.
- [x] Browser (Svelte demo): editor mounts (84 blocks, `$state.raw`, no `effect_update_depth_exceeded`, console clean); the status bar reads `6207 characters / 925 words` via the `createVizelEditorState` overload and updates live (typing two chars → 6209) — the explicit-source selector subscription works outside the provider.
