### PR TITLE
docs: clear comment rot, dangling references, and ADR-0009 narrative drift

### DIFF
--- a/.claude/rules/packages/react.md
+++ b/.claude/rules/packages/react.md
@@ -7,7 +7,7 @@ paths:
 
 `@vizel/react` provides React 19 components and hooks. The package wraps `@vizel/core` and adds React-specific code only.
 
-See `cross-framework.md` for component, hook, and props parity requirements.
+See `.claude/rules/feature-manifest.md` for component, hook, and props parity requirements; `pnpm check:feature-parity` enforces them.
 
 ## Component Structure
 

--- a/.claude/rules/packages/vue.md
+++ b/.claude/rules/packages/vue.md
@@ -7,7 +7,7 @@ paths:
 
 `@vizel/vue` provides Vue 3 components and composables. The package wraps `@vizel/core` and adds Vue-specific code only.
 
-See `cross-framework.md` for component, composable, and props parity requirements.
+See `.claude/rules/feature-manifest.md` for component, composable, and props parity requirements; `pnpm check:feature-parity` enforces them.
 
 ## Component Structure
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -46,7 +46,7 @@ packages. The single permitted asymmetry is the idiom prefix:
 | `UseVizelContext.spec.{tsx,ts}` | `GetVizelContext.spec.ts` | `VizelContext` |
 
 The `Use*` to `Create*` / `Get*` mapping mirrors the symbol parity
-rules in `scripts/check-cross-framework-parity.ts`.
+rules in `scripts/check-ct-parity.ts`.
 
 ### How to verify
 
@@ -60,9 +60,9 @@ Actions job blocks merge.
 ### How to add a parity exception
 
 Spec parity has **no** exception catalog. If a component genuinely
-does not exist on one framework (rare; the cross-framework rules in
-`.claude/rules/cross-framework.md` already forbid this), revisit the
-component before adding a spec asymmetry.
+does not exist on one framework (rare; the feature manifest in
+`packages/core/src/feature-manifest.ts` and `.claude/rules/feature-manifest.md`
+already forbid this), revisit the component before adding a spec asymmetry.
 
 ---
 

