### PR TITLE
refactor(react): selector receives the {editor,transaction} snapshot

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -130,7 +130,7 @@ type PanelTab = "markdown" | "json" | "history" | "comments";
  */
 function StatsBar() {
   const stats = useVizelEditorState(
-    (editor) => ({
+    ({ editor }) => ({
       characters: editor?.storage.characterCount?.characters() ?? 0,
       words: editor?.storage.characterCount?.words() ?? 0,
     }),

--- a/docs/adr/ADR-0004-per-framework-idiomatic-api.md
+++ b/docs/adr/ADR-0004-per-framework-idiomatic-api.md
@@ -14,7 +14,7 @@
 
 - Hooks-first. Components are functional. Refs use `React.Ref<HTMLElement>`; the custom `VizelEditorRef` retires.
 - `useVizelEditor(options): Editor | null` returns the editor directly. No destructured-getter wrappers.
-- `useVizelEditorState<T>(selector, { equalityFn? }): T` is the selector subscription primitive. Implementation uses `useSyncExternalStore` (see [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)).
+- `useVizelEditorState<T>(selector, { equalityFn? }): T` is the selector subscription primitive. The selector receives a `{ editor, transaction }` snapshot, the React-idiomatic single-argument shape `useSyncExternalStore` / `useSelector` expect; the snapshot also lets the React selector read the transaction the feature manifest requires every adapter to expose. The selector INPUT shape converges across React, Vue, and Svelte only as a consequence of each framework idiom plus feature parity — not for API symmetry. The RETURN/delivery stays framework-native: this hook returns `T`, Vue returns a `ComputedRef<T>`, Svelte returns a `$derived` accessor. Implementation uses `useSyncExternalStore` (see [ADR-0009](./ADR-0009-first-party-editor-reactivity.md)).
 - Imperative APIs surface through React 19's ref-as-prop convention (`ref` is a regular prop; `forwardRef` is intentionally not used — see `.claude/rules/packages/react.md`).
 - Render-props use React's standard pattern: `children` of type `(props) => ReactNode`, or named function props.
 

--- a/docs/adr/ADR-0009-first-party-editor-reactivity.md
+++ b/docs/adr/ADR-0009-first-party-editor-reactivity.md
@@ -29,7 +29,7 @@ Per-adapter implementation:
 
 Positive:
 
-- Reactivity semantics stay under Vizel's control. SSR boundaries, selector semantics, and cleanup behave identically across adapters because Vizel writes the same contract three times.
+- Reactivity semantics stay under Vizel's control. SSR boundaries, selector semantics, and cleanup stay under one owner across adapters. The selector INPUT shape converges on a `{ editor, transaction }` snapshot only as a consequence of each framework's selector idiom plus the feature-parity requirement that every adapter read the transaction — not because Vizel pursues API symmetry. The RETURN/delivery stays framework-native: React returns `T`, Vue a `ComputedRef<T>`, Svelte a `$derived` accessor.
 - The Tiptap dependency surface shrinks. The runtime closure no longer pulls in two framework integrations the project does not consume.
 - The Svelte implementation is no longer the divergent case. Every adapter follows the same "first-party reactivity" pattern.
 
@@ -81,3 +81,34 @@ decision.
 
 A later work item (WI-8) revises the React selector-input bullet separately;
 this Update stays focused on the factual drift above.
+
+## Update (2026-06-03, WI-8)
+
+This Update records the selector-input correction the WI-9 Update deferred.
+The Decision bullets above stay immutable; the correction describes the
+shipped React selector contract.
+
+- **The React `useVizelEditorState` selector receives a
+  `{ editor, transaction }` snapshot, not the bare editor.** The Decision
+  bullet writes the React signature as
+  `useVizelEditorState(selector, { equalityFn? })` and the React adapter
+  originally passed the selector the bare `Editor | null`. The shipped
+  selector now receives a `VizelEditorSnapshot`
+  (`{ editor: Editor | null; transaction: Transaction | null }`), matching
+  the Vue and Svelte adapters. Two forces land on this shape independently:
+  React's `useSyncExternalStore` / selector convention passes a selector a
+  single snapshot object, and the feature manifest requires every adapter's
+  selector to be able to read the transaction (only Vue and Svelte could
+  before). The input shape therefore converges across adapters as a
+  consequence of each framework idiom plus parity — not for API symmetry.
+  The RETURN/delivery stays framework-native: React returns `T`, Vue a
+  `ComputedRef<T>`, Svelte a `$derived` accessor.
+- **Tearing-safety is preserved.** `getSnapshot` still returns the
+  monotonic version counter, so the `useSyncExternalStore` referential
+  contract is unchanged. The store records the latest transaction
+  alongside the counter, and the hook rebuilds the `{ editor, transaction }`
+  snapshot object only when the version counter advances (a new
+  `transaction` / `selectionUpdate`) or the editor identity changes —
+  mirroring the existing `useMemo([editor])` stability — so the snapshot
+  object identity stays stable across no-op reads and the equality
+  short-circuit holds under concurrent rendering.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,6 +64,7 @@
     "@tiptap/extension-superscript": "^3.23.4",
     "@tiptap/extension-text-style": "^3.23.4",
     "@tiptap/extension-underline": "^3.23.4",
+    "@tiptap/pm": "^3.23.4",
     "@vizel/core": "workspace:^",
     "react": "^19",
     "react-dom": "^19"
@@ -79,6 +80,7 @@
     "@tiptap/extension-superscript": "^3.23.6",
     "@tiptap/extension-text-style": "^3.23.6",
     "@tiptap/extension-underline": "^3.23.6",
+    "@tiptap/pm": "^3.23.6",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/packages/react/src/_reactivity.ts
+++ b/packages/react/src/_reactivity.ts
@@ -11,6 +11,16 @@
  * official guidance recommends for editor-style external stores that must
  * stay tearing-safe under concurrent rendering.
  *
+ * The selector receives a `{ editor, transaction }` snapshot. React's
+ * `useSyncExternalStore` / selector convention passes a selector a single
+ * snapshot object, so the React-idiomatic form lands on a snapshot rather
+ * than a bare editor. That same shape lets a React selector read the
+ * transaction, closing the feature-parity gap the Vue and Svelte adapters
+ * already covered. The input shape converges across adapters only as a
+ * consequence of each framework idiom plus parity; the return value stays
+ * framework-native — React returns `T`, Vue a `ComputedRef<T>`, Svelte a
+ * `$derived` accessor.
+ *
  * The module exposes one public hook (`useVizelEditorState`) plus two
  * equality helpers re-exported from `@vizel/core`. Consumers select the
  * slice they care about and optionally supply an equality function to
@@ -19,9 +29,27 @@
  * same store so selector behaviour stays uniform.
  */
 
+import type { Transaction } from "@tiptap/pm/state";
 import { type Editor, shallowEqualArray, shallowEqualObject } from "@vizel/core";
 import { useMemo, useRef, useSyncExternalStore } from "react";
 import { useVizelContextSafe } from "./components/VizelContext.tsx";
+
+/**
+ * Snapshot delivered to a {@link useVizelEditorState} selector on every
+ * re-evaluation.
+ *
+ * The snapshot pairs the editor identity with the transaction that drove
+ * the most recent notification. `transaction` is `null` until the first
+ * `transaction` or `selectionUpdate` event fires — most commonly during
+ * the SSR pass and the first browser render before Tiptap has dispatched
+ * any transaction.
+ */
+export interface VizelEditorSnapshot {
+  /** The active editor instance, or `null` while it is still initializing. */
+  readonly editor: Editor | null;
+  /** The transaction that triggered the most recent re-evaluation, or `null` before the first event. */
+  readonly transaction: Transaction | null;
+}
 
 /**
  * Shape returned by {@link createEditorStore} — a `useSyncExternalStore`
@@ -30,7 +58,9 @@ import { useVizelContextSafe } from "./components/VizelContext.tsx";
  * The store does not surface the editor itself. The version counter
  * (returned by `getSnapshot`) increments on every transaction, which
  * forces React to invoke the selector against the latest editor state
- * without changing the snapshot's referential identity contract.
+ * without changing the snapshot's referential identity contract. The
+ * store also records the most recent transaction so the hook can build a
+ * `{ editor, transaction }` snapshot for the selector.
  */
 export interface VizelReactEditorStore {
   /**
@@ -52,6 +82,13 @@ export interface VizelReactEditorStore {
    * stable value avoids hydration mismatches.
    */
   getServerSnapshot(): number;
+  /**
+   * Read the transaction that drove the most recent notification, or
+   * `null` before the first `transaction` / `selectionUpdate` event. The
+   * hook reads this lazily when it rebuilds the snapshot, so the value
+   * never enters the version counter's referential-stability contract.
+   */
+  getTransaction(): Transaction | null;
 }
 
 /**
@@ -69,8 +106,13 @@ export interface VizelReactEditorStore {
 export function createEditorStore(editor: Editor | null): VizelReactEditorStore {
   // Closure-shared mutable state. A typed object keeps the binding
   // const-safe at the file scope and survives `Find Usages` better than
-  // a free `let` would (see `.claude/rules/code-style.md`).
-  const state = { version: 0 };
+  // a free `let` would (see `.claude/rules/code-style.md`). `transaction`
+  // holds the payload from the most recent notification; the version
+  // counter alone drives `getSnapshot`'s referential-stability contract.
+  const state: { version: number; transaction: Transaction | null } = {
+    version: 0,
+    transaction: null,
+  };
 
   const bumpVersion = (): void => {
     // 32-bit wrap-around stops the counter from drifting toward
@@ -89,7 +131,13 @@ export function createEditorStore(editor: Editor | null): VizelReactEditorStore 
           /* no-op cleanup when the editor is still initializing */
         };
       }
-      const handler = (): void => {
+      const handler = (payload: { editor: Editor; transaction: Transaction }): void => {
+        // Record the transaction before bumping the version so the
+        // snapshot the hook rebuilds on the next read pairs the editor
+        // with the transaction that drove this notification. Tiptap
+        // surfaces the transaction on both events, so the selector
+        // observes a consistent shape regardless of which signal fired.
+        state.transaction = payload.transaction;
         bumpVersion();
         onChange();
       };
@@ -110,6 +158,9 @@ export function createEditorStore(editor: Editor | null): VizelReactEditorStore 
     },
     getServerSnapshot() {
       return 0;
+    },
+    getTransaction() {
+      return state.transaction;
     },
   };
 }
