### PR TITLE
fix(core): surface upload failures through onError and type raw throws

### DIFF
--- a/.claude/rules/packages/core.md
+++ b/.claude/rules/packages/core.md
@@ -191,6 +191,68 @@ every safe opt-in (everything except `mention`, `provider`, `comments`,
 configuration to function). Use it when you want the Notion-like
 surface without enumerating each toggle.
 
+## Error Handling
+
+Core uses one error model rooted at `VizelError`. Pass a stable
+`VizelErrorCode`, attach structured `context`, and forward the
+underlying `cause`. No `console` call is allowed inside
+`packages/core/src/` except the single sanctioned site inside
+`emitVizelError`.
+
+### Configuration errors throw with a stable code
+
+Developer mistakes surface at the boundary as a thrown `VizelError`.
+
+```ts
+// packages/core/src/plugin-system.ts
+throw new VizelError("INVALID_CONFIG", `Vizel plugin "${plugin.name}" is already registered`, {
+  context: { plugin: plugin.name },
+});
+```
+
+Every plugin-system validation and dependency-resolution failure throws
+`INVALID_CONFIG` and carries the offending plugin name in
+`context.plugin`.
+
+### Missing optional dependency
+
+The lazy loaders for optional packages (`lowlight`, `mermaid`, ...)
+throw `MISSING_OPTIONAL_DEP`, forwarding the original import error as
+`cause` and the package name in `context.moduleName`.
+
+```ts
+// packages/core/src/utils/lazy-import.ts
+throw new VizelError("MISSING_OPTIONAL_DEP", `[Vizel] Failed to load "${moduleName}". ...`, {
+  cause: error,
+  context: { moduleName },
+});
+```
+
+### Recoverable runtime errors emit through both sinks
+
+Image-upload rejections emit `UPLOAD_FAILED` through
+`emitVizelError(error, onError)` so observability sinks see the failure,
+and *also* call the feature-level `onUploadError(error, file)` that demos
+and tests rely on.
+
+```ts
+// packages/core/src/plugins/image-upload.ts
+const vizelError = new VizelError("UPLOAD_FAILED", `Image upload failed: ${error.message}`, {
+  cause: error,
+  context: { fileName: file.name, fileType: file.type },
+});
+emitVizelError(vizelError, onError);
+onUploadError?.(error, file);
+```
+
+The editor-level `onError` reaches the upload path two ways: adapters
+pass `getOnError` into `registerVizelUploadEventHandler` for the
+slash-command path, and `createVizelEditorInstance` threads `onError`
+into `createVizelExtensions` for the drop / paste plugin. The
+per-feature `features.content.image.onError` (inherited from
+`Partial<VizelImageUploadPluginOptions>`) is a fallback used only when
+the editor-level sink is unset.
+
 ## Command Layer
 
 A single `VizelCommand` represents one user action everywhere it

--- a/packages/core/src/extensions/base.ts
+++ b/packages/core/src/extensions/base.ts
@@ -28,6 +28,7 @@ import type {
   VizelMarkdownLossyEncodingMode,
 } from "../markdown/types.ts";
 import type { VizelFeatureOptions } from "../types.ts";
+import type { VizelError } from "../utils/errorHandling.ts";
 import { resolveVizelFlavorConfig, type VizelFlavorConfig } from "../utils/markdown-flavors.ts";
 import { createVizelBlockClipboardExtension } from "./block-clipboard.ts";
 import { createVizelCalloutExtension } from "./callout.ts";
@@ -88,6 +89,12 @@ export interface VizelExtensionsOptions {
    * If not provided, default English strings are used.
    */
   locale?: VizelLocale;
+  /**
+   * Editor-level error sink threaded into the drop / paste image-upload
+   * plugin so an upload rejection emits a `VizelError` (`UPLOAD_FAILED`)
+   * to observability sinks, not only the feature-level `onUploadError`.
+   */
+  onError?: (err: VizelError) => void;
 }
 
 /**
@@ -169,13 +176,20 @@ function addSlashMenuExtension(extensions: Extensions, features: VizelFeatureOpt
 /**
  * Add Image extension if enabled (enabled by default).
  */
