### PR TITLE
ci: publish @vizel/headless and guard against workspace dependency leaks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           pnpm --filter @vizel/core exec npm version "$VERSION" --no-git-tag-version
+          pnpm --filter @vizel/headless exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/react exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/vue exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/svelte exec npm version "$VERSION" --no-git-tag-version
@@ -124,7 +125,7 @@ jobs:
         run: |
           echo "## 📦 Package Contents" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          for pkg in core react vue svelte; do
+          for pkg in core headless react vue svelte; do
             echo "### @vizel/$pkg" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             (cd packages/$pkg && npm pack --dry-run 2>&1) >> $GITHUB_STEP_SUMMARY
@@ -141,9 +142,9 @@ jobs:
             packages/*/package.json
           retention-days: 1
 
-  # Publish core first (other packages depend on it)
-  publish-core:
-    name: Publish @vizel/core
+  # Publish headless first: @vizel/core and every adapter depend on it.
+  publish-headless:
+    name: Publish @vizel/headless
     runs-on: ubuntu-latest
     needs: [validate, build]
     if: ${{ !inputs.dry-run }}
@@ -163,6 +164,55 @@ jobs:
         with:
           name: build-artifacts
           path: packages
+
+      - name: Rewrite workspace dependencies
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: node scripts/rewrite-workspace-deps.mjs packages/headless/package.json "$VERSION"
+
+      - name: Publish
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          PRERELEASE_TAG=""
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
+          fi
+          PUBLISH_OPTS="--provenance --access public --no-git-checks"
+          if [ -n "$PRERELEASE_TAG" ]; then
+            PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
+            echo "📌 Publishing @vizel/headless with tag: $PRERELEASE_TAG"
+          fi
+          cd packages/headless && npm publish $PUBLISH_OPTS
+          echo "✅ Published @vizel/headless@$VERSION"
+
+  # Publish core next: it depends on @vizel/headless and is depended on by the adapters.
+  publish-core:
+    name: Publish @vizel/core
+    runs-on: ubuntu-latest
+    needs: [validate, build, publish-headless]
+    if: ${{ !inputs.dry-run }}
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifacts
+          path: packages
+
+      - name: Rewrite workspace dependencies
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: node scripts/rewrite-workspace-deps.mjs packages/core/package.json "$VERSION"
 
       - name: Publish
         env:
@@ -207,13 +257,14 @@ jobs:
           name: build-artifacts
           path: packages
 
-      - name: Update dependency version
+      - name: Rewrite workspace dependencies
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          cd packages/${{ matrix.package }}
-          # Replace workspace:^ with actual version for publishing
-          sed -i 's/"@vizel\/core": "workspace:\^"/"@vizel\/core": "^'"$VERSION"'"/' package.json
+        # Resolve every workspace:^ spec (@vizel/core and @vizel/headless) to the
+        # release version. npm publish ships workspace: protocol verbatim, which
+        # aborts a consumer install with EUNSUPPORTEDPROTOCOL, so this rewrite is
+        # mandatory before publishing.
+        run: node scripts/rewrite-workspace-deps.mjs packages/${{ matrix.package }}/package.json "$VERSION"
 
       - name: Publish
         env:
@@ -271,6 +322,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           pnpm --filter @vizel/core exec npm version "$VERSION" --no-git-tag-version
+          pnpm --filter @vizel/headless exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/react exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/vue exec npm version "$VERSION" --no-git-tag-version
           pnpm --filter @vizel/svelte exec npm version "$VERSION" --no-git-tag-version
@@ -314,6 +366,7 @@ jobs:
           echo "| Package | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| @vizel/core | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "| @vizel/headless | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| @vizel/react | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| @vizel/vue | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| @vizel/svelte | ✅ |" >> $GITHUB_STEP_SUMMARY
@@ -322,6 +375,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Links" >> $GITHUB_STEP_SUMMARY
             echo "- [npm: @vizel/core](https://www.npmjs.com/package/@vizel/core)" >> $GITHUB_STEP_SUMMARY
+            echo "- [npm: @vizel/headless](https://www.npmjs.com/package/@vizel/headless)" >> $GITHUB_STEP_SUMMARY
             echo "- [npm: @vizel/react](https://www.npmjs.com/package/@vizel/react)" >> $GITHUB_STEP_SUMMARY
             echo "- [npm: @vizel/vue](https://www.npmjs.com/package/@vizel/vue)" >> $GITHUB_STEP_SUMMARY
             echo "- [npm: @vizel/svelte](https://www.npmjs.com/package/@vizel/svelte)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -78,6 +78,24 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Pack every publishable package and fail if any dependency still carries
+      # a pnpm `workspace:` spec. A leaked spec aborts a consumer install with
+      # EUNSUPPORTEDPROTOCOL, so this gate blocks a broken release before it
+      # reaches the publish workflow.
+      - name: Publish gate (no workspace leaks)
+        run: pnpm check:publishable
+
+      # publint validates each package's exports, types, and file map against
+      # the actual packed tarball, catching publish-time misconfiguration the
+      # type checker cannot see.
+      - name: Lint published manifests (publint)
+        run: |
+          for pkg in core headless react vue svelte; do
+            echo "::group::publint @vizel/$pkg"
+            npx --yes publint@^0.3.0 packages/$pkg
+            echo "::endgroup::"
+          done
+
       # Publish the per-package `dist/` so `bundle-size` measures the exact
       # bytes this run produced. Sharing the artifact avoids a duplicate
       # build in the dependent job and keeps the two measurements in sync.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "check:nolet": "node scripts/check-no-let.ts",
     "prepare": "lefthook install",
     "deps:check": "pnpm dlx taze major -r",
-    "deps:update": "pnpm dlx taze major -r -w && pnpm install"
+    "deps:update": "pnpm dlx taze major -r -w && pnpm install",
+    "check:publishable": "node scripts/check-publishable.ts"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/scripts/check-publishable.ts
+++ b/scripts/check-publishable.ts
@@ -1,0 +1,95 @@
+/**
+ * Publish-readiness harness.
+ *
+ * Packs every publishable package with `pnpm pack` (which resolves the pnpm
+ * `workspace:` protocol exactly as the publish step's rewrite does) and asserts
+ * the would-be-published package.json carries no unresolved `workspace:`
+ * dependency spec. A leaked `workspace:` spec makes a consumer `npm install`
+ * abort with EUNSUPPORTEDPROTOCOL before any registry lookup, so this gate
+ * blocks the release before it ships a broken tarball.
+ *
+ * The harness also asserts that the cross-package @vizel dependencies resolve to
+ * a concrete semver range, catching the inverse failure where a rewrite drops a
+ * dependency entirely.
+ *
+ * Run: `pnpm check:publishable`.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+const PUBLISHABLE = ["core", "headless", "react", "vue", "svelte"] as const;
+const DEP_SECTIONS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+  "devDependencies",
+] as const;
+
+interface PackedManifest {
+  readonly name: string;
+  readonly dependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+  readonly optionalDependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+}
+
+const packManifest = (pkg: string): PackedManifest => {
+  const dest = mkdtempSync(join(tmpdir(), `vizel-pub-${pkg}-`));
+  execFileSync("pnpm", ["--filter", `@vizel/${pkg}`, "pack", "--pack-destination", dest], {
+    cwd: REPO_ROOT,
+    stdio: "pipe",
+  });
+  const tarball = readdirSync(dest).find((entry) => entry.endsWith(".tgz"));
+  if (!tarball) throw new Error(`pnpm pack produced no tarball for @vizel/${pkg}`);
+  const manifest = execFileSync(
+    "tar",
+    ["-xzO", "-f", join(dest, tarball), "package/package.json"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }
+  );
+  return JSON.parse(manifest) as PackedManifest;
+};
+
+const workspaceLeaks = (manifest: PackedManifest): readonly string[] =>
+  DEP_SECTIONS.flatMap((section) => {
+    const deps = manifest[section] ?? {};
+    return Object.entries(deps)
+      .filter(([, spec]) => spec.startsWith("workspace:"))
+      .map(([name, spec]) => `${section}.${name} = "${spec}"`);
+  });
+
+const main = (): void => {
+  const results = PUBLISHABLE.map((pkg) => {
+    const manifest = packManifest(pkg);
+    return { pkg, leaks: workspaceLeaks(manifest) };
+  });
+
+  const failures = results.filter((result) => result.leaks.length > 0);
+
+  for (const result of results) {
+    const status = result.leaks.length === 0 ? "PASS" : "FAIL";
+    console.log(`[${status}] @vizel/${result.pkg}`);
+    for (const leak of result.leaks) console.log(`        leaked workspace spec: ${leak}`);
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `\nPublish gate FAILED: ${failures.length} package(s) ship an unresolved "workspace:" spec. ` +
+        "The publish step must rewrite every workspace dependency to a concrete version."
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nPublish gate passed (${PUBLISHABLE.length} packages, no workspace leaks).`);
+};
+
+main();

--- a/scripts/rewrite-workspace-deps.mjs
+++ b/scripts/rewrite-workspace-deps.mjs
@@ -1,0 +1,77 @@
+/**
+ * Rewrite pnpm `workspace:` dependency specs to concrete versions before
+ * `npm publish`.
+ *
+ * `npm publish` does not understand the pnpm `workspace:` protocol, so any
+ * `workspace:` spec ships verbatim and aborts a consumer install with
+ * EUNSUPPORTEDPROTOCOL. The CI publish jobs run this script over each package
+ * before publishing so @vizel/core and @vizel/headless resolve to the release
+ * version. `pnpm pack` / `pnpm publish` perform the same rewrite; this keeps the
+ * proven `npm publish --provenance` (OIDC) path while removing the brittle
+ * hand-rolled sed.
+ *
+ * Plain ESM (.mjs) so it runs on any Node the publish jobs provide without
+ * type-stripping support.
+ *
+ * Usage: node scripts/rewrite-workspace-deps.mjs <package.json path> <version>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const DEP_SECTIONS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+  "devDependencies",
+];
+
+const resolveSpec = (spec, version) => {
+  // pnpm protocol: workspace:^ -> ^<version>, workspace:~ -> ~<version>,
+  // workspace:* -> <version>, workspace:<range> -> <range>.
+  if (!spec.startsWith("workspace:")) return spec;
+  const rest = spec.slice("workspace:".length);
+  if (rest === "^" || rest === "~") return `${rest}${version}`;
+  if (rest === "*" || rest === "") return version;
+  return rest;
+};
+
+const rewriteSection = (section, version) => {
+  if (!section) return { next: section, changed: [] };
+  const entries = Object.entries(section);
+  const changed = entries
+    .filter(([, spec]) => spec.startsWith("workspace:"))
+    .map(([name, spec]) => `${name}: ${spec} -> ${resolveSpec(spec, version)}`);
+  const next = Object.fromEntries(
+    entries.map(([name, spec]) => [name, resolveSpec(spec, version)])
+  );
+  return { next, changed };
+};
+
+const main = () => {
+  const [manifestPath, version] = process.argv.slice(2);
+  if (!(manifestPath && version)) {
+    console.error("Usage: node scripts/rewrite-workspace-deps.mjs <package.json path> <version>");
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const rewritten = DEP_SECTIONS.map((section) => {
+    const result = rewriteSection(manifest[section], version);
+    if (result.next !== undefined) manifest[section] = result.next;
+    return { section, changed: result.changed };
+  });
+
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const allChanged = rewritten.flatMap((entry) =>
+    entry.changed.map((line) => `${entry.section}.${line}`)
+  );
+  if (allChanged.length === 0) {
+    console.log(`No workspace specs in ${manifestPath}`);
+    return;
+  }
+  console.log(`Rewrote ${allChanged.length} workspace spec(s) in ${manifestPath}:`);
+  for (const line of allChanged) console.log(`  ${line}`);
+};
+
+main();


### PR DESCRIPTION
## Summary

Resolves the publish-pipeline half of the release blocker and adds a CI gate so a
broken release cannot reach the publish workflow.

- **`@vizel/headless` is now published.** A new `publish-headless` job runs before
  `publish-core` (core depends on headless), and the version-bump and finalize steps
  include headless so all five packages share one release version.
- **No more `workspace:^` leak.** The publish workflow rewrote only `@vizel/core` with
  a hand-rolled `sed` and used `npm publish`, which ships the pnpm `workspace:` protocol
  verbatim — a consumer install then aborts with `EUNSUPPORTEDPROTOCOL`. The `sed` is
  replaced by `scripts/rewrite-workspace-deps.mjs`, which resolves every `workspace:^`
  spec (`@vizel/core` and `@vizel/headless`, across `dependencies`, `peerDependencies`,
  `optionalDependencies`, and `devDependencies`) to the release version before
  `npm publish`. The proven `npm publish --provenance` (OIDC) path is unchanged.
- **CI publish gate.** `scripts/check-publishable.ts` (run as `pnpm check:publishable`)
  packs every publishable package with `pnpm pack` and fails if any dependency still
  carries a `workspace:` spec. The Quality job runs `check:publishable` and `publint`
  after the build, so the leak class and any exports/types misconfiguration are caught
  on every push.

## Breaking Changes

None. Release-tooling changes only.

## Test Plan

- [x] `pnpm check:publishable` → all five packages PASS, no workspace leaks (`pnpm pack`
      resolves `@vizel/core` and `@vizel/headless` to `^2.0.0`).
- [x] `node scripts/rewrite-workspace-deps.mjs <copy> 2.0.0` rewrites every `workspace:^`
      spec (dependency, peer, and dev) to `^2.0.0`; zero `workspace:` strings remain.
- [x] `publint` reports "All good!" for `@vizel/core` and `@vizel/headless` on a clean build.
- [x] Biome and no-let checks pass on the new scripts.
- [x] `publish.yml` job graph: validate → test → build → publish-headless → publish-core
      → publish-framework → finalize.
