### PR TITLE
test(ct): add an executable find-replace scenario across frameworks

### DIFF
--- a/tests/ct/react/specs/FindReplace.spec.tsx
+++ b/tests/ct/react/specs/FindReplace.spec.tsx
@@ -1,0 +1,36 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testFindReplaceOpens,
+  testFindReportsMatchCount,
+  testReplaceAll,
+  testReplaceButtonsAreLocalized,
+  testReplaceOne,
+} from "../../scenarios/find-replace.scenario";
+import { FindReplaceFixture } from "./FindReplaceFixture";
+
+test.describe("VizelFindReplace - React", () => {
+  test("opens the panel in replace mode", async ({ mount, page }) => {
+    const component = await mount(<FindReplaceFixture />);
+    await testFindReplaceOpens(component, page);
+  });
+
+  test("renders localized replace buttons", async ({ mount, page }) => {
+    const component = await mount(<FindReplaceFixture />);
+    await testReplaceButtonsAreLocalized(component, page);
+  });
+
+  test("reports the match count", async ({ mount, page }) => {
+    const component = await mount(<FindReplaceFixture />);
+    await testFindReportsMatchCount(component, page);
+  });
+
+  test("replaces a single match", async ({ mount, page }) => {
+    const component = await mount(<FindReplaceFixture />);
+    await testReplaceOne(component, page);
+  });
+
+  test("replaces all matches", async ({ mount, page }) => {
+    const component = await mount(<FindReplaceFixture />);
+    await testReplaceAll(component, page);
+  });
+});