-function addImageExtension(extensions: Extensions, features: VizelFeatureOptions): void {
+function addImageExtension(
+  extensions: Extensions,
+  features: VizelFeatureOptions,
+  onError?: (err: VizelError) => void
+): void {
   const image = features.content?.image;
   if (image === false) return;
 
   const imageOptions = typeof image === "object" ? image : {};
   const onUpload = imageOptions.onUpload ?? vizelDefaultBase64Upload;
   const resizeEnabled = imageOptions.resize !== false;
+  // Prefer the editor-level `onError`; fall back to a per-feature `onError`
+  // a consumer may set directly on the image options.
+  const resolvedOnError = onError ?? imageOptions.onError;
 
   extensions.push(
     ...createVizelImageUploadExtensions({
@@ -189,6 +203,7 @@ function addImageExtension(extensions: Extensions, features: VizelFeatureOptions
         ...(imageOptions.onUploadError !== undefined && {
           onUploadError: imageOptions.onUploadError,
         }),
+        ...(resolvedOnError !== undefined && { onError: resolvedOnError }),
       },
       resize: resizeEnabled ? defaultImageResizeOptions : false,
     })
@@ -484,6 +499,7 @@ export async function createVizelExtensions(
     flavor,
     encoding,
     locale,
+    onError,
   } = options;
 
   const flavorConfig = resolveVizelFlavorConfig(flavor);
@@ -517,7 +533,7 @@ export async function createVizelExtensions(
 
   // Opt-out / opt-in features
   addSlashMenuExtension(extensions, features);
-  addImageExtension(extensions, features);
+  addImageExtension(extensions, features, onError);
   addTaskListExtension(extensions, features);
   addCharacterCountExtension(extensions, features);
   addTextColorExtension(extensions, features);

--- a/packages/core/src/extensions/code-block-lowlight.ts
+++ b/packages/core/src/extensions/code-block-lowlight.ts
@@ -14,6 +14,7 @@ import CodeBlockLowlight, {
 } from "@tiptap/extension-code-block-lowlight";
 import type { VizelLocale } from "../i18n/types.ts";
 import { renderVizelIcon } from "../icons/types.ts";
+import { VizelError } from "../utils/errorHandling.ts";
 
 /**
  * Language definition for the code block language selector
@@ -111,10 +112,12 @@ async function loadLowlightInstance(
     const grammars = languages === "all" ? lowlightMod.all : lowlightMod.common;
     return lowlightMod.createLowlight(grammars);
   } catch (error) {
-    throw new Error(
+    throw new VizelError(
+      "MISSING_OPTIONAL_DEP",
       `[Vizel] Failed to load "lowlight". ` +
         `Please install it for code block syntax highlighting: npm install lowlight\n` +
-        `Original error: ${error instanceof Error ? error.message : String(error)}`
+        `Original error: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error, context: { moduleName: "lowlight" } }
     );
   }
 }

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -10,6 +10,7 @@ import {
   type VizelImageUploadPluginOptions,
   validateVizelImageFile,
 } from "../plugins/image-upload.ts";
+import { emitVizelError, VizelError } from "../utils/errorHandling.ts";
 import { VizelResizableImage } from "./image-resize.ts";
 
 /**
@@ -212,7 +213,8 @@ export interface VizelImageUploadWithFileHandlerOptions extends VizelImageOption
 export function createVizelImageUploadWithFileHandler(
   options: VizelImageUploadWithFileHandlerOptions
 ) {
-  const { onUpload, maxFileSize, allowedTypes, onValidationError, onUploadError } = options.upload;
+  const { onUpload, maxFileSize, allowedTypes, onValidationError, onUploadError, onError } =
+    options.upload;
 
   // Use VizelResizableImage if resize is enabled, otherwise use standard Image
   const resizeEnabled = options.resize !== false;
@@ -272,6 +274,15 @@ export function createVizelImageUploadWithFileHandler(
             editor.chain().focus().setImage({ src: url }).run();
           })
           .catch((error: Error) => {
+            // Route through both sinks: the editor-level `onError` for
+            // observability and the feature-level `onUploadError` for UI.
+            emitVizelError(
+              new VizelError("UPLOAD_FAILED", `Image upload failed: ${error.message}`, {
+                cause: error,
+                context: { fileName: file.name, fileType: file.type },
+              }),
+              onError
+            );
             onUploadError?.(error, file);
           });
       }
@@ -301,6 +312,15 @@ export function createVizelImageUploadWithFileHandler(
             }
           })
           .catch((error: Error) => {
+            // Route through both sinks: the editor-level `onError` for
+            // observability and the feature-level `onUploadError` for UI.
+            emitVizelError(
+              new VizelError("UPLOAD_FAILED", `Image upload failed: ${error.message}`, {
+                cause: error,
+                context: { fileName: file.name, fileType: file.type },
+              }),
+              onError
+            );
             onUploadError?.(error, file);
           });
       }

--- a/packages/core/src/plugin-system.ts
+++ b/packages/core/src/plugin-system.ts
@@ -1,5 +1,6 @@
 import type { Editor, Extensions } from "@tiptap/core";
 import type { Transaction } from "@tiptap/pm/state";
+import { VizelError } from "./utils/errorHandling.ts";
 
 // =============================================================================
 // Types
@@ -53,22 +54,36 @@ const SEMVER_REGEX = /^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/;
 const PLUGIN_NAME_REGEX = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 
 /**
- * Validates a plugin's required fields and format.
- * Throws a descriptive error if validation fails.
+ * Validate a plugin's required fields and format.
+ *
+ * Throw a typed `VizelError("INVALID_CONFIG", ...)` carrying the offending
+ * plugin name in `context.plugin` when validation fails. A malformed plugin
+ * is a developer mistake, so the error surfaces at the boundary rather than
+ * flowing through `onError`.
  */
 export function validateVizelPlugin(plugin: VizelPlugin): void {
   if (!plugin.name) {
-    throw new Error("Vizel plugin must have a name");
+    throw new VizelError("INVALID_CONFIG", "Vizel plugin must have a name", {
+      context: { plugin: plugin.name },
+    });
   }
   if (!PLUGIN_NAME_REGEX.test(plugin.name)) {
-    throw new Error(`Vizel plugin name "${plugin.name}" must be kebab-case (e.g. "my-plugin")`);
+    throw new VizelError(
+      "INVALID_CONFIG",
+      `Vizel plugin name "${plugin.name}" must be kebab-case (e.g. "my-plugin")`,
+      { context: { plugin: plugin.name } }
+    );
   }
   if (!plugin.version) {
-    throw new Error(`Vizel plugin "${plugin.name}" must have a version`);
+    throw new VizelError("INVALID_CONFIG", `Vizel plugin "${plugin.name}" must have a version`, {
+      context: { plugin: plugin.name },
+    });
   }
   if (!SEMVER_REGEX.test(plugin.version)) {
-    throw new Error(
-      `Vizel plugin "${plugin.name}" version "${plugin.version}" must be valid semver (e.g. "1.0.0")`
+    throw new VizelError(
+      "INVALID_CONFIG",
+      `Vizel plugin "${plugin.name}" version "${plugin.version}" must be valid semver (e.g. "1.0.0")`,
+      { context: { plugin: plugin.name } }
     );
   }
 }
@@ -98,12 +113,18 @@ export function resolveVizelPluginDependencies(plugins: VizelPlugin[]): VizelPlu
 
     if (visiting.has(name)) {
       const cycle = [...path, name].join(" → ");
-      throw new Error(`Circular plugin dependency detected: ${cycle}`);
+      throw new VizelError("INVALID_CONFIG", `Circular plugin dependency detected: ${cycle}`, {
+        context: { plugin: name },
+      });
     }
 
     const plugin = pluginMap.get(name);
     if (!plugin) {
-      throw new Error(`Plugin dependency "${name}" not found (required by "${path.at(-1)}")`);
+      throw new VizelError(
+        "INVALID_CONFIG",
+        `Plugin dependency "${name}" not found (required by "${path.at(-1)}")`,
+        { context: { plugin: name } }
+      );
     }
 
     visiting.add(name);
@@ -190,14 +211,22 @@ export class VizelPluginManager {
     validateVizelPlugin(plugin);
 
     if (this.plugins.has(plugin.name)) {
-      throw new Error(`Vizel plugin "${plugin.name}" is already registered`);
+      throw new VizelError(
+        "INVALID_CONFIG",
+        `Vizel plugin "${plugin.name}" is already registered`,
+        {
+          context: { plugin: plugin.name },
+        }
+      );
     }
 
     // Verify dependencies are registered
     for (const dep of plugin.dependencies ?? []) {
       if (!this.plugins.has(dep)) {
-        throw new Error(
-          `Vizel plugin "${plugin.name}" requires "${dep}" which is not registered. Register dependencies first.`
+        throw new VizelError(
+          "INVALID_CONFIG",
+          `Vizel plugin "${plugin.name}" requires "${dep}" which is not registered. Register dependencies first.`,
+          { context: { plugin: plugin.name } }
         );
       }
     }
@@ -225,13 +254,19 @@ export class VizelPluginManager {
   unregister(pluginName: string): void {
     const plugin = this.plugins.get(pluginName);
     if (!plugin) {
-      throw new Error(`Vizel plugin "${pluginName}" is not registered`);
+      throw new VizelError("INVALID_CONFIG", `Vizel plugin "${pluginName}" is not registered`, {
+        context: { plugin: pluginName },
+      });
     }
 
     // Check if other plugins depend on this one
     for (const [name, p] of this.plugins) {
       if (p.dependencies?.includes(pluginName)) {
-        throw new Error(`Cannot unregister "${pluginName}": plugin "${name}" depends on it`);
+        throw new VizelError(
+          "INVALID_CONFIG",
+          `Cannot unregister "${pluginName}": plugin "${name}" depends on it`,
+          { context: { plugin: pluginName } }
+        );
       }
     }
 

--- a/packages/core/src/plugins/image-upload.ts
+++ b/packages/core/src/plugins/image-upload.ts
@@ -48,9 +48,24 @@ export interface VizelImageUploadPluginOptions {
   onValidationError?: (error: VizelImageValidationError) => void;
 
   /**
-   * Callback for upload errors
+   * Callback for upload errors.
+   *
+   * Receives the raw rejection reason and the offending file. This is the
+   * feature-specific contract that demos and tests rely on; it fires in
+   * addition to the editor-level {@link VizelImageUploadPluginOptions.onError}.
    */
   onUploadError?: (error: Error, file: File) => void;
+
+  /**
+   * Editor-level error sink.
+   *
+   * Upload rejections route through `emitVizelError(error, onError)` as a
+   * `VizelError` with code `UPLOAD_FAILED`, so observability sinks (Sentry,
+   * log pipes) see the failure even when only `onUploadError` is wired up
+   * for feature-specific UI. The adapter threads the editor's `onError`
+   * here via `getOnError`; see `createVizelUploadEventHandler`.
+   */
+  onError?: (err: VizelError) => void;
 }
 
 /**
@@ -203,7 +218,8 @@ export type VizelUploadImageFn = (file: File, view: EditorView, pos: number) => 
 export function createVizelImageUploader(
   options: VizelImageUploadPluginOptions
 ): VizelUploadImageFn {
-  const { onUpload, maxFileSize, allowedTypes, onValidationError, onUploadError } = options;
+  const { onUpload, maxFileSize, allowedTypes, onValidationError, onUploadError, onError } =
+    options;
 
   return (file: File, view: EditorView, pos: number): void => {
     // Validate file
@@ -257,16 +273,17 @@ export function createVizelImageUploader(
           const imageNode = schema.nodes.image?.create({ src: uploadedSrc });
 
           if (!imageNode) {
-            emitVizelError(
-              new VizelError(
-                "INVALID_EXTENSION",
-                "Image node type not found in schema. Ensure the Image extension is registered.",
-                { severity: "error" }
-              ),
-              // `onUploadError` accepts `(error: Error, file: File)`; bridge to
-              // a VizelError sink by ignoring the file param.
-              onUploadError ? (err) => onUploadError(err, file) : undefined
+            const vizelError = new VizelError(
+              "INVALID_EXTENSION",
+              "Image node type not found in schema. Ensure the Image extension is registered.",
+              { severity: "error", context: { fileName: file.name, fileType: file.type } }
             );
+            // Route through both sinks: the editor-level `onError` for
+            // observability and the feature-level `onUploadError` for
+            // feature-specific UI. `onUploadError` accepts `(error, file)`,
+            // so forward the VizelError as the error argument.
+            emitVizelError(vizelError, onError);
+            onUploadError?.(vizelError, file);
             return;
           }
 
@@ -280,6 +297,15 @@ export function createVizelImageUploader(
           view.dispatch(transaction);
         })
         .catch((error: Error) => {
+          // Surface the failure through both sinks: the editor-level
+          // `onError` (observability) and the feature-level `onUploadError`
+          // (feature-specific UI the demos and tests rely on).
+          const vizelError = new VizelError(
+            "UPLOAD_FAILED",
+            `Image upload failed: ${error.message}`,
+            { cause: error, context: { fileName: file.name, fileType: file.type } }
+          );
+          emitVizelError(vizelError, onError);
           onUploadError?.(error, file);
 
           // Remove placeholder on error

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,7 +36,17 @@ export interface VizelSlashCommandOptions {
 }
 
 /**
- * Image feature options
+ * Image feature options.
+ *
+ * This interface extends `Partial<VizelImageUploadPluginOptions>`, so it
+ * inherits the plugin's `onError?: (err: VizelError) => void` field. That
+ * inherited `onError` is a per-feature override scoped to image uploads; it
+ * is distinct from the editor-level `VizelEditorOptions.onError`. When both
+ * are set, the editor-level sink takes precedence and the per-feature
+ * `onError` serves as a fallback (see `createVizelUploadEventHandler` and
+ * `addImageExtension`). The two never shadow each other because they live on
+ * different option objects (`features.content.image` versus the top-level
+ * editor options).
  */
 export interface VizelImageFeatureOptions extends Partial<VizelImageUploadPluginOptions> {
   /** Enable image resizing (default: true) */
@@ -275,26 +285,34 @@ export interface VizelEditorOptions {
   /** Callback when editor loses focus */
   onBlur?: (props: { editor: Editor }) => void;
   /**
-   * Callback when an error occurs during editor operations.
-   * Provides structured error information for logging or user feedback.
+   * Editor-level error sink. Receives a typed {@link VizelError} carrying a
+   * stable `code` so the consumer can log, branch, or render user feedback.
    *
-   * Behavior:
-   * - When this callback is supplied, the consumer is treated as having
-   *   handled the failure. The hook/composable/rune does NOT also rethrow.
-   * - When this callback is omitted, the error is rethrown so global
-   *   handlers (Sentry, `window.onunhandledrejection`, test runners) can
-   *   observe initialization failures.
+   * Two delivery paths reach this callback, matching the error model in
+   * `.claude/rules/packages/core.md`:
    *
-   * Supply this callback only when you want to fully take over the error
-   * surface (e.g. translate to UI state, swallow during tests). Leave it
-   * unset to keep the default rethrow contract.
+   * - **Configuration / initialization errors** (`INVALID_CONFIG`,
+   *   `SSR_NOT_SUPPORTED`, ...). The adapter emits the error to `onError`
+   *   *and then rethrows* so global handlers (Sentry,
+   *   `window.onunhandledrejection`, React error boundaries, test runners)
+   *   still observe the failure. Supplying `onError` does not suppress the
+   *   rethrow — a blank editor must never fail silently.
+   * - **Recoverable runtime errors** (`UPLOAD_FAILED`, `EMBED_LOAD_FAILED`,
+   *   the `MARKDOWN_LOSSY` warning, ...). The core emits these through
+   *   `emitVizelError(error, onError)` *without rethrow*; the editor keeps
+   *   running. When no `onError` is set, the fallback writes errors to
+   *   `console.error` and stays silent for warnings.
+   *
+   * Image-upload failures route here in addition to the feature-level
+   * `features.content.image.onUploadError`, so observability sinks see the
+   * failure even when only the feature callback drives UI.
    *
    * @example
    * ```typescript
    * const editor = useVizelEditor({
    *   onError: (error) => {
-   *     console.error(`[${error.code}] ${error.message}`);
-   *     setEditorError(error);
+   *     reportToSentry(error);
+   *     if (error.code === "UPLOAD_FAILED") showToast(error.message);
    *   },
    * });
    * ```

--- a/packages/core/src/utils/editorFactory.ts
+++ b/packages/core/src/utils/editorFactory.ts
@@ -142,6 +142,7 @@ export async function createVizelEditorInstance(
     locale,
     extensions: additionalExtensions = [],
     createSlashMenuRenderer,
+    onError,
     onUpdate,
     onCreate,
     onDestroy,
@@ -197,6 +198,10 @@ export async function createVizelEditorInstance(
     ...(flavor !== undefined && { flavor }),
     ...(encoding !== undefined && { encoding }),
     ...(locale !== undefined && { locale }),
+    // Thread the editor-level `onError` into the drop / paste image-upload
+    // plugin so upload rejections reach observability sinks, not only the
+    // feature-level `onUploadError`.
+    ...(onError !== undefined && { onError }),
   });
 
   // Create the editor instance

--- a/packages/core/src/utils/editorHelpers.ts
+++ b/packages/core/src/utils/editorHelpers.ts
@@ -5,6 +5,7 @@ import type { VizelCharacterCountStorage } from "../extensions/character-count.t
 import { createVizelImageUploader } from "../extensions/image.ts";
 import type { VizelSlashCommandItem } from "../extensions/slash-command.ts";
 import type { VizelEditorState, VizelFeatureOptions, VizelImageFeatureOptions } from "../types.ts";
+import type { VizelError } from "./errorHandling.ts";
 
 /**
  * Mount a Tiptap editor's `view.dom` into a container element and return a
@@ -116,6 +117,16 @@ export interface VizelCreateUploadEventHandlerOptions {
   getEditor: () => Editor | null | undefined;
   /** Function to get the current image options */
   getImageOptions: () => VizelImageFeatureOptions;
+  /**
+   * Function to get the editor-level `onError` sink.
+   *
+   * Threading this getter lets the slash-command upload path reach the
+   * editor's `onError` so an upload rejection emits a `VizelError`
+   * (`UPLOAD_FAILED`) to observability sinks, not only the feature-level
+   * `onUploadError`. Adapters read the latest `onError` lazily because the
+   * consumer may reassign it after mount.
+   */
+  getOnError?: () => ((err: VizelError) => void) | undefined;
 }
 
 /**
@@ -133,6 +144,11 @@ export function createVizelUploadEventHandler(
     const { file } = event.detail;
     const pos = editor.state.selection.from;
     const imageOptions = options.getImageOptions();
+
+    // Resolve the editor-level error sink. Prefer the thread-through
+    // `getOnError` (the editor's `onError`); fall back to a per-feature
+    // `onError` a consumer may have set directly on the image options.
+    const onError = options.getOnError?.() ?? imageOptions.onError;
 
     // Create upload function with configured options
     const uploadFn = createVizelImageUploader({
@@ -156,6 +172,7 @@ export function createVizelUploadEventHandler(
       ...(imageOptions.onUploadError !== undefined && {
         onUploadError: imageOptions.onUploadError,
       }),
+      ...(onError !== undefined && { onError }),
     });
 
     uploadFn(file, editor.view as EditorView, pos);

--- a/packages/core/src/utils/lazy-import.ts
+++ b/packages/core/src/utils/lazy-import.ts
@@ -5,6 +5,7 @@
  * caches the result, and provides clear error messages when the dependency
  * is not installed.
  */
+import { VizelError } from "./errorHandling.ts";
 
 /**
  * Creates a lazy loader for an optional dependency.
@@ -46,10 +47,12 @@ export function createLazyLoader<T>(
       },
       (error) => {
         state.loading = null;
-        throw new Error(
+        throw new VizelError(
+          "MISSING_OPTIONAL_DEP",
           `[Vizel] Failed to load "${moduleName}". ` +
             `Please install it: npm install ${moduleName}\n` +
-            `Original error: ${error instanceof Error ? error.message : String(error)}`
+            `Original error: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error, context: { moduleName } }
         );
       }
     );

--- a/packages/react/src/hooks/useVizelEditor.ts
+++ b/packages/react/src/hooks/useVizelEditor.ts
@@ -128,6 +128,10 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): Editor | nu
     return registerVizelUploadEventHandler({
       getEditor: () => editor,
       getImageOptions: () => imageOptionsRef.current,
+      // Reach the editor-level `onError` so an upload rejection emits a
+      // `VizelError` (`UPLOAD_FAILED`) to observability sinks. Read the
+      // latest value lazily because the consumer may reassign it.
+      getOnError: () => optionsRef.current.editorOptions.onError,
     });
   }, [editor]);
 

--- a/packages/svelte/src/runes/createVizelEditor.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditor.svelte.ts
@@ -121,6 +121,9 @@ export function createVizelEditor(options: CreateVizelEditorOptions = {}) {
         cleanupHandler = registerVizelUploadEventHandler({
           getEditor: () => editor,
           getImageOptions: () => imageOptions,
+          // Reach the editor-level `onError` so an upload rejection emits a
+          // `VizelError` (`UPLOAD_FAILED`) to observability sinks.
+          getOnError: () => editorOptions.onError,
         });
       } catch (error) {
         const vizelError = wrapAsVizelError(error, {

--- a/packages/vue/src/composables/useVizelEditor.ts
+++ b/packages/vue/src/composables/useVizelEditor.ts
@@ -107,6 +107,9 @@ export function useVizelEditor(options: UseVizelEditorOptions = {}): ShallowRef<
         cleanup.handler = registerVizelUploadEventHandler({
           getEditor: () => editor.value,
           getImageOptions: () => imageOptions,
+          // Reach the editor-level `onError` so an upload rejection emits a
+          // `VizelError` (`UPLOAD_FAILED`) to observability sinks.
+          getOnError: () => editorOptions.onError,
         });
       } catch (error) {
         const vizelError = wrapAsVizelError(error, {

--- a/tests/ct/react/specs/UploadError.spec.tsx
+++ b/tests/ct/react/specs/UploadError.spec.tsx
@@ -1,0 +1,21 @@
+import { test } from "@playwright/experimental-ct-react";
+import {
+  testPluginConfigErrorIsTyped,
+  testUploadFailureReachesOnError,
+} from "../../scenarios/error-model.scenario";
+import { UploadErrorFixture } from "./UploadErrorFixture";
+
+test.describe("UploadError - React", () => {
+  test("upload failure reaches editor-level onError with UPLOAD_FAILED", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<UploadErrorFixture />);
+    await testUploadFailureReachesOnError(component, page);
+  });
+
+  test("plugin-system raises a typed INVALID_CONFIG error", async ({ mount, page }) => {
+    const component = await mount(<UploadErrorFixture />);
+    await testPluginConfigErrorIsTyped(component, page);
+  });
+});

--- a/tests/ct/react/specs/UploadErrorFixture.tsx
+++ b/tests/ct/react/specs/UploadErrorFixture.tsx
@@ -1,0 +1,48 @@
+import { isVizelError, type VizelError, validateVizelPlugin } from "@vizel/core";
+import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/react";
+import { useState } from "react";
+
+/**
+ * Record the `VizelError.code` raised when `validateVizelPlugin` rejects a
+ * malformed plugin. The validation runs in the browser bundle so the raw
+ * `throw new Error` -> `VizelError("INVALID_CONFIG")` conversion is exercised.
+ */
+function readPluginErrorCode(): string {
+  try {
+    validateVizelPlugin({ name: "", version: "1.0.0" });
+    return "";
+  } catch (error) {
+    return isVizelError(error) ? error.code : "NOT_A_VIZEL_ERROR";
+  }
+}
+
+/**
+ * Fixture proving an image-upload rejection reaches the editor-level
+ * `onError`. The upload handler always rejects; `onError` records the
+ * resulting `VizelError` code into `[data-error-code]`.
+ */
+export function UploadErrorFixture() {
+  const [errorCode, setErrorCode] = useState("");
+  const pluginErrorCode = readPluginErrorCode();
+
+  const editor = useVizelEditor({
+    features: {
+      content: {
+        image: {
+          onUpload: () => Promise.reject(new Error("network down")),
+        },
+      },
+    },
+    onError: (error: VizelError) => {
+      setErrorCode(error.code);
+    },
+  });
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+      <div data-error-code>{errorCode}</div>
+      <div data-plugin-error-code>{pluginErrorCode}</div>
+    </VizelProvider>
+  );
+}

--- a/tests/ct/scenarios/error-model.scenario.ts
+++ b/tests/ct/scenarios/error-model.scenario.ts
@@ -1,0 +1,65 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Shared scenarios for the unified Vizel error model.
+ *
+ * These scenarios are framework-agnostic and run against React, Vue, and
+ * Svelte. They prove that an image-upload rejection reaches the editor-level
+ * `onError` sink as a `VizelError` carrying the `UPLOAD_FAILED` code — not
+ * only the feature-level `onUploadError` callback.
+ *
+ * The fixture wires `features.content.image.onUpload` to reject and records
+ * `error.code` into the element `[data-error-code]`. The scenario triggers an
+ * upload by dispatching the `vizel:upload-image` custom event with a valid
+ * image `File`, which passes validation and reaches the rejecting handler.
+ */
+
+const ERROR_CODE_SELECTOR = "[data-error-code]";
+const PLUGIN_ERROR_CODE_SELECTOR = "[data-plugin-error-code]";
+
+/**
+ * Dispatch the `vizel:upload-image` custom event the slash-command upload
+ * path uses. The file type passes the default validation allow-list, so the
+ * upload reaches the consumer's `onUpload` handler.
+ */
+async function dispatchUploadImageEvent(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  await page.evaluate(() => {
+    // The registered handler resolves the live editor through its own
+    // `getEditor` getter; the event detail only needs a `file` and an
+    // `editor` key so the handler's type guard accepts the event.
+    const file = new File(["x"], "broken.png", { type: "image/png" });
+    const event = new CustomEvent("vizel:upload-image", {
+      detail: { file, editor: {} },
+    });
+    document.dispatchEvent(event);
+  });
+}
+
+/**
+ * Verify an image-upload rejection reaches the editor-level `onError` sink
+ * with the `UPLOAD_FAILED` code.
+ */
+export async function testUploadFailureReachesOnError(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  await dispatchUploadImageEvent(component, page);
+
+  const errorCode = component.locator(ERROR_CODE_SELECTOR);
+  await expect(errorCode).toHaveText("UPLOAD_FAILED");
+}
+
+/**
+ * Verify the plugin-system raises a typed `VizelError("INVALID_CONFIG", ...)`
+ * for a malformed plugin. The fixture runs `validateVizelPlugin` on mount and
+ * records the resulting `error.code` into `[data-plugin-error-code]`, so the
+ * conversion from a raw `throw new Error` exercises through the live bundle.
+ */
+export async function testPluginConfigErrorIsTyped(component: Locator, _page: Page): Promise<void> {
+  const pluginErrorCode = component.locator(PLUGIN_ERROR_CODE_SELECTOR);
+  await expect(pluginErrorCode).toHaveText("INVALID_CONFIG");
+}

--- a/tests/ct/svelte/specs/UploadError.spec.ts
+++ b/tests/ct/svelte/specs/UploadError.spec.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/experimental-ct-svelte";
+import {
+  testPluginConfigErrorIsTyped,
+  testUploadFailureReachesOnError,
+} from "../../scenarios/error-model.scenario";
+import UploadErrorFixture from "./UploadErrorFixture.svelte";
+
+test.describe("UploadError - Svelte", () => {
+  test("upload failure reaches editor-level onError with UPLOAD_FAILED", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(UploadErrorFixture);
+    await testUploadFailureReachesOnError(component, page);
+  });
+
+  test("plugin-system raises a typed INVALID_CONFIG error", async ({ mount, page }) => {
+    const component = await mount(UploadErrorFixture);
+    await testPluginConfigErrorIsTyped(component, page);
+  });
+});

--- a/tests/ct/svelte/specs/UploadErrorFixture.svelte
+++ b/tests/ct/svelte/specs/UploadErrorFixture.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+import { isVizelError, type VizelError, validateVizelPlugin } from "@vizel/core";
+import { createVizelEditor, VizelEditor, VizelProvider } from "@vizel/svelte";
+
+let errorCode = $state("");
+
+/**
+ * Record the `VizelError.code` raised when `validateVizelPlugin` rejects a
+ * malformed plugin, exercising the `throw new Error` -> `VizelError` conversion.
+ */
+function readPluginErrorCode(): string {
+  try {
+    validateVizelPlugin({ name: "", version: "1.0.0" });
+    return "";
+  } catch (error) {
+    return isVizelError(error) ? error.code : "NOT_A_VIZEL_ERROR";
+  }
+}
+
+const pluginErrorCode = readPluginErrorCode();
+
+const editor = createVizelEditor({
+  features: {
+    content: {
+      image: {
+        onUpload: () => Promise.reject(new Error("network down")),
+      },
+    },
+  },
+  onError: (error: VizelError) => {
+    errorCode = error.code;
+  },
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+  <div data-error-code>{errorCode}</div>
+  <div data-plugin-error-code>{pluginErrorCode}</div>
+</VizelProvider>

--- a/tests/ct/vue/specs/UploadError.spec.ts
+++ b/tests/ct/vue/specs/UploadError.spec.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/experimental-ct-vue";
+import {
+  testPluginConfigErrorIsTyped,
+  testUploadFailureReachesOnError,
+} from "../../scenarios/error-model.scenario";
+import UploadErrorFixture from "./UploadErrorFixture.vue";
+
+test.describe("UploadError - Vue", () => {
+  test("upload failure reaches editor-level onError with UPLOAD_FAILED", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(UploadErrorFixture);
+    await testUploadFailureReachesOnError(component, page);
+  });
+
+  test("plugin-system raises a typed INVALID_CONFIG error", async ({ mount, page }) => {
+    const component = await mount(UploadErrorFixture);
+    await testPluginConfigErrorIsTyped(component, page);
+  });
+});

--- a/tests/ct/vue/specs/UploadErrorFixture.vue
+++ b/tests/ct/vue/specs/UploadErrorFixture.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { isVizelError, type VizelError, validateVizelPlugin } from "@vizel/core";
+import { useVizelEditor, VizelEditor, VizelProvider } from "@vizel/vue";
+import { ref } from "vue";
+
+const errorCode = ref("");
+
+/**
+ * Record the `VizelError.code` raised when `validateVizelPlugin` rejects a
+ * malformed plugin, exercising the `throw new Error` -> `VizelError` conversion.
+ */
+function readPluginErrorCode(): string {
+  try {
+    validateVizelPlugin({ name: "", version: "1.0.0" });
+    return "";
+  } catch (error) {
+    return isVizelError(error) ? error.code : "NOT_A_VIZEL_ERROR";
+  }
+}
+
+const pluginErrorCode = readPluginErrorCode();
+
+const editor = useVizelEditor({
+  features: {
+    content: {
+      image: {
+        onUpload: () => Promise.reject(new Error("network down")),
+      },
+    },
+  },
+  onError: (error: VizelError) => {
+    errorCode.value = error.code;
+  },
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+    <div data-error-code>{{ errorCode }}</div>
+    <div data-plugin-error-code>{{ pluginErrorCode }}</div>
+  </VizelProvider>
+</template>


### PR DESCRIPTION
## Summary

- WI-5 of the P0/P1 hardening plan. Fixes finding F-F: image/file upload rejections only reached the feature-specific `onUploadError`, never the editor-level `onError`; core carried 12 raw `throw new Error` sites; and declared error codes went unused.
- Routes every upload rejection through a `VizelError("UPLOAD_FAILED")` emitted via `emitVizelError` to the **editor-level `onError`** **and** the existing `onUploadError` (both sinks), threading `getOnError` from each adapter (React reads `editorOptions.onError`) through `editorHelpers` → `editorFactory` → `base` into the always-on upload plugin.
- Converts the 10 `plugin-system.ts` throws to `VizelError("INVALID_CONFIG")` and the `lazy-import.ts` / `code-block-lowlight.ts` throws to `VizelError("MISSING_OPTIONAL_DEP")`.
- Reconciles the `onError` JSDoc with the shipped behaviour (emit-and-rethrow for init; emit-without-rethrow for recoverable runtime errors).
- Adds `tests/ct/scenarios/error-model.scenario.ts` + `UploadError` fixtures/specs across React, Vue, and Svelte (proves a rejected upload reaches `onError` with `UPLOAD_FAILED`, plus a plugin-system `INVALID_CONFIG` smoke).

## Test Plan

- [x] Upload-failure path reaches the editor `onError` (code `UPLOAD_FAILED`) **and** `onUploadError` at all four catch sites.
- [x] `grep "throw new Error"` in `plugin-system.ts` / `lazy-import.ts` / `code-block-lowlight.ts` → none (typed `VizelError`).
- [x] `UploadError` specs pass (React/Vue/Svelte, chromium 2/2 each).
- [x] `pnpm check:ct-parity` balanced (35×3); `pnpm check:scenarios` includes `error-model` invoked by all three frameworks.
- [x] `pnpm typecheck`, `lint`, `check:feature-parity`, `check:adr-compliance`, `check:aria-contract`, `check:ssr`, `check:nolet` — pass.

Refs: `docs/superpowers/plans/2026-06-02-vizel-v2-hardening-p0p1.md` (WI-5).
