### PR TITLE
refactor: purge v1/v2 version wording and the for-compat re-export

### DIFF
--- a/.claude/agents/phase-review.md
+++ b/.claude/agents/phase-review.md
@@ -1,6 +1,6 @@
 ---
 name: phase-review
-description: Review a completed Phase of the Vizel v2 rebuild against the Phase plan, the ADRs, and the mechanical compliance harness. Use proactively at every Phase boundary (Phase 0a, 0b, 1, 1.5, 2, 2.5, 3a-stepN, 3b-stepN, 3c-stepN, 4, 5) and on demand when the maintainer wants a fresh compliance snapshot.
+description: Review a completed milestone against its implementation plan, the ADRs, and the mechanical compliance harness. Use proactively when a milestone closes and on demand when the maintainer wants a fresh compliance snapshot.
 tools: Glob, Grep, Read, Bash, NotebookRead, BashOutput
 disallowedTools: Write, Edit, NotebookEdit
 color: green
@@ -9,32 +9,32 @@ model: haiku
 
 # Phase Review
 
-This subagent verifies that a completed Phase actually closed the plan deliverables and the ADR gaps it claimed to. It runs read-only and reports findings; it never edits files.
+This subagent verifies that a completed milestone actually closed the plan deliverables and the ADR gaps it claimed to. It runs read-only and reports findings; it never edits files.
 
 ## Inputs
 
-- The Phase identifier (e.g., `0b`, `1`, `3a-step2`).
+- The milestone identifier from the plan.
 - The implementation plan at `/Users/seiji/.claude/plans/starry-petting-planet.md`.
 - The ADRs under `docs/adr/`.
 - The mechanical harness output from `pnpm check:adr-compliance`.
-- The `git log` since the previous Phase's merge commit.
+- The `git log` since the previous milestone's merge commit.
 
 ## Process
 
-1. **Locate the Phase definition.** Read the relevant section of the plan to extract the declared deliverables: files created, files modified, files deleted, scripts added, hooks added, CI jobs added.
-2. **Run the mechanical harness.** Invoke `pnpm check:adr-compliance` via Bash and read the report. Map each FAIL or WARN back to the Phase's stated scope.
-3. **Diff the git history.** Run `git log --oneline <previous-phase-merge>..HEAD` and `git diff --stat <previous-phase-merge>..HEAD` to confirm the Phase's commits match the plan's expected change footprint.
-4. **Cross-check the ADRs.** For every ADR referenced by the Phase's plan section, confirm:
+1. **Locate the milestone definition.** Read the relevant section of the plan to extract the declared deliverables: files created, files modified, files deleted, scripts added, hooks added, CI jobs added.
+2. **Run the mechanical harness.** Invoke `pnpm check:adr-compliance` via Bash and read the report. Map each FAIL or WARN back to the milestone's stated scope.
+3. **Diff the git history.** Run `git log --oneline <previous-milestone-merge>..HEAD` and `git diff --stat <previous-milestone-merge>..HEAD` to confirm the milestone's commits match the plan's expected change footprint.
+4. **Cross-check the ADRs.** For every ADR referenced by the milestone's plan section, confirm:
    - The ADR's binding rules are honoured in the diff.
-   - The Phase did not silently exceed scope (touching unrelated ADRs without a written justification).
-5. **Verify follow-up annotations.** When the Phase ships intentional deferrals (e.g., "the legacy script remains until Phase X"), confirm the deferral is recorded in the PR body, the ADR, or a follow-up issue.
+   - The milestone did not silently exceed scope (touching unrelated ADRs without a written justification).
+5. **Verify follow-up annotations.** When the milestone ships intentional deferrals (e.g., "the legacy script remains until a later milestone"), confirm the deferral is recorded in the PR body, the ADR, or a follow-up issue.
 
 ## Output
 
 Report findings in the following format. Cite file paths in `path:line` form.
 
 ```markdown
-## Phase Review: <Phase ID>
+## Phase Review: <milestone ID>
 
 ### Mechanical harness summary
 
@@ -53,13 +53,13 @@ Report findings in the following format. Cite file paths in `path:line` form.
 
 | ADR | Status | Notes |
 |-----|:------:|-------|
-| 0007 | ✅ | React = 0 listener calls; Vue / Svelte intentionally deferred to 3b-step2 / 3c-step2 |
-| 0008 | ⚠️ | CSS centralisation pending Phase 2.5 |
+| 0007 | ✅ | React = 0 listener calls; Vue / Svelte intentionally deferred |
+| 0008 | ⚠️ | CSS centralisation pending a later milestone |
 
 ### Recommendations
 
 - [ ] Add the missing harness script before merging.
-- [ ] Record the Phase 2.5 deferral in `docs/adr/ADR-0008-css-belongs-in-core.md`.
+- [ ] Record the deferral in `docs/adr/ADR-0008-css-belongs-in-core.md`.
 ```
 
 ## Constraints
@@ -67,4 +67,4 @@ Report findings in the following format. Cite file paths in `path:line` form.
 - Read-only. The `disallowedTools` frontmatter blocks Write, Edit, and NotebookEdit.
 - Defer prose-style enforcement to the `lint-instructions` skill.
 - Defer commit-message validation to lefthook's `commit-msg` hook.
-- The mechanical harness is the authoritative source for binding ADR invariants. Treat its FAIL output as a hard block before approving the Phase.
+- The mechanical harness is the authoritative source for binding ADR invariants. Treat its FAIL output as a hard block before approving the milestone.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This rule states the binding architecture invariants for Vizel v2.0.0. The detailed rationale for each invariant lives in `docs/adr/`. Read the relevant ADR before changing a binding rule.
+This rule states the binding architecture invariants for Vizel. The detailed rationale for each invariant lives in `docs/adr/`. Read the relevant ADR before changing a binding rule.
 
 ## Product identity
 

--- a/.claude/rules/feature-manifest.md
+++ b/.claude/rules/feature-manifest.md
@@ -8,9 +8,7 @@ paths:
 
 # Feature Manifest
 
-Vizel v2 expresses cross-framework feature parity as TypeScript, not prose. The Single Source of Truth (SSOT) is `packages/core/src/feature-manifest.ts`. The full rationale lives in [ADR-0002](../../docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md).
-
-> **Status as of 2026-05-28**: this rule documents the target contract. The manifest file lands in Phase 1 alongside `scripts/check-parity.ts`. Until then, treat this rule as the design specification for that work.
+Vizel expresses cross-framework feature parity as TypeScript, not prose. The Single Source of Truth (SSOT) is `packages/core/src/feature-manifest.ts`. The full rationale lives in [ADR-0002](../../docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md). `scripts/check-feature-parity.ts` verifies coverage against the manifest.
 
 ## What the manifest contains
 

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -40,7 +40,7 @@ This project uses Conventional Commits. The lefthook `commit-msg` hook validates
 | `docs` | VitePress docs site under `docs/` |
 | `ct` | Playwright Component Tests under `tests/ct/` |
 | `deps` | Dependency-only changes (typically `chore(deps)`) |
-| `spec` | v2 design spec under `docs/superpowers/specs/` |
+| `spec` | design spec under `docs/superpowers/specs/` |
 | `guide` | User-facing guide pages under `docs/guide/` |
 | `plan` | Implementation plans under `docs/superpowers/plans/` |
 | `i18n` | Locale files |

--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -71,7 +71,7 @@ Every UI scaffold consumes one of five canonical spec types. New builders produc
 | `VizelCommandSpec` | Actionable item shared across command surfaces | slash item, toolbar action, bubble menu action, block menu item |
 | `VizelGridSpec<TCell>` | Two-dimensional cell grid | color picker grid, future emoji picker |
 
-Builder function names follow the pattern `buildVizel<Component>Spec(...)`. Section 2 of the v2.0.0 redesign retires the legacy `*Skeleton` naming and migrates each existing builder to one of the five spec types above.
+Builder function names follow the pattern `buildVizel<Component>Spec(...)`. Each builder returns one of the five spec types above.
 
 Component composition (target state):
 
@@ -198,7 +198,7 @@ appears. The same logical command (e.g. "format/bold") shows up in
 the toolbar, the bubble menu, and the keyboard shortcut table without
 being defined more than once. Surface-specific builders consume a
 `readonly VizelCommand[]` and project each entry into the matching
-Section 2 spec for a specific editor and locale.
+spec for a specific editor and locale.
 
 ### Surfaces and builders
 
@@ -257,7 +257,7 @@ reason in a comment on the command definition.
 
 ## Markdown Pipeline
 
-The Markdown extension is part of the always-on core (Section 8) — it
+The Markdown extension is part of the always-on core — it
 loads without an opt-in flag, and consumer Markdown output is governed
 by the `markdown` option on `VizelEditorOptions`:
 
@@ -481,7 +481,7 @@ toggles, no host-environment side effects.
 A single CSS entry per framework package
 (`@vizel/<framework>/styles.css`) makes every built-in component
 render correctly. Three import patterns are supported via the
-subpath exports landed in Section 6c:
+package's subpath exports:
 
 | Pattern | Import | Use case |
 |---------|--------|----------|

--- a/.claude/rules/packages/headless.md
+++ b/.claude/rules/packages/headless.md
@@ -7,8 +7,6 @@ paths:
 
 `@vizel/headless` provides framework-neutral UI primitives that every adapter consumes. The rationale lives in [ADR-0003](../../../docs/adr/ADR-0003-vizel-headless-package.md).
 
