### PR TITLE
fix: emit node16-resolvable declaration imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:vue": "pnpm --filter @vizel/demo-vue dev",
     "dev:svelte": "pnpm --filter @vizel/demo-svelte dev",
     "dev:all": "concurrently -n react,vue,svelte -c blue,green,magenta \"pnpm dev:react\" \"pnpm dev:vue\" \"pnpm dev:svelte\"",
-    "build": "pnpm -r --if-present run build",
+    "build": "pnpm -r --if-present run build && node scripts/add-dts-extensions.mjs packages/core/dist packages/headless/dist packages/react/dist packages/vue/dist packages/svelte/dist",
     "docs:api": "typedoc && node scripts/postprocess-typedoc.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "pnpm build && pnpm docs:api && vitepress build docs && pnpm docs:build:demos",

--- a/scripts/add-dts-extensions.mjs
+++ b/scripts/add-dts-extensions.mjs
@@ -1,0 +1,64 @@
+/**
+ * Add explicit `.js` extensions to relative imports in emitted `.d.ts` files.
+ *
+ * vite-plugin-dts emits extensionless relative specifiers (`from "./x"`), which
+ * TypeScript's node16 / nodenext module resolution rejects. This post-build step
+ * rewrites every relative specifier in each package's dist `.d.ts` to the form
+ * node16 requires: `./x.js` for a sibling file or `./x/index.js` for a directory.
+ * Bundler resolution already accepts both forms, so the rewrite is safe across
+ * every consumer.
+ *
+ * Usage: node scripts/add-dts-extensions.mjs <dist dir> [<dist dir> ...]
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const collectDtsFiles = (dir) =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return collectDtsFiles(full);
+    return entry.name.endsWith(".d.ts") ? [full] : [];
+  });
+
+const resolveSpecifier = (fileDir, specifier) => {
+  // Already extensioned (.js, .json, .css, ...) — leave untouched.
+  if (/\.[a-z]+$/i.test(specifier)) return specifier;
+  if (existsSync(join(fileDir, `${specifier}.d.ts`))) return `${specifier}.js`;
+  const asDir = join(fileDir, specifier);
+  if (existsSync(asDir) && statSync(asDir).isDirectory() && existsSync(join(asDir, "index.d.ts"))) {
+    return `${specifier}/index.js`;
+  }
+  return specifier;
+};
+
+const REL_SPECIFIER =
+  /(from\s+|import\(\s*|export\s+\*\s+from\s+|export\s+\{[^}]*\}\s+from\s+)(["'])(\.\.?\/[^"']+)\2/g;
+
+const rewriteFile = (file) => {
+  const fileDir = dirname(file);
+  const source = readFileSync(file, "utf8");
+  const next = source.replace(REL_SPECIFIER, (match, prefix, quote, specifier) => {
+    const resolved = resolveSpecifier(fileDir, specifier);
+    return resolved === specifier ? match : `${prefix}${quote}${resolved}${quote}`;
+  });
+  if (next === source) return 0;
+  writeFileSync(file, next);
+  return 1;
+};
+
+const main = () => {
+  const dirs = process.argv.slice(2).filter((arg) => existsSync(arg));
+  if (dirs.length === 0) {
+    console.error("Usage: node scripts/add-dts-extensions.mjs <dist dir> [<dist dir> ...]");
+    process.exit(1);
+  }
+  const changed = dirs
+    .flatMap((dir) => collectDtsFiles(dir))
+    .reduce((sum, file) => sum + rewriteFile(file), 0);
+  console.log(
+    `Added .js extensions in ${changed} declaration file(s) across ${dirs.length} dir(s).`
+  );
+};
+
+main();


### PR DESCRIPTION
Add scripts/add-dts-extensions.mjs (run after the package build) to rewrite extensionless relative imports in emitted .d.ts to the .js / /index.js form node16 and nodenext require. Fixes @vizel/core's table.d.ts internal resolution error; safe for bundler resolution and idempotent. attw now reports zero internal resolution errors for @vizel/core.