### PR TITLE
fix: make the feature-parity check resolve the real adapter surface

### DIFF
--- a/.claude/rules/feature-manifest.md
+++ b/.claude/rules/feature-manifest.md
@@ -46,7 +46,7 @@ Each feature entry exports a `VizelFeatureDefinition`:
 
 ## CI verification
 
-- `pnpm check:feature-parity` — TypeScript-level check: every manifest entry exports a matching symbol from each adapter.
+- `pnpm check:feature-parity` — static export-surface check. The script parses each adapter's `src/index.ts` with the TypeScript compiler API and computes its effective export set: the adapter's own named exports unioned with the `@vizel/core` surface that the mandatory `export * from "@vizel/core"` forwards. The Core surface is resolved by recursively walking the re-export declarations rooted at `packages/core/src/index.ts`. The check reads source only — it imports no built artefacts — and fails when any adapter omits a manifest-declared component or companion symbol.
 - `pnpm check:ct-parity` — Playwright-level check: every manifest entry has a scenario that runs across every framework.
 - `pnpm check:scenarios` — scenarios compile without errors.
 

--- a/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
+++ b/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
@@ -18,7 +18,7 @@ The parity SSOT moves into TypeScript as `packages/core/src/feature-manifest.ts`
 - Each entry also declares the expected adapter symbol for React, Vue, and Svelte (component name, optional hook or composable or rune name).
 - The manifest is the authoritative parity contract. The TypeScript type system enforces structural integrity at compile time. A CI script (`scripts/check-feature-parity.ts`) enforces cross-package coverage at build time.
 
-The CI script imports the manifest, then dynamically imports the declared symbol from each of `@vizel/react`, `@vizel/vue`, and `@vizel/svelte`. Missing entries fail the build. The script runs on `pre-push` and as a CI job before the test matrix.
+The CI script imports the manifest, then resolves each declared symbol against an adapter's statically computed export surface — it never imports built artefacts. The script parses each adapter's `src/index.ts` with the TypeScript compiler API and computes the adapter's effective export set: the adapter's own named exports unioned with the public surface of `@vizel/core`, which every adapter forwards through the mandatory `export * from "@vizel/core"`. The script resolves the Core surface by recursively walking the re-export declarations rooted at `packages/core/src/index.ts`. A manifest-declared symbol that is absent from an adapter's effective set fails the build. The script runs on `pre-push` and as a CI job before the test matrix.
 
 ## Consequences
 

