### PR TITLE
refactor(headless): adopt popover primitive in VizelBlockMenu

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -510,8 +510,6 @@ export type {
 export {
   type CreateVizelEditorInstanceOptions,
   type CreateVizelEditorInstanceResult,
-  // Menu positioning utilities
-  clampMenuPosition,
   // Editor helpers
   convertVizelCodeBlocksToDiagrams,
   // Lazy import utility
@@ -549,7 +547,6 @@ export {
   isVizelMacPlatform,
   // Color utilities
   isVizelValidHexColor,
-  type MenuPosition,
   mountToVizelPortal,
   mountVizelEditorView,
   normalizeVizelHexColor,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -89,8 +89,8 @@ export {
   vizelObsidianFlavor,
   vizelPandocFlavor,
 } from "./markdown-flavors.ts";
-// Menu positioning utilities
-export { clampMenuPosition, type MenuPosition, shouldFlipSubmenu } from "./menuPositioning.ts";
+// Submenu flip utility
+export { shouldFlipSubmenu } from "./menuPositioning.ts";
 // SSR-safe rAF helpers (used by markdown sync hooks)
 export {
   vizelCancelAnimationFrame,

--- a/packages/core/src/utils/menuPositioning.ts
+++ b/packages/core/src/utils/menuPositioning.ts
@@ -1,57 +1,11 @@
 /**
- * Menu positioning utilities for viewport boundary clamping.
+ * Submenu flip utility for viewport boundary handling.
  *
- * Ensures fixed-position menus and their submenus stay within
- * the visible viewport area.
+ * Keeps a Cascading Style Sheets (CSS) flyout submenu within the visible
+ * viewport by reporting when the submenu must open to the left. The block
+ * menu positions its body through `@vizel/headless`'s floating controller;
+ * only the submenu, a CSS-positioned child, still needs this helper.
  */
-
-export interface MenuPosition {
-  x: number;
-  y: number;
-}
-
-/**
- * Clamps a fixed-position menu's coordinates so it stays within
- * the visible viewport.
- *
- * @param anchorRect - Bounding rect of the anchor element (e.g. drag handle)
- * @param menuWidth - offsetWidth of the menu element
- * @param menuHeight - offsetHeight of the menu element
- * @param gap - Vertical gap between anchor and menu (default 4)
- * @param padding - Minimum distance from viewport edges (default 8)
- * @returns Clamped {x, y} coordinates
- *
- * @example
- * ```ts
- * const rect = handle.getBoundingClientRect();
- * const pos = clampMenuPosition(rect, menu.offsetWidth, menu.offsetHeight);
- * menu.style.left = `${pos.x}px`;
- * menu.style.top = `${pos.y}px`;
- * ```
- */
-export function clampMenuPosition(
-  anchorRect: DOMRect,
-  menuWidth: number,
-  menuHeight: number,
-  gap = 4,
-  padding = 8
-): MenuPosition {
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-
-  const rawX = anchorRect.left;
-  const rawY = anchorRect.bottom + gap;
-
-  // Clamp horizontal: prevent overflow on right edge first, then left edge
-  const clampedRight = rawX + menuWidth > vw - padding ? vw - menuWidth - padding : rawX;
-  const x = clampedRight < padding ? padding : clampedRight;
-
-  // Clamp vertical: flip above anchor if overflow, then clamp top edge
-  const flippedY = rawY + menuHeight > vh - padding ? anchorRect.top - menuHeight - gap : rawY;
-  const y = flippedY < padding ? padding : flippedY;
-
-  return { x, y };
-}
 
 /**
  * Determines whether a submenu should open to the left instead of the right.

--- a/packages/headless/__tests__/floating.test.ts
+++ b/packages/headless/__tests__/floating.test.ts
@@ -12,6 +12,9 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
+// Type-only import is erased at compile time, so it does not load the
+// module before `mock.module` registers the `@floating-ui/dom` stub.
+import type { VizelVirtualElement } from "../src/floating/index.ts";
 
 interface FloatingMockState {
   readonly computeCalls: { anchor: unknown; body: unknown; config: unknown }[];
@@ -156,5 +159,27 @@ describe("createVizelFloatingController", () => {
     controller.mount();
     assert.equal(floatingMock.computeCalls.length, 0);
     assert.equal(floatingMock.autoUpdateCalls.length, 0);
+  });
+
+  it("positions against a virtual anchor that exposes only getBoundingClientRect", async () => {
+    // The block menu captures the drag-handle rect, not a stable element,
+    // so it supplies a virtual anchor. `getAnchor` accepts the virtual
+    // element without a cast, and the controller forwards it to
+    // `computePosition` so the body still receives fixed-position styles.
+    const rect = { left: 5, top: 7, bottom: 9, right: 11, width: 6, height: 2 } as DOMRect;
+    const virtualAnchor: VizelVirtualElement = { getBoundingClientRect: () => rect };
+    const controller = createVizelFloatingController({
+      getAnchor: () => virtualAnchor,
+      getBody: () => env.body as unknown as HTMLElement,
+    });
+    controller.mount();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(floatingMock.computeCalls[0]?.anchor, virtualAnchor);
+    assert.equal(floatingMock.autoUpdateCalls[0]?.anchor, virtualAnchor);
+    assert.equal(env.body.style.position, "fixed");
+    assert.equal(env.body.style.left, "12px");
+    assert.equal(env.body.style.top, "34px");
   });
 });

--- a/packages/headless/__tests__/popover.test.ts
+++ b/packages/headless/__tests__/popover.test.ts
@@ -179,4 +179,21 @@ describe("createVizelPopoverController dismiss semantics", () => {
     controller.mount();
     assert.equal(fake.document.registrations.length, 0);
   });
+
+  it("dismisses on an outside pointer event when the anchor is virtual", () => {
+    // The block menu anchors to a captured drag-handle rect — a virtual
+    // element with only `getBoundingClientRect` and no `contains`. The
+    // anchor-exclusion guard therefore skips, so a pointer event outside
+    // the body dismisses, matching the block menu's drag-handle behaviour.
+    const calls = { dismiss: 0 };
+    const rect = { left: 1, top: 2, bottom: 3, right: 4, width: 3, height: 1 } as DOMRect;
+    const controller = createVizelPopoverController({
+      getAnchor: () => ({ getBoundingClientRect: () => rect }),
+      getBody: () => env.body as unknown as HTMLElement,
+      onDismiss: () => calls.dismiss++,
+    });
+    controller.mount();
+    fake.document.dispatch("pointerdown", { target: env.outside });
+    assert.equal(calls.dismiss, 1);
+  });
 });

--- a/packages/headless/src/floating/index.ts
+++ b/packages/headless/src/floating/index.ts
@@ -21,6 +21,28 @@
 import { autoUpdate, computePosition, flip, offset, type Placement, shift } from "@floating-ui/dom";
 
 /**
+ * A virtual anchor for the floating engine.
+ *
+ * `@floating-ui/dom`'s `computePosition` positions a body against any
+ * object exposing `getBoundingClientRect`, not only a live DOM element
+ * (see https://floating-ui.com/docs/virtual-elements). A surface that
+ * captures a rect — for example the block menu, which receives the
+ * drag-handle's `DOMRect` through a custom event rather than a stable
+ * element reference — supplies a `VizelVirtualElement` so the body still
+ * positions, flips, and shifts against the captured geometry.
+ */
+export interface VizelVirtualElement {
+  /** Return the rectangle the body positions against. */
+  readonly getBoundingClientRect: () => DOMRect;
+}
+
+/**
+ * The anchor a floating body positions against: a live element or a
+ * virtual element carrying only a `getBoundingClientRect`.
+ */
+export type VizelFloatingAnchor = HTMLElement | VizelVirtualElement;
+
+/**
  * Default placement applied when the caller omits `placement`. Vizel
  * surfaces open below the trigger and left-align by convention.
  */
@@ -80,8 +102,12 @@ export function buildVizelFloatingSpec(options: VizelFloatingSpecOptions = {}): 
  * Options for {@link createVizelFloatingController}.
  */
 export interface VizelFloatingControllerOptions extends VizelFloatingSpecOptions {
-  /** Return the anchor element the body positions against, or `null`. */
-  readonly getAnchor: () => HTMLElement | null;
+  /**
+   * Return the anchor the body positions against, or `null`. The anchor
+   * is a live element or a {@link VizelVirtualElement} that exposes only
+   * `getBoundingClientRect`.
+   */
+  readonly getAnchor: () => VizelFloatingAnchor | null;
   /** Return the floating body element to position, or `null`. */
   readonly getBody: () => HTMLElement | null;
   /**

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -35,10 +35,12 @@ export {
   createVizelFloatingController,
   VIZEL_FLOATING_DEFAULT_OFFSET,
   VIZEL_FLOATING_DEFAULT_PLACEMENT,
+  type VizelFloatingAnchor,
   type VizelFloatingController,
   type VizelFloatingControllerOptions,
   type VizelFloatingSpec,
   type VizelFloatingSpecOptions,
+  type VizelVirtualElement,
 } from "./floating/index.ts";
 export {
   buildVizelGridNavSpec,

--- a/packages/headless/src/popover/index.ts
+++ b/packages/headless/src/popover/index.ts
@@ -28,9 +28,22 @@ import { createVizelDismissable } from "../dismissable/index.ts";
 import {
   buildVizelFloatingSpec,
   createVizelFloatingController,
+  type VizelFloatingAnchor,
   type VizelFloatingSpec,
   type VizelFloatingSpecOptions,
 } from "../floating/index.ts";
+
+/**
+ * Report whether the anchor exposes a DOM `contains` method.
+ *
+ * A live element answers `true`; a {@link VizelFloatingAnchor} virtual
+ * element, which carries only `getBoundingClientRect`, answers `false`.
+ * The guard reads the property without naming the `HTMLElement` global,
+ * which is undefined under Server-Side Rendering (SSR) and in the Node
+ * test runner.
+ */
+const hasContains = (anchor: VizelFloatingAnchor): anchor is HTMLElement =>
+  typeof (anchor as { contains?: unknown }).contains === "function";
 
 /**
  * Options for {@link buildVizelPopoverPositionSpec}.
@@ -68,8 +81,14 @@ export function buildVizelPopoverPositionSpec(
  * Options for {@link createVizelPopoverController}.
  */
 export interface VizelPopoverControllerOptions extends VizelFloatingSpecOptions {
-  /** Return the anchor element the body positions against, or `null`. */
-  readonly getAnchor: () => HTMLElement | null;
+  /**
+   * Return the anchor the body positions against, or `null`. The anchor
+   * is a live element or a {@link VizelFloatingAnchor} virtual element
+   * carrying only `getBoundingClientRect`. A virtual anchor cannot
+   * contain a pointer target, so the controller excludes it from
+   * "outside" detection only when it exposes `contains`.
+   */
+  readonly getAnchor: () => VizelFloatingAnchor | null;
   /** Return the floating body element to position, or `null`. */
   readonly getBody: () => HTMLElement | null;
   /** Called when the controller decides the popover should close. */
@@ -161,9 +180,20 @@ export function createVizelPopoverController(
       // anchor too: the trigger lives outside the body, so toggling the
       // popover by clicking the trigger must not count as an outside
       // click. The legacy core controller modelled this with a multi-
-      // element "outside" set ([anchor, body]).
+      // element "outside" set ([anchor, body]). A virtual anchor exposes
+      // only `getBoundingClientRect`, so probe for `contains` rather than
+      // `instanceof HTMLElement`: the global is undefined under SSR and in
+      // the Node test runner, and the capability check covers both an
+      // element anchor and a virtual one.
       const anchor = options.getAnchor();
-      if (target instanceof Node && anchor?.contains(target)) return;
+      if (
+        target instanceof Node &&
+        anchor !== null &&
+        hasContains(anchor) &&
+        anchor.contains(target)
+      ) {
+        return;
+      }
       options.onDismiss();
     },
     ...(options.dismissOnEscape === false ? {} : { onEscape: () => options.onDismiss() }),

--- a/packages/react/src/components/VizelBlockMenu.tsx
+++ b/packages/react/src/components/VizelBlockMenu.tsx
@@ -1,7 +1,6 @@
 import type { Editor } from "@vizel/core";
 import {
   buildVizelBlockMenuSpec,
-  clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelBlockMenuTriggerController,
   createVizelNodeTypes,
@@ -15,7 +14,7 @@ import {
   vizelDefaultNodeTypes,
   vizelRequestAnimationFrame,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelPopoverController } from "@vizel/headless";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
@@ -38,19 +37,16 @@ export interface VizelBlockMenuProps {
   locale?: VizelLocale;
 }
 
-interface BlockMenuState extends VizelBlockMenuOpenDetail {
-  x: number;
-  y: number;
-}
-
 /**
  * Block context menu that appears when clicking the drag handle.
  *
  * DOM/ARIA scaffolding (sections, submenu trigger, submenu list) comes
  * from `@vizel/core`'s `buildVizelBlockMenuSpec`; the React component
- * owns positioning, focus management, and runtime action binding. Both
- * the open-channel (`VIZEL_BLOCK_MENU_EVENT`) and the dismiss-channel
- * (pointer-outside + Escape) route through controllers so this file
+ * owns focus management and runtime action binding. The open-channel
+ * (`VIZEL_BLOCK_MENU_EVENT`), positioning, and dismissal all route
+ * through controllers: `createVizelPopoverController` anchors the menu to
+ * the captured drag-handle rect (a `@floating-ui/dom` virtual element)
+ * and owns the pointer-outside and Escape listeners, so this file
  * attaches no document-level listeners directly (ADR-0003, ADR-0007).
  */
 export function VizelBlockMenu({
@@ -70,7 +66,7 @@ export function VizelBlockMenu({
     () => nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes),
     [nodeTypes, locale]
   );
-  const [menuState, setMenuState] = useState<BlockMenuState | null>(null);
+  const [menuState, setMenuState] = useState<VizelBlockMenuOpenDetail | null>(null);
   const [showTurnInto, setShowTurnInto] = useState(false);
   const [submenuFlipped, setSubmenuFlipped] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -84,37 +80,16 @@ export function VizelBlockMenu({
   }, []);
 
   useEffect(() => {
-    // `isMounted` guards the rAF callback against the React 19 strict-mode
-    // setup → cleanup → setup sequence, where the rAF scheduled in the
-    // first setup can fire after the first cleanup has detached the
-    // listener — without the guard the callback would call setMenuState
-    // against a stale closure.
-    const lifecycle = { isMounted: true };
     const controller = createVizelBlockMenuTriggerController({
       onOpen: (detail: VizelBlockMenuOpenDetail) => {
         if (boundEditor && detail.editor !== boundEditor) return;
         menuEditorRef.current = detail.editor;
-        setMenuState({
-          ...detail,
-          x: detail.handleRect.left,
-          y: detail.handleRect.bottom + 4,
-        });
+        setMenuState(detail);
         setShowTurnInto(false);
-
-        vizelRequestAnimationFrame(() => {
-          if (!lifecycle.isMounted) return;
-          const el = menuRef.current;
-          if (!el) return;
-          const clamped = clampMenuPosition(detail.handleRect, el.offsetWidth, el.offsetHeight);
-          setMenuState((prev) => (prev ? { ...prev, x: clamped.x, y: clamped.y } : prev));
-        });
       },
     });
     controller.mount();
-    return () => {
-      lifecycle.isMounted = false;
-      controller.unmount();
-    };
+    return () => controller.unmount();
   }, [boundEditor]);
 
   useEffect(() => {
@@ -135,15 +110,23 @@ export function VizelBlockMenu({
     const menu = menuRef.current;
     if (!menu) return;
 
-    // The submenu lives inside `menuRef`, so a single mount target covers
-    // both surfaces for outside-pointer detection. Escape keeps v1's
-    // semantics (close without preventDefault), so `captureEscape` stays
-    // off.
-    const controller = createVizelDismissable({
-      onPointerOutside: () => closeRef.current(),
-      onEscape: () => closeRef.current(),
+    // Anchor the menu to the captured drag-handle rect through a virtual
+    // element: the handle is a transient overlay node, so the menu reads
+    // its geometry rather than holding an element reference. The popover
+    // controller positions the body with floating-ui flip/shift (which
+    // replaces the former manual clamp) and owns the pointer-outside and
+    // Escape listeners. The submenu lives inside `menuRef`, so the single
+    // body mount target also covers it for outside-pointer detection.
+    const handleRect = menuState.handleRect;
+    const controller = createVizelPopoverController({
+      getAnchor: () => ({ getBoundingClientRect: () => handleRect }),
+      getBody: () => menuRef.current,
+      placement: "bottom-start",
+      offset: 4,
+      onDismiss: () => closeRef.current(),
+      dismissOnEscape: true,
     });
-    controller.mount(menu);
+    controller.mount();
     return () => controller.unmount();
   }, [menuState]);
 
@@ -221,7 +204,6 @@ export function VizelBlockMenu({
     <div
       ref={menuRef}
       className={`vizel-block-menu ${className ?? ""}`}
-      style={{ left: menuState.x, top: menuState.y }}
       role="menu"
       aria-label={spec.root["aria-label"]}
       data-vizel-block-menu=""

--- a/packages/svelte/src/components/VizelBlockMenu.svelte
+++ b/packages/svelte/src/components/VizelBlockMenu.svelte
@@ -23,7 +23,6 @@ export interface VizelBlockMenuProps {
 <script lang="ts">
 import {
   buildVizelBlockMenuSpec,
-  clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelBlockMenuTriggerController,
   createVizelNodeTypes,
@@ -33,15 +32,10 @@ import {
   vizelDefaultNodeTypes,
   type VizelBlockMenuOpenDetail,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelPopoverController } from "@vizel/headless";
 import { tick } from "svelte";
 import { getVizelContextSafe } from "./VizelContext.js";
 import VizelIcon from "./VizelIcon.svelte";
-
-interface BlockMenuState extends VizelBlockMenuOpenDetail {
-  x: number;
-  y: number;
-}
 
 let {
   editor: editorProp,
@@ -57,7 +51,7 @@ const boundEditor = $derived<Editor | null>(editorProp ?? contextEditor?.current
 const effectiveActions = $derived(actions ?? (locale ? createVizelBlockMenuActions(locale) : vizelDefaultBlockMenuActions));
 const effectiveNodeTypes = $derived(nodeTypes ?? (locale ? createVizelNodeTypes(locale) : vizelDefaultNodeTypes));
 
-let menuState = $state<BlockMenuState | null>(null);
+let menuState = $state<VizelBlockMenuOpenDetail | null>(null);
 let showTurnInto = $state(false);
 let submenuFlipped = $state(false);
 let menuRef = $state<HTMLDivElement | null>(null);
@@ -137,49 +131,38 @@ $effect(() => {
 // component never attaches the custom-event listener directly
 // (ADR-0003, ADR-0007).
 $effect(() => {
-  const lifecycle = { isMounted: true };
   const controller = createVizelBlockMenuTriggerController({
     onOpen: (detail: VizelBlockMenuOpenDetail) => {
       if (boundEditor && detail.editor !== boundEditor) return;
-      menuState = {
-        ...detail,
-        x: detail.handleRect.left,
-        y: detail.handleRect.bottom + 4,
-      };
+      menuState = detail;
       showTurnInto = false;
-
-      void tick().then(() => {
-        // Guard against menus that close while the microtask is queued —
-        // without the check, a stale `menuState` would be re-published with
-        // clamped coordinates.
-        if (!lifecycle.isMounted) return;
-        const el = menuRef;
-        if (!el || !menuState) return;
-        const clamped = clampMenuPosition(detail.handleRect, el.offsetWidth, el.offsetHeight);
-        menuState = { ...menuState, x: clamped.x, y: clamped.y };
-      });
     },
   });
   controller.mount();
-  return () => {
-    lifecycle.isMounted = false;
-    controller.unmount();
-  };
+  return () => controller.unmount();
 });
 
-// Pointer-outside and Escape dismissal route through `createVizelDismissable`
-// from `@vizel/headless` so this component never attaches document listeners
-// directly (ADR-0003, ADR-0007). The submenu lives inside `menuRef`, so a
-// single mount target covers both surfaces for outside-pointer detection.
-// Escape keeps the original semantics (close without `preventDefault`), so
-// `captureEscape` stays off.
+// Anchor the menu to the captured drag-handle rect through a virtual
+// element: the handle is a transient overlay node, so the menu reads its
+// geometry rather than holding an element reference. The popover
+// controller positions the body with floating-ui flip/shift (which
+// replaces the former manual clamp) and owns the pointer-outside and
+// Escape listeners. The effect re-runs when `menuState` changes, so each
+// open re-positions against the fresh rect. The submenu lives inside
+// `menuRef`, so the single body mount target also covers it for
+// outside-pointer detection.
 $effect(() => {
   if (!menuState || !menuRef) return;
-  const controller = createVizelDismissable({
-    onPointerOutside: () => close(),
-    onEscape: () => close(),
+  const handleRect = menuState.handleRect;
+  const controller = createVizelPopoverController({
+    getAnchor: () => ({ getBoundingClientRect: () => handleRect }),
+    getBody: () => menuRef,
+    placement: "bottom-start",
+    offset: 4,
+    onDismiss: () => close(),
+    dismissOnEscape: true,
   });
-  controller.mount(menuRef);
+  controller.mount();
   return () => controller.unmount();
 });
 
@@ -202,7 +185,6 @@ $effect(() => {
   <div
     bind:this={menuRef}
     class="vizel-block-menu {className ?? ''}"
-    style="left: {menuState.x}px; top: {menuState.y}px;"
     role={spec.root.role}
     aria-label={spec.root["aria-label"]}
     data-vizel-block-menu

--- a/packages/vue/src/components/VizelBlockMenu.vue
+++ b/packages/vue/src/components/VizelBlockMenu.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import {
   buildVizelBlockMenuSpec,
-  clampMenuPosition,
   createVizelBlockMenuActions,
   createVizelBlockMenuTriggerController,
   createVizelNodeTypes,
@@ -15,7 +14,7 @@ import {
   vizelDefaultBlockMenuActions,
   vizelDefaultNodeTypes,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelPopoverController } from "@vizel/headless";
 import {
   computed,
   nextTick,
@@ -47,11 +46,6 @@ export interface VizelBlockMenuProps {
   locale?: VizelLocale;
 }
 
-interface BlockMenuState extends VizelBlockMenuOpenDetail {
-  x: number;
-  y: number;
-}
-
 const props = defineProps<VizelBlockMenuProps>();
 
 const contextEditor = useVizelContextSafe();
@@ -67,7 +61,7 @@ const effectiveNodeTypes = computed(
     props.nodeTypes ?? (props.locale ? createVizelNodeTypes(props.locale) : vizelDefaultNodeTypes)
 );
 
-const menuState = shallowRef<BlockMenuState | null>(null);
+const menuState = shallowRef<VizelBlockMenuOpenDetail | null>(null);
 const showTurnInto = ref(false);
 const submenuFlipped = ref(false);
 const menuRef = useTemplateRef<HTMLDivElement>("menuRef");
@@ -162,21 +156,33 @@ watch(showTurnInto, (isOpen) => {
   });
 });
 
-// The submenu lives inside `menuRef`, so a single mount target covers both
-// surfaces for outside-pointer detection. Escape keeps v1's semantics (close
-// without preventDefault), so `captureEscape` stays off.
-const dismissable = createVizelDismissable({
-  onPointerOutside: close,
-  onEscape: close,
+// Anchor the menu to the captured drag-handle rect through a virtual
+// element: the handle is a transient overlay node, so the menu reads its
+// geometry rather than holding an element reference. The popover
+// controller positions the body with floating-ui flip/shift (which
+// replaces the former manual clamp) and owns the pointer-outside and
+// Escape listeners. The submenu lives inside `menuRef`, so the single
+// body mount target also covers it for outside-pointer detection.
+const popover = createVizelPopoverController({
+  getAnchor: () => {
+    const rect = menuState.value?.handleRect;
+    return rect ? { getBoundingClientRect: () => rect } : null;
+  },
+  getBody: () => menuRef.value,
+  placement: "bottom-start",
+  offset: 4,
+  onDismiss: close,
+  dismissOnEscape: true,
 });
 
 watch(
   [menuState, menuRef],
   ([state, menu]) => {
+    // Re-mount on every open so floating-ui re-positions against the
+    // fresh drag-handle rect; `unmount` is a no-op when not yet mounted.
+    popover.unmount();
     if (state && menu) {
-      dismissable.mount(menu);
-    } else {
-      dismissable.unmount();
+      popover.mount();
     }
   },
   { flush: "post" }
@@ -188,19 +194,8 @@ watch(
 const triggerController = createVizelBlockMenuTriggerController({
   onOpen: (detail: VizelBlockMenuOpenDetail) => {
     if (boundEditor.value && detail.editor !== boundEditor.value) return;
-    menuState.value = {
-      ...detail,
-      x: detail.handleRect.left,
-      y: detail.handleRect.bottom + 4,
-    };
+    menuState.value = detail;
     showTurnInto.value = false;
-
-    void nextTick(() => {
-      const el = menuRef.value;
-      if (!(el && menuState.value)) return;
-      const clamped = clampMenuPosition(detail.handleRect, el.offsetWidth, el.offsetHeight);
-      menuState.value = { ...menuState.value, x: clamped.x, y: clamped.y };
-    });
   },
 });
 
@@ -210,7 +205,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   triggerController.unmount();
-  dismissable.unmount();
+  popover.unmount();
 });
 </script>
 
@@ -219,7 +214,6 @@ onBeforeUnmount(() => {
     v-if="menuState"
     ref="menuRef"
     :class="['vizel-block-menu', $props.class]"
-    :style="{ left: menuState.x + 'px', top: menuState.y + 'px' }"
     :role="spec.root.role"
     :aria-label="spec.root['aria-label']"
     data-vizel-block-menu

--- a/tests/ct/svelte/playwright-ct.config.ts
+++ b/tests/ct/svelte/playwright-ct.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
           "@vizel/svelte": resolve(import.meta.dirname, "../../../packages/svelte/src"),
         },
       },
+      // `@vizel/headless` resolves to source, so Vite discovers
+      // `@floating-ui/dom` only after it has chunked the entry. Pre-bundle
+      // the dependency to a clean ES module up front; without this the
+      // Svelte CT build references esbuild's `__commonJSMin` interop helper
+      // before it is defined and the mount throws at runtime.
+      optimizeDeps: {
+        include: ["@floating-ui/dom"],
+      },
     },
   },
   projects: [


### PR DESCRIPTION
## Summary

Phase C / PR-2b: adopt the `@vizel/headless/popover` primitive in `VizelBlockMenu` — its first internal consumer (PR-2 shipped the primitive unused). `VizelBlockMenu` is the one JS-positioned floating popover in the product (it anchors to the drag-handle rect).

- All three `VizelBlockMenu` adapters drop the bespoke `clampMenuPosition` + inline `left`/`top` + separate `createVizelDismissable` and mount a single `createVizelPopoverController`: a `@floating-ui/dom` **virtual anchor** at the captured drag-handle rect, `placement: "bottom-start"`, `offset: 4`, with `flip()`/`shift()` keeping it in the viewport, and `dismissOnEscape`.
- Widened the `floating` primitive's `getAnchor` to `HTMLElement | VizelVirtualElement` (`{ getBoundingClientRect(): DOMRect }`) — `@floating-ui/dom` already supports virtual references, so this is a type-surface widening. Added virtual-anchor unit tests.
- Removed `clampMenuPosition` + `MenuPosition` from `@vizel/core` (only the block menus used them). Kept `shouldFlipSubmenu` (the "Turn into" submenu is a CSS flyout, not a JS-positioned body).

## Breaking Changes

- `clampMenuPosition` / `MenuPosition` are removed from `@vizel/core`. v2.0.0 is unreleased.

## Test Plan

- [x] `pnpm --filter @vizel/headless test` → 35 (virtual-anchor tests added).
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS — ADR-0007 controller-delegation + 120-line stay green), `check:ssr`/`check:nolet`/`check:scenarios`/`check:ct-parity`.
- [x] `pnpm test:ct:{react,vue,svelte} --project=chromium` → BlockMenu 9/9 each.
- [x] Browser (Svelte demo — the first floating-ui consumer, highest risk): hovering a block reveals the drag handle; clicking it opens the block menu positioned `bottom-start` at the handle (handle 704,359 → menu 704,387), 5 items, console clean; Escape dismisses; `@floating-ui/dom` resolves in both the dev server and a production `vite build` (no CJS-interop error).
