### PR TITLE
feat(headless): add combobox primitive and adopt in suggestion menus

### DIFF
--- a/packages/core/src/builders/slash-menu.ts
+++ b/packages/core/src/builders/slash-menu.ts
@@ -40,13 +40,25 @@ export interface VizelSlashMenuSpecOptions {
 }
 
 /**
+ * Return the stable `role="option"` id for a slash item.
+ *
+ * The id matches the listbox root's `aria-activedescendant` when the item
+ * is the active selection. The prefix mirrors `vizel-mention-${id}` from
+ * `buildVizelMentionMenuSpec` so both suggestion menus follow the same
+ * combobox `aria-activedescendant` relationship.
+ */
+const slashOptionId = (item: VizelSlashCommandItem): string => `vizel-slash-${item.id}`;
+
+/**
  * Build a {@link VizelMenuSpec} for the slash command menu.
  *
  * Slash menus use `role="listbox"` and may render multiple sections
- * (groups) each with a header label. Items defer their own role / ARIA
- * to the framework `VizelSlashMenuItem` component (which is itself a
- * `role="option"` button), so the spec-level item `attrs` are empty —
- * the spec carries identity (key, index) and view data only.
+ * (groups) each with a header label. The active option carries the id the
+ * root's `aria-activedescendant` points at, matching
+ * `buildVizelMentionMenuSpec`. The framework `VizelSlashMenuItem` component
+ * owns the `role="option"` element, so the spec threads the id (and the
+ * selection flag) to that component while leaving the role itself to the
+ * component.
  *
  * The empty `sections` array represents the no-items state; the
  * component renders its default `VizelSlashMenuEmpty` (or a custom
@@ -58,10 +70,16 @@ export function buildVizelSlashMenuSpec(
   options: VizelSlashMenuSpecOptions = {}
 ): VizelMenuSpec<VizelSlashItemView> {
   const { showGroups = true, groupOrder } = options;
-  const rootAttrs = { role: "listbox", "aria-label": "Commands" } as const;
+  const activeItem = items[selectedIndex];
+  const activeId = activeItem ? slashOptionId(activeItem) : undefined;
+  const rootAttrs = {
+    role: "listbox",
+    "aria-label": "Commands",
+    ...(activeId && { "aria-activedescendant": activeId }),
+  } as const;
 
   if (items.length === 0) {
-    return { root: rootAttrs, sections: [] };
+    return { root: { role: "listbox", "aria-label": "Commands" }, sections: [] };
   }
 
   const groups =
@@ -84,7 +102,7 @@ export function buildVizelSlashMenuSpec(
         key: item.id,
         index,
         data: { item, isSelected: index === selectedIndex },
-        attrs: {},
+        attrs: { id: slashOptionId(item) },
       };
     });
     return {

--- a/packages/headless/__tests__/combobox.test.ts
+++ b/packages/headless/__tests__/combobox.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for the combobox primitive.
+ *
+ * The pure-resolver suite asserts that {@link buildVizelComboboxKeySpec}
+ * delegates navigation to the keyboard primitive and adds the
+ * combobox-specific verbs. The controller suite builds a minimal fake DOM —
+ * an element that records attribute writes and `keydown` listeners, plus
+ * `[role=option]` children with mutable ids — so the headless package stays
+ * free of a DOM-emulation dependency, matching the dismissable, keyboard,
+ * and focus-trap suites.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { buildVizelComboboxKeySpec, createVizelComboboxController } from "../src/combobox/index.ts";
+
+describe("buildVizelComboboxKeySpec", () => {
+  it("maps arrows and Home/End to navigate, delegating to the list resolver", () => {
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "ArrowDown", currentIndex: 0, length: 3 }), {
+      type: "navigate",
+      index: 1,
+    });
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "ArrowUp", currentIndex: 1, length: 3 }), {
+      type: "navigate",
+      index: 0,
+    });
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "Home", currentIndex: 2, length: 3 }), {
+      type: "navigate",
+      index: 0,
+    });
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "End", currentIndex: 0, length: 3 }), {
+      type: "navigate",
+      index: 2,
+    });
+  });
+
+  it("wraps the navigate index at both edges, inheriting list wraparound", () => {
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "ArrowDown", currentIndex: 2, length: 3 }), {
+      type: "navigate",
+      index: 0,
+    });
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "ArrowUp", currentIndex: 0, length: 3 }), {
+      type: "navigate",
+      index: 2,
+    });
+  });
+
+  it("maps Enter to select with the current index", () => {
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "Enter", currentIndex: 2, length: 3 }), {
+      type: "select",
+      index: 2,
+    });
+  });
+
+  it("maps Escape to close", () => {
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "Escape", currentIndex: 1, length: 3 }), {
+      type: "close",
+    });
+  });
+
+  it("maps Tab to groupNext", () => {
+    assert.deepEqual(buildVizelComboboxKeySpec({ key: "Tab", currentIndex: 0, length: 3 }), {
+      type: "groupNext",
+    });
+  });
+
+  it("returns null for an unhandled key", () => {
+    assert.equal(buildVizelComboboxKeySpec({ key: "a", currentIndex: 0, length: 3 }), null);
+  });
+
+  it("returns null for every key when the menu is empty", () => {
+    // The empty-menu fall-through preserves the pre-adoption behaviour: an
+    // open-but-empty menu lets Tiptap consume Enter, Tab, and the arrows.
+    for (const key of ["ArrowDown", "ArrowUp", "Enter", "Escape", "Tab", "Home", "End"]) {
+      assert.equal(buildVizelComboboxKeySpec({ key, currentIndex: 0, length: 0 }), null);
+    }
+  });
+});
+
+/**
+ * Minimal stand-in for the element subset the controller touches:
+ * attribute reads / writes, `keydown` listeners, and a `[role=option]`
+ * query that returns seeded children. The controller reads only `event.key`
+ * plus `preventDefault` / `stopPropagation`, so a full `KeyboardEvent` is
+ * unnecessary.
+ */
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly listeners: ((event: KeyboardEvent) => void)[] = [];
+  readonly attributes = new Map<string, string>();
+  id = "";
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  querySelectorAll(_selector: string): FakeElement[] {
+    // The controller queries `[role=option]`; the fake returns the seeded
+    // option children directly.
+    return [...this.children];
+  }
+
+  addEventListener(type: string, handler: (event: KeyboardEvent) => void): void {
+    if (type === "keydown") this.listeners.push(handler);
+  }
+
+  removeEventListener(type: string, handler: (event: KeyboardEvent) => void): void {
+    if (type !== "keydown") return;
+    const index = this.listeners.indexOf(handler);
+    if (index !== -1) this.listeners.splice(index, 1);
+  }
+
+  dispatchKeydown(key: string): { readonly prevented: boolean } {
+    const calls = { prevented: false };
+    const event = {
+      key,
+      preventDefault: () => {
+        calls.prevented = true;
+      },
+      stopPropagation: () => undefined,
+    } as unknown as KeyboardEvent;
+    for (const handler of [...this.listeners]) handler(event);
+    return calls;
+  }
+}
+
+function asElement(element: FakeElement): HTMLElement {
+  return element as unknown as HTMLElement;
+}
+
+/**
+ * Build a listbox root seeded with `count` `[role=option]` children.
+ */
+function createListbox(count: number): FakeElement {
+  const root = new FakeElement();
+  for (const _ of Array.from({ length: count })) {
+    root.children.push(new FakeElement());
+  }
+  return root;
+}
+
+describe("createVizelComboboxController", () => {
+  // The SSR guard reads the global `document`; define a sentinel so the
+  // controller treats the run as a browser. The value is never dereferenced
+  // beyond the `typeof` check.
+  beforeEach(() => {
+    (globalThis as { document?: unknown }).document = {};
+  });
+  afterEach(() => {
+    (globalThis as { document?: unknown }).document = undefined;
+  });
+
+  it("sets aria-expanded on the owner and points activedescendant at the first option on mount", () => {
+    const root = createListbox(3);
+    const owner = new FakeElement();
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      getOwner: () => asElement(owner),
+      onChange: () => undefined,
+    });
+
+    controller.mount();
+
+    assert.equal(owner.getAttribute("aria-expanded"), "true");
+    // The mount assigned a deterministic id to the first option and pointed
+    // the root at it.
+    assert.notEqual(root.children[0].id, "");
+    assert.equal(root.getAttribute("aria-activedescendant"), root.children[0].id);
+  });
+
+  it("preserves an option's existing id rather than overwriting it", () => {
+    const root = createListbox(2);
+    root.children[0].id = "existing-id";
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: () => undefined,
+    });
+
+    controller.mount();
+    assert.equal(root.getAttribute("aria-activedescendant"), "existing-id");
+  });
+
+  it("moves selection and activedescendant on arrow navigation", () => {
+    const root = createListbox(3);
+    const changes: number[] = [];
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: (index) => changes.push(index),
+    });
+
+    controller.mount();
+    const result = root.dispatchKeydown("ArrowDown");
+
+    assert.equal(result.prevented, true);
+    assert.deepEqual(changes, [1]);
+    assert.equal(controller.getSelectedIndex(), 1);
+    assert.equal(root.getAttribute("aria-activedescendant"), root.children[1].id);
+  });
+
+  it("invokes onSelect with the current index on Enter and leaves it to the caller", () => {
+    const root = createListbox(3);
+    const selected: number[] = [];
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: () => undefined,
+      onSelect: (index) => selected.push(index),
+    });
+
+    controller.mount();
+    root.dispatchKeydown("ArrowDown");
+    root.dispatchKeydown("Enter");
+
+    assert.deepEqual(selected, [1]);
+  });
+
+  it("invokes onClose on Escape", () => {
+    const root = createListbox(2);
+    const calls = { closed: 0 };
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: () => undefined,
+      onClose: () => {
+        calls.closed += 1;
+      },
+    });
+
+    controller.mount();
+    const result = root.dispatchKeydown("Escape");
+
+    assert.equal(result.prevented, true);
+    assert.equal(calls.closed, 1);
+  });
+
+  it("reports Tab as unhandled so the listener-owning surface keeps grouping", () => {
+    const root = createListbox(3);
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: () => undefined,
+    });
+
+    controller.mount();
+    // Tab resolves to groupNext, which the controller cannot target without
+    // feature-specific knowledge; it returns the key as unhandled.
+    const result = root.dispatchKeydown("Tab");
+    assert.equal(result.prevented, false);
+  });
+
+  it("syncs activedescendant when update is called for an external selection", () => {
+    const root = createListbox(3);
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      onChange: () => undefined,
+    });
+
+    controller.mount();
+    controller.update(2);
+
+    assert.equal(controller.getSelectedIndex(), 2);
+    assert.equal(root.getAttribute("aria-activedescendant"), root.children[2].id);
+  });
+
+  it("removes the ARIA wiring on unmount and is idempotent", () => {
+    const root = createListbox(2);
+    const owner = new FakeElement();
+    const controller = createVizelComboboxController({
+      getRoot: () => asElement(root),
+      getOwner: () => asElement(owner),
+      onChange: () => undefined,
+    });
+
+    controller.mount();
+    assert.equal(root.listeners.length, 1);
+
+    controller.unmount();
+    controller.unmount();
+
+    assert.equal(root.listeners.length, 0);
+    assert.equal(root.getAttribute("aria-activedescendant"), null);
+    assert.equal(owner.getAttribute("aria-expanded"), null);
+  });
+});

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./combobox": {
+      "types": "./dist/combobox/index.d.ts",
+      "import": "./dist/combobox/index.js",
+      "default": "./dist/combobox/index.js"
+    },
     "./dismissable": {
       "types": "./dist/dismissable/index.d.ts",
       "import": "./dist/dismissable/index.js",

--- a/packages/headless/src/combobox/index.ts
+++ b/packages/headless/src/combobox/index.ts
@@ -1,0 +1,310 @@
+/**
+ * Combobox primitive.
+ *
+ * Resolves the keyboard contract shared by every Vizel autocomplete-style
+ * menu — the slash menu and the mention menu — and supplies the
+ * `aria-activedescendant` / `aria-expanded` wiring the WAI-ARIA combobox
+ * pattern requires. ADR-0003 (headless package) lists combobox as the
+ * primitive that backs typeahead and roving-tabindex menus; this module is
+ * the last entry in that catalogue.
+ *
+ * The module composes the keyboard primitive rather than re-deriving
+ * navigation: {@link buildVizelComboboxKeySpec} delegates the arrow / Home
+ * / End geometry to {@link buildVizelListNavSpec} and only adds the
+ * combobox-specific verbs (select, close, group-next). ADR-0007
+ * (controller delegation) records why the DOM-touching variant follows the
+ * `{ mount, unmount, update }` contract.
+ *
+ * A Vizel suggestion menu does not own its `keydown` listener: a Tiptap
+ * suggestion renderer forwards each raw `KeyboardEvent` through an
+ * `onKeyDown(event): boolean` handle. Those menus consume the pure
+ * {@link buildVizelComboboxKeySpec} resolver directly.
+ * {@link createVizelComboboxController} exists for surfaces that do own the
+ * listener and want the ARIA wiring managed for them; it completes the
+ * primitive's `{ buildSpec, createController }` shape.
+ */
+
+import {
+  buildVizelListNavSpec,
+  createVizelKeyboardListController,
+  type VizelKeyboardController,
+  type VizelKeyboardListControllerOptions,
+} from "../keyboard/index.ts";
+
+const isBrowser = (): boolean => typeof document !== "undefined";
+
+/**
+ * Input geometry for the combobox key resolver.
+ *
+ * The shape mirrors {@link VizelListNavInput} so a caller forwards the same
+ * `{ key, currentIndex, length }` triple it already computes for list
+ * navigation.
+ */
+export interface VizelComboboxKeyInput {
+  /** The pressed key, taken from `KeyboardEvent.key`. */
+  readonly key: string;
+  /** The current selected index. */
+  readonly currentIndex: number;
+  /** The number of items in the menu. */
+  readonly length: number;
+}
+
+/**
+ * Action a combobox surface performs in response to a key.
+ *
+ * The discriminated union lets a caller `switch` on `type` and map each
+ * verb to its own state update:
+ *
+ * - `navigate` — move the keyboard selection to `index` (arrow / Home /
+ *   End, computed by {@link buildVizelListNavSpec}, so it wraps at the
+ *   edges).
+ * - `select` — activate the item at `index` (Enter).
+ * - `close` — dismiss the surface (Escape).
+ * - `groupNext` — jump to the next group. The resolver does not know the
+ *   feature-specific next-group index, so the caller computes it (the
+ *   slash menu uses `getNextVizelSlashMenuGroupIndex`; the mention menu
+ *   has no groups and treats the verb as unhandled).
+ */
+export type VizelComboboxAction =
+  | { readonly type: "navigate"; readonly index: number }
+  | { readonly type: "select"; readonly index: number }
+  | { readonly type: "close" }
+  | { readonly type: "groupNext" };
+
+/**
+ * Resolve a key press to a {@link VizelComboboxAction}, or `null` when the
+ * combobox does not handle the key.
+ *
+ * The resolver is pure and Server-Side Rendering (SSR) safe. It returns
+ * `null` for an empty menu (`length === 0`) regardless of the key, so an
+ * open-but-empty suggestion menu lets the editor consume Enter, Tab, and
+ * the arrows instead of swallowing them — matching the behaviour each
+ * adapter menu shipped before adopting this primitive.
+ *
+ * Arrow keys plus Home and End delegate to {@link buildVizelListNavSpec};
+ * the resolver wraps that result in a `navigate` action. Enter selects the
+ * current index, Escape closes, and Tab requests the next group. Any other
+ * key returns `null`.
+ *
+ * @example
+ * ```ts
+ * const action = buildVizelComboboxKeySpec({ key: "ArrowDown", currentIndex: 2, length: 3 });
+ * // action === { type: "navigate", index: 0 } (wraps to the start)
+ * ```
+ */
+export function buildVizelComboboxKeySpec(
+  input: VizelComboboxKeyInput
+): VizelComboboxAction | null {
+  const { key, currentIndex, length } = input;
+  // An empty menu hands every key back to the caller (and thence to
+  // Tiptap). Returning early keeps the no-results state inert.
+  if (length === 0) return null;
+
+  const navIndex = buildVizelListNavSpec({ key, currentIndex, length });
+  if (navIndex !== null) return { type: "navigate", index: navIndex };
+
+  switch (key) {
+    case "Enter":
+      return { type: "select", index: currentIndex };
+    case "Escape":
+      return { type: "close" };
+    case "Tab":
+      return { type: "groupNext" };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Options for {@link createVizelComboboxController}.
+ *
+ * The shape extends {@link VizelKeyboardListControllerOptions} so the
+ * controller reuses the keyboard primitive's root accessor, item selector,
+ * initial index, and `onChange` callback, then adds the combobox-specific
+ * owner accessor and activation callbacks.
+ */
+export interface VizelComboboxControllerOptions extends VizelKeyboardListControllerOptions {
+  /**
+   * Return the element that carries `aria-expanded` (typically the input or
+   * trigger that owns the listbox), or `null` when the surface has none. The
+   * controller sets `aria-expanded="true"` on mount and removes it on
+   * unmount.
+   */
+  readonly getOwner?: () => HTMLElement | null;
+  /** Fires with the item index when Enter selects an option. */
+  readonly onSelect?: (index: number) => void;
+  /** Fires when Escape requests dismissal. */
+  readonly onClose?: () => void;
+}
+
+/**
+ * Returned by {@link createVizelComboboxController}.
+ *
+ * The controller extends the keyboard controller contract (`mount`,
+ * `unmount`, `handleKey`, `getSelectedIndex`, `setSelectedIndex`) with an
+ * `update(selectedIndex)` method that re-points `aria-activedescendant`
+ * after an external selection change.
+ */
+export interface VizelComboboxController extends VizelKeyboardController {
+  /**
+   * Sync `aria-activedescendant` to the option at `selectedIndex`. Call
+   * after a click or any state change that moves the selection outside the
+   * controller's own key handling.
+   */
+  update(selectedIndex: number): void;
+}
+
+/**
+ * Return the `[role=option]` elements under `root` in document order.
+ *
+ * The query matches the canonical Vizel listbox shape; the result drives
+ * both the deterministic id assignment and the `aria-activedescendant`
+ * lookup.
+ */
+const collectOptions = (root: HTMLElement, itemSelector: string): readonly HTMLElement[] =>
+  Array.from(root.querySelectorAll<HTMLElement>(itemSelector));
+
+/**
+ * Construct a combobox controller that owns the `keydown` listener and the
+ * combobox ARIA wiring.
+ *
+ * The controller composes {@link createVizelKeyboardListController} for the
+ * navigation state and listener lifecycle, then layers three concerns on
+ * top:
+ *
+ * 1. **Selection and dismissal.** A wrapped key handler maps Enter to
+ *    `onSelect(index)` and Escape to `onClose()` before delegating arrow /
+ *    Home / End to the keyboard controller.
+ * 2. **`aria-expanded`.** `mount` sets `aria-expanded="true"` on the
+ *    `getOwner` element; `unmount` removes the attribute.
+ * 3. **`aria-activedescendant`.** `mount` and `update` assign a
+ *    deterministic id to any option lacking one, then point the root's
+ *    `aria-activedescendant` at the active option's id.
+ *
+ * Every DOM method opens with an SSR guard, and `mount` / `unmount` are
+ * idempotent.
+ *
+ * @example
+ * ```ts
+ * const combobox = createVizelComboboxController({
+ *   getRoot: () => listboxRef.current,
+ *   getOwner: () => inputRef.current,
+ *   onChange: setSelectedIndex,
+ *   onSelect: selectItem,
+ *   onClose: closeMenu,
+ * });
+ * combobox.mount();
+ * // teardown: combobox.unmount();
+ * ```
+ */
+export function createVizelComboboxController(
+  options: VizelComboboxControllerOptions
+): VizelComboboxController {
+  const itemSelector = options.itemSelector ?? "[role=option]";
+  const state = {
+    isMounted: false,
+    // Monotonic suffix so each generated option id stays unique within the
+    // controller instance even as the option list re-renders.
+    idCounter: 0,
+  };
+
+  const keyboard = createVizelKeyboardListController(options);
+
+  const syncActiveDescendant = (selectedIndex: number): void => {
+    if (!isBrowser()) return;
+    const root = options.getRoot();
+    if (!root) return;
+    const optionElements = collectOptions(root, itemSelector);
+    const active = optionElements[selectedIndex];
+    if (!active) {
+      root.removeAttribute("aria-activedescendant");
+      return;
+    }
+    if (active.id === "") {
+      state.idCounter += 1;
+      active.id = `vizel-combobox-option-${state.idCounter}`;
+    }
+    root.setAttribute("aria-activedescendant", active.id);
+  };
+
+  const setExpanded = (expanded: boolean): void => {
+    if (!isBrowser()) return;
+    const owner = options.getOwner?.();
+    if (!owner) return;
+    if (expanded) {
+      owner.setAttribute("aria-expanded", "true");
+      return;
+    }
+    owner.removeAttribute("aria-expanded");
+  };
+
+  const handleKey = (event: KeyboardEvent): boolean => {
+    const root = options.getRoot();
+    if (!root) return false;
+    const length = collectOptions(root, itemSelector).length;
+    const action = buildVizelComboboxKeySpec({
+      key: event.key,
+      currentIndex: keyboard.getSelectedIndex(),
+      length,
+    });
+    if (action === null) return false;
+    switch (action.type) {
+      case "navigate":
+        // The keyboard controller owns the navigation state; delegate so
+        // its selected index and `onChange` callback stay authoritative,
+        // then re-point `aria-activedescendant`.
+        keyboard.setSelectedIndex(action.index);
+        options.onChange(action.index);
+        syncActiveDescendant(action.index);
+        return true;
+      case "select":
+        options.onSelect?.(action.index);
+        return true;
+      case "close":
+        options.onClose?.();
+        return true;
+      default:
+        // `groupNext` has no framework-neutral target; the listener-owning
+        // surface that needs grouping computes the index itself. Report the
+        // key as unhandled here.
+        return false;
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (handleKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  return {
+    mount(): void {
+      if (!isBrowser()) return;
+      if (state.isMounted) return;
+      const root = options.getRoot();
+      if (!root) return;
+      root.addEventListener("keydown", handleKeyDown);
+      setExpanded(true);
+      syncActiveDescendant(keyboard.getSelectedIndex());
+      state.isMounted = true;
+    },
+    unmount(): void {
+      if (!isBrowser()) return;
+      if (!state.isMounted) return;
+      options.getRoot()?.removeEventListener("keydown", handleKeyDown);
+      options.getRoot()?.removeAttribute("aria-activedescendant");
+      setExpanded(false);
+      state.isMounted = false;
+    },
+    update(selectedIndex: number): void {
+      keyboard.setSelectedIndex(selectedIndex);
+      syncActiveDescendant(selectedIndex);
+    },
+    handleKey,
+    getSelectedIndex: () => keyboard.getSelectedIndex(),
+    setSelectedIndex: (index: number): void => {
+      keyboard.setSelectedIndex(index);
+    },
+  };
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -23,11 +23,22 @@
  * - `focus-trap/` confines keyboard focus to a modal-style surface; the
  *   link editor and find-replace forms mount it to keep Tab inside the
  *   form and to return focus to the trigger on close.
+ * - `combobox/` resolves the slash-menu and mention-menu keyboard contract
+ *   and supplies the `aria-activedescendant` / `aria-expanded` wiring; the
+ *   menus consume the pure resolver because a Tiptap suggestion renderer
+ *   forwards the raw `KeyboardEvent`s.
  *
- * The remaining primitive (combobox) lands in a follow-up commit
- * alongside the adapter rewrite that needs it.
+ * The catalogue is now complete: every primitive ADR-0003 lists ships.
  */
 
+export {
+  buildVizelComboboxKeySpec,
+  createVizelComboboxController,
+  type VizelComboboxAction,
+  type VizelComboboxController,
+  type VizelComboboxControllerOptions,
+  type VizelComboboxKeyInput,
+} from "./combobox/index.ts";
 export {
   createVizelDismissable,
   type VizelDismissableController,

--- a/packages/headless/vite.config.ts
+++ b/packages/headless/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(__dirname, "src/index.ts"),
+        "combobox/index": resolve(__dirname, "src/combobox/index.ts"),
         "dismissable/index": resolve(__dirname, "src/dismissable/index.ts"),
         "floating/index": resolve(__dirname, "src/floating/index.ts"),
         "focus-trap/index": resolve(__dirname, "src/focus-trap/index.ts"),

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -1,5 +1,5 @@
 import { buildVizelMentionMenuSpec, type VizelLocale, type VizelMentionItem } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import type { ReactNode, Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 
@@ -88,19 +88,26 @@ export function VizelMentionMenu({
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
-      if (event.key === "Enter") {
-        if (items.length === 0) return false;
-        selectItem(selectedIndex);
-        return true;
-      }
-      const next = buildVizelListNavSpec({
+      // The mention menu is flat: it handles `navigate` and `select` only.
+      // `groupNext` (Tab) and `close` (Escape) fall through as unhandled —
+      // mention has no groups and no own close path — so Tiptap consumes
+      // those keys, matching the menu's pre-adoption behaviour.
+      const action = buildVizelComboboxKeySpec({
         key: event.key,
         currentIndex: selectedIndex,
         length: items.length,
       });
-      if (next === null) return false;
-      setSelectedIndex(next);
-      return true;
+      if (action === null) return false;
+      switch (action.type) {
+        case "navigate":
+          setSelectedIndex(action.index);
+          return true;
+        case "select":
+          selectItem(action.index);
+          return true;
+        default:
+          return false;
+      }
     },
   }));
 

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -3,7 +3,7 @@ import {
   getNextVizelSlashMenuGroupIndex,
   type VizelSlashCommandItem,
 } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import type { ReactNode, Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { VizelSlashMenuEmpty } from "./VizelSlashMenuEmpty.tsx";
@@ -106,30 +106,31 @@ export function VizelSlashMenu({
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
-      if (event.key === "Tab") {
-        if (flatItemCount === 0) return false;
-        event.preventDefault();
-        setSelectedIndex(getNextVizelSlashMenuGroupIndex(spec, selectedIndex));
-        return true;
-      }
-      if (event.key === "Enter") {
-        if (flatItemCount === 0) return false;
-        selectItem(selectedIndex);
-        return true;
-      }
-      // ArrowUp/ArrowDown/Home/End — delegate to the headless builder. It
-      // returns `null` for unknown keys *and* for `flatItemCount === 0`,
-      // so the empty-menu case naturally falls through and lets Tiptap
-      // consume the key instead of being silently swallowed with a `NaN`
-      // write to `selectedIndex`.
-      const next = buildVizelListNavSpec({
+      // The combobox resolver returns `null` for unknown keys *and* for
+      // `flatItemCount === 0`, so the empty-menu case falls through and lets
+      // Tiptap consume the key. `groupNext` (Tab) carries the slash-only
+      // group jump; `close` (Escape) is reported unhandled because the menu
+      // has no own close path — Tiptap dismisses it.
+      const action = buildVizelComboboxKeySpec({
         key: event.key,
         currentIndex: selectedIndex,
         length: flatItemCount,
       });
-      if (next === null) return false;
-      setSelectedIndex(next);
-      return true;
+      if (action === null) return false;
+      switch (action.type) {
+        case "navigate":
+          setSelectedIndex(action.index);
+          return true;
+        case "select":
+          selectItem(action.index);
+          return true;
+        case "groupNext":
+          event.preventDefault();
+          setSelectedIndex(getNextVizelSlashMenuGroupIndex(spec, selectedIndex));
+          return true;
+        default:
+          return false;
+      }
     },
   }));
 
@@ -152,6 +153,9 @@ export function VizelSlashMenu({
       data-vizel-slash-menu=""
       role="listbox"
       aria-label={spec.root["aria-label"]}
+      {...(spec.root["aria-activedescendant"] && {
+        "aria-activedescendant": spec.root["aria-activedescendant"],
+      })}
     >
       {spec.sections.map((section) => {
         const renderedItems = section.items.map((slot) => {
@@ -163,6 +167,7 @@ export function VizelSlashMenu({
               item={slot.data.item}
               isSelected={slot.data.isSelected}
               onClick={onClick}
+              id={slot.attrs.id}
             />
           );
           return (

--- a/packages/react/src/components/VizelSlashMenuItem.tsx
+++ b/packages/react/src/components/VizelSlashMenuItem.tsx
@@ -6,6 +6,15 @@ export interface VizelSlashMenuItemProps {
   isSelected?: boolean;
   onClick: () => void;
   className?: string;
+  /**
+   * Stable id for the `role="option"` element. The listbox root's
+   * `aria-activedescendant` points at this id when the item is the active
+   * selection, matching the WAI-ARIA combobox pattern. The spec always
+   * supplies the id for a rendered item; the optional `undefined` keeps the
+   * prop assignable from the optional spec field under
+   * `exactOptionalPropertyTypes`.
+   */
+  id?: string | undefined;
   /** Match indices for highlighting (from fuzzy search) */
   titleMatches?: [number, number][];
 }
@@ -49,6 +58,7 @@ export function VizelSlashMenuItem({
   isSelected = false,
   onClick,
   className,
+  id,
   titleMatches,
 }: VizelSlashMenuItemProps) {
   return (
@@ -59,6 +69,7 @@ export function VizelSlashMenuItem({
       role="option"
       aria-selected={isSelected}
       data-selected={isSelected || undefined}
+      {...(id && { id })}
     >
       <span className="vizel-slash-menu-icon">
         <VizelIcon name={item.icon} />

--- a/packages/svelte/src/components/VizelMentionMenu.svelte
+++ b/packages/svelte/src/components/VizelMentionMenu.svelte
@@ -41,7 +41,7 @@ export interface VizelMentionMenuProps {
 
 <script lang="ts">
 import { buildVizelMentionMenuSpec } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { tick } from "svelte";
 
 let {
@@ -90,16 +90,23 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "Enter") {
-    if (items.length === 0) return false;
-    selectItem(selectedIndex);
-    return true;
+  // The mention menu is flat: it handles `navigate` and `select` only.
+  // `groupNext` (Tab) and `close` (Escape) fall through as unhandled —
+  // mention has no groups and no own close path — so Tiptap consumes those
+  // keys, matching the menu's pre-adoption behaviour.
+  const action = buildVizelComboboxKeySpec({ key: event.key, currentIndex: selectedIndex, length: items.length });
+  if (action === null) return false;
+  switch (action.type) {
+    case "navigate":
+      selectedIndex = action.index;
+      scrollToSelected();
+      return true;
+    case "select":
+      selectItem(action.index);
+      return true;
+    default:
+      return false;
   }
-  const next = buildVizelListNavSpec({ key: event.key, currentIndex: selectedIndex, length: items.length });
-  if (next === null) return false;
-  selectedIndex = next;
-  scrollToSelected();
-  return true;
 }
 
 // Expose the keyboard handler through the optional ref prop so suggestion

--- a/packages/svelte/src/components/VizelSlashMenu.svelte
+++ b/packages/svelte/src/components/VizelSlashMenu.svelte
@@ -35,7 +35,7 @@ export interface VizelSlashMenuProps {
 
 <script lang="ts">
 import { buildVizelSlashMenuSpec, getNextVizelSlashMenuGroupIndex } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { tick } from "svelte";
 import VizelSlashMenuItem from "./VizelSlashMenuItem.svelte";
 import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.svelte";
@@ -97,26 +97,27 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "Tab") {
-    if (flatItemCount === 0) return false;
-    event.preventDefault();
-    selectedIndex = getNextVizelSlashMenuGroupIndex(spec, selectedIndex);
-    return true;
+  // The combobox resolver returns `null` for unknown keys *and* for
+  // `flatItemCount === 0`, so the empty-menu case falls through and lets
+  // Tiptap consume the key. `groupNext` (Tab) carries the slash-only group
+  // jump; `close` (Escape) is reported unhandled because the menu has no own
+  // close path — Tiptap dismisses it.
+  const action = buildVizelComboboxKeySpec({ key: event.key, currentIndex: selectedIndex, length: flatItemCount });
+  if (action === null) return false;
+  switch (action.type) {
+    case "navigate":
+      selectedIndex = action.index;
+      return true;
+    case "select":
+      selectItem(action.index);
+      return true;
+    case "groupNext":
+      event.preventDefault();
+      selectedIndex = getNextVizelSlashMenuGroupIndex(spec, selectedIndex);
+      return true;
+    default:
+      return false;
   }
-  if (event.key === "Enter") {
-    if (flatItemCount === 0) return false;
-    selectItem(selectedIndex);
-    return true;
-  }
-  // ArrowUp/ArrowDown/Home/End — delegate to the headless builder. It
-  // returns `null` for unknown keys *and* for `flatItemCount === 0`, so
-  // the empty-menu case naturally falls through and lets Tiptap consume
-  // the key instead of being silently swallowed with a `NaN` write to
-  // `selectedIndex`.
-  const next = buildVizelListNavSpec({ key: event.key, currentIndex: selectedIndex, length: flatItemCount });
-  if (next === null) return false;
-  selectedIndex = next;
-  return true;
 }
 
 // Expose the keyboard handler through the optional ref prop so suggestion
@@ -130,11 +131,13 @@ if (ref) {
 }
 </script>
 
+<!-- svelte-ignore a11y_aria_activedescendant_has_tabindex -->
 <div
   class="vizel-slash-menu {className ?? ''}"
   data-vizel-slash-menu
   role={spec.root.role}
   aria-label={spec.root["aria-label"]}
+  aria-activedescendant={spec.root["aria-activedescendant"]}
 >
   {#if spec.sections.length === 0}
     {#if renderEmpty}
@@ -158,6 +161,7 @@ if (ref) {
                 })}
               {:else}
                 <VizelSlashMenuItem
+                  id={slot.attrs.id}
                   item={slot.data.item}
                   isSelected={slot.data.isSelected}
                   onclick={() => selectItem(slot.index)}

--- a/packages/svelte/src/components/VizelSlashMenuItem.svelte
+++ b/packages/svelte/src/components/VizelSlashMenuItem.svelte
@@ -8,6 +8,15 @@ export interface VizelSlashMenuItemProps {
   isSelected?: boolean;
   /** Custom class name */
   class?: string;
+  /**
+   * Stable id for the `role="option"` element. The listbox root's
+   * `aria-activedescendant` points at this id when the item is the active
+   * selection, matching the WAI-ARIA combobox pattern. The spec always
+   * supplies the id for a rendered item; the optional `undefined` keeps the
+   * prop assignable from the optional spec field under
+   * `exactOptionalPropertyTypes`.
+   */
+  id?: string | undefined;
   /** Click handler */
   onclick?: () => void;
   /** Match indices for highlighting (from fuzzy search) */
@@ -23,6 +32,7 @@ let {
   item,
   isSelected = false,
   class: className,
+  id,
   onclick,
   titleMatches,
 }: VizelSlashMenuItemProps = $props();
@@ -32,6 +42,7 @@ const parts = $derived(splitVizelTextByMatches(item.title, titleMatches));
 
 <button
   type="button"
+  {id}
   class="vizel-slash-menu-item {isSelected ? 'is-selected' : ''} {className ?? ''}"
   role="option"
   aria-selected={isSelected}

--- a/packages/vue/src/components/VizelMentionMenu.vue
+++ b/packages/vue/src/components/VizelMentionMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { buildVizelMentionMenuSpec, type VizelLocale, type VizelMentionItem } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { computed, nextTick, ref, watch } from "vue";
 
 export interface VizelMentionMenuRef {
@@ -79,20 +79,27 @@ function selectItem(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent): boolean {
-  if (event.key === "Enter") {
-    if (props.items.length === 0) return false;
-    selectItem(selectedIndex.value);
-    return true;
-  }
-  const next = buildVizelListNavSpec({
+  // The mention menu is flat: it handles `navigate` and `select` only.
+  // `groupNext` (Tab) and `close` (Escape) fall through as unhandled —
+  // mention has no groups and no own close path — so Tiptap consumes those
+  // keys, matching the menu's pre-adoption behaviour.
+  const action = buildVizelComboboxKeySpec({
     key: event.key,
     currentIndex: selectedIndex.value,
     length: props.items.length,
   });
-  if (next === null) return false;
-  selectedIndex.value = next;
-  scrollToSelected();
-  return true;
+  if (action === null) return false;
+  switch (action.type) {
+    case "navigate":
+      selectedIndex.value = action.index;
+      scrollToSelected();
+      return true;
+    case "select":
+      selectItem(action.index);
+      return true;
+    default:
+      return false;
+  }
 }
 
 defineExpose<VizelMentionMenuRef>({ onKeyDown });

--- a/packages/vue/src/components/VizelSlashMenu.vue
+++ b/packages/vue/src/components/VizelSlashMenu.vue
@@ -4,7 +4,7 @@ import {
   getNextVizelSlashMenuGroupIndex,
   type VizelSlashCommandItem,
 } from "@vizel/core";
-import { buildVizelListNavSpec } from "@vizel/headless/keyboard";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { computed, nextTick, ref, watch } from "vue";
 import VizelSlashMenuEmpty from "./VizelSlashMenuEmpty.vue";
 import VizelSlashMenuItem from "./VizelSlashMenuItem.vue";
@@ -106,31 +106,31 @@ function selectItem(index: number) {
 }
 
 function handleKeyDown(event: KeyboardEvent): boolean {
-  const count = flatItemCount.value;
-  if (event.key === "Tab") {
-    if (count === 0) return false;
-    event.preventDefault();
-    selectedIndex.value = getNextVizelSlashMenuGroupIndex(spec.value, selectedIndex.value);
-    return true;
-  }
-  if (event.key === "Enter") {
-    if (count === 0) return false;
-    selectItem(selectedIndex.value);
-    return true;
-  }
-  // ArrowUp/ArrowDown/Home/End — delegate to the headless builder. It
-  // returns `null` for unknown keys *and* for `count === 0`, so the
-  // empty-menu case naturally falls through and lets Tiptap consume the
-  // key instead of being silently swallowed with a `NaN` write to
-  // `selectedIndex`.
-  const next = buildVizelListNavSpec({
+  // The combobox resolver returns `null` for unknown keys *and* for
+  // `count === 0`, so the empty-menu case falls through and lets Tiptap
+  // consume the key. `groupNext` (Tab) carries the slash-only group jump;
+  // `close` (Escape) is reported unhandled because the menu has no own
+  // close path — Tiptap dismisses it.
+  const action = buildVizelComboboxKeySpec({
     key: event.key,
     currentIndex: selectedIndex.value,
-    length: count,
+    length: flatItemCount.value,
   });
-  if (next === null) return false;
-  selectedIndex.value = next;
-  return true;
+  if (action === null) return false;
+  switch (action.type) {
+    case "navigate":
+      selectedIndex.value = action.index;
+      return true;
+    case "select":
+      selectItem(action.index);
+      return true;
+    case "groupNext":
+      event.preventDefault();
+      selectedIndex.value = getNextVizelSlashMenuGroupIndex(spec.value, selectedIndex.value);
+      return true;
+    default:
+      return false;
+  }
 }
 
 defineExpose({
@@ -144,6 +144,7 @@ defineExpose({
     data-vizel-slash-menu
     :role="spec.root.role"
     :aria-label="spec.root['aria-label']"
+    :aria-activedescendant="spec.root['aria-activedescendant']"
   >
     <template v-if="spec.sections.length === 0">
       <slot v-if="slots.empty" name="empty" />
@@ -172,6 +173,7 @@ defineExpose({
             />
             <VizelSlashMenuItem
               v-else
+              :id="slot.attrs.id"
               :item="slot.data.item"
               :is-selected="slot.data.isSelected"
               @click="selectItem(slot.index)"
@@ -194,6 +196,7 @@ defineExpose({
             />
             <VizelSlashMenuItem
               v-else
+              :id="slot.attrs.id"
               :item="slot.data.item"
               :is-selected="slot.data.isSelected"
               @click="selectItem(slot.index)"

--- a/packages/vue/src/components/VizelSlashMenuItem.vue
+++ b/packages/vue/src/components/VizelSlashMenuItem.vue
@@ -9,6 +9,15 @@ export interface VizelSlashMenuItemProps {
   isSelected?: boolean;
   /** Custom class name */
   class?: string;
+  /**
+   * Stable id for the `role="option"` element. The listbox root's
+   * `aria-activedescendant` points at this id when the item is the active
+   * selection, matching the WAI-ARIA combobox pattern. The spec always
+   * supplies the id for a rendered item; the optional `undefined` keeps the
+   * prop assignable from the optional spec field under
+   * `exactOptionalPropertyTypes`.
+   */
+  id?: string | undefined;
   /** Match indices for highlighting (from fuzzy search) */
   titleMatches?: [number, number][];
 }
@@ -23,6 +32,7 @@ const emit = defineEmits<{
 <template>
   <button
     type="button"
+    :id="id"
     :class="[
       'vizel-slash-menu-item',
       { 'is-selected': isSelected },


### PR DESCRIPTION
## Summary

Phase C / PR-4 — the final `@vizel/headless` primitive (ADR-0003): adds the **`combobox`** primitive and adopts it in the suggestion menus (`VizelSlashMenu`, `VizelMentionMenu`). This completes the headless buildout — every primitive ADR-0003 lists now exists and has an internal consumer.

- **`packages/headless/src/combobox/`** — `buildVizelComboboxKeySpec(input)` resolves one forwarded `KeyboardEvent` into a `VizelComboboxAction`: `{ type: "navigate"; index } | { type: "select"; index } | { type: "close" } | { type: "groupNext" }`, or `null`. It composes `buildVizelListNavSpec` for arrow/Home/End → `navigate` (inheriting wraparound), maps Enter → `select`, Escape → `close`, Tab → `groupNext`, and returns `null` for unhandled keys and the empty list (so an empty menu lets the editor consume the key). `createVizelComboboxController` ships for primitive completeness (the listener-owning surface that manages `aria-expanded` + `aria-activedescendant`). 15 `node:test` unit tests.
- **Adopted in all six menu components** — React/Vue/Svelte `VizelSlashMenu` and `VizelMentionMenu` replace their bespoke `onKeyDown` switches with `buildVizelComboboxKeySpec`, mapping the action to their state (slash maps `groupNext` to `getNextVizelSlashMenuGroupIndex`; mention ignores it). Behaviour is preserved exactly: arrows navigate, Enter selects, Tab cycles groups (slash), and an empty menu falls through.
- **Unified `aria-activedescendant`** — `buildVizelSlashMenuSpec` now emits `root["aria-activedescendant"]` and a stable per-option `id` (mirroring the mention spec); the id threads into `VizelSlashMenuItem` (`role="option"`) and the listbox root renders the active id in all three adapters. The slash menu now honours the `aria-activedescendant` contract the manifest already declared but the component never emitted, matching the mention menu.

## Breaking Changes

- None for consumers. The `combobox` primitive is additive; the menus keep their public API. The slash menu only ADDS ARIA attributes. v2.0.0 is unreleased.

## Test Plan

- [x] `pnpm --filter @vizel/headless test` → 63 (48 prior + 15 combobox).
- [x] `pnpm typecheck`, `pnpm lint` (615 files), `pnpm check:feature-parity`, `pnpm check:adr-compliance` (14 PASS / 0 WARN / 0 FAIL), `check:ssr`/`check:nolet`/`check:scenarios`/`check:ct-parity`.
- [x] `pnpm test:ct:{react,vue,svelte} --project=chromium` → 283 each (SlashMenu keyboard/Tab-group/empty-state and MentionMenu specs green, no spec edits).
- [x] Browser (Vue demo): typing `/` opens the slash menu with `aria-activedescendant="vizel-slash-heading1"`; ArrowDown advances the selection and the listbox `aria-activedescendant` follows (`heading1` → `heading2`); Tab jumps to the next group's first item (`bulletList`) with `aria-activedescendant` tracking; Enter inserts the selected block and closes the menu; console clean throughout. The mention menu's identical resolver path is covered by the cross-framework CT (the menu's `onKeyDown` runs only once the suggestion renderer has mounted the popup, which sits upstream of this change).