--- a/scripts/check-feature-parity.ts
+++ b/scripts/check-feature-parity.ts
@@ -1,28 +1,48 @@
 /**
  * Feature manifest parity check.
  *
- * Loads `VIZEL_FEATURE_MANIFEST` from `@vizel/core` and verifies that
- * every adapter (`@vizel/react`, `@vizel/vue`, `@vizel/svelte`) exports
- * the declared `component` and `companion` symbols for every feature.
+ * The check asserts that every adapter (`@vizel/react`, `@vizel/vue`,
+ * `@vizel/svelte`) exports the `component` and `companion` symbols the
+ * feature manifest declares for each feature. The manifest in
+ * `packages/core/src/feature-manifest.ts` is the parity SSOT; see
+ * ADR-0002 and `.claude/rules/feature-manifest.md`.
  *
- * The check runs in two layers:
+ * Mechanism — static export-surface resolution (build-independent):
  *
- * 1. Structural — the manifest itself is valid TypeScript (unique IDs,
- *    every adapter shape resolves).
- * 2. Surface — each adapter's `src/index.ts` exports the declared
- *    symbols. The check tolerates symbols that re-export from
- *    `@vizel/core` because `export * from "@vizel/core"` is mandatory
- *    per the v2 architecture.
+ * 1. The check parses each adapter's `src/index.ts` with the TypeScript
+ *    compiler API and computes its EFFECTIVE export set. The effective
+ *    set is the union of the adapter's own explicitly named exports and
+ *    the public export surface of `@vizel/core`, which every adapter
+ *    forwards through the mandatory `export * from "@vizel/core"`.
+ * 2. The check resolves the Core surface by recursively walking the
+ *    `export { ... } from "./x"`, `export type { ... }`, and
+ *    `export * from "./x"` declarations rooted at
+ *    `packages/core/src/index.ts`, following relative re-export targets
+ *    until every forwarded name is enumerated.
+ * 3. A manifest-declared symbol is PRESENT when it appears in an
+ *    adapter's effective set, and MISSING otherwise. Adapter components
+ *    such as `VizelEditor` live in the adapter, never in Core, so the
+ *    check fails the moment any adapter drops a declared component or
+ *    companion symbol. Per-framework-only extras (Svelte
+ *    `getVizelTheme`, React `use*`) never false-fail because the check
+ *    only asserts that the manifest-declared symbols exist.
+ *
+ * The check reads source files only; it never imports built artefacts.
+ * The earlier implementation accepted any symbol whenever the adapter
+ * re-exported `@vizel/core`, which silenced every regression because
+ * the wildcard re-export is mandatory. This version enumerates the
+ * forwarded names instead, so a dropped symbol surfaces as a failure.
+ *
+ * `verifyManifestStructure` keeps the unique-id invariant that the type
+ * system cannot express.
  *
  * Exits 0 on success, 1 on any divergence.
- *
- * See ADR-0002 for the rationale and `.claude/rules/feature-manifest.md`
- * for the contributor workflow.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import {
   VIZEL_FEATURE_MANIFEST,
   type VizelFeatureAdapters,
@@ -31,6 +51,7 @@ import {
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const CORE_INDEX = resolve(REPO_ROOT, "packages/core/src/index.ts");
 
 interface AdapterPaths {
   readonly framework: keyof VizelFeatureAdapters;
@@ -42,6 +63,8 @@ const ADAPTERS: readonly AdapterPaths[] = [
   { framework: "vue", indexPath: resolve(REPO_ROOT, "packages/vue/src/index.ts") },
   { framework: "svelte", indexPath: resolve(REPO_ROOT, "packages/svelte/src/index.ts") },
 ];
+
+const CORE_SPECIFIER = "@vizel/core";
 
 interface ParityFinding {
   readonly featureId: string;
@@ -55,70 +78,184 @@ interface ParityFinding {
  * invariant the type system cannot express.
  */
 function verifyManifestStructure(manifest: readonly VizelFeatureDefinition[]): readonly string[] {
-  const errors: string[] = [];
   const seen = new Set<string>();
-  for (const feature of manifest) {
-    if (seen.has(feature.id)) errors.push(`Duplicate feature id: ${feature.id}`);
+  return manifest.flatMap((feature) => {
+    const duplicate = seen.has(feature.id);
     seen.add(feature.id);
-  }
-  return errors;
+    return duplicate ? [`Duplicate feature id: ${feature.id}`] : [];
+  });
+}
+
+/** Parse a source file into a TypeScript AST without type checking. */
+function parseSourceFile(filePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS
+  );
 }
 
 /**
- * Read an adapter's `src/index.ts` and return the set of identifiers it
- * exports. The check looks for direct named exports and the wildcard
- * `export * from "@vizel/core"` that flags Core surface availability.
+ * Resolve a relative module specifier to a source file on disk. The
+ * specifiers in this repository carry an explicit `.ts` extension; the
+ * resolver also tries `index.ts` for directory targets so future
+ * `./dir` re-exports keep resolving.
  */
