### PR TITLE
refactor: adopt headless grid and combobox in ColorPicker and NodeSelector

### DIFF
--- a/packages/core/src/builders/link-editor.ts
+++ b/packages/core/src/builders/link-editor.ts
@@ -33,8 +33,9 @@ export function resolveVizelLinkEditorLabels(
   const le = locale?.linkEditor;
   return {
     // The URL input's aria-label has no locale field today — the
-    // component baselines have always shipped "Link URL". Keep it
-    // hardcoded here so framework components can drop the inline literal.
+    // component baselines have always shipped "Link URL". Keep the
+    // aria-label hardcoded here so framework components can drop the
+    // inline literal.
     urlAriaLabel: "Link URL",
     urlPlaceholder: le?.urlPlaceholder ?? "Enter URL...",
     apply: le?.apply ?? "Apply",

--- a/packages/core/src/controllers/transactionStore.ts
+++ b/packages/core/src/controllers/transactionStore.ts
@@ -22,8 +22,8 @@ export interface VizelEditorTransactionStore {
    */
   subscribe(onChange: () => void): () => void;
   /**
-   * Read the current version counter. Increments by 1 (with 32-bit wrap-
-   * around) on every transaction.
+   * Return the current version counter, which increments by 1 (with
+   * 32-bit wrap-around) on every transaction.
    */
   getVersion(): number;
 }

--- a/packages/react/src/components/VizelColorPicker.tsx
+++ b/packages/react/src/components/VizelColorPicker.tsx
@@ -3,6 +3,7 @@ import {
   normalizeVizelHexColor,
   type VizelColorDefinition,
 } from "@vizel/core";
+import { createVizelKeyboardGridController } from "@vizel/headless";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VizelIcon } from "./VizelIcon.tsx";
 
@@ -60,6 +61,26 @@ export function VizelColorPicker({
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const swatchRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // The grid keyboard navigation (arrows, Home, End) is owned by the
+  // shared @vizel/headless controller (ADR-0003, ADR-0007) so the three
+  // adapters no longer duplicate the resolver. The swatches own their own
+  // keydown listener, so this component forwards each event through
+  // `handleKey` instead of letting the controller attach its own listener.
+  const gridController = useMemo(
+    () =>
+      createVizelKeyboardGridController({
+        getRoot: () => gridRef.current,
+        columns: GRID_COLUMNS,
+        itemSelector: "[role=option]",
+        onChange: (index) => {
+          setFocusedIndex(index);
+          swatchRefs.current[index]?.focus();
+        },
+      }),
+    []
+  );
 
   // Build flat list of all selectable colors for keyboard navigation
   const allColors = useMemo(
@@ -114,8 +135,7 @@ export function VizelColorPicker({
   // Keyboard navigation handler
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, currentIndex: number) => {
-      const totalColors = allColors.length;
-      if (totalColors === 0) return;
+      if (allColors.length === 0) return;
 
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
@@ -126,32 +146,14 @@ export function VizelColorPicker({
         return;
       }
 
-      const newIndex = ((): number | null => {
-        switch (e.key) {
-          case "ArrowRight":
-            return (currentIndex + 1) % totalColors;
-          case "ArrowLeft":
-            return (currentIndex - 1 + totalColors) % totalColors;
-          case "ArrowDown":
-            return Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
-          case "ArrowUp":
-            return Math.max(currentIndex - GRID_COLUMNS, 0);
-          case "Home":
-            return 0;
-          case "End":
-            return totalColors - 1;
-          default:
-            return null;
-        }
-      })();
-
-      if (newIndex !== null) {
+      // Resolve the focused swatch as the controller's current cell, then
+      // let the shared grid resolver compute the next index.
+      gridController.setSelectedIndex(currentIndex);
+      if (gridController.handleKey(e.nativeEvent)) {
         e.preventDefault();
-        setFocusedIndex(newIndex);
-        swatchRefs.current[newIndex]?.focus();
       }
     },
-    [allColors, handleSelect]
+    [allColors, handleSelect, gridController]
   );
 
   // Update input value when value prop changes
@@ -178,6 +180,7 @@ export function VizelColorPicker({
 
   return (
     <div
+      ref={gridRef}
       className={`vizel-color-picker-content ${className ?? ""}`}
       role="listbox"
       aria-label={label}

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -237,7 +237,7 @@ export function VizelFindReplace({
             aria-label={labels.replaceAriaLabel}
             title={labels.replaceTitle}
           >
-            Replace
+            {labels.replaceAriaLabel}
           </button>
           <button
             type="button"
@@ -247,7 +247,7 @@ export function VizelFindReplace({
             aria-label={labels.replaceAllAriaLabel}
             title={labels.replaceAllTitle}
           >
-            All
+            {labels.replaceAllAriaLabel}
           </button>
         </div>
       )}

--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -7,6 +7,7 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useVizelEditorState } from "../_reactivity.ts";
 import { useVizelContextSafe } from "./VizelContext.tsx";
@@ -29,9 +30,10 @@ export interface VizelNodeSelectorProps {
  * DOM/ARIA scaffolding (trigger + listbox popover) comes from
  * `@vizel/core`'s `buildVizelNodeSelectorSpec`. Pointer-outside
  * dismissal routes through `createVizelDismissable` from
- * `@vizel/headless` (ADR-0003, ADR-0007); the component still owns
- * keyboard navigation and Escape because the dropdown root captures
- * keydown directly inside React.
+ * `@vizel/headless` (ADR-0003, ADR-0007). The dropdown root owns the
+ * keydown listener but delegates navigate / select / close resolution to
+ * the shared `buildVizelComboboxKeySpec`, matching the slash and mention
+ * menus.
  */
 export function VizelNodeSelector({
   editor: editorProp,
@@ -107,38 +109,43 @@ export function VizelNodeSelector({
       return;
     }
 
-    switch (event.key) {
-      case "Escape":
+    // The open dropdown is a single-group listbox, so it delegates the
+    // navigate / select / close verbs to the shared combobox resolver
+    // (ADR-0003), matching VizelSlashMenu and VizelMentionMenu. The dropdown
+    // root (not a native button) owns the keydown, so Space activates like
+    // Enter; normalise it before resolving. Tab (`groupNext`) has no group to
+    // advance and falls through so focus leaves the dropdown.
+    const action = buildVizelComboboxKeySpec({
+      key: event.key === " " ? "Enter" : event.key,
+      currentIndex: focusedIndex,
+      length: effectiveNodeTypes.length,
+    });
+    if (action === null) return;
+    // The open listbox owns its navigation keys. `stopPropagation` keeps the
+    // Escape `close` from reaching the document-level bubble-menu escape
+    // controller, which would otherwise collapse the selection and unmount the
+    // host bubble menu (and the trigger) before focus can return to it. Tab
+    // (`groupNext`) is the default no-op so focus can leave the dropdown.
+    switch (action.type) {
+      case "navigate":
         event.preventDefault();
-        setIsOpen(false);
-        triggerRef.current?.focus();
+        event.stopPropagation();
+        setFocusedIndex(action.index);
         break;
-      case "ArrowDown":
+      case "select": {
         event.preventDefault();
-        setFocusedIndex((prev) => (prev + 1) % effectiveNodeTypes.length);
-        break;
-      case "ArrowUp":
-        event.preventDefault();
-        setFocusedIndex(
-          (prev) => (prev - 1 + effectiveNodeTypes.length) % effectiveNodeTypes.length
-        );
-        break;
-      case "Enter":
-      case " ": {
-        event.preventDefault();
-        const selectedNodeType = effectiveNodeTypes[focusedIndex];
+        event.stopPropagation();
+        const selectedNodeType = effectiveNodeTypes[action.index];
         if (selectedNodeType) {
           handleSelectNodeType(selectedNodeType);
         }
         break;
       }
-      case "Home":
+      case "close":
         event.preventDefault();
-        setFocusedIndex(0);
-        break;
-      case "End":
-        event.preventDefault();
-        setFocusedIndex(effectiveNodeTypes.length - 1);
+        event.stopPropagation();
+        setIsOpen(false);
+        triggerRef.current?.focus();
         break;
       default:
         break;

--- a/packages/svelte/src/components/VizelColorPicker.svelte
+++ b/packages/svelte/src/components/VizelColorPicker.svelte
@@ -33,6 +33,7 @@ export interface VizelColorPickerProps {
 
 <script lang="ts">
 import { isVizelValidHexColor, normalizeVizelHexColor } from "@vizel/core";
+import { createVizelKeyboardGridController } from "@vizel/headless";
 import { untrack } from "svelte";
 import VizelIcon from "./VizelIcon.svelte";
 
@@ -58,6 +59,22 @@ let inputValue = $state("");
 let focusedIndex = $state(-1);
 let swatchRefs: (HTMLButtonElement | null)[] = $state([]);
 let inputRef: HTMLInputElement | null = $state(null);
+let gridRef: HTMLElement | null = $state(null);
+
+// The grid keyboard navigation (arrows, Home, End) is owned by the shared
+// @vizel/headless controller (ADR-0003, ADR-0007) so the three adapters no
+// longer duplicate the resolver. The swatches own their own keydown
+// listener, so this component forwards each event through `handleKey`
+// instead of letting the controller attach its own listener.
+const gridController = createVizelKeyboardGridController({
+  getRoot: () => gridRef,
+  columns: GRID_COLUMNS,
+  itemSelector: "[role=option]",
+  onChange: (index) => {
+    focusedIndex = index;
+    swatchRefs[index]?.focus();
+  },
+});
 
 // Clean up swatchRefs when colors decrease
 $effect(() => {
@@ -117,52 +134,22 @@ function handleInputKeyDown(e: KeyboardEvent) {
 
 // Keyboard navigation handler
 function handleKeyDown(e: KeyboardEvent, currentIndex: number) {
-  const totalColors = allColors.length;
-  if (totalColors === 0) return;
+  if (allColors.length === 0) return;
 
-  let newIndex = currentIndex;
-  let handled = false;
-
-  switch (e.key) {
-    case "ArrowRight":
-      newIndex = (currentIndex + 1) % totalColors;
-      handled = true;
-      break;
-    case "ArrowLeft":
-      newIndex = (currentIndex - 1 + totalColors) % totalColors;
-      handled = true;
-      break;
-    case "ArrowDown":
-      newIndex = Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
-      handled = true;
-      break;
-    case "ArrowUp":
-      newIndex = Math.max(currentIndex - GRID_COLUMNS, 0);
-      handled = true;
-      break;
-    case "Home":
-      newIndex = 0;
-      handled = true;
-      break;
-    case "End":
-      newIndex = totalColors - 1;
-      handled = true;
-      break;
-    case "Enter":
-    case " ": {
-      e.preventDefault();
-      const selectedColor = allColors[currentIndex];
-      if (selectedColor) {
-        handleSelect(selectedColor);
-      }
-      return;
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    const selectedColor = allColors[currentIndex];
+    if (selectedColor) {
+      handleSelect(selectedColor);
     }
+    return;
   }
 
-  if (handled) {
+  // Resolve the focused swatch as the controller's current cell, then let
+  // the shared grid resolver compute the next index.
+  gridController.setSelectedIndex(currentIndex);
+  if (gridController.handleKey(e)) {
     e.preventDefault();
-    focusedIndex = newIndex;
-    swatchRefs[newIndex]?.focus();
   }
 }
 
@@ -196,6 +183,7 @@ const previewColor = $derived(isInputValid ? normalizeVizelHexColor(inputValue) 
 </script>
 
 <div
+  bind:this={gridRef}
   class="vizel-color-picker-content {className ?? ''}"
   role="listbox"
   aria-label={label}

--- a/packages/svelte/src/components/VizelNodeSelector.svelte
+++ b/packages/svelte/src/components/VizelNodeSelector.svelte
@@ -16,6 +16,7 @@ export interface VizelNodeSelectorProps {
 <script lang="ts">
 import { buildVizelNodeSelectorSpec, createVizelNodeTypes, vizelDefaultNodeTypes } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { createVizelState } from "../runes/createVizelState.svelte.js";
 import { getVizelContextSafe } from "./VizelContext.js";
 import VizelIcon from "./VizelIcon.svelte";
@@ -42,8 +43,8 @@ const spec = $derived.by(() => {
 });
 
 // Pointer-outside dismissal routes through `createVizelDismissable` from
-// `@vizel/headless` (ADR-0003, ADR-0007). The dropdown owns Escape and
-// arrow-key navigation inside its own `onkeydown` handler, so the
+// `@vizel/headless` (ADR-0003, ADR-0007). The dropdown owns the keydown
+// handler and resolves it through `buildVizelComboboxKeySpec`, so the
 // controller only handles outside-pointer dismissal.
 $effect(() => {
   if (!isOpen || !containerRef) return;
@@ -72,36 +73,43 @@ function handleKeyDown(event: KeyboardEvent) {
     return;
   }
 
-  switch (event.key) {
-    case "Escape":
+  // The open dropdown is a single-group listbox, so it delegates the
+  // navigate / select / close verbs to the shared combobox resolver
+  // (ADR-0003), matching VizelSlashMenu and VizelMentionMenu. The dropdown
+  // root (not a native button) owns the keydown, so Space activates like
+  // Enter; normalise it before resolving. Tab (`groupNext`) has no group to
+  // advance and falls through so focus leaves the dropdown.
+  const action = buildVizelComboboxKeySpec({
+    key: event.key === " " ? "Enter" : event.key,
+    currentIndex: focusedIndex,
+    length: effectiveNodeTypes.length,
+  });
+  if (action === null) return;
+  // The open listbox owns its navigation keys. `stopPropagation` keeps the
+  // Escape `close` from reaching the document-level bubble-menu escape
+  // controller, which would otherwise collapse the selection and unmount the
+  // host bubble menu (and the trigger) before focus can return to it. Tab
+  // (`groupNext`) is the default no-op so focus can leave the dropdown.
+  switch (action.type) {
+    case "navigate":
       event.preventDefault();
-      isOpen = false;
-      triggerRef?.focus();
+      event.stopPropagation();
+      focusedIndex = action.index;
       break;
-    case "ArrowDown":
+    case "select": {
       event.preventDefault();
-      focusedIndex = (focusedIndex + 1) % effectiveNodeTypes.length;
-      break;
-    case "ArrowUp":
-      event.preventDefault();
-      focusedIndex = (focusedIndex - 1 + effectiveNodeTypes.length) % effectiveNodeTypes.length;
-      break;
-    case "Enter":
-    case " ": {
-      event.preventDefault();
-      const selectedNodeType = effectiveNodeTypes[focusedIndex];
+      event.stopPropagation();
+      const selectedNodeType = effectiveNodeTypes[action.index];
       if (selectedNodeType) {
         handleSelectNodeType(selectedNodeType);
       }
       break;
     }
-    case "Home":
+    case "close":
       event.preventDefault();
-      focusedIndex = 0;
-      break;
-    case "End":
-      event.preventDefault();
-      focusedIndex = effectiveNodeTypes.length - 1;
+      event.stopPropagation();
+      isOpen = false;
+      triggerRef?.focus();
       break;
     default:
       break;

--- a/packages/vue/src/components/VizelColorPicker.vue
+++ b/packages/vue/src/components/VizelColorPicker.vue
@@ -4,7 +4,8 @@ import {
   normalizeVizelHexColor,
   type VizelColorDefinition,
 } from "@vizel/core";
-import { computed, onMounted, ref, watch } from "vue";
+import { createVizelKeyboardGridController } from "@vizel/headless";
+import { computed, onMounted, ref, useTemplateRef, watch } from "vue";
 import VizelIcon from "./VizelIcon.vue";
 
 export interface VizelColorPickerProps {
@@ -60,6 +61,22 @@ const GRID_COLUMNS = 4;
 const inputValue = ref("");
 const focusedIndex = ref(-1);
 const swatchRefs = ref<(HTMLButtonElement | null)[]>([]);
+const gridRef = useTemplateRef<HTMLElement>("gridRef");
+
+// The grid keyboard navigation (arrows, Home, End) is owned by the shared
+// @vizel/headless controller (ADR-0003, ADR-0007) so the three adapters no
+// longer duplicate the resolver. The swatches own their own keydown
+// listener, so this component forwards each event through `handleKey`
+// instead of letting the controller attach its own listener.
+const gridController = createVizelKeyboardGridController({
+  getRoot: () => gridRef.value,
+  columns: GRID_COLUMNS,
+  itemSelector: "[role=option]",
+  onChange: (index) => {
+    focusedIndex.value = index;
+    swatchRefs.value[index]?.focus();
+  },
+});
 
 // Build flat list of all selectable colors for keyboard navigation
 const allColors = computed(() => [
@@ -121,8 +138,7 @@ function handleInputKeyDown(e: KeyboardEvent) {
 
 // Keyboard navigation handler
 function handleKeyDown(e: KeyboardEvent, currentIndex: number) {
-  const totalColors = allColors.value.length;
-  if (totalColors === 0) return;
+  if (allColors.value.length === 0) return;
 
   if (e.key === "Enter" || e.key === " ") {
     e.preventDefault();
@@ -133,29 +149,11 @@ function handleKeyDown(e: KeyboardEvent, currentIndex: number) {
     return;
   }
 
-  const newIndex = ((): number | null => {
-    switch (e.key) {
-      case "ArrowRight":
-        return (currentIndex + 1) % totalColors;
-      case "ArrowLeft":
-        return (currentIndex - 1 + totalColors) % totalColors;
-      case "ArrowDown":
-        return Math.min(currentIndex + GRID_COLUMNS, totalColors - 1);
-      case "ArrowUp":
-        return Math.max(currentIndex - GRID_COLUMNS, 0);
-      case "Home":
-        return 0;
-      case "End":
-        return totalColors - 1;
-      default:
-        return null;
-    }
-  })();
-
-  if (newIndex !== null) {
+  // Resolve the focused swatch as the controller's current cell, then let
+  // the shared grid resolver compute the next index.
+  gridController.setSelectedIndex(currentIndex);
+  if (gridController.handleKey(e)) {
     e.preventDefault();
-    focusedIndex.value = newIndex;
-    swatchRefs.value[newIndex]?.focus();
   }
 }
 
@@ -190,6 +188,7 @@ const previewColor = computed(() =>
 
 <template>
   <div
+    ref="gridRef"
     :class="['vizel-color-picker-content', $props.class]"
     role="listbox"
     :aria-label="props.label"

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -7,7 +7,7 @@ import {
   type VizelLocale,
 } from "@vizel/core";
 import { createVizelDismissable, createVizelFocusTrapController } from "@vizel/headless";
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
+import { computed, ref, useTemplateRef, watch } from "vue";
 import { useVizelContextSafe } from "./VizelContext.ts";
 import VizelIcon from "./VizelIcon.vue";
 
@@ -73,31 +73,24 @@ const dismissable = createVizelDismissable({
 // so the dismissable stays the sole owner of the close gesture.
 const focusTrap = createVizelFocusTrapController();
 
+// A single watch owns the controller lifecycle (ADR-0004 Vue idiom). The
+// `onCleanup` parameter unmounts the controllers before each re-run and on
+// scope disposal, so the cleanup runs even inside a detached `effectScope()`
+// — unlike a separate `onBeforeUnmount` hook. `immediate: true` covers the
+// first mount; `flush: "post"` defers the mount until the form is in the DOM.
 watch(
   [viewState, formRef],
-  ([view, form]) => {
-    if (view && form) {
-      dismissable.mount(form);
-      focusTrap.mount(form);
-    } else {
+  ([view, form], _old, onCleanup) => {
+    if (!(view && form)) return;
+    dismissable.mount(form);
+    focusTrap.mount(form);
+    onCleanup(() => {
       dismissable.unmount();
       focusTrap.unmount();
-    }
+    });
   },
-  { flush: "post" }
+  { immediate: true, flush: "post" }
 );
-
-onMounted(() => {
-  if (viewState.value && formRef.value) {
-    dismissable.mount(formRef.value);
-    focusTrap.mount(formRef.value);
-  }
-});
-
-onBeforeUnmount(() => {
-  dismissable.unmount();
-  focusTrap.unmount();
-});
 
 function handleSubmit(e: Event) {
   e.preventDefault();

--- a/packages/vue/src/components/VizelNodeSelector.vue
+++ b/packages/vue/src/components/VizelNodeSelector.vue
@@ -8,6 +8,7 @@ import {
   vizelDefaultNodeTypes,
 } from "@vizel/core";
 import { createVizelDismissable } from "@vizel/headless";
+import { buildVizelComboboxKeySpec } from "@vizel/headless/combobox";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useVizelState } from "../composables/useVizelState.ts";
 import { useVizelContextSafe } from "./VizelContext.ts";
@@ -55,10 +56,11 @@ const spec = computed(() => {
   );
 });
 
-// The dropdown owns Escape and arrow-key navigation inside its own
-// `handleKeyDown`; the controller only handles outside-pointer dismissal.
-// `captureEscape` stays `false` because the dropdown's own keydown listener
-// handles Escape via `event.preventDefault()` plus `triggerRef.value?.focus()`.
+// The dropdown owns the keydown handler and resolves it through
+// `buildVizelComboboxKeySpec`; the controller only handles outside-pointer
+// dismissal. `captureEscape` stays `false` because the dropdown's own keydown
+// listener handles the combobox `close` verb via `event.preventDefault()` plus
+// `triggerRef.value?.focus()`.
 const dismissable = createVizelDismissable({
   onPointerOutside: () => {
     isOpen.value = false;
@@ -105,38 +107,43 @@ function handleKeyDown(event: KeyboardEvent) {
     return;
   }
 
-  switch (event.key) {
-    case "Escape":
+  // The open dropdown is a single-group listbox, so it delegates the
+  // navigate / select / close verbs to the shared combobox resolver
+  // (ADR-0003), matching VizelSlashMenu and VizelMentionMenu. The dropdown
+  // root (not a native button) owns the keydown, so Space activates like
+  // Enter; normalise it before resolving. Tab (`groupNext`) has no group to
+  // advance and falls through so focus leaves the dropdown.
+  const action = buildVizelComboboxKeySpec({
+    key: event.key === " " ? "Enter" : event.key,
+    currentIndex: focusedIndex.value,
+    length: effectiveNodeTypes.value.length,
+  });
+  if (action === null) return;
+  // The open listbox owns its navigation keys. `stopPropagation` keeps the
+  // Escape `close` from reaching the document-level bubble-menu escape
+  // controller, which would otherwise collapse the selection and unmount the
+  // host bubble menu (and the trigger) before focus can return to it. Tab
+  // (`groupNext`) is the default no-op so focus can leave the dropdown.
+  switch (action.type) {
+    case "navigate":
       event.preventDefault();
-      isOpen.value = false;
-      triggerRef.value?.focus();
+      event.stopPropagation();
+      focusedIndex.value = action.index;
       break;
-    case "ArrowDown":
+    case "select": {
       event.preventDefault();
-      focusedIndex.value = (focusedIndex.value + 1) % effectiveNodeTypes.value.length;
-      break;
-    case "ArrowUp":
-      event.preventDefault();
-      focusedIndex.value =
-        (focusedIndex.value - 1 + effectiveNodeTypes.value.length) %
-        effectiveNodeTypes.value.length;
-      break;
-    case "Enter":
-    case " ": {
-      event.preventDefault();
-      const selectedNodeType = effectiveNodeTypes.value[focusedIndex.value];
+      event.stopPropagation();
+      const selectedNodeType = effectiveNodeTypes.value[action.index];
       if (selectedNodeType) {
         handleSelectNodeType(selectedNodeType);
       }
       break;
     }
-    case "Home":
+    case "close":
       event.preventDefault();
-      focusedIndex.value = 0;
-      break;
-    case "End":
-      event.preventDefault();
-      focusedIndex.value = effectiveNodeTypes.value.length - 1;
+      event.stopPropagation();
+      isOpen.value = false;
+      triggerRef.value?.focus();
       break;
     default:
       break;


### PR DESCRIPTION
## Summary

A qualitative audit of the v2 adapters against the three mandates (feature reach,
per-framework idiom, feature parity) surfaced one real parity bug and a set of
idiom-delegation gaps. This PR closes them. Mechanical compliance stays green
(`check:adr-compliance` 14 PASS, `check:feature-parity` 23×3, SSR / no-let /
scenarios / CT parity).

- **Find/replace parity (fix).** The React `VizelFindReplace` hardcoded the English
  strings `Replace` and `All` on its two buttons, while Vue and Svelte already read
  the localized labels. Under a non-English locale the React buttons stayed English.
  React now renders `labels.replaceAriaLabel` / `labels.replaceAllAriaLabel`, so all
  three adapters show the same text (the second button reads `Replace all`, not a
  bare `All`).

- **ColorPicker keyboard delegation (refactor).** React, Vue, and Svelte each
  re-derived the grid keyboard resolver inline. All three now consume the shared
  `createVizelKeyboardGridController` from `@vizel/headless`. In-grid navigation and
  Enter / Space selection are unchanged.

- **NodeSelector keyboard delegation (refactor) + Escape focus (fix).** The open-state
  key handling now flows through the shared `buildVizelComboboxKeySpec`, matching
  `VizelSlashMenu` and `VizelMentionMenu`. Space normalizes to Enter so both still
  activate the highlighted option. The open listbox now calls `event.stopPropagation()`
  on the keys it consumes, fixing a pre-existing focus bug: Escape used to bubble to
  the document-level bubble-menu escape controller, which collapsed the selection and
  unmounted the host (and the trigger), dropping focus to `<body>`. Escape now closes
  only the dropdown and returns focus to the trigger; a second Escape dismisses the
  bubble menu.

- **Vue LinkEditor lifecycle (refactor).** `VizelLinkEditor.vue` collapses its
  `watch` + `onMounted` + `onBeforeUnmount` controller wiring into a single `watch`
  with an `onCleanup` teardown, matching the Vue 3.5 idiom already used in
  `VizelBubbleMenu.vue`.

- **Technical-writing nits (docs).** A passive-voice docstring on
  `VizelEditorTransactionStore.getVersion` and an ambiguous pronoun in the
  link-editor builder comment.

## Breaking Changes

v2.0.0 is unreleased, so these are behavior refinements rather than consumer-facing
breaks:

- **ColorPicker grid edges.** The shared grid controller applies standard grid
  accessibility at the boundaries: left / right no longer wrap around the absolute
  ends, and a vertical move past the grid keeps the current cell (previously the
  adapters wrapped horizontally and clamped to the last cell). All three adapters
  change identically, so parity holds. In-grid movement is unchanged.
- **NodeSelector Escape.** Escape over an open dropdown now closes only the dropdown
  (focus returns to the trigger). A second Escape dismisses the bubble menu. The
  previous single Escape tore down the whole bubble menu.

## Test Plan

- [x] `pnpm typecheck` (core, react, vue, svelte).
- [x] `pnpm lint` (615 files, no warnings).
- [x] `pnpm check:adr-compliance` (14 PASS / 0 WARN / 0 FAIL), `check:feature-parity`
      (23×3), `check:ssr`, `check:nolet`, `check:scenarios`, `check:ct-parity`.
- [x] `pnpm test:ct:{react,vue,svelte} ColorPicker` → 15 each (45 total) green.
- [x] Real-browser verification (React :3000 / Vue :3001 / Svelte :3002) of the
      built demos:
  - ColorPicker: arrow / Home / End grid navigation, intentional non-wrapping edges,
    Enter and Space apply a color.
  - NodeSelector: open by click and by keyboard, arrow navigation with wrap, Home /
    End, Enter and Space change the block type; two-level Escape verified — first
    Escape closes the dropdown and returns focus to the trigger with the bubble menu
    intact, second Escape dismisses the bubble menu.
  - FindReplace: the two replace buttons render `Replace` and `Replace all`;
    replace-one and replace-all mutate the document.
  - LinkEditor (Vue): focus moves to the URL input on open, Escape returns focus to
    the editor, click-outside closes.
  - Console clean across all three (only unrelated KaTeX demo-font noise).