-> **Status as of 2026-05-28**: this rule documents the target contract. The package scaffolds in Phase 2. Until then, treat this rule as the design specification.
-
 ## What the package contains
 
 | Primitive | Purpose |
@@ -38,6 +36,6 @@ Each primitive exports `{ buildSpec, createController }`. The spec is a pure fun
 
 `@vizel/headless` ships no CSS. The single CSS catalogue lives in `@vizel/core/styles.css` (see [ADR-0008](../../../docs/adr/ADR-0008-css-belongs-in-core.md)).
 
-## Migration target
+## Global listeners
 
-The 21 `document.addEventListener` calls that currently live inside adapter components migrate into the `dismissable/` primitive during Phase 2. Adapter components consume the primitive thereafter; they never attach global listeners directly.
+Global `document.addEventListener` calls live inside the `dismissable/` primitive, never inside adapter components. Adapter components consume the primitive; they never attach global listeners directly.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -6,10 +6,10 @@ paths:
 
 # Testing
 
-Vizel ships seven testing pillars. Section 14 of the v2.0.0 spec
-(`docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`,
-lines 1175-1210) is the SSOT; this file is the project-rule projection
-of that spec and is what PR review uses to gate coverage.
+Vizel ships seven testing pillars. The design spec
+(`docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`)
+is the SSOT; this file is the project-rule projection of that spec and
+is what PR review uses to gate coverage.
 
 ## The Seven Pillars
 
@@ -23,7 +23,7 @@ of that spec and is what PR review uses to gate coverage.
 | 6 | Visual regression | not yet | CI-only snapshots (planned) |
 | 7 | Coverage discipline | shipped (this document) | Required-test matrix below |
 
-Pillars 5 and 6 are tracked as follow-up work for the v2.0.0 push. Do
+Pillars 5 and 6 are tracked as follow-up work. Do
 not block PRs on missing a11y or visual snapshots until those suites
 land — but every other pillar gates merge.
 
@@ -62,9 +62,8 @@ component before adding a spec asymmetry.
 
 ## Pillar 2 — Behavior tests for every shipped feature
 
-Sections 1-13 of the v2.0.0 spec each introduce features (builders,
-controllers, commands, block operations, static view modes, etc.).
-Each feature receives:
+Every shipped feature (builders, controllers, commands, block
+operations, static view modes, etc.) receives:
 
 1. A shared scenario at `tests/ct/scenarios/<feature>.scenario.ts`.
 2. Three per-framework specs at
@@ -195,11 +194,11 @@ await expect(element).toContainText("Hello");
 
 ## Pillar 3 — Markdown round-trip suite
 
-`tests/markdown-roundtrip/` drives the Section 10 round-trip matrix:
+`tests/markdown-roundtrip/` drives the round-trip matrix:
 every supported flavor parses and re-serializes a corpus of samples
 without lossy edits.
 
-The Section 10 long-term target is 100+ samples per flavor. The
+The long-term target is 100+ samples per flavor. The
 current corpus ships a representative cross-section (heading,
 paragraph, list, blockquote, inline emphasis, inline code, fenced
 code, image, link, plus the flavor-specific syntax). Expanding the
@@ -266,15 +265,15 @@ inside function bodies remains permitted.
 
 ## Pillar 5 — Accessibility suite (NOT YET SHIPPED)
 
-The Section 14 target is `tests/a11y/` driven by `@axe-core/playwright`
+The target is `tests/a11y/` driven by `@axe-core/playwright`
 asserting WCAG 2.1 AA conformance against every component. The
-Section 2 spec-based ARIA wiring keeps the per-component cost low.
+spec-based ARIA wiring keeps the per-component cost low.
 
 ### Status
 
 - Directory: not yet created.
 - Dependency: `@axe-core/playwright` not yet added.
-- Tracking: follow-up work for the v2.0.0 release push.
+- Tracking: follow-up work.
 
 ### How to bootstrap (when work starts)
 
@@ -324,7 +323,7 @@ pnpm test:visual:update
 The shipped suite covers a representative slice; broader coverage
 (slash menu open, bubble menu over selection, block menu, color
 picker, outline, link editor, find/replace) is a
-follow-up tracked against the v2.0.0 polish milestone.
+follow-up tracked against the polish milestone.
 
 ---
 
@@ -353,7 +352,7 @@ become "required" once it lands.
 2. For each "required" pillar, confirm a spec / scenario / sample /
    case exists in the PR diff.
 3. For each "follow-up" pillar, note the future work in the PR body
-   under "Follow-up" so the v2.0.0 push retains the tracking.
+   under "Follow-up" so the tracking is retained.
 4. Run `pnpm check:ct-parity` and the relevant `pnpm test:*` commands
    before requesting review.
 