-function loadAdapterSurface(indexPath: string): {
-  readonly named: ReadonlySet<string>;
+function resolveRelativeModule(fromFile: string, specifier: string): string | null {
+  const base = resolve(dirname(fromFile), specifier);
+  const candidates = [base, `${base}.ts`, resolve(base, "index.ts")];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+interface ModuleExports {
+  /** Names this module exports under its own surface. */
+  readonly names: ReadonlySet<string>;
+  /** Whether the module re-exports the full `@vizel/core` surface. */
   readonly reexportsCore: boolean;
-} {
-  const source = readFileSync(indexPath, "utf8");
-  const named = new Set<string>();
-  const reexportsCore = /export\s*\*\s*from\s*["']@vizel\/core["']/.test(source);
-  for (const match of source.matchAll(/export\s*\{([^}]+)\}/g)) {
-    for (const raw of match[1].split(",")) {
-      const trimmed = raw
-        .trim()
-        .replace(/\s+as\s+\w+$/u, "")
-        .replace(/^type\s+/u, "");
-      if (trimmed) named.add(trimmed);
-    }
-  }
-  for (const match of source.matchAll(
-    /export\s+(?:function|class|const|let|interface|type|enum)\s+(\w+)/g
-  )) {
-    named.add(match[1]);
-  }
-  return { named, reexportsCore };
 }
 
 /**
- * Verify a single adapter against the manifest. Returns a finding when
- * the adapter is missing any declared symbol.
+ * Return the binding names a node declares with the `export` modifier.
+ * Covers named declarations (`export function f`, `export const c`,
+ * `export class C`, `export interface I`, `export type T`, `export enum
+ * E`). A node without the `export` modifier contributes nothing.
+ */
+function collectDeclaredExportNames(node: ts.Statement): readonly string[] {
+  const exported = ts.canHaveModifiers(node)
+    ? ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+    : false;
+  if (!exported) return [];
+  if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
+    return node.name ? [node.name.text] : [];
+  }
+  if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+    return [node.name.text];
+  }
+  if (ts.isEnumDeclaration(node)) {
+    return [node.name.text];
+  }
+  if (ts.isVariableStatement(node)) {
+    return node.declarationList.declarations.flatMap((declaration) =>
+      ts.isIdentifier(declaration.name) ? [declaration.name.text] : []
+    );
+  }
+  return [];
+}
+
+/** Return an export declaration's string module specifier, or null. */
+function moduleSpecifierText(node: ts.ExportDeclaration): string | null {
+  return node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
+    ? node.moduleSpecifier.text
+    : null;
+}
+
+/**
+ * Return the names a single `export` declaration exposes. Named clauses
+ * (`export { a, b as c } [from "..."]`) expose the listed names; a
+ * relative `export * from "./x"` forwards every name in the target, which
+ * `recurse` resolves. Bare `export * from "pkg"` contributes nothing — its
+ * surface is external and the adapter check treats `@vizel/core` apart.
+ */
+function collectExportDeclarationNames(
+  node: ts.ExportDeclaration,
+  fromFile: string,
+  recurse: (target: string) => ReadonlySet<string>
+): readonly string[] {
+  if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+    return node.exportClause.elements.map((element) => element.name.text);
+  }
+  const specifier = moduleSpecifierText(node);
+  if (!node.exportClause && specifier && specifier.startsWith(".")) {
+    const target = resolveRelativeModule(fromFile, specifier);
+    return target ? [...recurse(target)] : [];
+  }
+  return [];
+}
+
+/**
+ * Return the names a single statement contributes to its module's export
+ * surface, delegating relative wildcard re-exports to `recurse`.
+ */
+function collectStatementExportNames(
+  statement: ts.Statement,
+  fromFile: string,
+  recurse: (target: string) => ReadonlySet<string>
+): readonly string[] {
+  const declared = collectDeclaredExportNames(statement);
+  const reexported = ts.isExportDeclaration(statement)
+    ? collectExportDeclarationNames(statement, fromFile, recurse)
+    : [];
+  return [...declared, ...reexported];
+}
+
+/**
+ * Compute the public export surface of a module file. The function
+ * recurses through relative `export * from "./x"` and
+ * `export { ... } from "./x"` targets so the returned set contains every
+ * forwarded name. The `visited` set guards against re-export cycles.
+ */
+function resolveModuleExports(filePath: string, visited: Set<string>): ReadonlySet<string> {
+  if (visited.has(filePath)) return new Set<string>();
+  visited.add(filePath);
+  const recurse = (target: string): ReadonlySet<string> => resolveModuleExports(target, visited);
+  const names = parseSourceFile(filePath).statements.flatMap((statement) =>
+    collectStatementExportNames(statement, filePath, recurse)
+  );
+  return new Set<string>(names);
+}
+
+/** Return whether a statement is `export * from "@vizel/core"`. */
+function reexportsCoreSurface(statement: ts.Statement): boolean {
+  return (
+    ts.isExportDeclaration(statement) &&
+    !statement.exportClause &&
+    moduleSpecifierText(statement) === CORE_SPECIFIER
+  );
+}
+
+/**
+ * Compute an adapter's effective export set. The set is the union of the
+ * adapter's own export surface and the `@vizel/core` surface, which the
+ * adapter forwards through the mandatory `export * from "@vizel/core"`.
+ */
+function loadAdapterSurface(indexPath: string, coreSurface: ReadonlySet<string>): ModuleExports {
+  const statements = parseSourceFile(indexPath).statements;
+  const reexportsCore = statements.some(reexportsCoreSurface);
+  const recurse = (target: string): ReadonlySet<string> =>
+    resolveModuleExports(target, new Set<string>());
+  const ownNames = statements.flatMap((statement) =>
+    collectStatementExportNames(statement, indexPath, recurse)
+  );
+  const names = new Set<string>(ownNames);
+  if (reexportsCore) {
+    for (const name of coreSurface) names.add(name);
+  }
+  return { names, reexportsCore };
+}
+
+/**
+ * Verify a single adapter against the manifest. Return a finding when the
+ * adapter's effective export set omits a declared component or companion
+ * symbol.
  */
 function verifyAdapter(
   manifest: readonly VizelFeatureDefinition[],
-  adapter: AdapterPaths
+  adapter: AdapterPaths,
+  coreSurface: ReadonlySet<string>
 ): readonly ParityFinding[] {
-  const surface = loadAdapterSurface(adapter.indexPath);
-  const findings: ParityFinding[] = [];
-  for (const feature of manifest) {
+  const surface = loadAdapterSurface(adapter.indexPath, coreSurface);
+  return manifest.flatMap((feature) => {
     const adapterShape = feature.adapters[adapter.framework];
-    const missing: string[] = [];
-    for (const symbol of [adapterShape.component, adapterShape.companion]) {
-      if (!symbol) continue;
-      if (surface.named.has(symbol)) continue;
-      // The wildcard re-export forwards every Core symbol. The check
-      // accepts it as a presence signal; future iterations may resolve
-      // Core's index.ts to enumerate the forwarded names explicitly.
-      if (surface.reexportsCore) continue;
-      missing.push(symbol);
-    }
-    if (missing.length > 0)
-      findings.push({ featureId: feature.id, framework: adapter.framework, missing });
-  }
-  return findings;
+    const declared = [adapterShape.component, adapterShape.companion].filter(
+      (symbol): symbol is string => typeof symbol === "string"
+    );
+    const missing = declared.filter((symbol) => !surface.names.has(symbol));
+    return missing.length > 0
+      ? [{ featureId: feature.id, framework: adapter.framework, missing }]
+      : [];
+  });
 }
 
 function main(): void {
@@ -129,10 +266,10 @@ function main(): void {
     process.exit(1);
   }
 
-  const allFindings: ParityFinding[] = [];
-  for (const adapter of ADAPTERS) {
-    allFindings.push(...verifyAdapter(VIZEL_FEATURE_MANIFEST, adapter));
-  }
+  const coreSurface = resolveModuleExports(CORE_INDEX, new Set<string>());
+  const allFindings = ADAPTERS.flatMap((adapter) =>
+    verifyAdapter(VIZEL_FEATURE_MANIFEST, adapter, coreSurface)
+  );
 
   if (allFindings.length === 0) {
     const featureCount = VIZEL_FEATURE_MANIFEST.length;


### PR DESCRIPTION
## Summary

- WI-2 of the P0/P1 hardening plan. Fixes finding F-A: `scripts/check-feature-parity.ts` accepted any symbol whenever an adapter carried the mandatory `export * from "@vizel/core"`, so the check could never flag a dropped adapter component. Parity held in practice, but the guard was asleep.
- Replaces the `reexportsCore` short-circuit with **static TypeScript-compiler resolution**: each adapter's effective export set = its own named exports ∪ the recursively resolved `@vizel/core` public surface (464 names). A manifest-declared component/companion symbol that is in neither set fails the check.
- The check is source-only — no build dependency, and it never imports the Svelte built dist (which throws `ERR_PACKAGE_PATH_NOT_EXPORTED` via `@iconify/svelte`).
- Reconciles ADR-0002 and `.claude/rules/feature-manifest.md` with the shipped mechanism (the ADR previously claimed a dynamic-import that never existed).

## Test Plan

- [x] `pnpm check:feature-parity` — passes (23 features × 3 frameworks).
- [x] Negative regression (React): removing a declared symbol from `packages/react/src/index.ts` → exit 1 naming `react`.
- [x] Negative regression (Svelte): removing a declared symbol from `packages/svelte/src/index.ts` → exit 1 naming `svelte`.
- [x] Per-framework-only symbols (`createVizel*`, `getVizelTheme`, `useVizel*`) do not false-fail.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm check:nolet` — pass. CI/lefthook unchanged (static check).

Refs: `docs/superpowers/plans/2026-06-02-vizel-v2-hardening-p0p1.md` (WI-2).
