### PR TITLE
feat(headless): add focus-trap primitive and adopt in modal forms

### DIFF
--- a/packages/headless/__tests__/focus-trap.test.ts
+++ b/packages/headless/__tests__/focus-trap.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the focus-trap primitive.
+ *
+ * The controller reads `document.activeElement`, queries focusable
+ * elements, attaches a `keydown` listener to the trapped element, and
+ * moves focus. The suite builds a minimal fake DOM that models those
+ * operations — element `focus()` writes back to `document.activeElement`,
+ * `querySelectorAll` returns the seeded children, and `contains` reports
+ * ancestry — so the headless package stays free of a DOM-emulation
+ * dependency, matching the dismissable and keyboard suites.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  buildVizelFocusTrapSpec,
+  createVizelFocusTrapController,
+} from "../src/focus-trap/index.ts";
+
+/**
+ * The shared mutable focus state. `focus()` on any fake element writes
+ * its node here so the controller reads it through `document.activeElement`.
+ */
+const env = {
+  activeElement: null as FakeElement | null,
+};
+
+/**
+ * Minimal stand-in for the `HTMLElement` surface the controller touches:
+ * `focus()`, `addEventListener`/`removeEventListener` for `keydown`,
+ * `contains`, the focusability properties, and `isConnected`. A real
+ * `KeyboardEvent` is unnecessary because the handler reads only `key`,
+ * `shiftKey`, and `preventDefault`.
+ */
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly listeners: ((event: KeyboardEvent) => void)[] = [];
+  parent: FakeElement | null = null;
+  disabled = false;
+  hidden = false;
+  ariaHidden: string | null = null;
+  rendered = true;
+  isConnected = true;
+  focusCount = 0;
+
+  get offsetParent(): FakeElement | null {
+    return this.rendered ? (this.parent ?? this) : null;
+  }
+
+  hasAttribute(name: string): boolean {
+    return name === "disabled" ? this.disabled : false;
+  }
+
+  getAttribute(name: string): string | null {
+    return name === "aria-hidden" ? this.ariaHidden : null;
+  }
+
+  focus(): void {
+    this.focusCount += 1;
+    env.activeElement = this;
+  }
+
+  contains(node: unknown): boolean {
+    if (node === this) return true;
+    return this.children.some((child) => child.contains(node));
+  }
+
+  querySelectorAll(_selector: string): FakeElement[] {
+    // The controller filters the result with its own focusability guard,
+    // so the fake returns every descendant and lets the guard decide.
+    return this.descendants();
+  }
+
+  querySelector(_selector: string): FakeElement | null {
+    return this.descendants()[0] ?? null;
+  }
+
+  addEventListener(type: string, handler: (event: KeyboardEvent) => void): void {
+    if (type === "keydown") this.listeners.push(handler);
+  }
+
+  removeEventListener(type: string, handler: (event: KeyboardEvent) => void): void {
+    if (type !== "keydown") return;
+    const index = this.listeners.indexOf(handler);
+    if (index !== -1) this.listeners.splice(index, 1);
+  }
+
+  dispatchKeydown(event: { key: string; shiftKey?: boolean }): boolean {
+    const calls = { prevented: false };
+    const full = {
+      key: event.key,
+      shiftKey: event.shiftKey ?? false,
+      preventDefault: () => {
+        calls.prevented = true;
+      },
+    } as unknown as KeyboardEvent;
+    for (const handler of [...this.listeners]) handler(full);
+    return calls.prevented;
+  }
+
+  private descendants(): FakeElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+/**
+ * Build a target element seeded with `count` focusable children.
+ */
+function createTarget(count: number): FakeElement {
+  const target = new FakeElement();
+  for (const _ of Array.from({ length: count })) {
+    const child = new FakeElement();
+    child.parent = target;
+    target.children.push(child);
+  }
+  return target;
+}
+
+function asElement(element: FakeElement): HTMLElement {
+  return element as unknown as HTMLElement;
+}
+
+describe("buildVizelFocusTrapSpec", () => {
+  it("resolves defaults when no options are passed", () => {
+    assert.deepEqual(buildVizelFocusTrapSpec(), {
+      initialFocusSelector: null,
+      returnFocusOnUnmount: true,
+    });
+  });
+
+  it("passes through an initial-focus selector and a return-focus opt-out", () => {
+    assert.deepEqual(
+      buildVizelFocusTrapSpec({ initialFocusSelector: ".x", returnFocusOnUnmount: false }),
+      { initialFocusSelector: ".x", returnFocusOnUnmount: false }
+    );
+  });
+});
+
+describe("createVizelFocusTrapController", () => {
+  beforeEach(() => {
+    env.activeElement = null;
+    (globalThis as { document?: unknown }).document = {
+      get activeElement() {
+        return env.activeElement;
+      },
+    };
+    // The controller narrows the recorded active element with
+    // `instanceof HTMLElement`; expose the fake base as the global so the
+    // guard passes inside the Node runner.
+    (globalThis as { HTMLElement?: unknown }).HTMLElement = FakeElement;
+  });
+  afterEach(() => {
+    (globalThis as { document?: unknown }).document = undefined;
+    (globalThis as { HTMLElement?: unknown }).HTMLElement = undefined;
+  });
+
+  it("moves focus to the first focusable element on mount", () => {
+    const target = createTarget(3);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+    assert.equal(env.activeElement, target.children[0]);
+    assert.equal(target.children[0].focusCount, 1);
+  });
+
+  it("focuses the initialFocusSelector match when one is supplied", () => {
+    const target = createTarget(3);
+    // The fake `querySelector` returns the first descendant; assert the
+    // controller routes through the selector branch by checking the
+    // matched element receives focus.
+    const controller = createVizelFocusTrapController({ initialFocusSelector: "input" });
+    controller.mount(asElement(target));
+    assert.equal(env.activeElement, target.children[0]);
+  });
+
+  it("wraps focus from the last element to the first on Tab", () => {
+    const target = createTarget(3);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+
+    // Move focus to the last element, then press Tab.
+    target.children[2].focus();
+    const prevented = target.dispatchKeydown({ key: "Tab" });
+
+    assert.equal(prevented, true);
+    assert.equal(env.activeElement, target.children[0]);
+  });
+
+  it("wraps focus from the first element to the last on Shift+Tab", () => {
+    const target = createTarget(3);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+
+    // Focus already sits on the first element after mount; press Shift+Tab.
+    const prevented = target.dispatchKeydown({ key: "Tab", shiftKey: true });
+
+    assert.equal(prevented, true);
+    assert.equal(env.activeElement, target.children[2]);
+  });
+
+  it("leaves a mid-list Tab to the browser", () => {
+    const target = createTarget(3);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+
+    // Focus the middle element; Tab there does not wrap, so the controller
+    // does not call preventDefault and the browser advances focus.
+    target.children[1].focus();
+    const prevented = target.dispatchKeydown({ key: "Tab" });
+    assert.equal(prevented, false);
+  });
+
+  it("ignores non-Tab keys, leaving Escape to the dismissable", () => {
+    const target = createTarget(3);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+
+    const prevented = target.dispatchKeydown({ key: "Escape" });
+    assert.equal(prevented, false);
+  });
+
+  it("returns focus to the previously-active element on unmount", () => {
+    const trigger = new FakeElement();
+    trigger.focus();
+    assert.equal(env.activeElement, trigger);
+
+    const target = createTarget(2);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+    // Mount moved focus into the trap.
+    assert.equal(env.activeElement, target.children[0]);
+
+    controller.unmount();
+    assert.equal(env.activeElement, trigger);
+    assert.equal(trigger.focusCount, 2);
+  });
+
+  it("skips focus restoration when returnFocusOnUnmount is false", () => {
+    const trigger = new FakeElement();
+    trigger.focus();
+
+    const target = createTarget(2);
+    const controller = createVizelFocusTrapController({ returnFocusOnUnmount: false });
+    controller.mount(asElement(target));
+    controller.unmount();
+
+    // Focus stays on the last element the trap focused, not the trigger.
+    assert.equal(env.activeElement, target.children[0]);
+    assert.equal(trigger.focusCount, 1);
+  });
+
+  it("does not restore focus to a disconnected trigger", () => {
+    const trigger = new FakeElement();
+    trigger.focus();
+
+    const target = createTarget(2);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+    // The trigger leaves the document before the trap closes.
+    trigger.isConnected = false;
+    const focusBefore = trigger.focusCount;
+    controller.unmount();
+
+    assert.equal(trigger.focusCount, focusBefore);
+  });
+
+  it("detaches the keydown listener on unmount and tolerates repeat calls", () => {
+    const target = createTarget(2);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+    assert.equal(target.listeners.length, 1);
+
+    controller.unmount();
+    controller.unmount();
+    assert.equal(target.listeners.length, 0);
+  });
+
+  it("pins focus inside an empty trap so Tab cannot escape", () => {
+    const target = createTarget(0);
+    const controller = createVizelFocusTrapController();
+    controller.mount(asElement(target));
+
+    const prevented = target.dispatchKeydown({ key: "Tab" });
+    assert.equal(prevented, true);
+  });
+});

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/floating/index.js",
       "default": "./dist/floating/index.js"
     },