--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -121,7 +121,7 @@ interface DemoFeatures {
 type PanelTab = "markdown" | "json" | "history" | "comments";
 
 /**
- * Read character and word counts via the v2 selector API.
+ * Read character and word counts via the selector API.
  *
  * `useVizelEditorState` reads the editor from the surrounding
  * `VizelProvider` and re-renders only when the selector slice changes

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -281,7 +281,7 @@ function handleJsonChange(event: Event) {
           onCreate={handleCreate}
           onUpdate={handleUpdate}
         >
-          <!-- Svelte 5 snippet — the v2 render-prop idiom for Svelte
+          <!-- Svelte 5 snippet — the render-prop idiom for Svelte
                (ADR-0004). The snippet receives the bound editor; the
                find-replace panel re-renders against it on every
                transaction. Lowercase event props (`onclick`,

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -61,7 +61,7 @@ const replyTexts = ref<Record<string, string>>({});
 // Store editor reference from Vizel component. The Vizel component
 // updates this ref through `@create`; the surrounding `VizelProvider`
 // then forwards the editor to descendants such as `StatsBar`, which
-// drives the character / word count display via the v2
+// drives the character / word count display via the
 // `useVizelEditorState` selector API (see `StatsBar.vue`).
 const editorRef = shallowRef<Editor | null>(null);
 
@@ -262,7 +262,7 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
               @create="handleCreate"
               @update="handleUpdate"
             >
-              <!-- Vue scoped slot — the v2 render-prop idiom for Vue.
+              <!-- Vue scoped slot — the render-prop idiom for Vue.
                    The slot exposes the bound editor through its props
                    so consumers can drop in any component that needs it. -->
               <template #default="{ editor: slotEditor }">
@@ -275,7 +275,7 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
                 <span v-if="features.stats" class="status-divider">·</span>
               </template>
               <!-- StatsBar consumes the editor through `VizelProvider`
-                   via the v2 selector composable. See `StatsBar.vue`
+                   via the selector composable. See `StatsBar.vue`
                    for the `useVizelEditorState` selector definition. -->
               <StatsBar v-if="features.stats" />
             </div>

--- a/apps/demo/vue/src/StatsBar.vue
+++ b/apps/demo/vue/src/StatsBar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { shallowEqualObject, useVizelEditorState } from "@vizel/vue";
 
-// Read character and word counts via the v2 selector composable.
+// Read character and word counts via the selector composable.
 //
 // `useVizelEditorState` reads the editor from the surrounding
 // `VizelProvider` and re-evaluates the selector only when the selector

--- a/packages/core/src/_internal/README.md
+++ b/packages/core/src/_internal/README.md
@@ -9,14 +9,13 @@ must not appear in the public API.
 - Framework packages (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) must
   not re-export symbols from this directory.
 - The directory exists to give internal helpers a clear home and to let
-  `scripts/check-reexport-mirror.ts` (introduced in Section 6 of the
-  v2.0.0 redesign) distinguish public from internal exports physically
-  rather than by convention.
+  `scripts/check-reexport-mirror.ts` distinguish public from internal
+  exports physically rather than by convention.
 
 ## Examples of suitable contents
 
-- Lazy-loader helper (`createLazyOptionalLoader`, Section 10)
-- Diagnostic emitter (`emitVizelError`, Section 7)
+- Lazy-loader helper (`createLazyOptionalLoader`)
+- Diagnostic emitter (`emitVizelError`)
 - Test fixtures shared across internal tests but not exposed to
   consumers
 

--- a/packages/core/src/builders/block-menu-from-commands.ts
+++ b/packages/core/src/builders/block-menu-from-commands.ts
@@ -18,7 +18,7 @@ export interface VizelBlockMenuFromCommandsOptions {
  * Build the block-menu action list from a {@link VizelCommand} array.
  *
  * Filters by `surfaces.blockMenu`, sorts by priority ascending, and
- * projects each command into a Section 2 {@link VizelCommandSpec}.
+ * projects each command into a {@link VizelCommandSpec}.
  *
  * The framework `VizelBlockMenu` component composes the resulting
  * action list with the popover spec built by `buildVizelBlockMenuSpec`

--- a/packages/core/src/builders/bubble-menu.ts
+++ b/packages/core/src/builders/bubble-menu.ts
@@ -19,7 +19,7 @@ export interface VizelBubbleMenuSpecOptions {
  *
  * Filters by `surfaces.bubbleMenu`, applies each command's optional
  * `showWhen` predicate against the editor, sorts by priority
- * ascending, and projects each command into a Section 2
+ * ascending, and projects each command into a
  * {@link VizelCommandSpec}.
  */
 export function buildVizelBubbleMenuSpec(

--- a/packages/core/src/builders/slash-menu.ts
+++ b/packages/core/src/builders/slash-menu.ts
@@ -140,7 +140,7 @@ export function getNextVizelSlashMenuGroupIndex(
 }
 
 // ============================================================================
-// VizelCommand-based derivation (Section 9)
+// VizelCommand-based derivation
 // ============================================================================
 
 /**

--- a/packages/core/src/builders/toolbar.ts
+++ b/packages/core/src/builders/toolbar.ts
@@ -18,7 +18,7 @@ export interface VizelToolbarSpecOptions {
  * Build the toolbar spec from a {@link VizelCommand} array.
  *
  * Filters by `surfaces.toolbar`, sorts by priority ascending (lower
- * priority appears first), and projects each command into a Section 2
+ * priority appears first), and projects each command into a
  * {@link VizelCommandSpec}. The framework `VizelToolbar` component
  * iterates the result to render its buttons.
  */

--- a/packages/core/src/builders/types.ts
+++ b/packages/core/src/builders/types.ts
@@ -190,11 +190,10 @@ export interface VizelShortcutSpec {
  * fuzzy-match keywords, and the runtime-evaluated enable / active
  * flags.
  *
- * Section 9 of the v2.0.0 redesign introduces `VizelCommand` (the
- * runtime-bearing form with `canRun`, `isActive`, `run`); builders use
- * `VizelCommand` to derive a `VizelCommandSpec` for a specific editor
- * instance. Until Section 9 ships, builders construct
- * `VizelCommandSpec` values directly from the legacy item-view types.
+ * `VizelCommand` carries the runtime-bearing form (`canRun`, `isActive`,
+ * `run`); builders derive a `VizelCommandSpec` from a `VizelCommand` for
+ * a specific editor instance, stripping the runtime fields so renderers
+ * receive view-only data.
  */
 export interface VizelCommandSpec {
   /** Stable identifier shared across surfaces (e.g. "format/bold"). */

--- a/packages/core/src/commands/derive.ts
+++ b/packages/core/src/commands/derive.ts
@@ -9,7 +9,7 @@ import type { VizelCommand } from "./types.ts";
  * Surface builders call this helper for each command they include in
  * their output so the resulting spec carries the localized strings and
  * the runtime-evaluated `isEnabled` / `isActive` flags expected by the
- * Section 2 spec shapes.
+ * spec shapes.
  */
 export function deriveVizelCommandSpec(
   command: VizelCommand,

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,4 +1,4 @@
-// VizelCommand unified abstraction (Section 9).
+// VizelCommand unified abstraction.
 export { deriveVizelCommandSpec } from "./derive.ts";
 export {
   vizelBlockCommands,

--- a/packages/core/src/commands/registry/block-ops.ts
+++ b/packages/core/src/commands/registry/block-ops.ts
@@ -56,7 +56,7 @@ function duplicateCurrentBlock(editor: Editor): boolean {
 }
 
 /**
- * Built-in block-operation commands (Section 11).
+ * Built-in block-operation commands.
  *
  * Each command joins the block menu surface plus a keyboard shortcut.
  * They build on Tiptap's command APIs (`joinBackward`, `splitBlock`,

--- a/packages/core/src/commands/registry/insert.ts
+++ b/packages/core/src/commands/registry/insert.ts
@@ -33,9 +33,9 @@ export const vizelInsertCommands: readonly VizelCommand[] = [
     keywords: ["picture", "photo", "img", "url"],
     canRun: (editor) => typeof editor.commands.setImage === "function",
     run: (editor) => {
-      // window.prompt is the legacy slash-menu UX. Section 11 replaces
-      // it with a proper VizelLinkEditor-style form; the run callback
-      // continues to work in the meantime.
+      // window.prompt is a placeholder slash-menu UX pending a proper
+      // VizelLinkEditor-style form. The run callback stays functional so
+      // image insertion works today.
       if (typeof window === "undefined") return false;
       const url = window.prompt("Enter image URL:");
       if (!url) return false;

--- a/packages/core/src/commands/types.ts
+++ b/packages/core/src/commands/types.ts
@@ -50,12 +50,12 @@ export interface VizelCommandSurfaceSet {
 /**
  * Unified runtime-bearing command shared across editor surfaces.
  *
- * A single `VizelCommand` replaces the legacy slash item, toolbar
- * action, bubble menu action, block menu action, and shortcut binding.
- * Surface-specific builders (`buildVizelSlashMenuSpec`,
+ * A single `VizelCommand` defines one user action for the slash item,
+ * toolbar action, bubble menu action, block menu action, and shortcut
+ * binding at once. Surface-specific builders (`buildVizelSlashMenuSpec`,
  * `buildVizelToolbarSpec`, `buildVizelBubbleMenuSpec`,
- * `buildVizelBlockMenuSpec`) consume `VizelCommand[]` and derive
- * Section 2 spec shapes; `registerVizelShortcuts` consumes the same
+ * `buildVizelBlockMenuSpec`) consume `VizelCommand[]` and derive the
+ * matching spec shapes; `registerVizelShortcuts` consumes the same
  * list to wire keyboard bindings.
  *
  * @example

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -130,9 +130,9 @@ function createBaseExtensions(
     Dropcursor.configure({ color: "#3b82f6", width: 2 }),
     Gapcursor,
     ListKeymap,
-    // Multi-block range selection — always-on (Section 11b)
+    // Multi-block range selection — always-on
     createVizelMultiBlockSelectionExtension(),
-    // Block-aware clipboard — always-on (Section 11c)
+    // Block-aware clipboard — always-on
     createVizelBlockClipboardExtension(),
   ];
 

--- a/packages/core/src/extensions/block-clipboard.ts
+++ b/packages/core/src/extensions/block-clipboard.ts
@@ -1,10 +1,9 @@
 /**
  * Block-aware clipboard extension.
  *
- * Section 11c of the v2.0.0 spec promotes the clipboard pipeline into
- * the always-on core. The extension hooks `copy`, `cut`, and `paste`
- * DOM events on the editor view through a single ProseMirror plugin
- * and:
+ * The clipboard pipeline is part of the always-on core. The extension
+ * hooks `copy`, `cut`, and `paste` DOM events on the editor view
+ * through a single ProseMirror plugin and:
  *
  * - **Copy / Cut.** When the active selection covers a multi-block
  *   range (resolved via `getVizelMultiBlockSelectionState`), it writes

--- a/packages/core/src/extensions/drag-handle.ts
+++ b/packages/core/src/extensions/drag-handle.ts
@@ -167,7 +167,7 @@ export function createVizelDragHandleExtension(options: VizelDragHandleOptions =
       edgeDetection: "none",
     },
     onElementDragStart() {
-      // Multi-block forwarding (Section 11c). When a multi-block range
+      // Multi-block forwarding. When a multi-block range
       // is active and the drag handle's current node falls inside that
       // range, expand the editor selection to cover the entire range
       // before the underlying `dragHandler` runs. `dragHandler` checks

--- a/packages/core/src/extensions/embed.ts
+++ b/packages/core/src/extensions/embed.ts
@@ -391,7 +391,7 @@ export interface VizelEmbedOptions {
    */
   onFetchError?: (error: Error, url: string) => void;
   /**
-   * Markdown encoding mode (Section 10).
+   * Markdown encoding mode.
    *
    * - `"default"` emits the lossy form `[title || url](url)`. Metadata
    *   such as `type` and `provider` is lost on round-trip.

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -1,6 +1,6 @@
 // Base extensions
 export { createVizelExtensions, type VizelExtensionsOptions } from "./base.ts";
-// Block-aware clipboard (Section 11c)
+// Block-aware clipboard
 export {
   createVizelBlockClipboardExtension,
   type VizelBlockClipboardOptions,
@@ -38,7 +38,7 @@ export {
   type VizelCodeBlockLanguage,
   type VizelCodeBlockOptions,
 } from "./code-block-lowlight.ts";
-// Command shortcuts (Section 9)
+// Command shortcuts
 export {
   createVizelCommandShortcutsExtension,
   type VizelCommandShortcutsOptions,
@@ -172,7 +172,7 @@ export {
   type VizelMentionItem,
   type VizelMentionOptions,
 } from "./mention.ts";
-// Multi-block range selection (Section 11b)
+// Multi-block range selection
 export {
   createVizelMultiBlockSelectionExtension,
   getVizelMultiBlockSelectionState,

--- a/packages/core/src/extensions/mention.ts
+++ b/packages/core/src/extensions/mention.ts
@@ -73,7 +73,7 @@ export interface VizelMentionOptions {
   deleteTriggerWithBackspace?: boolean;
 
   /**
-   * Markdown encoding mode (Section 10).
+   * Markdown encoding mode.
    *
    * - `"default"` emits the lossy form `@username`. The mention id is
    *   lost on round-trip if the label and id differ.

--- a/packages/core/src/extensions/multi-block-selection.ts
+++ b/packages/core/src/extensions/multi-block-selection.ts
@@ -7,8 +7,8 @@
  * keyboard shortcuts (Backspace / Delete / Tab / Shift+Tab) that apply
  * to every block in the range.
  *
- * This is part of the always-on core (Section 11b of the v2.0.0 spec)
- * and ships without an opt-in feature flag.
+ * This extension is part of the always-on core and ships without an
+ * opt-in feature flag.
  */
 import { Extension } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";

--- a/packages/core/src/extensions/wiki-link.ts
+++ b/packages/core/src/extensions/wiki-link.ts
@@ -76,7 +76,7 @@ export interface VizelWikiLinkOptions {
   serializeAsWikiLink?: boolean;
 
   /**
-   * Markdown encoding mode (Section 10).
+   * Markdown encoding mode.
    *
    * - `"default"` emits the lossy form (`[[page]]` for Obsidian-style
    *   flavors, `[display](wiki://page)` otherwise). The page identifier
@@ -330,10 +330,9 @@ function registerWikiLinkRule(md: MarkdownIt): void {
 /**
  * Escape a value for inclusion inside a `vizel:` metadata comment.
  *
- * Mirrors the escape table from spec A.3: `&`, `"`, `<`, `>`, and the
- * literal `-->` sequence map to their HTML-entity equivalents so the
- * value cannot prematurely close the host HTML comment or collide
- * with the attribute delimiter.
+ * Escapes `&`, `"`, `<`, `>`, and the literal `-->` sequence to their
+ * HTML-entity equivalents so the value cannot prematurely close the
+ * host HTML comment or collide with the attribute delimiter.
  */
 function escapeMetadataCommentValue(value: string): string {
   return value

--- a/packages/core/src/feature-manifest.ts
+++ b/packages/core/src/feature-manifest.ts
@@ -7,10 +7,11 @@
  * (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports the declared
  * symbol for every entry.
  *
- * The manifest deliberately replaces v1's `cross-framework.md` prose
- * tables. ADR-0001, ADR-0002, and ADR-0006 explain the rationale; the
- * companion rule `.claude/rules/feature-manifest.md` documents the
- * workflow for adding, modifying, and removing features.
+ * The manifest replaces prose parity tables with type-checked entries
+ * so an adapter can never silently drift from the declared surface.
+ * ADR-0001, ADR-0002, and ADR-0006 explain the rationale; the companion
+ * rule `.claude/rules/feature-manifest.md` documents the workflow for
+ * adding, modifying, and removing features.
  */
 
 /** Stable identifier for every advertised Vizel feature. */
@@ -86,8 +87,7 @@ export interface VizelFeatureDefinition {
   readonly keyboardMap: VizelKeyboardMap;
   /**
    * Scenario identifiers under `tests/ct/scenarios/<feature-id>/`.
-   * Phase 1.5 populates the scenario folders; entries can stay empty
-   * until that work lands.
+   * An entry may stay empty until its scenario folder is populated.
    */
   readonly scenarios: readonly string[];
   readonly adapters: VizelFeatureAdapters;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,16 +8,16 @@
  */
 
 // Side-effect import: augment `@tiptap/core`'s Editor with the always-on
-// `getMarkdown()` / `markdown.parse(md)` surface (Section 10 of the v2.0.0
-// spec). Must load before any consumer touches the augmented members.
+// `getMarkdown()` / `markdown.parse(md)` surface. Must load before any
+// consumer touches the augmented members.
 import "./markdown/augment.ts";
 
 // =============================================================================
 // Tiptap Re-exports (for framework packages)
 // =============================================================================
-// Tiptap symbol re-exports — see Section 6 of the v2.0.0 spec. Consumers
-// can install only one Vizel framework package and import these without
-// adding @tiptap/core to their dependencies.
+// Re-export the Tiptap symbols that adapters need. Consumers can install
+// only one Vizel framework package and import these without adding
+// @tiptap/core to their dependencies.
 export type {
   ChainedCommands,
   Editor,
@@ -44,7 +44,7 @@ export {
   type VizelStorageBackend,
 } from "./auto-save.ts";
 // =============================================================================
-// Builders (Section 2)
+// Builders
 // =============================================================================
 export {
   applyVizelLinkEdit,
@@ -119,7 +119,7 @@ export {
 } from "./collaboration.ts";
 export type { VizelCollaborationProvider } from "./collaboration-provider.ts";
 // =============================================================================
-// Commands (Section 9 — VizelCommand unified abstraction)
+// Commands (VizelCommand unified abstraction)
 // =============================================================================
 export {
   deriveVizelCommandSpec,
@@ -171,6 +171,27 @@ export {
   type VizelRelativeTimeTickerOptions,
   type VizelSystemThemeListener,
 } from "./controllers/index.ts";
+// Portal controller: shared layered overlay container for adapter portals.
+export {
+  createVizelPortalElement,
+  getVizelPortalContainer,
+  hasVizelPortalContainer,
+  mountToVizelPortal,
+  removeVizelPortalContainer,
+  unmountFromVizelPortal,
+  VIZEL_PORTAL_ID,
+  VIZEL_PORTAL_Z_INDEX,
+  type VizelMountPortalOptions,
+  type VizelPortalLayer,
+} from "./controllers/portal.ts";
+// Suggestion container controller: positioned container for slash and mention menus.
+export {
+  createVizelSuggestionContainer,
+  handleVizelSuggestionEscape,
+  VIZEL_SUGGESTION_Z_INDEX,
+  type VizelDOMRectGetter,
+  type VizelSuggestionContainer,
+} from "./controllers/suggestionContainer.ts";
 // =============================================================================
 // Extensions
 // =============================================================================
@@ -178,7 +199,7 @@ export {
   // Text color
   addVizelRecentColor,
   applyVizelColorToEditor,
-  // Block-aware clipboard (Section 11c)
+  // Block-aware clipboard
   createVizelBlockClipboardExtension,
   // Block menu (locale-aware)
   createVizelBlockMenuActions,
@@ -188,7 +209,7 @@ export {
   createVizelCharacterCountExtension,
   // Code block with syntax highlighting
   createVizelCodeBlockExtension,
-  // Command shortcuts (Section 9)
+  // Command shortcuts
   createVizelCommandShortcutsExtension,
   // Comment
   createVizelCommentExtension,
@@ -225,7 +246,7 @@ export {
   createVizelMathematicsExtensions,
   // Mention
   createVizelMentionExtension,
-  // Multi-block range selection (Section 11b)
+  // Multi-block range selection
   createVizelMultiBlockSelectionExtension,
   // Node types (locale-aware)
   createVizelNodeTypes,
@@ -433,7 +454,7 @@ export {
   vizelDefaultIconIds,
 } from "./icons/index.ts";
 // =============================================================================
-// Markdown flavor plugin types (Section 10)
+// Markdown flavor plugin types
 // =============================================================================
 export {
   assertMarkdownRoundtrip,
@@ -520,9 +541,6 @@ export {
   createVizelError,
   // Markdown utilities
   createVizelMarkdownSyncHandlers,
-  createVizelPortalElement,
-  // Suggestion container utilities
-  createVizelSuggestionContainer,
   createVizelUploadEventHandler,
   emitVizelError,
   // Keyboard shortcut utilities
@@ -532,13 +550,10 @@ export {
   getVizelBlockPath,
   getVizelEditorState,
   getVizelMarkdown,
-  getVizelPortalContainer,
   // Collection utilities
   groupByConsecutiveField,
-  handleVizelSuggestionEscape,
   // Type guard utilities
   hasFunction,
-  hasVizelPortalContainer,
   initializeVizelMarkdownContent,
   isOptionalString,
   isRecord,
@@ -547,12 +562,10 @@ export {
   isVizelMacPlatform,
   // Color utilities
   isVizelValidHexColor,
-  mountToVizelPortal,
   mountVizelEditorView,
   normalizeVizelHexColor,
   parseVizelMarkdown,
   registerVizelUploadEventHandler,
-  removeVizelPortalContainer,
   resolveVizelFeatures,
   // Markdown flavor utilities
   resolveVizelFlavorConfig,
@@ -564,30 +577,22 @@ export {
   // Text highlight utilities
   splitVizelTextByMatches,
   transformVizelDiagramCodeBlocks,
-  unmountFromVizelPortal,
   VIZEL_DEFAULT_FLAVOR,
   VIZEL_DEFAULT_MARKDOWN_DEBOUNCE_MS,
-  VIZEL_PORTAL_ID,
-  VIZEL_PORTAL_Z_INDEX,
-  VIZEL_SUGGESTION_Z_INDEX,
   VIZEL_UPLOAD_IMAGE_EVENT,
   type VizelBlockPathSegment,
   type VizelCalloutMarkdownFormat,
   type VizelContentNode,
   type VizelCreateUploadEventHandlerOptions,
-  type VizelDOMRectGetter,
   VizelError,
   type VizelErrorCode,
   type VizelErrorOptions,
   type VizelErrorSeverity,
   type VizelFlavorConfig,
   type VizelMarkdownSyncHandlers,
-  type VizelMountPortalOptions,
-  type VizelPortalLayer,
   type VizelResolveFeaturesOptions,
-  type VizelSuggestionContainer,
   type VizelTextSegment,
-  // SSR utilities (Section 12)
+  // SSR utilities
   type VizelThemeInitScriptOptions,
   vizelCancelAnimationFrame,
   vizelCommonMarkFlavor,

--- a/packages/core/src/markdown/augment.ts
+++ b/packages/core/src/markdown/augment.ts
@@ -2,10 +2,10 @@
  * Module augmentation that makes the Markdown extension's runtime
  * surface available on the `Editor` type unconditionally.
  *
- * Vizel always installs the Markdown extension (Section 8 of the
- * v2.0.0 spec promotes it to the always-on core), so consumers can
- * call `editor.getMarkdown()` and `editor.markdown.parse(md)` without
- * a capability check. This file declares the augmentation; the runtime
+ * Vizel always installs the Markdown extension as part of the always-on
+ * core, so consumers can call `editor.getMarkdown()` and
+ * `editor.markdown.parse(md)` without a capability check. This file
+ * declares the augmentation; the runtime
  * implementation lives in `extensions/markdown.ts` via the
  * `tiptap-markdown` extension's `onBeforeCreate` hook plus a per-editor
  * wrapper that pins `editor.markdown` / `editor.getMarkdown`.

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -1,4 +1,4 @@
-// VizelMarkdownFlavor as a first-class plugin type (Section 10).
+// VizelMarkdownFlavor as a first-class plugin type.
 export {
   composeVizelMarkdownFlavors,
   vizelCommonMarkFlavor,

--- a/packages/core/src/markdown/types.ts
+++ b/packages/core/src/markdown/types.ts
@@ -5,12 +5,10 @@ import type { JSONContent } from "@tiptap/core";
  * plugins interact with at registration time.
  *
  * Defined locally so consumers do not need `@types/markdown-it`
- * installed to author a flavor plugin. When the eventual library
- * swap (Section 10b) wires the real markdown-it instance through,
- * `markdownItPlugins` callbacks receive the full markdown-it API —
- * the structural type below covers the `.use()` registration that
- * every plugin needs, and any narrower call is available via a
- * `(md as any).foo()` cast inside the callback.
+ * installed to author a flavor plugin. `markdownItPlugins` callbacks
+ * receive the full markdown-it API — the structural type below covers
+ * the `.use()` registration that every plugin needs, and any narrower
+ * call is available via a `(md as any).foo()` cast inside the callback.
  */
 export interface VizelMarkdownItInstance {
   // biome-ignore lint/suspicious/noExplicitAny: structural placeholder mirrors markdown-it's open plugin signature
@@ -109,9 +107,9 @@ export type VizelMarkdownLossyEncodingMode = "default" | "metadata-comment";
 /**
  * Per-node encoding mode map.
  *
- * Keys correspond to the lossy node types listed in spec Section 10
- * (`embed`, `mention`, `wikiLink`). Other node types are unaffected
- * and follow the flavor's serializer hooks.
+ * Keys correspond to the lossy node types (`embed`, `mention`,
+ * `wikiLink`). Other node types are unaffected and follow the flavor's
+ * serializer hooks.
  */
 export interface VizelMarkdownEncodingOptions {
   readonly embed?: VizelMarkdownLossyEncodingMode;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -141,8 +141,7 @@ export interface VizelInteractionFeatureOptions {
   typography?: VizelTypographyOptions | boolean;
   /**
    * Placeholder text shown when the editor is empty.
-   * Replaces the top-level `VizelEditorOptions.placeholder` option from
-   * v1.x. Default: "Type '/' for commands...".
+   * Default: "Type '/' for commands...".
    */
   placeholder?: string;
   /**

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -121,9 +121,8 @@ export async function createVizelEditorInstance(
   // Refuse to construct an editor on the server. Tiptap mounts to a
   // contenteditable element that only exists in the browser, so
   // calling this factory from a Node / edge runtime is a programming
-  // error. Section 12 of the v2.0 design surfaces this as the
-  // `SSR_NOT_SUPPORTED` typed error so consumers can distinguish it
-  // from runtime failures.
+  // error. Surface this as the `SSR_NOT_SUPPORTED` typed error so
+  // consumers can distinguish it from runtime failures.
   if (typeof document === "undefined") {
     throw createVizelError(
       "SSR_NOT_SUPPORTED",

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,26 +1,5 @@
 // Editor helpers
 
-// Portal utilities (relocated to controllers/ in v2.0.0 Section 1; re-exported here for compat)
-export {
-  createVizelPortalElement,
-  getVizelPortalContainer,
-  hasVizelPortalContainer,
-  mountToVizelPortal,
-  removeVizelPortalContainer,
-  unmountFromVizelPortal,
-  VIZEL_PORTAL_ID,
-  VIZEL_PORTAL_Z_INDEX,
-  type VizelMountPortalOptions,
-  type VizelPortalLayer,
-} from "../controllers/portal.ts";
-// Suggestion container utilities (relocated to controllers/ in v2.0.0 Section 1; re-exported here for compat)
-export {
-  createVizelSuggestionContainer,
-  handleVizelSuggestionEscape,
-  VIZEL_SUGGESTION_Z_INDEX,
-  type VizelDOMRectGetter,
-  type VizelSuggestionContainer,
-} from "../controllers/suggestionContainer.ts";
 // Block path utilities
 export { getVizelBlockPath, type VizelBlockPathSegment } from "./block-path.ts";
 // Color utilities
@@ -96,7 +75,7 @@ export {
   vizelCancelAnimationFrame,
   vizelRequestAnimationFrame,
 } from "./raf.ts";
-// SSR utilities (Section 12)
+// SSR utilities
 export {
   type VizelThemeInitScriptOptions,
   vizelThemeInitScript,

--- a/packages/core/src/utils/markdown-flavors.ts
+++ b/packages/core/src/utils/markdown-flavors.ts
@@ -53,10 +53,9 @@ export function resolveVizelFlavorConfig(
   return { calloutFormat, wikiLinkSerialize };
 }
 
-// Surface the built-in flavors here so existing import sites that pull
-// from `utils/markdown-flavors.ts` (Section 10 will retire these in
-// favor of `@vizel/core` root re-exports) keep working without the
-// callers having to chase the new module path.
+// Surface the built-in flavors here so import sites that pull from
+// `utils/markdown-flavors.ts` keep working alongside the `@vizel/core`
+// root re-exports without chasing a separate module path.
 export {
   vizelCommonMarkFlavor,
   vizelDocusaurusFlavor,

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -17,8 +17,7 @@ export const VIZEL_DEFAULT_MARKDOWN_DEBOUNCE_MS = 300;
  *
  * The Markdown extension is always installed by Vizel, so
  * `editor.getMarkdown()` is guaranteed to exist when the editor is
- * non-null (Section 10 of the v2.0.0 spec). Returns an empty string
- * when the editor is missing.
+ * non-null. Returns an empty string when the editor is missing.
  *
  * @param editor - The editor instance
  * @param _onError - Reserved for future use. The current implementation

--- a/packages/core/src/utils/ssr.ts
+++ b/packages/core/src/utils/ssr.ts
@@ -36,10 +36,10 @@ export interface VizelThemeInitScriptOptions {
  * the wrong theme.
  *
  * The script touches only `document.documentElement` — Vizel's other
- * code stays scoped to the editor wrapper, per the theme policy in
- * Section 13 of the v2.0 design. The output is a self-contained IIFE
- * that the framework adapter places inside a `<script>` tag using
- * the framework's idiomatic inline-script mechanism.
+ * code stays scoped to the editor wrapper, per the theme policy. The
+ * output is a self-contained IIFE that the framework adapter places
+ * inside a `<script>` tag using the framework's idiomatic inline-script
+ * mechanism.
  *
  * The script body is fully synthesized from typed options inside this
  * helper and never embeds consumer-supplied raw markup, so it carries

--- a/packages/headless/src/dismissable/index.ts
+++ b/packages/headless/src/dismissable/index.ts
@@ -69,10 +69,10 @@ const isBrowser = (): boolean => typeof document !== "undefined";
 /**
  * Construct a dismissable controller for a floating surface.
  *
- * The controller is the home for the listener wiring that v1
- * framework components attached directly to `document`. Adapter code
- * obtains the controller through `@vizel/headless`, passes its root
- * element into `mount`, and detaches via `unmount` on lifecycle
+ * The controller centralizes the global `document` listener wiring so
+ * adapter components never attach those listeners themselves. Adapter
+ * code obtains the controller through `@vizel/headless`, passes its
+ * root element into `mount`, and detaches via `unmount` on lifecycle
  * teardown.
  */
 export function createVizelDismissable(

--- a/packages/headless/src/floating/index.ts
+++ b/packages/headless/src/floating/index.ts
@@ -49,8 +49,8 @@ export type VizelFloatingAnchor = HTMLElement | VizelVirtualElement;
 export const VIZEL_FLOATING_DEFAULT_PLACEMENT = "bottom-start" satisfies Placement;
 
 /**
- * Default gap, in pixels, between the anchor and the body. Matches the
- * spacing the legacy core popover controller applied.
+ * Default gap, in pixels, between the anchor and the body. The value
+ * keeps anchored surfaces visually attached to their trigger.
  */
 export const VIZEL_FLOATING_DEFAULT_OFFSET = 4;
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -11,8 +11,9 @@
  *
  * Current scope:
  * - `dismissable/` ships click-outside, Escape, and focus-return
- *   wiring; it is the migration target for the adapter components that
- *   v1 attached `document` listeners directly.
+ *   wiring; adapter components mount this controller instead of
+ *   attaching global `document` listeners themselves, so the wiring
+ *   lives in one place and detaches deterministically on teardown.
  * - `keyboard/` ships list and grid navigation spec builders plus
  *   `keydown`-owning controllers; adapter menus consume the pure
  *   builders.

--- a/packages/headless/src/popover/index.ts
+++ b/packages/headless/src/popover/index.ts
@@ -15,10 +15,10 @@
  * DOM. `createVizelPopoverController` owns the positioning subscription
  * and the dismiss listeners.
  *
- * Dismiss semantics match the legacy core popover controller: a pointer
- * event inside the body or inside the anchor does not dismiss; a pointer
- * event truly outside both dismisses; Escape dismisses when
- * `dismissOnEscape` stays enabled. The anchor exclusion is necessary
+ * Dismiss semantics: a pointer event inside the body or inside the
+ * anchor does not dismiss; a pointer event truly outside both
+ * dismisses; Escape dismisses when `dismissOnEscape` stays enabled.
+ * The anchor exclusion is necessary
  * because the trigger lives outside the body element the dismissable
  * controller mounts, so clicking the trigger to toggle the popover must
  * not also register as an outside click.
@@ -179,12 +179,11 @@ export function createVizelPopoverController(
       // The dismissable controller already excluded the body. Exclude the
       // anchor too: the trigger lives outside the body, so toggling the
       // popover by clicking the trigger must not count as an outside
-      // click. The legacy core controller modelled this with a multi-
-      // element "outside" set ([anchor, body]). A virtual anchor exposes
-      // only `getBoundingClientRect`, so probe for `contains` rather than
-      // `instanceof HTMLElement`: the global is undefined under SSR and in
-      // the Node test runner, and the capability check covers both an
-      // element anchor and a virtual one.
+      // click. The "outside" set therefore spans both the anchor and the
+      // body. A virtual anchor exposes only `getBoundingClientRect`, so
+      // probe for `contains` rather than `instanceof HTMLElement`: the
+      // global is undefined under SSR and in the Node test runner, and the
+      // capability check covers both an element anchor and a virtual one.
       const anchor = options.getAnchor();
       if (
         target instanceof Node &&

--- a/packages/react/src/_reactivity.ts
+++ b/packages/react/src/_reactivity.ts
@@ -3,8 +3,8 @@
 /**
  * First-party React reactivity primitive for the Vizel editor.
  *
- * The module replaces v1's reliance on `@tiptap/react` for selector
- * subscriptions. ADR-0009 mandates a first-party implementation in every
+ * The module owns selector subscriptions without depending on
+ * `@tiptap/react`. ADR-0009 mandates a first-party implementation in every
  * adapter so the SSR boundary, the selector contract, and the cleanup
  * behaviour stay under Vizel's control. The React implementation wraps a
  * monotonic version counter inside `useSyncExternalStore`, which React's
@@ -14,11 +14,9 @@
  * The module exposes one public hook (`useVizelEditorState`) plus two
  * equality helpers re-exported from `@vizel/core`. Consumers select the
  * slice they care about and optionally supply an equality function to
- * suppress re-renders when the slice is structurally unchanged.
- *
- * Phase 3a-step1 lands this primitive. Later steps migrate every
- * framework component to consume it; `useVizelEditor` itself moves onto
- * the same store in Phase 3a-step4.
+ * suppress re-renders when the slice is structurally unchanged. Every
+ * framework component, including `useVizelEditor`, subscribes through the
+ * same store so selector behaviour stays uniform.
  */
 
 import { type Editor, shallowEqualArray, shallowEqualObject } from "@vizel/core";
@@ -60,8 +58,8 @@ export interface VizelReactEditorStore {
  * Build a {@link VizelReactEditorStore} for the supplied editor.
  *
  * The factory is an internal building block consumed by
- * {@link useVizelEditorState} and, in later Phase 3a steps, by the
- * `useVizelEditor` hook itself. The factory is intentionally
+ * {@link useVizelEditorState} and by the `useVizelEditor` hook itself.
+ * The factory is intentionally
  * framework-agnostic at the function-signature level — it only depends
  * on Tiptap's `Editor.on` / `Editor.off` event surface — so the test
  * suite can exercise it without rendering React.

--- a/packages/react/src/components/VizelContext.tsx
+++ b/packages/react/src/components/VizelContext.tsx
@@ -6,7 +6,7 @@ import { createContext, type ReactNode, useContext } from "react";
  * `Vizel` down to descendants.
  *
  * The context value is the editor itself (or `null` while it is still
- * initializing). The wrapping `{ editor }` object was removed in v2.0 so the
+ * initializing). The context carries no wrapping `{ editor }` object so the
  * public hook surface (`useVizelContext`) returns the editor directly,
  * matching the React idiom that "the hook is the value" (ADR-0004).
  *

--- a/packages/react/src/components/VizelLinkEditor.tsx
+++ b/packages/react/src/components/VizelLinkEditor.tsx
@@ -35,8 +35,8 @@ export interface VizelLinkEditorProps {
  * skeleton helpers. The component owns input state and event wiring.
  * Pointer-outside and Escape dismissal route through
  * `createVizelDismissable` from `@vizel/headless`; `deferPointerHandler`
- * mirrors v1's `setTimeout(..., 0)` install so the opening pointerdown
- * does not register as an outside click (ADR-0003, ADR-0007).
+ * installs the outside-click listener on the next tick so the opening
+ * pointerdown does not register as an outside click (ADR-0003, ADR-0007).
  * `createVizelFocusTrapController` traps Tab inside the form, focuses the
  * URL input on open, and returns focus to the bubble-menu trigger on
  * close, so the two headless controllers own every form-level listener.
@@ -89,8 +89,9 @@ export function VizelLinkEditor({
       onPointerOutside: () => onCloseRef.current?.(),
       onEscape: () => onCloseRef.current?.(),
       captureEscape: true,
-      // Mirrors v1's `setTimeout(..., 0)` so the pointerdown that opens the
-      // link editor does not immediately register as an outside click.
+      // Defer the outside-click listener to the next tick so the pointerdown
+      // that opens the link editor does not immediately register as an
+      // outside click.
       deferPointerHandler: true,
     });
     controller.mount(form);

--- a/packages/react/src/components/VizelMentionMenu.tsx
+++ b/packages/react/src/components/VizelMentionMenu.tsx
@@ -6,9 +6,9 @@ import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState 
 export interface VizelMentionMenuRef {
   /**
    * Handle keyboard navigation events.
-   * The renderer forwards the raw `KeyboardEvent`; the React component
-   * previously accepted `{ event }`. v2.0 unifies the signature across
-   * React/Vue/Svelte to the raw-event form.
+   * The renderer forwards the raw `KeyboardEvent`. React, Vue, and Svelte
+   * share the raw-event signature so the renderer wires the same way in
+   * every adapter.
    */
   onKeyDown: (event: KeyboardEvent) => boolean;
 }

--- a/packages/react/src/components/VizelSlashMenu.tsx
+++ b/packages/react/src/components/VizelSlashMenu.tsx
@@ -12,9 +12,9 @@ import { VizelSlashMenuItem, type VizelSlashMenuItemProps } from "./VizelSlashMe
 export interface VizelSlashMenuRef {
   /**
    * Handle keyboard navigation events.
-   * The renderer forwards the raw `KeyboardEvent`; the React component
-   * previously accepted `{ event }`. v2.0 unifies the signature across
-   * React/Vue/Svelte to the raw-event form.
+   * The renderer forwards the raw `KeyboardEvent`. React, Vue, and Svelte
+   * share the raw-event signature so the renderer wires the same way in
+   * every adapter.
    */
   onKeyDown: (event: KeyboardEvent) => boolean;
 }

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -17,9 +17,8 @@ export {
 export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 // `useVizelEditorState` ships from `../_reactivity.ts` per ADR-0009 — the
-// selector-style hook that closes the v1 drift. The legacy convenience
-// hook that combined `useVizelState` + `getVizelEditorState` is removed;
-// consumers select the slice they care about through the v2 selector API.
+// selector-style hook. Consumers select the slice they care about through
+// the selector API rather than reading a combined editor-state object.
 export {
   type UseVizelMarkdownOptions,
   type UseVizelMarkdownResult,

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -107,9 +107,9 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
         // Always emit to the consumer handler so observability sinks
         // (Sentry, log pipes) see configuration failures, *and* always
         // rethrow so global handlers / React error boundaries can react.
-        // Earlier v2.0.0 suppressed the rethrow when a handler was set,
-        // which silently blanked the editor when an `onError` was wired up
-        // purely for telemetry — a real consumer-review footgun.
+        // Suppressing the rethrow when a handler is set silently blanks the
+        // editor whenever an `onError` is wired up purely for telemetry, so
+        // the rethrow stays unconditional.
         opts.editorOptions.onError?.(vizelError);
         throw vizelError;
       }

--- a/packages/react/src/hooks/useVizelTheme.ts
+++ b/packages/react/src/hooks/useVizelTheme.ts
@@ -54,7 +54,7 @@ export function useVizelTheme(): UseVizelThemeResult {
 
   // Surface only the resolved theme through the public `theme` field. The
   // underlying `VizelThemeState` keeps `theme` (user setting) and
-  // `resolvedTheme` (applied) separate; v2 collapses both into a single
+  // `resolvedTheme` (applied) separate; the hook collapses both into a single
   // observable so the toggle pattern stays a one-liner.
   //
   // `setTheme` is re-wrapped so the parameter type is physically narrowed

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -16,7 +16,7 @@ initVizelIconRenderer();
 
 // Re-export the full @vizel/core public API so consumers can install only
 // the framework package and import every shared symbol from one place.
-// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+// biome-ignore lint/performance/noReExportAll: mirror the full Core surface so named exports never drift whenever Core adds a symbol.
 export * from "@vizel/core";
 // First-party `useSyncExternalStore`-backed reactivity primitive.
 // ADR-0009 mandates that every adapter implements editor reactivity

--- a/packages/svelte/src/components/VizelLinkEditor.svelte
+++ b/packages/svelte/src/components/VizelLinkEditor.svelte
@@ -24,7 +24,7 @@ export interface VizelLinkEditorProps {
 /**
  * Pointer-outside and Escape dismissal route through
  * `createVizelDismissable` from `@vizel/headless`; `deferPointerHandler`
- * mirrors v1's `setTimeout(..., 0)` install so the opening pointerdown
+ * defers the outside-click listener install so the opening pointerdown
  * does not register as an outside click (ADR-0003, ADR-0007).
  * `createVizelFocusTrapController` traps Tab inside the form, focuses the
  * URL input on open, and returns focus to the bubble-menu trigger on
@@ -81,8 +81,9 @@ $effect(() => {
     onPointerOutside: () => onclose?.(),
     onEscape: () => onclose?.(),
     captureEscape: true,
-    // Mirrors v1's `setTimeout(..., 0)` so the pointerdown that opens the
-    // link editor does not immediately register as an outside click.
+    // Defer the outside-click listener install so the pointerdown that
+    // opens the link editor does not immediately register as an outside
+    // click.
     deferPointerHandler: true,
   });
   controller.mount(formElement);

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -14,7 +14,7 @@ initVizelIconRenderer();
 
 // Re-export the full @vizel/core public API so consumers can install only
 // the framework package and import every shared symbol from one place.
-// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+// biome-ignore lint/performance/noReExportAll: mirror the full Core surface so named exports never drift whenever Core adds a symbol.
 export * from "@vizel/core";
 
 // Explicit re-export so the cross-framework literal parity check picks

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -129,10 +129,10 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
         });
         // Always emit to the consumer handler so observability sinks
         // (Sentry, log pipes) see configuration failures, *and* always
-        // rethrow so global handlers can react. Earlier v2.0.0 suppressed
-        // the rethrow when a handler was set, which silently blanked the
-        // editor when an `onError` was wired up purely for telemetry — a
-        // real consumer-review footgun.
+        // rethrow so global handlers can react. Suppressing the rethrow
+        // when a handler is set silently blanks the editor whenever an
+        // `onError` is wired up purely for telemetry, so the rethrow runs
+        // unconditionally.
         editorOptions.onError?.(vizelError);
         throw vizelError;
       }

--- a/packages/vue/src/_reactivity.ts
+++ b/packages/vue/src/_reactivity.ts
@@ -16,9 +16,9 @@
  * to suppress no-op recomputations when the slice is structurally
  * unchanged.
  *
- * Phase 3b-step1 lands this primitive. Later phases migrate Vue
- * components onto the same selector contract; `@tiptap/vue-3` retires
- * in Phase 3b-step4.
+ * ADR-0009 mandates a first-party implementation in every adapter, so
+ * Vizel owns the selector contract and cleanup behaviour and depends on
+ * no `@tiptap/vue-3` reactivity layer.
  */
 
 import type { Transaction } from "@tiptap/pm/state";

--- a/packages/vue/src/components/VizelColorPicker.vue
+++ b/packages/vue/src/components/VizelColorPicker.vue
@@ -48,7 +48,7 @@ const props = withDefaults(defineProps<VizelColorPickerProps>(), {
 /**
  * Selected color, exposed as a two-way binding (`v-model:value`).
  * Selecting a swatch or applying a valid HEX value writes the new color
- * back to the parent through the model, replacing the v1 `change` emit.
+ * back to the parent through the model, the idiomatic Vue two-way pattern.
  * The model accepts `undefined` so callers can bind a source that has no
  * color yet (e.g. an editor attribute that is unset).
  */

--- a/packages/vue/src/components/VizelLinkEditor.vue
+++ b/packages/vue/src/components/VizelLinkEditor.vue
@@ -57,9 +57,9 @@ const viewState = computed(() =>
 // capture phase and calls `stopImmediatePropagation()` so the editor's
 // bubble-phase keymap does not also fire — without that the bubble-phase
 // keymap resets the selection, closes the popover, and drops focus from the
-// input. `deferPointerHandler: true` mirrors v1's `nextTick` install so the
-// pointerdown that opens the link editor does not register as an outside
-// click.
+// input. `deferPointerHandler: true` installs the pointer-outside handler on
+// the next tick so the pointerdown that opens the link editor does not
+// register as an outside click.
 const dismissable = createVizelDismissable({
   onPointerOutside: () => emit("close"),
   onEscape: () => emit("close"),

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -11,10 +11,9 @@ export {
 export { type UseVizelCommentResult, useVizelComment } from "./useVizelComment.ts";
 export { type UseVizelEditorOptions, useVizelEditor } from "./useVizelEditor.ts";
 // `useVizelEditorState` ships from `../_reactivity.ts` per ADR-0009 — the
-// selector-style composable that closes the v1 drift. The legacy
-// convenience composable that combined `useVizelState` +
-// `getVizelEditorState` is removed; consumers select the slice they care
-// about through the v2 selector API.
+// selector-style composable. Consumers select the slice of editor state
+// they care about through the selector API, which subscribes only to the
+// selected value and avoids re-rendering on unrelated transactions.
 export {
   type UseVizelMarkdownOptions,
   type UseVizelMarkdownResult,

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -115,10 +115,10 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
         });
         // Always emit to the consumer handler so observability sinks
         // (Sentry, log pipes) see configuration failures, *and* always
-        // rethrow so global handlers can react. Earlier v2.0.0 suppressed
-        // the rethrow when a handler was set, which silently blanked the
-        // editor when an `@error` listener was wired up purely for
-        // telemetry — a real consumer-review footgun.
+        // rethrow so global handlers can react. Suppressing the rethrow
+        // when a handler is set would silently blank the editor whenever an
+        // `@error` listener is wired up purely for telemetry, so the rethrow
+        // stays unconditional.
         editorOptions.onError?.(vizelError);
         throw vizelError;
       }

--- a/packages/vue/src/composables/useVizelTheme.ts
+++ b/packages/vue/src/composables/useVizelTheme.ts
@@ -57,8 +57,8 @@ export function useVizelTheme(): UseVizelThemeResult {
   return {
     // Surface the resolved theme through the public `theme` field. The
     // underlying `VizelThemeState` keeps `theme` (user setting) and
-    // `resolvedTheme` (applied) separate; v2 collapses both into a single
-    // observable so the toggle pattern stays a one-liner.
+    // `resolvedTheme` (applied) separate; the composable collapses both into
+    // a single observable so the toggle pattern stays a one-liner.
     theme: computed<VizelResolvedTheme>(() => context.resolvedTheme),
     // Physically narrow `setTheme` to `VizelResolvedTheme` so the public
     // type matches the runtime guarantee; the underlying provider's

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -14,7 +14,7 @@ initVizelIconRenderer();
 
 // Re-export the full @vizel/core public API so consumers can install only
 // the framework package and import every shared symbol from one place.
-// biome-ignore lint/performance/noReExportAll: intentional re-export mirror per Section 6 of the v2.0.0 spec; named-only would diverge whenever Core adds a symbol.
+// biome-ignore lint/performance/noReExportAll: mirror the full Core surface so named exports never drift whenever Core adds a symbol.
 export * from "@vizel/core";
 // First-party `shallowRef`-backed reactivity primitive.
 // ADR-0009 mandates that every adapter implements editor reactivity

--- a/tests/a11y/react/playwright-ct.config.ts
+++ b/tests/a11y/react/playwright-ct.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/experimental-ct-react";
 import react from "@vitejs/plugin-react";
 
 /**
- * Pillar 5 — accessibility (Section 14).
+ * Pillar 5 — accessibility.
  *
  * Runs `@axe-core/playwright` against each shipped component to assert
  * WCAG 2.1 AA conformance. Chromium-only by design: axe-core reports a

--- a/tests/a11y/scenarios/axe.scenario.ts
+++ b/tests/a11y/scenarios/axe.scenario.ts
@@ -39,7 +39,7 @@ const DISABLED_RULES: readonly string[] = ["region", "color-contrast", "aria-inp
 
 /**
  * WCAG conformance tags axe-core checks for. WCAG 2.1 AA is the
- * Section 14 Pillar 5 target.
+ * Pillar 5 accessibility target.
  */
 const WCAG_TAGS: readonly string[] = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
 

--- a/tests/a11y/svelte/playwright-ct.config.ts
+++ b/tests/a11y/svelte/playwright-ct.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/experimental-ct-svelte";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 /**
- * Pillar 5 — accessibility (Section 14).
+ * Pillar 5 — accessibility.
  *
  * Runs `@axe-core/playwright` against each shipped component to assert
  * WCAG 2.1 AA conformance. Chromium-only by design: axe-core reports a

--- a/tests/a11y/vue/playwright-ct.config.ts
+++ b/tests/a11y/vue/playwright-ct.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/experimental-ct-vue";
 import vue from "@vitejs/plugin-vue";
 
 /**
- * Pillar 5 — accessibility (Section 14).
+ * Pillar 5 — accessibility.
  *
  * Runs `@axe-core/playwright` against each shipped component to assert
  * WCAG 2.1 AA conformance. Chromium-only by design: axe-core reports a

--- a/tests/ct/react/specs/BlockClipboardFixture.tsx
+++ b/tests/ct/react/specs/BlockClipboardFixture.tsx
@@ -2,7 +2,7 @@ import { useVizelEditor, useVizelState, VizelEditor, VizelProvider } from "@vize
 import { useEffect } from "react";
 
 /**
- * Fixture for the block-aware clipboard scenarios (Section 11c).
+ * Fixture for the block-aware clipboard scenarios.
  *
  * Exposes the editor on `window.vizelTestEditor` so the scenarios can
  * drive selection and dispatch synthetic clipboard events.

--- a/tests/ct/react/specs/ThemeProviderFixture.tsx
+++ b/tests/ct/react/specs/ThemeProviderFixture.tsx
@@ -12,10 +12,10 @@ function ThemeContent() {
     setTheme(theme === "dark" ? "light" : "dark");
   };
 
-  // The v2 hook collapses `theme` (user setting) and `resolvedTheme` (applied)
-  // into a single resolved value. Render the same source under both legacy
-  // testids so existing scenarios keep passing without depending on the
-  // removed `VizelThemeState` shape.
+  // The hook exposes a single resolved theme value rather than separate
+  // `theme` (user setting) and `resolvedTheme` (applied) fields. Render
+  // that one source under both testids so a scenario can assert either
+  // without depending on a split-state shape.
   return (
     <div data-testid="theme-content">
       <span data-testid="current-theme">{theme}</span>

--- a/tests/ct/scenarios/block-clipboard.scenario.ts
+++ b/tests/ct/scenarios/block-clipboard.scenario.ts
@@ -2,8 +2,8 @@ import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 /**
- * Shared scenarios for the block-aware clipboard extension
- * (Section 11c). The fixture exposes the editor on
+ * Shared scenarios for the block-aware clipboard extension.
+ * The fixture exposes the editor on
  * `window.vizelTestEditor` so the scenarios can drive selection state
  * through Tiptap's command bus — synthetic keystrokes for
  * `ControlOrMeta+Home` and similar chords behave differently across

--- a/tests/ct/scenarios/multi-block-selection.scenario.ts
+++ b/tests/ct/scenarios/multi-block-selection.scenario.ts
@@ -2,8 +2,8 @@ import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 /**
- * Shared scenarios for the multi-block range selection extension
- * (Section 11b). The fixture exposes the active block range through a
+ * Shared scenarios for the multi-block range selection extension.
+ * The fixture exposes the active block range through a
  * `[data-testid="multi-block-state"]` element so the scenarios can
  * assert plugin state without driving the UI.
  *

--- a/tests/ct/svelte/specs/ThemeContent.svelte
+++ b/tests/ct/svelte/specs/ThemeContent.svelte
@@ -9,10 +9,10 @@ function toggleTheme() {
 </script>
 
 <!--
-  The v2 rune collapses `theme` (user setting) and `resolvedTheme` (applied)
-  into a single resolved value. Render the same source under both legacy
-  testids so existing scenarios keep passing without depending on the
-  removed `VizelThemeState` shape.
+  The rune exposes a single resolved theme value rather than separate
+  `theme` (user setting) and `resolvedTheme` (applied) fields. Render
+  that one source under both testids so a scenario can assert either
+  without depending on a split-state shape.
 -->
 <div data-testid="theme-content">
   <span data-testid="current-theme">{themeState.current}</span>

--- a/tests/markdown-roundtrip/samples/index.ts
+++ b/tests/markdown-roundtrip/samples/index.ts
@@ -3,16 +3,14 @@ import type { VizelRoundtripSample } from "@vizel/core";
 /**
  * Representative Markdown round-trip samples for each built-in flavor.
  *
- * The Section 10 long-term target (spec
- * `docs/superpowers/specs/2026-05-16-vizel-v2-ideal-interface-design.md`,
- * lines 854-859) is 100+ samples per flavor drawn from CommonMark / GFM
- * conformance suites, Obsidian-style notes, Docusaurus admonitions, and
- * Pandoc extension fixtures. This file ships a representative
- * cross-section — at least ten samples per flavor covering heading,
- * paragraph, list, blockquote, inline emphasis, inline code, fenced
- * code, image, link, and the flavor-specific syntax (e.g. GFM tables,
- * Obsidian wiki-links). Authors who add new flavor-specific syntax
- * must extend the corresponding bucket.
+ * The long-term target is 100+ samples per flavor drawn from
+ * CommonMark / GFM conformance suites, Obsidian-style notes, Docusaurus
+ * admonitions, and Pandoc extension fixtures. This file ships a
+ * representative cross-section — at least ten samples per flavor
+ * covering heading, paragraph, list, blockquote, inline emphasis,
+ * inline code, fenced code, image, link, and the flavor-specific syntax
+ * (e.g. GFM tables, Obsidian wiki-links). Authors who add new
+ * flavor-specific syntax must extend the corresponding bucket.
  *
  * Each sample is paired with the exact Markdown form Vizel emits via
  * the selected flavor; whitespace differences within a single trailing

--- a/tests/markdown-roundtrip/specs/Probe.spec.tsx
+++ b/tests/markdown-roundtrip/specs/Probe.spec.tsx
@@ -14,9 +14,8 @@ import { RoundtripFixture } from "./RoundtripFixture";
  * `pnpm test:md-roundtrip --grep probe` to refresh the catalog.
  *
  * This spec is skipped by default and lives in-tree only to make it
- * cheap to debug round-trip failures locally. It carries no
- * Section 10 acceptance criteria; the real assertions live in
- * `Roundtrip.spec.tsx`.
+ * cheap to debug round-trip failures locally. It carries no acceptance
+ * criteria; the real assertions live in `Roundtrip.spec.tsx`.
  */
 
 const ALL_SAMPLES: Record<string, readonly { name: string; input: string }[]> = {

--- a/tests/markdown-roundtrip/specs/Roundtrip.spec.tsx
+++ b/tests/markdown-roundtrip/specs/Roundtrip.spec.tsx
@@ -9,7 +9,7 @@ import {
 import { RoundtripFixture } from "./RoundtripFixture";
 
 /**
- * Markdown round-trip suite (spec Section 10, lines 854-859).
+ * Markdown round-trip suite.
  *
  * Each test mounts {@link RoundtripFixture}, then drives
  * `assertMarkdownRoundtrip(flavor, samples)` through `page.evaluate`
@@ -17,9 +17,9 @@ import { RoundtripFixture } from "./RoundtripFixture";
  * browser. The fixture itself does nothing more than publish the
  * helper and the five built-in flavors on `window`.
  *
- * The samples are a representative cross-section, not the full
- * Section 10 target of 100+ × 5 flavors. The follow-up work tracked
- * on the v2.0.0 release plan extends the sample buckets.
+ * The samples are a representative cross-section, not the full target
+ * of 100+ × 5 flavors. Expanding the sample buckets is tracked as
+ * follow-up work.
  */
 
 interface FlavorEvalResult {


### PR DESCRIPTION
## Summary

- Vizel v2 is a clean break with zero backward compatibility (ADR-0005), but shipped source, tests, demos, and `.claude` artefacts still carried v1/v2/version cruft in comments plus one structural residue.
- Rewrites or deletes all version wording in comments, JSDoc, and rule files: historical v1/prerelease comparisons (e.g. "Earlier v2.0.0 suppressed…", "mirrors v1's setTimeout"), redundant `v2` qualifiers ("the v2 selector API" → "the selector API"), and "Section N of the v2.0.0 spec" provenance.
- Removes the two `for compat` re-export blocks from `packages/core/src/utils/index.ts` and repoints the public portal and suggestion-container symbols in `packages/core/src/index.ts` to `./controllers/portal.ts` and `./controllers/suggestionContainer.ts` directly.
- No code identifier contained `v1`/`v2`; the change is comments plus the sanctioned export-source relocation.

## Scope

- 76 files changed (+248 / −284).
- The public `@vizel/core` export set is byte-identical (464 symbols, 0 added / 0 removed; all 15 portal/suggestion symbols preserved).
- No identifier renamed.

## Out of scope (intentionally kept)

- ADRs, plans, specs, `docs/guide/migration-v1-to-v2.md`, and package `version` fields.
- Demo sample content under `apps/demo/shared/*.md` (fake editor content).
- External strings: the Loom `/v1/oembed` URL and Mermaid `stateDiagram-v2` syntax.
- `tests/ct/scenarios/v2/` and `tests/ct/parity/check-scenarios.ts` (owned by a separate work item).

## Test Plan

- [x] `pnpm lint` — passes (625 files, 0 errors).
- [x] `pnpm typecheck` — passes (all packages, 0 errors / 0 warnings).
- [x] `pnpm build` — passes (all packages emit).
- [x] Public `@vizel/core` surface verified byte-identical (464 symbols).
- [x] Residual scan for in-scope version cruft returns clean.
