### PR TITLE
fix: publish @vizel/headless and ship license and repository metadata

### DIFF
--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seijikohara/vizel",
+    "url": "git+https://github.com/seijikohara/vizel.git",
     "directory": "packages/core"
   },
   "description": "Framework-agnostic core for Vizel block-based Markdown editor built on Tiptap",
@@ -158,10 +158,10 @@
   },
   "dependencies": {
     "@tiptap/extension-list": "^3.23.6",
-    "@vizel/headless": "workspace:^",
     "@tiptap/extension-node-range": "^3.23.6",
     "@tiptap/extensions": "^3.23.6",
     "@tiptap/y-tiptap": "^3.0.3",
+    "@vizel/headless": "workspace:^",
     "markdown-it": "^14.2.0",
     "markdown-it-deflist": "^3.0.1",
     "markdown-it-footnote": "^4.0.0",

--- a/packages/headless/LICENSE
+++ b/packages/headless/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -1,0 +1,31 @@
+# @vizel/headless
+
+Framework-neutral UI primitives that power the Vizel editor adapters.
+
+This package is a **transitive dependency** of `@vizel/react`, `@vizel/vue`, and
+`@vizel/svelte`. Install one of those adapters; npm resolves `@vizel/headless`
+automatically. You do not depend on this package directly.
+
+## What it provides
+
+Each primitive ships a pure spec builder plus a controller that owns its DOM
+side effects behind a `{ mount, unmount, update }` contract. Every primitive
+guards Server-Side Rendering (SSR) and imports no framework runtime.
+
+| Subpath | Primitive | Purpose |
+|---------|-----------|---------|
+| `@vizel/headless/combobox` | Combobox | Keyboard contract and ARIA wiring for autocomplete-style menus |
+| `@vizel/headless/popover` | Popover | Anchored popover positioning and dismissal |
+| `@vizel/headless/dismissable` | Dismissable | Outside-pointer and Escape dismissal with focus return |
+| `@vizel/headless/focus-trap` | Focus trap | Focus boundary for modal surfaces |
+| `@vizel/headless/floating` | Floating | `@floating-ui/dom` positioning wrapper |
+| `@vizel/headless/keyboard` | Keyboard | List and grid roving-selection navigation |
+
+## Design
+
+The rationale lives in [ADR-0003](https://github.com/seijikohara/vizel/blob/main/docs/adr/ADR-0003-vizel-headless-package.md).
+The package depends only on `@floating-ui/dom` and standard DOM APIs.
+
+## License
+
+MIT

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -2,10 +2,9 @@
   "name": "@vizel/headless",
   "version": "2.0.0",
   "type": "module",
-  "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/seijikohara/vizel",
+    "url": "git+https://github.com/seijikohara/vizel.git",
     "directory": "packages/headless"
   },
   "description": "Framework-neutral UI primitives consumed by every Vizel framework adapter",

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seijikohara/vizel",
+    "url": "git+https://github.com/seijikohara/vizel.git",
     "directory": "packages/react"
   },
   "description": "React 19 components and hooks for Vizel block-based Markdown editor",

--- a/packages/svelte/LICENSE
+++ b/packages/svelte/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seijikohara/vizel",
+    "url": "git+https://github.com/seijikohara/vizel.git",
     "directory": "packages/svelte"
   },
   "description": "Svelte 5 components and runes for Vizel block-based Markdown editor",

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seijikohara/vizel",
+    "url": "git+https://github.com/seijikohara/vizel.git",
     "directory": "packages/vue"
   },
   "description": "Vue 3 components and composables for Vizel block-based Markdown editor",


### PR DESCRIPTION
## Summary

First of the release-readiness fixes. Resolves the central publish blocker on the
package-metadata side and ships license text in every tarball.

- **`@vizel/headless` is now publishable.** The package carried `"private": true`,
  yet `@vizel/core` and all three adapters declare it as a runtime dependency and
  import it from their built `dist`. A consumer installing `@vizel/react` could not
  resolve `@vizel/headless` (it was never on the registry). Removing the private flag
  lets the package publish as the transitive dependency the architecture (ADR-0003)
  intends.
- **MIT `LICENSE` ships in every package.** None of the package tarballs carried the
  license text despite `"license": "MIT"`. A copy now sits in each package root; npm
  includes a root-level `LICENSE` in the tarball regardless of the `files` field.
- **`repository.url` normalized** to the `git+https://github.com/seijikohara/vizel.git`
  form that npm and publint expect (the `directory` field is preserved per package).
- **`@vizel/headless` gains a README** documenting it as a transitive-only package.

The publish-pipeline half of the blocker (the `workspace:^` spec leak and adding
headless to `publish.yml`) lands in the next PR.

## Breaking Changes

None. v2.0.0 is unreleased; these are packaging-correctness changes.

## Test Plan

- [x] `npm pack` of `@vizel/headless` now succeeds and the tarball contains `dist/`,
      `LICENSE`, `README.md`, and `package.json`.
- [x] Biome check passes on all five modified `package.json` files.
- [x] CI quality + test matrix.