@@ -156,13 +207,13 @@ export interface UseVizelEditorStateOptions<T> {
  *
  * @example
  * ```tsx
- * const isBold = useVizelEditorState((editor) => editor?.isActive("bold") ?? false);
+ * const isBold = useVizelEditorState(({ editor }) => editor?.isActive("bold") ?? false);
  * ```
  *
  * @example
  * ```tsx
  * const marks = useVizelEditorState(
- *   (editor) => ({
+ *   ({ editor }) => ({
  *     bold: editor?.isActive("bold") ?? false,
  *     italic: editor?.isActive("italic") ?? false,
  *   }),
@@ -171,7 +222,7 @@ export interface UseVizelEditorStateOptions<T> {
  * ```
  */
 export function useVizelEditorState<T>(
-  selector: (editor: Editor | null) => T,
+  selector: (snapshot: VizelEditorSnapshot) => T,
   options?: UseVizelEditorStateOptions<T>
 ): T {
   const contextEditor = useVizelContextSafe();
@@ -204,13 +255,38 @@ export function useVizelEditorState<T>(
     type SnapshotCache = { kind: "empty" } | { kind: "cached"; value: T };
     const cache: { current: SnapshotCache } = { current: { kind: "empty" } };
 
+    // Memoise the `{ editor, transaction }` snapshot object keyed on the
+    // store's version counter. The object identity must stay stable
+    // across `getSnapshot` reads that report no new notification;
+    // rebuilding it on every read would force every selector that
+    // closes over the snapshot to recompute even when nothing changed.
+    // The version counter advances exactly once per `transaction` /
+    // `selectionUpdate`, which is the only moment the transaction
+    // payload changes — so keying the snapshot on the version mirrors
+    // the existing `useMemo([editor])` editor-identity stability and
+    // keeps the `useSyncExternalStore` equality short-circuit intact
+    // under concurrent rendering.
+    type SnapshotMemo = { version: number; snapshot: VizelEditorSnapshot };
+    const snapshotMemo: { current: SnapshotMemo | null } = { current: null };
+
+    const readSnapshot = (): VizelEditorSnapshot => {
+      const version = store.getSnapshot();
+      const memo = snapshotMemo.current;
+      if (memo !== null && memo.version === version) {
+        return memo.snapshot;
+      }
+      const snapshot: VizelEditorSnapshot = { editor, transaction: store.getTransaction() };
+      snapshotMemo.current = { version, snapshot };
+      return snapshot;
+    };
+
     const getClientSnapshot = (): T => {
       // `getSnapshot` runs each time React reads from the store. The
-      // selector executes against the live editor; the cached previous
-      // value short-circuits when `equalityFn` declares the slice
-      // unchanged so consumers can rely on `Object.is` against the
+      // selector executes against the version-keyed snapshot; the cached
+      // previous value short-circuits when `equalityFn` declares the
+      // slice unchanged so consumers can rely on `Object.is` against the
       // hook's return value.
-      const next = selectorRef.current(editor);
+      const next = selectorRef.current(readSnapshot());
       const previous = cache.current;
       if (previous.kind === "cached" && equalityRef.current(previous.value, next)) {
         return previous.value;
@@ -221,10 +297,10 @@ export function useVizelEditorState<T>(
 
     const getServerSnapshot = (): T =>
       // React calls `getServerSnapshot` during server rendering, where
-      // the editor has not yet mounted. The selector receives `null` so
-      // the consumer's selector observes the same absence shape as the
+      // the editor has not yet mounted. The selector receives the
+      // absence snapshot so the consumer observes the same shape as the
       // first browser render before mount completes.
-      selectorRef.current(null);
+      selectorRef.current({ editor: null, transaction: null });
 
     return { subscribe: store.subscribe, getClientSnapshot, getServerSnapshot };
   }, [editor]);

--- a/packages/react/src/components/VizelBubbleMenuDefault.tsx
+++ b/packages/react/src/components/VizelBubbleMenuDefault.tsx
@@ -59,10 +59,13 @@ export function VizelBubbleMenuDefault({
   // re-rendered on every transaction (ADR-0004). The explicit `editor`
   // keeps the subscription working when the bubble menu renders outside a
   // `VizelProvider`.
-  const activeById = useVizelEditorState((current) => buildActiveById(allActions, current), {
-    editor,
-    equalityFn: shallowEqualObject,
-  });
+  const activeById = useVizelEditorState(
+    ({ editor: current }) => buildActiveById(allActions, current),
+    {
+      editor,
+      equalityFn: shallowEqualObject,
+    }
+  );
 
   if (showLinkEditor) {
     return (

--- a/packages/react/src/components/VizelFindReplace.tsx
+++ b/packages/react/src/components/VizelFindReplace.tsx
@@ -68,7 +68,7 @@ export function VizelFindReplace({
   // explicit `editor` keeps the subscription bound to the prop instance
   // when the panel renders outside a `VizelProvider`.
   const state = useVizelEditorState(
-    (current) => (current === null ? null : getVizelFindReplaceState(current.state)),
+    ({ editor: current }) => (current === null ? null : getVizelFindReplaceState(current.state)),
     { editor }
   );
 

--- a/packages/react/src/components/VizelNodeSelector.tsx
+++ b/packages/react/src/components/VizelNodeSelector.tsx
@@ -59,7 +59,7 @@ export function VizelNodeSelector({
   // moves within the same block type do not re-render, replacing the
   // coarse `useVizelState` tick.
   const activeNodeName = useVizelEditorState(
-    (current) =>
+    ({ editor: current }) =>
       current === null
         ? null
         : (effectiveNodeTypes.find((type) => type.isActive(current))?.name ?? null),

--- a/packages/react/src/components/VizelOutline.tsx
+++ b/packages/react/src/components/VizelOutline.tsx
@@ -47,7 +47,7 @@ export function VizelOutline({
   // memoised by a shallow comparator — deriving a primitive signature
   // keeps the subscription stable.
   const signature = useVizelEditorState(
-    (current) => (current === null ? null : buildVizelOutlineSignature(current)),
+    ({ editor: current }) => (current === null ? null : buildVizelOutlineSignature(current)),
     { editor }
   );
 

--- a/packages/react/src/components/VizelToolbarDefault.tsx
+++ b/packages/react/src/components/VizelToolbarDefault.tsx
@@ -59,10 +59,13 @@ export function VizelToolbarDefault({
   // flags flips, replacing the coarse `useVizelState` full-tick re-render
   // (ADR-0004). The explicit `editor` keeps the subscription bound when
   // the toolbar renders without a surrounding `VizelProvider`.
-  const stateById = useVizelEditorState((current) => buildButtonStateById(buttonActions, current), {
-    editor,
-    equalityFn: shallowEqualObject,
-  });
+  const stateById = useVizelEditorState(
+    ({ editor: current }) => buildButtonStateById(buttonActions, current),
+    {
+      editor,
+      equalityFn: shallowEqualObject,
+    }
+  );
 
   return (
     <div className={`vizel-toolbar-content ${className ?? ""}`} data-vizel-toolbar="">

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export {
   shallowEqualObject,
   type UseVizelEditorStateOptions,
   useVizelEditorState,
+  type VizelEditorSnapshot,
 } from "./_reactivity.ts";
 // Components
 export {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -135,5 +135,6 @@ export {
   createVizelVersionHistory,
   getVizelTheme,
   getVizelThemeSafe,
+  type VizelEditorSnapshot,
   type VizelSuggestionRendererOptions,
 } from "./runes/index.js";

--- a/packages/svelte/src/runes/createVizelEditorState.svelte.ts
+++ b/packages/svelte/src/runes/createVizelEditorState.svelte.ts
@@ -11,10 +11,19 @@ type VizelTransaction = Editor["state"]["tr"];
 
 /**
  * Snapshot delivered to a {@link createVizelEditorState} selector on
- * every re-evaluation. Mirrors the React adapter's `_reactivity` shape
- * (ADR-0009) so cross-framework selector code stays portable.
+ * every re-evaluation.
+ *
+ * Svelte's `$derived` selector idiom projects a single value, so the
+ * Svelte-idiomatic form passes the selector a snapshot rather than a
+ * bare editor, and the snapshot exposes the transaction the feature
+ * manifest requires every adapter to read. The selector INPUT shape
+ * converges across the React, Vue, and Svelte adapters only as a
+ * consequence of each framework idiom plus feature parity — not for API
+ * symmetry. The RETURN/delivery diverges idiomatically: this rune
+ * returns a `$derived` accessor, React returns `T`, and Vue returns a
+ * `ComputedRef<T>`.
  */
-export interface VizelEditorStateSnapshot {
+export interface VizelEditorSnapshot {
   /** Current editor instance, or `null` before mount and during SSR. */
   readonly editor: Editor | null;
   /** Latest Tiptap transaction, or `null` before the first one fires. */
@@ -98,19 +107,17 @@ export type VizelEditorStateSource = () => Editor | null | undefined;
  * ```
  */
 export function createVizelEditorState<T>(
-  selector: (snapshot: VizelEditorStateSnapshot) => T,
+  selector: (snapshot: VizelEditorSnapshot) => T,
   options?: CreateVizelEditorStateOptions<T>
 ): { readonly current: T };
 export function createVizelEditorState<T>(
   getEditor: VizelEditorStateSource,
-  selector: (snapshot: VizelEditorStateSnapshot) => T,
+  selector: (snapshot: VizelEditorSnapshot) => T,
   options?: CreateVizelEditorStateOptions<T>
 ): { readonly current: T };
 export function createVizelEditorState<T>(
-  selectorOrGetEditor: ((snapshot: VizelEditorStateSnapshot) => T) | VizelEditorStateSource,
-  selectorOrOptions?:
-    | ((snapshot: VizelEditorStateSnapshot) => T)
-    | CreateVizelEditorStateOptions<T>,
+  selectorOrGetEditor: ((snapshot: VizelEditorSnapshot) => T) | VizelEditorStateSource,
+  selectorOrOptions?: ((snapshot: VizelEditorSnapshot) => T) | CreateVizelEditorStateOptions<T>,
   maybeOptions?: CreateVizelEditorStateOptions<T>
 ): { readonly current: T } {
   // Disambiguate the two call forms by the second argument's type. A
@@ -118,7 +125,7 @@ export function createVizelEditorState<T>(
   // anything else means `(selector, options)`.
   const hasExplicitSource = typeof selectorOrOptions === "function";
   const selector = (hasExplicitSource ? selectorOrOptions : selectorOrGetEditor) as (
-    snapshot: VizelEditorStateSnapshot
+    snapshot: VizelEditorSnapshot
   ) => T;
   const options = (hasExplicitSource ? maybeOptions : selectorOrOptions) ?? {};
   const explicitSource = hasExplicitSource ? (selectorOrGetEditor as VizelEditorStateSource) : null;
@@ -212,7 +219,7 @@ export function createVizelEditorState<T>(
       latest.transaction = null;
     }
 
-    const snapshot: VizelEditorStateSnapshot = {
+    const snapshot: VizelEditorSnapshot = {
       editor,
       transaction: latest.transaction,
     };

--- a/packages/svelte/src/runes/index.ts
+++ b/packages/svelte/src/runes/index.ts
@@ -17,7 +17,7 @@ export {
 export {
   type CreateVizelEditorStateOptions,
   createVizelEditorState,
-  type VizelEditorStateSnapshot,
+  type VizelEditorSnapshot,
 } from "./createVizelEditorState.svelte.js";
 export {
   type CreateVizelMarkdownOptions,

--- a/packages/vue/src/_reactivity.ts
+++ b/packages/vue/src/_reactivity.ts
@@ -10,6 +10,17 @@
  * the composable and detach through `onScopeDispose`, so consumers cannot
  * leak handlers regardless of where they call `useVizelEditorState`.
  *
+ * The selector receives a `{ editor, transaction }` snapshot. Vue's
+ * `computed`-based selector idiom passes the selector a single value, so
+ * the Vue-idiomatic form lands on a snapshot rather than a bare editor,
+ * and the snapshot exposes the transaction the feature manifest requires
+ * every adapter to read. The selector INPUT shape converges across the
+ * React, Vue, and Svelte adapters only as a consequence of each
+ * framework idiom plus feature parity — not for API symmetry. The
+ * RETURN/delivery diverges idiomatically: this composable returns a
+ * `ComputedRef<T>`, React returns `T`, and Svelte returns a `$derived`
+ * accessor.
+ *
  * The composable exposes a single public function (`useVizelEditorState`)
  * plus two equality helpers re-exported from `@vizel/core`. Consumers
  * select the slice they care about and optionally supply an `equalityFn`

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -27,6 +27,7 @@ export {
   shallowEqualObject,
   type UseVizelEditorStateOptions,
   useVizelEditorState,
+  type VizelEditorSnapshot,
 } from "./_reactivity.ts";
 
 // Components

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       '@tiptap/extension-underline':
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/pm':
+        specifier: ^3.23.6
+        version: 3.24.0
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.16

--- a/tests/ct/react/specs/UseVizelEditorState.spec.tsx
+++ b/tests/ct/react/specs/UseVizelEditorState.spec.tsx
@@ -1,6 +1,7 @@
 import { test } from "@playwright/experimental-ct-react";
 import {
   testEqualityFnShortCircuitsConsumer,
+  testSelectorReadsTransaction,
   testSelectorReceivesEditorOnMount,
   testSelectorRerunsOnTransaction,
 } from "../../scenarios/use-vizel-editor-state.scenario";
@@ -20,5 +21,10 @@ test.describe("useVizelEditorState - React", () => {
   test("equalityFn short-circuits downstream consumers", async ({ mount, page }) => {
     const component = await mount(<UseVizelEditorStateFixture />);
     await testEqualityFnShortCircuitsConsumer(component, page);
+  });
+
+  test("selector reads the transaction off the snapshot", async ({ mount, page }) => {
+    const component = await mount(<UseVizelEditorStateFixture />);
+    await testSelectorReadsTransaction(component, page);
   });
 });

--- a/tests/ct/react/specs/UseVizelEditorStateFixture.tsx
+++ b/tests/ct/react/specs/UseVizelEditorStateFixture.tsx
@@ -25,15 +25,23 @@ export function UseVizelEditorStateFixture() {
 function Inner() {
   // Track the editor through the selector seam so the test exercises
   // the new `useVizelContextSafe`-backed reactivity path.
-  const editorReady = useVizelEditorState((editor) => editor !== null);
+  const editorReady = useVizelEditorState(({ editor }) => editor !== null);
 
   // The transaction tick changes on every Tiptap notification; using
   // `editor === null ? 0 : 1` would short-circuit through `Object.is`,
   // so the selector reaches inside `editor.state` for a value that
   // truly differs after every transaction.
-  const transactionTick = useVizelEditorState((editor) =>
+  const transactionTick = useVizelEditorState(({ editor }) =>
     editor === null ? 0 : editor.state.doc.nodeSize
   );
+
+  // Read the transaction directly off the snapshot. The value is `null`
+  // before the first Tiptap notification and a `Transaction` afterward,
+  // so the flag flips from `false` to `true` once typing dispatches the
+  // first transaction. The shared scenario asserts this transition
+  // across all three frameworks, proving the selector can read the
+  // transaction the React adapter previously withheld.
+  const hasTransaction = useVizelEditorState(({ transaction }) => transaction !== null);
 
   // Count store notifications outside the selector body so the
   // selector itself stays pure and React's `useSyncExternalStore`
@@ -50,7 +58,7 @@ function Inner() {
   // `shallowEqualArray` short-circuit must keep the returned reference
   // identical and stop the effect below from running.
   const stableProjection = useVizelEditorState<readonly string[]>(
-    (editor) => (editor === null ? ["idle"] : ["ready"]),
+    ({ editor }) => (editor === null ? ["idle"] : ["ready"]),
     { equalityFn: shallowEqualArray }
   );
 
@@ -69,6 +77,7 @@ function Inner() {
       <div data-testid="editor-ready">{String(editorReady)}</div>
       <div data-testid="selector-runs">{selectorRuns}</div>
       <div data-testid="consumer-runs">{consumerRuns}</div>
+      <div data-testid="has-transaction">{String(hasTransaction)}</div>
     </>
   );
 }

--- a/tests/ct/scenarios/use-vizel-editor-state.scenario.ts
+++ b/tests/ct/scenarios/use-vizel-editor-state.scenario.ts
@@ -41,6 +41,32 @@ export async function testSelectorRerunsOnTransaction(
 }
 
 /**
+ * Verify the selector reads the transaction off the snapshot. The
+ * fixture renders a `has-transaction` flag derived from
+ * `snapshot.transaction`. The flag starts `false` because no
+ * transaction has fired before the first keystroke, then flips to
+ * `true` once typing dispatches the first Tiptap transaction. The
+ * assertion runs identically across React, Vue, and Svelte, proving
+ * every adapter's selector now receives the transaction.
+ */
+export async function testSelectorReadsTransaction(component: Locator, page: Page): Promise<void> {
+  const editor = component.locator(".vizel-editor");
+  const ready = component.locator("[data-testid='editor-ready']");
+  const hasTransaction = component.locator("[data-testid='has-transaction']");
+
+  // Wait for the editor to mount; no transaction has fired yet, so the
+  // snapshot still carries `transaction: null`.
+  await expect(ready).toHaveText("true", { timeout: 10_000 });
+  await expect(hasTransaction).toHaveText("false");
+
+  // Typing dispatches the first transaction, so the snapshot now
+  // carries a non-null transaction the selector reads.
+  await editor.click();
+  await page.keyboard.type("a");
+  await expect(hasTransaction).toHaveText("true");
+}
+
+/**
  * Verify `equalityFn` short-circuits downstream re-renders when the
  * projection is structurally identical. The fixture maps the selector
  * onto a constant projection once the editor is ready and counts how

--- a/tests/ct/svelte/specs/CreateVizelEditorState.spec.ts
+++ b/tests/ct/svelte/specs/CreateVizelEditorState.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/experimental-ct-svelte";
 import {
   testEqualityFnShortCircuitsConsumer,
+  testSelectorReadsTransaction,
   testSelectorReceivesEditorOnMount,
   testSelectorRerunsOnTransaction,
 } from "../../scenarios/use-vizel-editor-state.scenario";
@@ -20,5 +21,10 @@ test.describe("createVizelEditorState - Svelte", () => {
   test("equalityFn short-circuits downstream consumers", async ({ mount, page }) => {
     const component = await mount(CreateVizelEditorStateFixture);
     await testEqualityFnShortCircuitsConsumer(component, page);
+  });
+
+  test("selector reads the transaction off the snapshot", async ({ mount, page }) => {
+    const component = await mount(CreateVizelEditorStateFixture);
+    await testSelectorReadsTransaction(component, page);
   });
 });

--- a/tests/ct/svelte/specs/CreateVizelEditorStateInner.svelte
+++ b/tests/ct/svelte/specs/CreateVizelEditorStateInner.svelte
@@ -8,6 +8,12 @@ import { untrack } from "svelte";
 // child of the provider.
 const editorReady = createVizelEditorState(({ editor }) => editor !== null);
 
+// Read the transaction directly off the snapshot. The flag flips from
+// `false` to `true` once typing dispatches the first Tiptap
+// transaction; the shared scenario asserts the transition uniformly
+// across all three frameworks.
+const hasTransaction = createVizelEditorState(({ transaction }) => transaction !== null);
+
 // Plain object holds the selector-run counter so the rune itself drives
 // the increment; the counter strictly grows on every Tiptap transaction
 // (no `let` needed at module scope).
@@ -44,3 +50,4 @@ $effect(() => {
 <div data-testid="editor-ready">{String(editorReady.current)}</div>
 <div data-testid="selector-runs">{selectorRuns.current.runs}</div>
 <div data-testid="consumer-runs">{consumerRuns}</div>
+<div data-testid="has-transaction">{String(hasTransaction.current)}</div>

--- a/tests/ct/vue/specs/UseVizelEditorState.spec.ts
+++ b/tests/ct/vue/specs/UseVizelEditorState.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/experimental-ct-vue";
 import {
   testEqualityFnShortCircuitsConsumer,
+  testSelectorReadsTransaction,
   testSelectorReceivesEditorOnMount,
   testSelectorRerunsOnTransaction,
 } from "../../scenarios/use-vizel-editor-state.scenario";
@@ -20,5 +21,10 @@ test.describe("useVizelEditorState - Vue", () => {
   test("equalityFn short-circuits downstream consumers", async ({ mount, page }) => {
     const component = await mount(UseVizelEditorStateFixture);
     await testEqualityFnShortCircuitsConsumer(component, page);
+  });
+
+  test("selector reads the transaction off the snapshot", async ({ mount, page }) => {
+    const component = await mount(UseVizelEditorStateFixture);
+    await testSelectorReadsTransaction(component, page);
   });
 });

--- a/tests/ct/vue/specs/UseVizelEditorStateFixture.vue
+++ b/tests/ct/vue/specs/UseVizelEditorStateFixture.vue
@@ -18,6 +18,12 @@ const StateConsumer = defineComponent({
   setup() {
     const editorReady = useVizelEditorState(({ editor }) => editor !== null);
 
+    // Read the transaction directly off the snapshot. The flag flips
+    // from `false` to `true` once typing dispatches the first Tiptap
+    // transaction; the shared scenario asserts the transition uniformly
+    // across all three frameworks.
+    const hasTransaction = useVizelEditorState(({ transaction }) => transaction !== null);
+
     const selectorMetrics = { runs: 0 };
     const selectorRuns = useVizelEditorState(({ editor }) => {
       selectorMetrics.runs += 1;
@@ -45,6 +51,7 @@ const StateConsumer = defineComponent({
       h("div", { "data-testid": "editor-ready" }, String(editorReady.value)),
       h("div", { "data-testid": "selector-runs" }, String(selectorRuns.value.runs)),
       h("div", { "data-testid": "consumer-runs" }, String(consumerMetrics.runs)),
+      h("div", { "data-testid": "has-transaction" }, String(hasTransaction.value)),
     ];
   },
 });


### PR DESCRIPTION
## Summary

- WI-8 of the P0/P1 hardening plan (decision D-6, **idiom-first**). Fixes finding F-I: React's `useVizelEditorState` selector received the bare editor while Vue/Svelte received an `{ editor, transaction }` snapshot, and React selectors could not read the transaction.
- React's `useSyncExternalStore` / `useSelector` idiom passes the selector a single snapshot, and feature parity needs the transaction — so the React selector now receives `{ editor, transaction }` too. **This is the idiomatic React form plus a parity fix, not symmetry**; the input shape converges across adapters only as a consequence of each framework's idiom + parity, while the return/delivery stays framework-native (React `T`, Vue `ComputedRef`, Svelte `$derived`).
- Tearing-safety preserved: `getSnapshot` still returns the monotonic version counter; the `{ editor, transaction }` snapshot is memoised on that version so `useSyncExternalStore` is not broken.
- Unifies the snapshot type to **`VizelEditorSnapshot`** across the three adapters (re-exported from each index), migrates the six React selector call sites, adds a transaction-derived assertion to all three editor-state fixtures, corrects the false "stays portable" JSDoc, and records the idiom-first rationale in ADR-0009 and ADR-0004.

## Test Plan

- [x] `pnpm typecheck` — passes; React package + demo compile against the snapshot selector; a `({ editor })` selector type-checks.
- [x] React/Vue/Svelte `UseVizelEditorState` / `CreateVizelEditorState` specs pass (chromium 4/4 each), including the new "selector reads the transaction" assertion.
- [x] `pnpm check:adr-compliance` (incl. `checkReactivityPrimitives` — React still uses `useSyncExternalStore`), `check:ct-parity` (35×3), `check:scenarios`, `check:feature-parity`, `check:aria-contract`, `check:ssr`, `lint`, `check:nolet` — pass.

Note: adds `@tiptap/pm` to `@vizel/react` peer/dev deps (newly imports the `Transaction` type); WI-10 finalises dependency hygiene.

Refs: `docs/superpowers/plans/2026-06-02-vizel-v2-hardening-p0p1.md` (WI-8).
