### PR TITLE
feat(core): statically enforce the manifest ARIA/keyboard contract

### DIFF
--- a/.claude/rules/feature-manifest.md
+++ b/.claude/rules/feature-manifest.md
@@ -44,10 +44,20 @@ Each feature entry exports a `VizelFeatureDefinition`:
 3. Delete the flat scenario `tests/ct/scenarios/<feature>.scenario.ts` and its per-framework specs.
 4. Note the removal in `docs/guide/migration-v1-to-v2.md` (or the next major release's migration guide).
 
+## ARIA and keyboard contract: static now, runtime later
+
+The manifest's `ariaContract` (`role` + `requiredAttributes`) and `keyboardMap` are enforced in two phases.
+
+- **Phase 1 (static, enforced now).** `pnpm check:aria-contract` (`scripts/check-aria-contract.ts`) reads source only. For every feature whose `ariaContract` declares a `role` or a non-empty `requiredAttributes`, the check resolves each adapter component under `packages/<fw>/src/components/` and asserts that the declared role and each attribute appears in the component source — as a literal attribute or, when the component renders the value off a builder spec (`role={spec.root.role}`), through the feature's builder file under `packages/core/src/builders/`. For `keyboardMap`, the check asserts every binding key belongs to the union of the `VizelCommand` identifiers parsed from `packages/core/src/commands/registry/*.ts` and the `VIZEL_KEYBOARD_COMMANDS` navigation-verb vocabulary the manifest exports. Companion-only features (no adapter `component`) carry no component source; the check skips them with a logged advisory note rather than passing silently. The check verifies presence in source, not the rendered Document Object Model (DOM).
+- **Phase 2 (runtime, planned).** Axe assertions and keyboard-interaction tests on the live DOM are deferred to the accessibility CI follow-up. The JSDoc for `VizelAriaContract` and `VizelKeyboardMap` records this split; do not restore "must honour" wording that overstates the current static guarantee.
+
+When you change a feature's `ariaContract` or `keyboardMap`, run `pnpm check:aria-contract` locally; the same check runs on `pre-push` and in CI. If a component and the manifest disagree on a role, fix whichever side is genuinely wrong under WAI-ARIA — do not relax the check.
+
 ## CI verification
 
 - `pnpm check:feature-parity` — static export-surface check. The script parses each adapter's `src/index.ts` with the TypeScript compiler API and computes its effective export set: the adapter's own named exports unioned with the `@vizel/core` surface that the mandatory `export * from "@vizel/core"` forwards. The Core surface is resolved by recursively walking the re-export declarations rooted at `packages/core/src/index.ts`. The check reads source only — it imports no built artefacts — and fails when any adapter omits a manifest-declared component or companion symbol.
+- `pnpm check:aria-contract` — static ARIA / keyboard contract check (Phase 1). See the section above for the resolution rules and the static-versus-runtime split.
 - `pnpm check:ct-parity` — Playwright-level check: every manifest entry has a scenario that runs across every framework.
 - `pnpm check:scenarios` — flat-scenario coverage check (`tests/ct/parity/check-scenarios.ts`). For every `tests/ct/scenarios/<feature>.scenario.ts`, the check asserts the scenario exports at least one `test*` function and that each framework's spec layer imports the scenario through `../../scenarios/<feature>.scenario` and invokes at least one of its `test*` exports. The check matches the import specifier, not the spec filename, so the `Use*`/`Create*` idiom does not break detection.
 
-The lefthook `pre-push` hook and the `Quality + Parity` CI job run all three checks.
+The lefthook `pre-push` hook and the `Quality + Parity` CI job run these checks.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Feature manifest parity
         run: pnpm check:feature-parity
 
+      # Statically enforce the manifest's ARIA contract (role +
+      # requiredAttributes present in component / builder source) and the
+      # keyboard-map command allow-list. Runtime axe / keyboard checks are
+      # Phase 2, deferred to the accessibility CI follow-up.
+      - name: Manifest ARIA/keyboard contract
+        run: pnpm check:aria-contract
+
       - name: Scenario foundation parity
         run: pnpm check:scenarios
 

--- a/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
+++ b/docs/adr/ADR-0002-feature-manifest-as-parity-ssot.md
@@ -39,6 +39,16 @@ Follow-up:
 - Implement `scripts/check-feature-parity.ts` and wire it into lefthook + CI.
 - Delete `.claude/rules/cross-framework.md` as part of the same pull request (see [ADR-0006](./ADR-0006-retire-cross-framework-rule.md)).
 
+## Update 2026-06-03: ARIA / keyboard contract gains static enforcement
+
+The original manifest carried `ariaContract` (`role` + `requiredAttributes`) and `keyboardMap` on every feature, but no check enforced either field. The contract read as binding ("every adapter implementation must honour") while remaining advisory — a component could render any role, or none, without failing a gate.
+
+`scripts/check-aria-contract.ts` now enforces these fields statically (Phase 1). For every feature whose `ariaContract` declares a `role` or a non-empty `requiredAttributes`, the check resolves each adapter component and asserts that the declared role and each attribute appears in the component source — as a literal or, when the component renders the value off a builder spec, through the feature's builder file under `packages/core/src/builders/`. For `keyboardMap`, the check asserts every binding key belongs to the union of the `VizelCommand` registry identifiers and the `VIZEL_KEYBOARD_COMMANDS` navigation-verb vocabulary the manifest exports, so a binding name cannot rot into a string the editor never handles. The check reads source only and runs on `pre-push` and in the `Quality + Parity` CI job, alongside `check:feature-parity`.
+
+Runtime enforcement — axe assertions and keyboard-interaction tests on the live DOM — is **phased** (Phase 2). It is deferred to the accessibility CI follow-up, because that job currently runs on `workflow_dispatch` and does not gate pull requests. The `VizelAriaContract` and `VizelKeyboardMap` JSDoc now scopes the guarantee to static presence and drops the over-stated "must honour" wording.
+
+Reconciling the manifest with the components surfaced five role contradictions, fixed by choosing the genuinely-correct WAI-ARIA role per case: `bubble-menu` `menu` -> `toolbar`; `toolbar-dropdown` `menu` -> `listbox`; `node-selector` `menu` -> `listbox`; `outline` `navigation` -> `tree`; `find-replace` dropped `aria-modal` from `requiredAttributes` because the panel is non-modal.
+
 ## References
 
 - Plan: `/Users/seiji/.claude/plans/starry-petting-planet.md` (Phase 1, R2)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,6 +55,9 @@ pre-push:
     feature-parity:
       run: pnpm check:feature-parity
 
+    aria-contract:
+      run: pnpm check:aria-contract
+
     scenarios:
       run: pnpm check:scenarios
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check": "biome check --error-on-warnings .",
     "check:fix": "biome check --write .",
     "check:feature-parity": "node scripts/check-feature-parity.ts",
+    "check:aria-contract": "node scripts/check-aria-contract.ts",
     "check:scenarios": "node tests/ct/parity/check-scenarios.ts",
     "check:adr-compliance": "node scripts/check-adr-compliance.ts",
     "check:ct-parity": "node scripts/check-ct-parity.ts",

--- a/packages/core/src/feature-manifest.ts
+++ b/packages/core/src/feature-manifest.ts
@@ -50,7 +50,21 @@ export type VizelFeatureCategory =
   | "form"
   | "infrastructure";
 
-/** ARIA contract that every adapter implementation must honour. */
+/**
+ * Accessibility contract for a feature's root element.
+ *
+ * `scripts/check-aria-contract.ts` statically enforces this contract: it
+ * resolves each adapter component for the feature and asserts that the
+ * declared `role` and every `requiredAttributes` entry appears in the
+ * component source — either as a literal attribute or through the
+ * feature's resolved builder spec. The check verifies presence in source,
+ * not the rendered Document Object Model (DOM).
+ *
+ * Runtime enforcement (axe assertions and keyboard-interaction tests on
+ * the live DOM) is planned as Phase 2 and is deferred to the
+ * accessibility Continuous Integration (CI) follow-up; this contract does
+ * not yet guarantee runtime behaviour.
+ */
 export interface VizelAriaContract {
   /** Optional ARIA role applied to the feature's root element. */
   readonly role?: string;
@@ -58,10 +72,39 @@ export interface VizelAriaContract {
   readonly requiredAttributes: readonly string[];
 }
 
-/** Keyboard bindings keyed by canonical command name. */
+/**
+ * Keyboard bindings keyed by canonical command name.
+ *
+ * Each key names a command the feature responds to; the value lists the
+ * `KeyboardEvent.key` values bound to that command.
+ * `scripts/check-aria-contract.ts` statically asserts that every key
+ * belongs to the allow-list formed by the union of the `VizelCommand`
+ * registry identifiers under `packages/core/src/commands/registry/` and
+ * the navigation-verb vocabulary in {@link VIZEL_KEYBOARD_COMMANDS}, so a
+ * binding name cannot rot into a string the editor never handles.
+ *
+ * Runtime enforcement (asserting each key actually triggers its command
+ * against the live editor) is planned as Phase 2 and is deferred to the
+ * accessibility CI follow-up.
+ */
 export interface VizelKeyboardMap {
   readonly bindings: Readonly<Record<string, readonly string[]>>;
 }
+
+/**
+ * Canonical navigation-verb vocabulary for {@link VizelKeyboardMap} keys.
+ *
+ * The manifest binds menus, popovers, and forms to abstract interaction
+ * verbs rather than to `VizelCommand` registry identifiers — a slash menu
+ * binds `next`/`previous`/`confirm`/`close`, not `format/bold`. This const
+ * is the Single Source of Truth (SSOT) for those verbs;
+ * `scripts/check-aria-contract.ts` reads it to validate every keyboard-map
+ * key, so adding a new verb requires extending this list.
+ */
+export const VIZEL_KEYBOARD_COMMANDS = ["next", "previous", "confirm", "submit", "close"] as const;
+
+/** A canonical navigation verb usable as a {@link VizelKeyboardMap} key. */
+export type VizelKeyboardCommand = (typeof VIZEL_KEYBOARD_COMMANDS)[number];
 
 /** Public symbol that an adapter exports for a feature. */
 export interface VizelAdapterSymbol {
@@ -119,7 +162,9 @@ export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
     id: "bubble-menu",
     category: "menu",
     description: "Floating menu surfaced when the user makes a non-empty text selection.",
-    ariaContract: { role: "menu", requiredAttributes: ["aria-label"] },
+    // A row of formatting toggle buttons is a WAI-ARIA toolbar, not a
+    // menu; every adapter renders role="toolbar".
+    ariaContract: { role: "toolbar", requiredAttributes: ["aria-label"] },
     keyboardMap: { bindings: { close: ["Escape"] } },
     scenarios: ["render", "selection-tracking", "keyboard-dismiss"],
     adapters: {
@@ -204,8 +249,11 @@ export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
     id: "toolbar-dropdown",
     category: "popover",
     description: "Dropdown surface used inside the toolbar for grouped actions.",
+    // The body renders role="option" rows with aria-selected and the
+    // trigger advertises aria-haspopup="listbox"; the surface is a
+    // single-select listbox, not a menu.
     ariaContract: {
-      role: "menu",
+      role: "listbox",
       requiredAttributes: ["aria-expanded", "aria-haspopup"],
     },
     keyboardMap: {
@@ -239,8 +287,11 @@ export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
     id: "node-selector",
     category: "popover",
     description: "Selector for swapping the current block's node type.",
+    // The body renders role="option" rows with aria-selected and the
+    // trigger advertises aria-haspopup="listbox"; the surface is a
+    // single-select listbox, not a menu.
     ariaContract: {
-      role: "menu",
+      role: "listbox",
       requiredAttributes: ["aria-expanded", "aria-haspopup"],
     },
     keyboardMap: {
@@ -280,9 +331,11 @@ export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
     id: "find-replace",
     category: "overlay",
     description: "Find-and-replace panel that searches and rewrites editor content.",
+    // The panel is non-modal: it coexists with live editing and never
+    // renders the document inert, so it must not claim aria-modal.
     ariaContract: {
       role: "dialog",
-      requiredAttributes: ["aria-label", "aria-modal"],
+      requiredAttributes: ["aria-label"],
     },
     keyboardMap: {
       bindings: {
@@ -314,8 +367,11 @@ export const VIZEL_FEATURE_MANIFEST: readonly VizelFeatureDefinition[] = [
     id: "outline",
     category: "infrastructure",
     description: "Document outline panel that summarises the heading structure.",
+    // The builder spec types role="tree" and the component renders
+    // role="treeitem" / role="group" children, a WAI-ARIA tree, not a
+    // navigation landmark.
     ariaContract: {
-      role: "navigation",
+      role: "tree",
       requiredAttributes: ["aria-label"],
     },
     keyboardMap: { bindings: {} },

--- a/scripts/check-aria-contract.ts
+++ b/scripts/check-aria-contract.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env tsx
+/**
+ * Manifest ARIA / keyboard contract check (Phase 1, static).
+ *
+ * The feature manifest (`packages/core/src/feature-manifest.ts`) declares
+ * an `ariaContract` (`role` + `requiredAttributes`) and a `keyboardMap`
+ * for every feature. Before this check those fields were advisory: no
+ * tool verified that an adapter actually rendered the declared role or
+ * attribute, so the manifest could claim a contract the components never
+ * honoured. This check closes that gap statically.
+ *
+ * For every feature whose `ariaContract` declares a `role` or a non-empty
+ * `requiredAttributes` list, the check resolves each adapter component
+ * (`packages/<fw>/src/components/<Component>.{tsx,vue,svelte}`) and asserts
+ * that:
+ *
+ * 1. the declared role appears in the component source — either as a
+ *    literal (`role="X"`, `role={"X"}`, `role: "X"`) or, when the
+ *    component renders the role off a builder spec (`role={spec.root.role}`,
+ *    `:role="spec.root.role"`), through the feature's builder file under
+ *    `packages/core/src/builders/`; and
+ * 2. every `requiredAttributes` entry appears the same way — as a literal
+ *    attribute in the component or as an attribute literal in the builder
+ *    spec.
+ *
+ * For `keyboardMap`, the check asserts that every binding key belongs to
+ * the allow-list formed by the union of (a) every `VizelCommand`
+ * identifier parsed from `packages/core/src/commands/registry/*.ts` and
+ * (b) the navigation-verb vocabulary exported as `VIZEL_KEYBOARD_COMMANDS`
+ * from the manifest. Deriving the allow-list from source keeps it from
+ * rotting when the registry or the verb vocabulary changes.
+ *
+ * Scope note (Decision D-7, A-PHASED): this is the STATIC phase. It
+ * verifies presence in source, not the rendered Document Object Model
+ * (DOM). Runtime axe / keyboard enforcement is Phase 2, deferred to the
+ * accessibility CI follow-up.
+ *
+ * Companion-only features (no adapter `component`) carry no component
+ * source to inspect; the check skips them with a logged advisory note
+ * rather than passing them silently. The manifest JSDoc records the same
+ * static-versus-runtime split.
+ *
+ * Exits 0 on success with a summary line, 1 on any divergence naming the
+ * feature, framework, and missing role / attribute / command.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  VIZEL_FEATURE_MANIFEST,
+  VIZEL_KEYBOARD_COMMANDS,
+  type VizelFeatureAdapters,
+  type VizelFeatureDefinition,
+} from "../packages/core/src/feature-manifest.ts";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const BUILDERS_DIR = resolve(REPO_ROOT, "packages/core/src/builders");
+const REGISTRY_DIR = resolve(REPO_ROOT, "packages/core/src/commands/registry");
+
+type Framework = keyof VizelFeatureAdapters;
+
+interface FrameworkPaths {
+  readonly framework: Framework;
+  readonly componentsDir: string;
+  readonly extension: string;
+}
+
+const FRAMEWORKS: readonly FrameworkPaths[] = [
+  {
+    framework: "react",
+    componentsDir: resolve(REPO_ROOT, "packages/react/src/components"),
+    extension: ".tsx",
+  },
+  {
+    framework: "vue",
+    componentsDir: resolve(REPO_ROOT, "packages/vue/src/components"),
+    extension: ".vue",
+  },
+  {
+    framework: "svelte",
+    componentsDir: resolve(REPO_ROOT, "packages/svelte/src/components"),
+    extension: ".svelte",
+  },
+];
+
+interface ContractFinding {
+  readonly featureId: string;
+  readonly framework: Framework;
+  readonly kind: "role" | "attribute";
+  readonly token: string;
+}
+
+interface AdvisoryNote {
+  readonly featureId: string;
+  readonly framework: Framework;
+  readonly reason: string;
+}
+
+/**
+ * Read a component file's source, or `null` when the file is absent. The
+ * caller treats a `null` as an advisory skip rather than a failure.
+ */
+function readComponentSource(feature: FrameworkPaths, component: string): string | null {
+  const filePath = join(feature.componentsDir, `${component}${feature.extension}`);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : null;
+}
+
+/**
+ * Resolve the builder source for a feature, or `null` when no builder
+ * file exists. The manifest maps a feature to its builder by the feature
+ * id (`bubble-menu` -> `builders/bubble-menu.ts`), which holds for every
+ * spec-rendering feature (`outline`, `slash-menu`, `mention-menu`,
+ * `block-menu`, `node-selector`, `toolbar-dropdown`). The check folds the
+ * builder source into the ARIA search so a component that renders
+ * `role={spec.root.role}` still resolves to its declared role literal.
+ */
+function readBuilderSource(feature: VizelFeatureDefinition): string | null {
+  const filePath = join(BUILDERS_DIR, `${feature.id}.ts`);
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : null;
+}
+
+/**
+ * Return whether a role literal appears in a source string. Matches the
+ * three literal forms a framework template uses: `role="X"` (JSX / Vue /
+ * Svelte attribute), `role={"X"}` (JSX expression), and `role: "X"`
+ * (builder spec property).
+ */
+const roleAppears = (source: string, role: string): boolean => {
+  const patterns = [
+    `role="${role}"`,
+    `role='${role}'`,
+    `role={"${role}"}`,
+    `role={'${role}'}`,
+    `role: "${role}"`,
+    `role: '${role}'`,
+  ];
+  return patterns.some((pattern) => source.includes(pattern));
+};
+
+/**
+ * Return whether an ARIA attribute name appears in a source string. The
+ * attribute matches whether the template binds it statically (`aria-label=`)
+ * or dynamically (`:aria-label=` in Vue, `"aria-label":` in a builder
+ * spec or a JSX spread object).
+ */
+const attributeAppears = (source: string, attribute: string): boolean => {
+  const patterns = [`${attribute}=`, `:${attribute}=`, `"${attribute}"`, `'${attribute}'`];
+  return patterns.some((pattern) => source.includes(pattern));
+};
+
+/**
+ * Verify one feature's ARIA contract against one framework's component.
+ * Return findings for every missing role or attribute; an empty array
+ * means the component honours the contract. A component the framework
+ * does not declare yields an advisory skip handled by the caller.
+ */
+function verifyAriaForFramework(
+  feature: VizelFeatureDefinition,
+  framework: FrameworkPaths,
+  builderSource: string | null
+): readonly ContractFinding[] {
+  const component = feature.adapters[framework.framework].component;
+  if (!component) return [];
+  const componentSource = readComponentSource(framework, component);
+  if (componentSource === null) return [];
+
+  const haystacks = [componentSource, builderSource ?? ""];
+  const declaredRole = feature.ariaContract.role;
+  const roleFindings: readonly ContractFinding[] =
+    typeof declaredRole === "string" &&
+    !haystacks.some((source) => roleAppears(source, declaredRole))
+      ? [
+          {
+            featureId: feature.id,
+            framework: framework.framework,
+            kind: "role",
+            token: declaredRole,
+          },
+        ]
+      : [];
+
+  const attributeFindings = feature.ariaContract.requiredAttributes.flatMap((attribute) =>
+    haystacks.some((source) => attributeAppears(source, attribute))
+      ? []
+      : [
+          {
+            featureId: feature.id,
+            framework: framework.framework,
+            kind: "attribute" as const,
+            token: attribute,
+          },
+        ]
+  );
+
+  return [...roleFindings, ...attributeFindings];
+}
+
+interface AriaResult {
+  readonly findings: readonly ContractFinding[];
+  readonly advisories: readonly AdvisoryNote[];
+  readonly checkedFeatureIds: ReadonlySet<string>;
+}
+
+/**
+ * Verify the ARIA contract for every feature that declares a role or a
+ * non-empty `requiredAttributes` list. A feature without any adapter
+ * component (companion-only features such as `comment`) cannot be
+ * statically inspected, so the check records it as an advisory note
+ * instead of passing it silently.
+ */
+function verifyAriaContracts(manifest: readonly VizelFeatureDefinition[]): AriaResult {
+  const relevant = manifest.filter(
+    (feature) =>
+      typeof feature.ariaContract.role === "string" ||
+      feature.ariaContract.requiredAttributes.length > 0
+  );
+
+  const builderByFeature = new Map<string, string | null>(
+    relevant.map((feature) => [feature.id, readBuilderSource(feature)])
+  );
+
+  const findings = relevant.flatMap((feature) =>
+    FRAMEWORKS.flatMap((framework) =>
+      verifyAriaForFramework(feature, framework, builderByFeature.get(feature.id) ?? null)
+    )
+  );
+
+  const advisories = relevant.flatMap((feature) =>
+    FRAMEWORKS.flatMap((framework) => {
+      const component = feature.adapters[framework.framework].component;
+      if (!component) {
+        return [
+          {
+            featureId: feature.id,
+            framework: framework.framework,
+            reason: "companion-only adapter declares no component to inspect",
+          },
+        ];
+      }
+      return readComponentSource(framework, component) === null
+        ? [
+            {
+              featureId: feature.id,
+              framework: framework.framework,
+              reason: `component file ${component}${framework.extension} not found`,
+            },
+          ]
+        : [];
+    })
+  );
+
+  return {
+    findings,
+    advisories,
+    checkedFeatureIds: new Set(relevant.map((feature) => feature.id)),
+  };
+}
+
+/**
+ * Parse every `VizelCommand` identifier from the command registry source.
+ * The check reads the literal `id: "..."` declarations rather than
+ * importing the registry so the allow-list tracks the registry source and
+ * cannot drift from it.
+ */
+function loadRegistryCommandIds(): ReadonlySet<string> {
+  const idPattern = /\bid:\s*["']([^"']+)["']/g;
+  const ids = readdirSync(REGISTRY_DIR)
+    .filter((entry) => entry.endsWith(".ts") && !entry.endsWith(".d.ts"))
+    .flatMap((entry) => {
+      const source = readFileSync(join(REGISTRY_DIR, entry), "utf8");
+      return [...source.matchAll(idPattern)].map((match) => match[1]);
+    });
+  return new Set(ids);
+}
+
+interface KeyboardFinding {
+  readonly featureId: string;
+  readonly command: string;
+}
+
+/**
+ * Verify every keyboard-map binding key against the allow-list. The
+ * allow-list is the union of the registry command identifiers and the
+ * navigation-verb vocabulary the manifest exports.
+ */
+function verifyKeyboardMaps(
+  manifest: readonly VizelFeatureDefinition[],
+  allowList: ReadonlySet<string>
+): readonly KeyboardFinding[] {
+  return manifest.flatMap((feature) =>
+    Object.keys(feature.keyboardMap.bindings)
+      .filter((command) => !allowList.has(command))
+      .map((command) => ({ featureId: feature.id, command }))
+  );
+}
+
+function main(): void {
+  const aria = verifyAriaContracts(VIZEL_FEATURE_MANIFEST);
+
+  const registryIds = loadRegistryCommandIds();
+  const keyboardAllowList = new Set<string>([...registryIds, ...VIZEL_KEYBOARD_COMMANDS]);
+  const keyboardFindings = verifyKeyboardMaps(VIZEL_FEATURE_MANIFEST, keyboardAllowList);
+
+  for (const advisory of aria.advisories) {
+    process.stdout.write(
+      `note: ${advisory.featureId} / ${advisory.framework} skipped (advisory): ${advisory.reason}\n`
+    );
+  }
+
+  const hasFailures = aria.findings.length > 0 || keyboardFindings.length > 0;
+  if (!hasFailures) {
+    const featureCount = aria.checkedFeatureIds.size;
+    process.stdout.write(
+      `Manifest ARIA/keyboard contract check passed (${featureCount} features checked across ` +
+        `${FRAMEWORKS.length} frameworks; keyboard allow-list = ${keyboardAllowList.size} commands).\n`
+    );
+    return;
+  }
+
+  process.stderr.write("Manifest ARIA/keyboard contract violations:\n");
+  for (const finding of aria.findings) {
+    process.stderr.write(
+      `  - ${finding.featureId} / ${finding.framework}: missing ${finding.kind} "${finding.token}"\n`
+    );
+  }
+  for (const finding of keyboardFindings) {
+    process.stderr.write(
+      `  - ${finding.featureId}: keyboardMap command "${finding.command}" is not in the registry or the navigation-verb allow-list\n`
+    );
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- WI-11 of the P0/P1 hardening plan (decision D-7, **A-phased**: static enforcement now, runtime deferred). Fixes finding F-K: the manifest declared an `ariaContract` (role + required attributes) and a `keyboardMap` on all 23 features, but **nothing enforced them**, and the JSDoc claimed adapters "must honour" a contract no check verified.
- Adds `scripts/check-aria-contract.ts`: per feature, it statically asserts the declared role and required ARIA attributes appear in the adapter component source **or the feature's resolved builder spec** (so `role={spec.root.role}` bindings resolve), and that every `keyboardMap` command name exists in the command registry or the navigation-verb vocabulary (allow-list derived from source — 42 commands).
- Reconciles five manifest/source role contradictions to their genuinely-correct ARIA roles:
  - bubble-menu `menu` → **`toolbar`** (row of toggle buttons)
  - toolbar-dropdown, node-selector `menu` → **`listbox`** (single-select option lists)
  - outline `navigation` → **`tree`** (full WAI-ARIA tree)
  - find-replace drops the **`aria-modal`** requirement (the panel is non-modal; it coexists with live editing)
- Wires `check:aria-contract` into the Quality + Parity job and lefthook pre-push; rescopes the manifest JSDoc; records the enforcement in ADR-0002; removes the "must honour" overstatement.

## Scope notes

- `comment` and `version-history` are companion-only (no adapter component) and recorded as **advisory**.
- The static check verifies **presence in source**, not root-element binding; element-level + runtime axe/keyboard enforcement is **Phase 2**, deferred (it depends on the a11y CI being PR-gated — tracked in #630).

## Test Plan

- [x] `pnpm check:aria-contract` — passes (15 features checked × 3 frameworks; 42-command allow-list).
- [x] Negative control: removing a declared `aria-label` from a component → exit 1 naming feature+framework+attribute.
- [x] Negative control: a `keyboardMap` command not in the registry/verb list → exit 1.
- [x] `pnpm check:feature-parity` (23×3), `check:adr-compliance` (14), `check:ct-parity`, `typecheck`, `lint`, `check:nolet` — pass.
- [x] `git grep "must honour"` in the manifest → gone.

Refs: `docs/superpowers/plans/2026-06-02-vizel-v2-hardening-p0p1.md` (WI-11). Runtime Phase 2 follow-up relates to #630.