--- a/docs/adr/ADR-0009-first-party-editor-reactivity.md
+++ b/docs/adr/ADR-0009-first-party-editor-reactivity.md
@@ -48,3 +48,36 @@ Follow-up:
 - Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (R3, Phase 3)
 - External: [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore), [`svelte/reactivity` `createSubscriber`](https://svelte.dev/docs/svelte/svelte-reactivity)
 - Related: [ADR-0004](./ADR-0004-per-framework-idiomatic-api.md), [ADR-0007](./ADR-0007-component-size-and-controller-delegation.md)
+
+## Update (2026-06-03)
+
+The Decision bullets above stay immutable. This Update corrects three
+factual drifts between the Decision narrative and the shipped code. The
+corrections describe the current implementation; they do not change the
+decision.
+
+- **React `getServerSnapshot` returns a version counter, not `null`.** The
+  Decision bullet states `getServerSnapshot` returns `null` for SSR safety.
+  The shipped store returns `0` — the initial value of the same monotonic
+  version counter that `getSnapshot` returns on the client (see
+  `packages/react/src/_reactivity.ts`). Returning the counter's zero value
+  keeps the client and server snapshot types identical and satisfies the
+  `useSyncExternalStore` contract.
+- **React `subscribe` attaches both `transaction` and `selectionUpdate`.**
+  The Decision bullet lists only `editor.on('transaction')`. The shipped
+  `subscribe` attaches `editor.on('transaction')` and
+  `editor.on('selectionUpdate')`, and detaches both in its cleanup. The
+  selection listener lets a selector that reads selection-only state
+  re-evaluate when the document content does not change.
+- **The Svelte selector subscription lives in a separate rune file.** The
+  Decision bullet attributes the `createSubscriber` selector subscription to
+  `createVizelEditor.svelte.ts`. The shipped split is:
+  `packages/svelte/src/runes/createVizelEditor.svelte.ts` holds only the
+  `$state.raw<Editor | null>` editor identity, while
+  `packages/svelte/src/runes/createVizelEditorState.svelte.ts` owns the
+  selector projection — it subscribes through `createSubscriber` (hooking
+  `transaction` and `selectionUpdate`) and exposes the result through a
+  `$derived` accessor.
+
+A later work item (WI-8) revises the React selector-input bullet separately;
+this Update stays focused on the factual drift above.

--- a/docs/adr/ADR-0013-adr-compliance-harness.md
+++ b/docs/adr/ADR-0013-adr-compliance-harness.md
@@ -32,7 +32,7 @@ A companion subagent (`.claude/agents/phase-review.md`) handles qualitative revi
 | ADR | Check | FAIL condition |
 |-----|-------|----------------|
 | 0005 | Every `packages/*/package.json` carries `"version": "2.0.0"` | Any other version |
-| 0006 | `.claude/rules/cross-framework.md` does not exist | File present after Phase 1 |
+| 0006 | `.claude/rules/cross-framework.md` does not exist and no live reference to the retired names (`cross-framework.md`, `check-cross-framework-parity.ts`) survives under `.claude/`, `packages/*/src`, or `scripts/` | File present, or any live dangling reference remains |
 | 0007 | `grep -r 'document\.addEventListener' packages/{react,vue,svelte}/src/` returns zero lines | Any match |
 | 0007 | View-template line count in every `Vizel*.{tsx,vue,svelte}` component ≤ 120 | Any file over budget |
 | 0008 | Every adapter `package.json` `exports."./styles.css"` resolves to `@vizel/core/styles.css` | Resolution to a different file |

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -17,10 +17,11 @@ initVizelIconRenderer();
 // biome-ignore lint/performance/noReExportAll: mirror the full Core surface so named exports never drift whenever Core adds a symbol.
 export * from "@vizel/core";
 
-// Explicit re-export so the cross-framework literal parity check picks
-// up the shallow-equality helpers from Core. The wildcard above already
-// forwards them; the named declaration keeps `scripts/check-cross-
-// framework-parity.ts`'s same-name literal scan happy.
+// Explicit re-export of the shallow-equality helpers from Core. The
+// wildcard above already forwards them; this named declaration documents
+// the manifest-mandated symbols so the feature manifest (verified by
+// `pnpm check:feature-parity` / `scripts/check-feature-parity.ts`)
+// resolves them to a single source across frameworks.
 export { shallowEqualArray, shallowEqualObject } from "@vizel/core";
 
 // Components

--- a/scripts/check-adr-compliance.ts
+++ b/scripts/check-adr-compliance.ts
@@ -114,35 +114,60 @@ function checkPackageVersions(): CheckResult {
 }
 
 /**
- * The cross-framework rule retires in Phase 1 per ADR-0006. The file
- * staying alive past Phase 1 is a drift signal.
+ * ADR-0006 retires `.claude/rules/cross-framework.md`. Retirement means
+ * two things: the file is gone, and no surviving artefact still points at
+ * the retired rule or the never-shipped `check-cross-framework-parity.ts`
+ * scan. The guard fails on either signal so a stale reference cannot rot
+ * undetected after the file leaves the tree.
+ *
+ * The dangling-reference scan covers `.claude/`, each adapter's `src/`,
+ * and `scripts/` for `.md`, `.ts`, and `.tsx` sources. It skips `docs/`
+ * because historical ADRs and plans legitimately cite the retired file as
+ * history, and skips this harness, which carries the literal token in its
+ * own regex. The pattern escapes the dots so `cross-framework-reviewer.md`
+ * (the live subagent file) does not false-match.
  */
 function checkCrossFrameworkRuleRetired(): CheckResult {
-  const path = resolve(REPO_ROOT, ".claude/rules/cross-framework.md");
-  if (!existsSync(path)) {
+  const filePath = resolve(REPO_ROOT, ".claude/rules/cross-framework.md");
+  if (existsSync(filePath)) {
     return {
       adr: "ADR-0006",
       title: "Retire cross-framework.md",
-      status: "PASS",
-      message: ".claude/rules/cross-framework.md is removed.",
+      status: "FAIL",
+      message: ".claude/rules/cross-framework.md still exists; ADR-0006 retires it.",
     };
   }
-  const content = readText(path) ?? "";
-  if (content.includes("DEPRECATED")) {
+  const danglingPattern = /cross-framework\.md|check-cross-framework-parity\.ts/g;
+  const selfPath = resolve(REPO_ROOT, "scripts/check-adr-compliance.ts");
+  const scanRoots = [
+    resolve(REPO_ROOT, ".claude"),
+    resolve(REPO_ROOT, "packages/react/src"),
+    resolve(REPO_ROOT, "packages/vue/src"),
+    resolve(REPO_ROOT, "packages/svelte/src"),
+    resolve(REPO_ROOT, "scripts"),
+  ];
+  const danglingRefs = scanRoots
+    .flatMap((root) => grepFiles(root, danglingPattern, [".md", ".ts", ".tsx"]))
+    // Exclude this harness (carries the literal token in its regex) and any
+    // generated `.d.ts` declaration that mirrors a `.ts` source comment.
+    .filter((hit) => hit.path !== selfPath && !hit.path.endsWith(".d.ts"));
+  if (danglingRefs.length > 0) {
+    const offenders = danglingRefs
+      .map((hit) => `${hit.path.replace(`${REPO_ROOT}/`, "")} (${hit.count})`)
+      .join(", ");
     return {
       adr: "ADR-0006",
       title: "Retire cross-framework.md",
-      status: "WARN",
-      message:
-        ".claude/rules/cross-framework.md carries a deprecation header; the retirement cleanup PR removes the file.",
+      status: "FAIL",
+      message: `.claude/rules/cross-framework.md is removed, but live references to the retired names remain: ${offenders}. Redirect each to .claude/rules/feature-manifest.md, scripts/check-feature-parity.ts, or scripts/check-ct-parity.ts.`,
     };
   }
   return {
     adr: "ADR-0006",
     title: "Retire cross-framework.md",
-    status: "WARN",
+    status: "PASS",
     message:
-      ".claude/rules/cross-framework.md still on main; PR #559 lands the deprecation header and a follow-up PR removes the file. Promote to FAIL after the cleanup PR merges.",
+      ".claude/rules/cross-framework.md is removed and no live reference to the retired names remains.",
   };
 }
 


### PR DESCRIPTION
## Summary

- WI-9 of the P0/P1 hardening plan. Fixes finding F-H: comment rot, dangling references to retired files, and ADR-0009 narrative drift.
- Rewrites the `packages/svelte/src/index.ts` comment that cited the non-existent `scripts/check-cross-framework-parity.ts` to match the React/Vue idiom (the feature manifest + `pnpm check:feature-parity`).
- Redirects the four dangling `cross-framework.md` / `check-cross-framework-parity.ts` references in `.claude/rules/packages/react.md`, `vue.md`, and `testing.md` to `feature-manifest.md` / `check-ct-parity.ts`.
- Extends `checkCrossFrameworkRuleRetired` so ADR-0006 now **fails on any live reference** to the retired names (escaped-dot match, scoped to `.claude/`/`packages/*/src`/`scripts/`, self + `*.d.ts` excluded), replacing its stale phase-era WARN branches. Stays a single check; the harness count stays 14.
- Appends a dated update to **ADR-0009** correcting the drift (`getServerSnapshot` returns `0`; `subscribe` also attaches `selectionUpdate`; the Svelte selector lives in `createVizelEditorState.svelte.ts`) without editing the immutable Decision. Updates the ADR-0006 row in **ADR-0013**.

## Test Plan

- [x] `pnpm check:adr-compliance` — 14 PASS; ADR-0006 row now also asserts zero live dangling references.
- [x] Negative control: injecting a `cross-framework.md` reference into a rule file → ADR-0006 check fails naming the file.
- [x] `grep` for the retired names across `.claude`/`packages/*/src`/`scripts` → zero live references.
- [x] ADR-0009 immutable Decision unchanged (dated `## Update` appended).
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm check:nolet` — pass.

Refs: `docs/superpowers/plans/2026-06-02-vizel-v2-hardening-p0p1.md` (WI-9).