--- a/tests/ct/react/specs/FindReplaceFixture.tsx
+++ b/tests/ct/react/specs/FindReplaceFixture.tsx
@@ -1,0 +1,31 @@
+import {
+  createVizelFindReplaceExtension,
+  useVizelEditor,
+  VizelEditor,
+  VizelFindReplace,
+  VizelProvider,
+} from "@vizel/react";
+import { useMemo } from "react";
+
+export function FindReplaceFixture() {
+  const extensions = useMemo(() => [createVizelFindReplaceExtension()], []);
+  const editor = useVizelEditor({
+    immediatelyRender: false,
+    initialMarkdown: "alpha beta alpha gamma alpha",
+    extensions,
+  });
+
+  return (
+    <VizelProvider editor={editor}>
+      <button
+        type="button"
+        data-testid="open-replace"
+        onClick={() => editor?.commands.openFindReplace("replace")}
+      >
+        open replace
+      </button>
+      <VizelFindReplace />
+      <VizelEditor />
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/find-replace.scenario.ts
+++ b/tests/ct/scenarios/find-replace.scenario.ts
@@ -1,0 +1,75 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared, framework-agnostic scenarios for the find-and-replace panel.
+ *
+ * Each fixture mounts an editor preloaded with the paragraph
+ * "alpha beta alpha gamma alpha" (the term "alpha" appears three times) plus a
+ * `[data-testid="open-replace"]` button that opens the panel in replace mode
+ * through `editor.commands.openFindReplace("replace")`. The replacement term
+ * "ZULU" shares no substring with "alpha", so a case-insensitive match count
+ * drops cleanly as occurrences are replaced.
+ */
+
+const PANEL = ".vizel-find-replace-panel";
+const INPUT = ".vizel-find-replace-input";
+const COUNT = ".vizel-find-replace-count";
+const EDITOR = ".vizel-editor";
+
+const openReplacePanel = async (component: Locator): Promise<void> => {
+  // The editor mounts asynchronously (immediatelyRender: false), so wait for its
+  // content before triggering the open command — clicking earlier no-ops against
+  // a still-null editor and the panel never appears.
+  await expect(component.locator(EDITOR)).toContainText("alpha");
+  await component.locator("[data-testid='open-replace']").click();
+  await expect(component.locator(PANEL)).toBeVisible();
+};
+
+/** Verify the panel opens in replace mode with both rows present. */
+export async function testFindReplaceOpens(component: Locator, _page: Page): Promise<void> {
+  await openReplacePanel(component);
+  // Find-row input plus replace-row input.
+  await expect(component.locator(INPUT)).toHaveCount(2);
+}
+
+/** Verify the two replace buttons render the localized labels, not a bare "All". */
+export async function testReplaceButtonsAreLocalized(
+  component: Locator,
+  _page: Page
+): Promise<void> {
+  await openReplacePanel(component);
+  await expect(component.getByRole("button", { name: "Replace", exact: true })).toBeVisible();
+  await expect(component.getByRole("button", { name: "Replace all", exact: true })).toBeVisible();
+}
+
+/** Verify typing a term highlights every match and reports the count. */
+export async function testFindReportsMatchCount(component: Locator, _page: Page): Promise<void> {
+  await openReplacePanel(component);
+  await component.locator(INPUT).first().fill("alpha");
+  await expect(component.locator(COUNT)).toContainText("3");
+}
+
+/** Verify "Replace" swaps a single match and leaves the rest. */
+export async function testReplaceOne(component: Locator, _page: Page): Promise<void> {
+  await openReplacePanel(component);
+  await component.locator(INPUT).first().fill("alpha");
+  await component.locator(INPUT).nth(1).fill("ZULU");
+  await component.getByRole("button", { name: "Replace", exact: true }).click();
+
+  await expect(component.locator(EDITOR)).toContainText("ZULU");
+  // Two "alpha" occurrences remain after replacing one.
+  await expect(component.locator(COUNT)).toContainText("2");
+}
+
+/** Verify "Replace all" swaps every remaining match. */
+export async function testReplaceAll(component: Locator, _page: Page): Promise<void> {
+  await openReplacePanel(component);
+  await component.locator(INPUT).first().fill("alpha");
+  await component.locator(INPUT).nth(1).fill("ZULU");
+  await component.getByRole("button", { name: "Replace all", exact: true }).click();
+
+  const editor = component.locator(EDITOR);
+  await expect(editor).not.toContainText("alpha");
+  await expect(editor).toContainText("ZULU");
+}

--- a/tests/ct/svelte/specs/FindReplace.spec.ts
+++ b/tests/ct/svelte/specs/FindReplace.spec.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testFindReplaceOpens,
+  testFindReportsMatchCount,
+  testReplaceAll,
+  testReplaceButtonsAreLocalized,
+  testReplaceOne,
+} from "../../scenarios/find-replace.scenario";
+import FindReplaceFixture from "./FindReplaceFixture.svelte";
+
+test.describe("VizelFindReplace - Svelte", () => {
+  test("opens the panel in replace mode", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testFindReplaceOpens(component, page);
+  });
+
+  test("renders localized replace buttons", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceButtonsAreLocalized(component, page);
+  });
+
+  test("reports the match count", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testFindReportsMatchCount(component, page);
+  });
+
+  test("replaces a single match", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceOne(component, page);
+  });
+
+  test("replaces all matches", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceAll(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/FindReplaceFixture.svelte
+++ b/tests/ct/svelte/specs/FindReplaceFixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import {
+  createVizelEditor,
+  createVizelFindReplaceExtension,
+  VizelEditor,
+  VizelFindReplace,
+  VizelProvider,
+} from "@vizel/svelte";
+
+const editor = createVizelEditor({
+  immediatelyRender: false,
+  initialMarkdown: "alpha beta alpha gamma alpha",
+  extensions: [createVizelFindReplaceExtension()],
+});
+
+function openReplace() {
+  editor.current?.commands.openFindReplace("replace");
+}
+</script>
+
+<VizelProvider editor={editor.current}>
+  <button type="button" data-testid="open-replace" onclick={openReplace}>open replace</button>
+  <VizelFindReplace />
+  <VizelEditor />
+</VizelProvider>

--- a/tests/ct/vue/specs/FindReplace.spec.ts
+++ b/tests/ct/vue/specs/FindReplace.spec.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testFindReplaceOpens,
+  testFindReportsMatchCount,
+  testReplaceAll,
+  testReplaceButtonsAreLocalized,
+  testReplaceOne,
+} from "../../scenarios/find-replace.scenario";
+import FindReplaceFixture from "./FindReplaceFixture.vue";
+
+test.describe("VizelFindReplace - Vue", () => {
+  test("opens the panel in replace mode", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testFindReplaceOpens(component, page);
+  });
+
+  test("renders localized replace buttons", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceButtonsAreLocalized(component, page);
+  });
+
+  test("reports the match count", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testFindReportsMatchCount(component, page);
+  });
+
+  test("replaces a single match", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceOne(component, page);
+  });
+
+  test("replaces all matches", async ({ mount, page }) => {
+    const component = await mount(FindReplaceFixture);
+    await testReplaceAll(component, page);
+  });
+});

--- a/tests/ct/vue/specs/FindReplaceFixture.vue
+++ b/tests/ct/vue/specs/FindReplaceFixture.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import {
+  createVizelFindReplaceExtension,
+  useVizelEditor,
+  VizelEditor,
+  VizelFindReplace,
+  VizelProvider,
+} from "@vizel/vue";
+
+const editor = useVizelEditor({
+  immediatelyRender: false,
+  initialMarkdown: "alpha beta alpha gamma alpha",
+  extensions: [createVizelFindReplaceExtension()],
+});
+
+function openReplace() {
+  editor.value?.commands.openFindReplace("replace");
+}
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <button type="button" data-testid="open-replace" @click="openReplace">open replace</button>
+    <VizelFindReplace />
+    <VizelEditor />
+  </VizelProvider>
+</template>


### PR DESCRIPTION
Add tests/ct/scenarios/find-replace.scenario.ts plus a fixture and spec for React, Vue, and Svelte. The scenario opens the panel via editor.commands.openFindReplace, verifies the localized Replace / Replace all buttons, the match counter, and single + all replacement. Closes the only shipped public component that had no executable CT (its v2 scenario was a Phase-3 stub). Verified 5 tests x 3 frameworks on chromium.