+    "./focus-trap": {
+      "types": "./dist/focus-trap/index.d.ts",
+      "import": "./dist/focus-trap/index.js",
+      "default": "./dist/focus-trap/index.js"
+    },
     "./keyboard": {
       "types": "./dist/keyboard/index.d.ts",
       "import": "./dist/keyboard/index.js",

--- a/packages/headless/src/focus-trap/index.ts
+++ b/packages/headless/src/focus-trap/index.ts
@@ -1,0 +1,296 @@
+/**
+ * Focus-trap primitive.
+ *
+ * Confines keyboard focus to one element subtree while a modal-style
+ * surface is open. Vizel's link editor and find-replace forms open over
+ * the editor as popover forms; a keyboard user who presses Tab past the
+ * last field must wrap to the first field instead of escaping into the
+ * page behind the form. ADR-0003 (headless package) records why the trap
+ * lives in `@vizel/headless` rather than each adapter, and lists the link
+ * editor and find-replace as its intended consumers; ADR-0007 (controller
+ * delegation) records why the DOM-touching variant follows the
+ * `{ mount, unmount, update }` contract so adapter components attach no
+ * listeners themselves.
+ *
+ * `buildVizelFocusTrapSpec` is pure: it merges caller options with the
+ * defaults and returns the resolved spec, so a test or a server render
+ * reads the configuration without a DOM. `createVizelFocusTrapController`
+ * owns the `keydown` listener on the trapped element and the focus moves.
+ *
+ * The controller composes with {@link createVizelDismissable}: the
+ * dismissable still closes the surface on Escape or an outside pointer,
+ * and the trap's `unmount` returns focus to the previously-active element
+ * once the surface closes. The trap deliberately ignores Escape so the
+ * dismissable remains the single owner of the close gesture.
+ */
+
+/**
+ * CSS selector matching the elements the trap treats as focusable.
+ *
+ * The list covers the natively-focusable form controls plus anchors with
+ * an `href` and any element carrying a non-negative `tabindex`. The
+ * `:not([tabindex="-1"])` clause drops elements explicitly removed from
+ * the tab order; the per-element visibility and `disabled` checks in
+ * {@link collectFocusable} drop the rest, because a CSS selector alone
+ * cannot observe computed visibility.
+ */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+const isBrowser = (): boolean => typeof document !== "undefined";
+
+/**
+ * Report whether an element can currently receive focus.
+ *
+ * The guard rejects a disabled control and an element the layout engine
+ * does not render (`offsetParent === null` covers `display: none` and a
+ * `display: none` ancestor). A `hidden` attribute also disqualifies the
+ * element. The check reads only properties present on a real
+ * `HTMLElement`, so a Server-Side Rendering (SSR) run never reaches it.
+ */
+const isFocusable = (element: HTMLElement): boolean => {
+  if (element.hasAttribute("disabled")) return false;
+  if (element.getAttribute("aria-hidden") === "true") return false;
+  if (element.hidden) return false;
+  // `offsetParent` is `null` for an element rendered with `display: none`
+  // (directly or through an ancestor). A trapped form hides optional rows
+  // conditionally, so this check excludes the rows the framework did not
+  // render into the visible tree.
+  return element.offsetParent !== null;
+};
+
+/**
+ * Collect the focusable elements inside `target` in document order.
+ *
+ * The function queries {@link FOCUSABLE_SELECTOR} and then filters with
+ * {@link isFocusable} so hidden or disabled matches drop out. The result
+ * drives both the initial focus move and the Tab wraparound.
+ */
+const collectFocusable = (target: HTMLElement): readonly HTMLElement[] => {
+  const matches = Array.from(target.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  return matches.filter(isFocusable);
+};
+
+/**
+ * Options shared by {@link buildVizelFocusTrapSpec} and
+ * {@link createVizelFocusTrapController}.
+ */
+export interface VizelFocusTrapOptions {
+  /**
+   * CSS selector for the element that receives focus on mount. When the
+   * selector matches nothing, or stays unset, the trap focuses the first
+   * focusable element inside the target. The link editor uses the default
+   * so focus lands on the URL input; a consumer that wants a different
+   * initial field passes a selector.
+   */
+  readonly initialFocusSelector?: string;
+  /**
+   * When `true` (the default), `unmount` returns focus to the element
+   * that held focus at mount time. A consumer that manages the return
+   * itself — for example a find-replace panel that focuses the editor in
+   * its own close handler — passes `false`.
+   */
+  readonly returnFocusOnUnmount?: boolean;
+}
+
+/**
+ * Resolved focus-trap configuration returned by
+ * {@link buildVizelFocusTrapSpec}.
+ *
+ * Every optional input resolves to a concrete value so a caller reads the
+ * effective behaviour without re-applying defaults. `initialFocusSelector`
+ * stays `null` when the caller supplies none, signalling "focus the first
+ * focusable element".
+ */
+export interface VizelFocusTrapSpec {
+  /** The resolved initial-focus selector, or `null` for first-focusable. */
+  readonly initialFocusSelector: string | null;
+  /** Whether `unmount` restores focus to the pre-mount element. */
+  readonly returnFocusOnUnmount: boolean;
+}
+
+/**
+ * Return the resolved focus-trap spec for the supplied options.
+ *
+ * The function is pure and Server-Side Rendering (SSR) safe; it merges the
+ * caller options with the defaults (`initialFocusSelector: null`,
+ * `returnFocusOnUnmount: true`) and returns the resolved spec.
+ *
+ * @example
+ * ```ts
+ * const spec = buildVizelFocusTrapSpec();
+ * // spec === { initialFocusSelector: null, returnFocusOnUnmount: true }
+ * ```
+ */
+export function buildVizelFocusTrapSpec(options: VizelFocusTrapOptions = {}): VizelFocusTrapSpec {
+  return {
+    initialFocusSelector: options.initialFocusSelector ?? null,
+    returnFocusOnUnmount: options.returnFocusOnUnmount !== false,
+  };
+}
+
+/**
+ * Returned by {@link createVizelFocusTrapController}.
+ *
+ * The controller owns the `keydown` listener on the trapped element and
+ * the focus moves, following the `{ mount, unmount, update }` contract
+ * ADR-0007 mandates.
+ */
+export interface VizelFocusTrapController {
+  /**
+   * Trap focus inside `target`. The controller records the active
+   * element, moves focus to the initial element, and installs the
+   * `keydown` listener. Re-mounting on a different target unmounts the
+   * previous target first.
+   */
+  mount(target: HTMLElement): void;
+  /**
+   * Detach the listener and, unless `returnFocusOnUnmount` is `false`,
+   * restore focus to the element that held it at mount time. Calling
+   * `unmount` more than once is a no-op.
+   */
+  unmount(): void;
+  /** Replace the options without re-attaching the listener. */
+  update(options: VizelFocusTrapOptions): void;
+}
+
+/**
+ * Resolve the element that receives focus on mount.
+ *
+ * The function prefers an `initialFocusSelector` match inside `target`
+ * (when the match is focusable) and falls back to the first focusable
+ * element. It returns `null` when the target holds no focusable element,
+ * leaving focus where the browser placed it.
+ */
+const resolveInitialFocus = (
+  target: HTMLElement,
+  spec: VizelFocusTrapSpec,
+  focusable: readonly HTMLElement[]
+): HTMLElement | null => {
+  if (spec.initialFocusSelector !== null) {
+    const preferred = target.querySelector<HTMLElement>(spec.initialFocusSelector);
+    if (preferred !== null && isFocusable(preferred)) return preferred;
+  }
+  return focusable[0] ?? null;
+};
+
+/**
+ * Construct a focus-trap controller for a modal-style surface.
+ *
+ * The controller wires three concerns under one `{ mount, unmount }`
+ * lifecycle:
+ *
+ * 1. **Initial focus.** `mount` records `document.activeElement`, then
+ *    focuses the `initialFocusSelector` match or the first focusable
+ *    element inside the target.
+ * 2. **Tab containment.** A `keydown` listener intercepts Tab and
+ *    Shift+Tab. When focus sits on the last focusable element, Tab wraps
+ *    to the first; when focus sits on the first, Shift+Tab wraps to the
+ *    last. The listener computes the focusable set on every keystroke so
+ *    a form that shows or hides rows mid-interaction wraps correctly.
+ * 3. **Return focus.** `unmount` restores focus to the recorded element
+ *    unless `returnFocusOnUnmount` is `false`.
+ *
+ * The controller never handles Escape: {@link createVizelDismissable}
+ * owns the close gesture, so the two controllers compose without fighting
+ * over the key. Server-Side Rendering (SSR) safe: `mount` short-circuits
+ * when the DOM is unavailable.
+ *
+ * @example
+ * ```ts
+ * const trap = createVizelFocusTrapController();
+ * trap.mount(formElement); // focuses the first field, traps Tab
+ * // teardown: trap.unmount(); // returns focus to the trigger
+ * ```
+ */
+export function createVizelFocusTrapController(
+  initialOptions: VizelFocusTrapOptions = {}
+): VizelFocusTrapController {
+  const state = {
+    options: initialOptions,
+    target: null as HTMLElement | null,
+    previousActive: null as HTMLElement | null,
+    keydownHandler: null as ((event: KeyboardEvent) => void) | null,
+  };
+
+  const handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== "Tab") return;
+    const target = state.target;
+    if (target === null) return;
+    const focusable = collectFocusable(target);
+    const first = focusable.at(0);
+    const last = focusable.at(-1);
+    if (first === undefined || last === undefined) {
+      // Nothing to focus inside the trap; keep focus pinned to the target
+      // so Tab does not escape into the page behind the surface.
+      event.preventDefault();
+      return;
+    }
+    const active = isBrowser() ? document.activeElement : null;
+    if (event.shiftKey) {
+      // Shift+Tab from the first element (or from outside the focusable
+      // set) wraps to the last element.
+      if (active === first || !target.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+    // Tab from the last element (or from outside the focusable set) wraps
+    // to the first element.
+    if (active === last || !target.contains(active)) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const detachListener = (): void => {
+    if (state.keydownHandler !== null && state.target !== null) {
+      state.target.removeEventListener("keydown", state.keydownHandler);
+    }
+    state.keydownHandler = null;
+  };
+
+  return {
+    mount(target: HTMLElement): void {
+      if (!isBrowser()) return;
+      if (state.target === target) return;
+      if (state.target !== null) detachListener();
+      state.target = target;
+      // Record the focused element before the move so `unmount` can
+      // restore it. `document.activeElement` is the trigger that opened
+      // the surface (a bubble-menu button or a shortcut-focused editor).
+      const active = document.activeElement;
+      state.previousActive = active instanceof HTMLElement ? active : null;
+      const spec = buildVizelFocusTrapSpec(state.options);
+      const focusable = collectFocusable(target);
+      resolveInitialFocus(target, spec, focusable)?.focus();
+      state.keydownHandler = handleKeydown;
+      target.addEventListener("keydown", handleKeydown);
+    },
+    unmount(): void {
+      if (state.target === null) return;
+      detachListener();
+      const spec = buildVizelFocusTrapSpec(state.options);
+      const previous = state.previousActive;
+      state.target = null;
+      state.previousActive = null;
+      // Restore focus only when the recorded element is still connected:
+      // the surface may have closed by a path that already removed the
+      // trigger, in which case focusing a detached node throws or silently
+      // no-ops. The `isConnected` guard keeps the restore best-effort.
+      if (spec.returnFocusOnUnmount && previous?.isConnected) {
+        previous.focus();
+      }
+    },
+    update(options: VizelFocusTrapOptions): void {
+      state.options = options;
+    },
+  };
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -20,9 +20,12 @@
  * - `popover/` composes `floating/` with `dismissable/` for the
  *   anchored block menu, toolbar dropdown, node selector, and color
  *   picker surfaces. `@vizel/core`'s popover controller re-exports it.
+ * - `focus-trap/` confines keyboard focus to a modal-style surface; the
+ *   link editor and find-replace forms mount it to keep Tab inside the
+ *   form and to return focus to the trigger on close.
  *
- * The remaining primitives (combobox, focus-trap) land in follow-up
- * commits alongside each adapter rewrite that needs them.
+ * The remaining primitive (combobox) lands in a follow-up commit
+ * alongside the adapter rewrite that needs it.
  */
 
 export {
@@ -42,6 +45,13 @@ export {
   type VizelFloatingSpecOptions,
   type VizelVirtualElement,
 } from "./floating/index.ts";
+export {
+  buildVizelFocusTrapSpec,
+  createVizelFocusTrapController,
+  type VizelFocusTrapController,
+  type VizelFocusTrapOptions,
+  type VizelFocusTrapSpec,
+} from "./focus-trap/index.ts";
 export {
   buildVizelGridNavSpec,
   buildVizelListNavSpec,

--- a/packages/headless/vite.config.ts
+++ b/packages/headless/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         index: resolve(__dirname, "src/index.ts"),
         "dismissable/index": resolve(__dirname, "src/dismissable/index.ts"),
         "floating/index": resolve(__dirname, "src/floating/index.ts"),
+        "focus-trap/index": resolve(__dirname, "src/focus-trap/index.ts"),
         "keyboard/index": resolve(__dirname, "src/keyboard/index.ts"),
         "popover/index": resolve(__dirname, "src/popover/index.ts"),
       },

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -5,6 +5,7 @@ import {
   resolveVizelFindReplaceLabels,
   type VizelLocale,
 } from "@vizel/core";
+import { createVizelFocusTrapController } from "@vizel/headless";
 import {
   type ChangeEvent,
   type KeyboardEvent,
@@ -36,7 +37,13 @@ export interface VizelFindReplaceProps {
 }
 
 /**
- * Find & Replace panel component for React
+ * Find and replace panel component for React.
+ *
+ * `createVizelFocusTrapController` from `@vizel/headless` traps Tab inside
+ * the panel and focuses the find input on open (replacing the former
+ * ad-hoc input focus). The panel keeps its own Escape and editor-return
+ * handling, so the trap mounts with `returnFocusOnUnmount: false`:
+ * `handleClose` focuses `editor.view.dom` directly (ADR-0007).
  */
 export function VizelFindReplace({
   editor: editorProp,
@@ -50,7 +57,7 @@ export function VizelFindReplace({
   const [findText, setFindText] = useState("");
   const [replaceText, setReplaceText] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
-  const findInputRef = useRef<HTMLInputElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // Read the Find & Replace plugin state through the flagship
   // `useVizelEditorState` primitive (ADR-0004), replacing the hand-rolled
@@ -65,12 +72,18 @@ export function VizelFindReplace({
     { editor }
   );
 
-  // Focus input when panel opens
+  // Trap focus inside the panel while it is open. The trap focuses the
+  // find input on open and wraps Tab within the panel; it returns no
+  // focus on close because `handleClose` focuses `editor.view.dom`
+  // itself. The effect keys on the open state so the trap mounts when the
+  // panel renders and unmounts when it closes (ADR-0007).
   useEffect(() => {
-    if (state?.isOpen) {
-      findInputRef.current?.focus();
-      findInputRef.current?.select();
-    }
+    if (!state?.isOpen) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusTrap = createVizelFocusTrapController({ returnFocusOnUnmount: false });
+    focusTrap.mount(panel);
+    return () => focusTrap.unmount();
   }, [state?.isOpen]);
 
   const handleFindInputChange = useCallback(
@@ -156,13 +169,13 @@ export function VizelFindReplace({
 
   return (
     <div
+      ref={panelRef}
       className={`vizel-find-replace-panel ${className || ""}`}
       role="dialog"
       aria-label={labels.label}
     >
       <div className="vizel-find-replace-row">
         <input
-          ref={findInputRef}
           type="text"
           className="vizel-find-replace-input"
           placeholder={labels.findPlaceholder}

--- a/packages/react/src/components/VizelLinkEditor.tsx
+++ b/packages/react/src/components/VizelLinkEditor.tsx
@@ -5,7 +5,7 @@ import {
   resolveVizelLinkEditorLabels,
   type VizelLocale,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelDismissable, createVizelFocusTrapController } from "@vizel/headless";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVizelContextSafe } from "./VizelContext.tsx";
 import { VizelIcon } from "./VizelIcon.tsx";
@@ -37,6 +37,9 @@ export interface VizelLinkEditorProps {
  * `createVizelDismissable` from `@vizel/headless`; `deferPointerHandler`
  * mirrors v1's `setTimeout(..., 0)` install so the opening pointerdown
  * does not register as an outside click (ADR-0003, ADR-0007).
+ * `createVizelFocusTrapController` traps Tab inside the form, focuses the
+ * URL input on open, and returns focus to the bubble-menu trigger on
+ * close, so the two headless controllers own every form-level listener.
  */
 export function VizelLinkEditor({
   editor: editorProp,
@@ -56,16 +59,11 @@ export function VizelLinkEditor({
   const [openInNewTab, setOpenInNewTab] = useState(initialState?.initialOpenInNewTab ?? false);
   const [asEmbed, setAsEmbed] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   const viewState = useMemo(
     () => (editor ? buildVizelLinkEditorSpec(editor, url, enableEmbed) : null),
     [editor, url, enableEmbed]
   );
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
 
   // Forward the latest `onClose` to the controller without re-mounting so
   // a prop change does not detach the listener mid-interaction.
@@ -96,7 +94,18 @@ export function VizelLinkEditor({
       deferPointerHandler: true,
     });
     controller.mount(form);
-    return () => controller.unmount();
+
+    // The focus trap moves focus to the URL input on open (replacing the
+    // former ad-hoc input focus), keeps Tab cycling inside the form, and
+    // returns focus to the bubble-menu trigger when the form unmounts. It
+    // ignores Escape so the dismissable stays the sole owner of the close
+    // gesture. ADR-0007 delegates these listeners to the controller.
+    const focusTrap = createVizelFocusTrapController();
+    focusTrap.mount(form);
+    return () => {
+      controller.unmount();
+      focusTrap.unmount();
+    };
   }, [hasFormTarget]);
 
   const handleSubmit = useCallback(
@@ -131,7 +140,6 @@ export function VizelLinkEditor({
     <form ref={formRef} onSubmit={handleSubmit} className={`vizel-link-editor ${className ?? ""}`}>
       <div className="vizel-link-editor-row">
         <input
-          ref={inputRef}
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}

--- a/packages/svelte/src/components/VizelFindReplace.svelte
+++ b/packages/svelte/src/components/VizelFindReplace.svelte
@@ -25,6 +25,7 @@ import {
   resolveVizelFindReplaceLabels,
   type VizelFindReplaceState,
 } from "@vizel/core";
+import { createVizelFocusTrapController } from "@vizel/headless";
 import { tick } from "svelte";
 import { getVizelContextSafe } from "./VizelContext.js";
 
@@ -47,7 +48,7 @@ let findText = $state("");
 let replaceText = $state("");
 let caseSensitive = $state(false);
 let findReplaceState = $state(emptyState);
-let findInputRef: HTMLInputElement | null = $state(null);
+let panelElement: HTMLDivElement | null = $state(null);
 
 const view = $derived(buildVizelFindReplaceSpec(findReplaceState, labels.noResults));
 const isOpen = $derived(view.isOpen);
@@ -70,14 +71,18 @@ $effect(() => {
   return undefined;
 });
 
-// Focus input when panel opens
+// Trap focus inside the panel while it is open. The trap focuses the find
+// input on open (replacing the former `findInputRef.focus()`) and wraps
+// Tab within the panel. It returns no focus on close because `handleClose`
+// focuses `editor.view.dom` itself (ADR-0007).
 $effect(() => {
-  if (isOpen && findInputRef) {
-    void tick().then(() => {
-      findInputRef?.focus();
-      findInputRef?.select();
-    });
+  if (isOpen && panelElement) {
+    const focusTrap = createVizelFocusTrapController({ returnFocusOnUnmount: false });
+    const element = panelElement;
+    void tick().then(() => focusTrap.mount(element));
+    return () => focusTrap.unmount();
   }
+  return undefined;
 });
 
 function handleFindInputChange(e: Event) {
@@ -142,13 +147,13 @@ function handleKeyDown(e: KeyboardEvent) {
 
 {#if isOpen}
   <div
+    bind:this={panelElement}
     class={`vizel-find-replace-panel ${className || ""}`}
     role="dialog"
     aria-label={labels.label}
   >
     <div class="vizel-find-replace-row">
       <input
-        bind:this={findInputRef}
         type="text"
         class="vizel-find-replace-input"
         placeholder={labels.findPlaceholder}

--- a/packages/svelte/src/components/VizelLinkEditor.svelte
+++ b/packages/svelte/src/components/VizelLinkEditor.svelte
@@ -26,13 +26,16 @@ export interface VizelLinkEditorProps {
  * `createVizelDismissable` from `@vizel/headless`; `deferPointerHandler`
  * mirrors v1's `setTimeout(..., 0)` install so the opening pointerdown
  * does not register as an outside click (ADR-0003, ADR-0007).
+ * `createVizelFocusTrapController` traps Tab inside the form, focuses the
+ * URL input on open, and returns focus to the bubble-menu trigger on
+ * close.
  */
 import {
   applyVizelLinkEdit,
   buildVizelLinkEditorSpec,
   resolveVizelLinkEditorLabels,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelDismissable, createVizelFocusTrapController } from "@vizel/headless";
 import { untrack } from "svelte";
 import { getVizelContextSafe } from "./VizelContext.js";
 import VizelIcon from "./VizelIcon.svelte";
@@ -49,7 +52,6 @@ const contextEditor = getVizelContextSafe();
 const editor = $derived(editorProp ?? contextEditor?.current ?? null);
 
 let formElement = $state<HTMLFormElement | undefined>(undefined);
-let inputElement = $state<HTMLInputElement | undefined>(undefined);
 
 const labels = $derived(resolveVizelLinkEditorLabels(locale));
 let url = $state(
@@ -64,15 +66,9 @@ let asEmbed = $state(false);
 
 const viewState = $derived(editor ? buildVizelLinkEditorSpec(editor, url, enableEmbed) : null);
 
-// Focus the URL input on first mount so keyboard users land in the field
-// without an extra tab.
-$effect(() => {
-  inputElement?.focus();
-});
-
-// Mount the dismissable controller once the form element binds. Reading
-// `formElement` keeps the effect reactive to the bind:this assignment that
-// fires only after `viewState` becomes non-null.
+// Mount the dismissable and focus-trap controllers once the form element
+// binds. Reading `formElement` keeps the effect reactive to the bind:this
+// assignment that fires only after `viewState` becomes non-null.
 $effect(() => {
   if (!formElement) return;
 
@@ -90,7 +86,18 @@ $effect(() => {
     deferPointerHandler: true,
   });
   controller.mount(formElement);
-  return () => controller.unmount();
+
+  // The trap focuses the URL input on open (replacing the former
+  // `inputElement.focus()`), keeps Tab inside the form, and returns focus
+  // to the trigger on close. It ignores Escape so the dismissable stays
+  // the sole owner of the close gesture.
+  const focusTrap = createVizelFocusTrapController();
+  focusTrap.mount(formElement);
+
+  return () => {
+    controller.unmount();
+    focusTrap.unmount();
+  };
 });
 
 function handleSubmit(e: Event) {
@@ -122,7 +129,6 @@ function handleVisit() {
 >
   <div class="vizel-link-editor-row">
     <input
-      bind:this={inputElement}
       bind:value={url}
       type="url"
       placeholder={labels.urlPlaceholder}

--- a/packages/vue/src/components/VizelFindReplace.vue
+++ b/packages/vue/src/components/VizelFindReplace.vue
@@ -7,6 +7,7 @@ import {
   type VizelFindReplaceState,
   type VizelLocale,
 } from "@vizel/core";
+import { createVizelFocusTrapController } from "@vizel/headless";
 import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 
@@ -36,7 +37,13 @@ const findText = ref("");
 const replaceText = ref("");
 const caseSensitive = ref(false);
 const state = ref<VizelFindReplaceState | null>(null);
-const findInputRef = useTemplateRef<HTMLInputElement>("findInputRef");
+const panelRef = useTemplateRef<HTMLDivElement>("panelRef");
+
+// The focus trap focuses the find input on open (replacing the former
+// `findInputRef.focus()`) and wraps Tab inside the panel. It returns no
+// focus on unmount because `handleClose` focuses `editor.view.dom`
+// directly (ADR-0007).
+const focusTrap = createVizelFocusTrapController({ returnFocusOnUnmount: false });
 
 const labels = computed(() => resolveVizelFindReplaceLabels(props.locale?.findReplace));
 const view = computed(() => buildVizelFindReplaceSpec(state.value, labels.value.noResults));
@@ -64,15 +71,19 @@ watch(
 
 onBeforeUnmount(() => {
   editorRef.value?.off("transaction", updateState);
+  focusTrap.unmount();
 });
 
-// Focus input when panel opens
+// Mount the focus trap when the panel opens and unmount it when it
+// closes. `nextTick` defers the mount until the panel renders so the trap
+// can find the panel element and its inputs.
 watch(isOpen, (open) => {
   if (open) {
     void nextTick(() => {
-      findInputRef.value?.focus();
-      findInputRef.value?.select();
+      if (panelRef.value) focusTrap.mount(panelRef.value);
     });
+  } else {
+    focusTrap.unmount();
   }
 });
 
@@ -139,13 +150,13 @@ function handleKeyDown(e: KeyboardEvent) {
 <template>
   <div
     v-if="isOpen"
+    ref="panelRef"
     :class="['vizel-find-replace-panel', props.class]"
     role="dialog"
     :aria-label="labels.label"
   >
     <div class="vizel-find-replace-row">
       <input
-        ref="findInputRef"
         type="text"
         class="vizel-find-replace-input"
         :placeholder="labels.findPlaceholder"

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -6,7 +6,7 @@ import {
   resolveVizelLinkEditorLabels,
   type VizelLocale,
 } from "@vizel/core";
-import { createVizelDismissable } from "@vizel/headless";
+import { createVizelDismissable, createVizelFocusTrapController } from "@vizel/headless";
 import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
@@ -39,7 +39,6 @@ const emit = defineEmits<{
 }>();
 
 const formRef = useTemplateRef<HTMLFormElement>("formRef");
-const inputRef = useTemplateRef<HTMLInputElement>("inputRef");
 
 const labels = computed(() => resolveVizelLinkEditorLabels(props.locale));
 const initialState = computed(() =>
@@ -68,27 +67,36 @@ const dismissable = createVizelDismissable({
   deferPointerHandler: true,
 });
 
+// The focus trap moves focus to the URL input on open (replacing the
+// former `inputRef.focus()`), keeps Tab cycling inside the form, and
+// returns focus to the bubble-menu trigger on unmount. It ignores Escape
+// so the dismissable stays the sole owner of the close gesture.
+const focusTrap = createVizelFocusTrapController();
+
 watch(
   [viewState, formRef],
   ([view, form]) => {
     if (view && form) {
       dismissable.mount(form);
+      focusTrap.mount(form);
     } else {
       dismissable.unmount();
+      focusTrap.unmount();
     }
   },
   { flush: "post" }
 );
 
 onMounted(() => {
-  inputRef.value?.focus();
   if (viewState.value && formRef.value) {
     dismissable.mount(formRef.value);
+    focusTrap.mount(formRef.value);
   }
 });
 
 onBeforeUnmount(() => {
   dismissable.unmount();
+  focusTrap.unmount();
 });
 
 function handleSubmit(e: Event) {
@@ -128,7 +136,6 @@ function handleVisit() {
   >
     <div class="vizel-link-editor-row">
       <input
-        ref="inputRef"
         v-model="url"
         type="url"
         :placeholder="labels.urlPlaceholder"


### PR DESCRIPTION
## Summary

Phase C / PR-3 of the `@vizel/headless` buildout (ADR-0003): adds the **`focus-trap`** primitive and adopts it in the two modal-style forms ADR-0003 names as its consumers — `VizelLinkEditor` and `VizelFindReplace` — across all three frameworks.

- **`packages/headless/src/focus-trap/`** — `buildVizelFocusTrapSpec` (pure defaults) + `createVizelFocusTrapController({ mount, unmount, update })`, mirroring the `dismissable` template (readonly options, closure state, `function` declarations, `isBrowser()` SSR guard). `mount(target)` records `document.activeElement`, focuses the first focusable element (or an `initialFocusSelector`), and installs a `keydown` listener on the target that wraps Tab/Shift+Tab within the form. The focusable set is recomputed on every Tab, so a form that shows or hides a row mid-interaction still wraps correctly. `unmount()` restores focus to the previously-active element unless `returnFocusOnUnmount: false`. The trap ignores all non-Tab keys (Escape passes through to the existing dismiss path). Added 13 `node:test` unit tests.
- **Adoption (3 frameworks each):**
  - `VizelLinkEditor` — the trap supplies initial focus and Tab containment; the existing `createVizelDismissable` (`captureEscape`, outside-click) stays the sole closer and returns focus to the bubble-menu trigger. The ad-hoc input-focus code and input refs are removed.
  - `VizelFindReplace` — the trap mounts on the panel root with `returnFocusOnUnmount: false` (the panel's own `handleClose` focuses `editor.view.dom`); the existing per-input Escape handling is unchanged. The search panel keeps its standard semantics (Escape from a field closes; clicking into the document keeps it open).
- No component attaches `document.*` / `window.*` listeners — ADR-0007 controller-delegation stays clean; every component stays under the 120-line view budget.

## Breaking Changes

- None for consumers. The `focus-trap` primitive is additive; the adopting components keep their public API. v2.0.0 is unreleased.

## Test Plan

- [x] `pnpm --filter @vizel/headless test` → 48 (35 prior + 13 focus-trap).
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS), `check:ssr`/`check:nolet`/`check:scenarios`/`check:ct-parity`.
- [x] `pnpm test:ct:{react,vue,svelte} --project=chromium` → 283 each (LinkEditor / FindReplace specs green, no spec edits needed).
- [x] Browser (React demo): link editor opens with focus on the URL input, Tab cycles url → submit → embed-toggle → url without escaping to the page, Shift+Tab wraps backward, Escape closes and returns focus to the editor; find-replace opens with focus on the Find input, Tab stays within the panel, Escape from the Find input closes it and returns focus to the editor; console clean throughout.
