### PR TITLE
docs: fix README dependency model, CSS import, and stale exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import '@vizel/core/mathematics.css'; // KaTeX styles for math rendering
 Vizel uses OKLCH color values by default, which are compatible with shadcn/ui's theming system. For shadcn/ui projects, import `components.css` (without CSS variable definitions) and map your theme colors:
 
 ```typescript
-import '@vizel/core/components.css';
+import '@vizel/core/styles/components.css';
 ```
 
 ```css
@@ -401,7 +401,7 @@ import '@vizel/core/styles.css';
 For shadcn/ui projects, use components-only styles (without CSS variable definitions):
 
 ```typescript
-import '@vizel/core/components.css';
+import '@vizel/core/styles/components.css';
 ```
 
 ### Custom Theming

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ Framework-agnostic core for Vizel block-based Markdown editor built on Tiptap.
 
 ## Installation
 
-If you already installed a framework adapter (`@vizel/react`, `@vizel/vue`, or `@vizel/svelte`), this package is already present in your dependency tree because framework adapters declare it as a peer dependency. Install it explicitly only when you use the framework-agnostic APIs directly:
+If you already installed a framework adapter (`@vizel/react`, `@vizel/vue`, or `@vizel/svelte`), this package is already present in your dependency tree because framework adapters declare it as a regular dependency. Install it explicitly only when you use the framework-agnostic APIs directly:
 
 ```bash
 npm install @vizel/core
@@ -27,7 +27,7 @@ This package provides:
 
 | Category | Examples |
 |----------|---------|
-| Types | `VizelEditorOptions`, `VizelFeatureOptions`, `VizelEditorState`, `VizelSlashCommandItem` |
+| Types | `VizelEditorOptions`, `VizelFeatureOptions`, `VizelEditorState`, `VizelCommand` |
 | Extensions | `createVizelExtensions()`, `resolveVizelFeatures()` |
 | Utilities | `getVizelEditorState()`, `getVizelMarkdown()`, `createVizelImageUploader()` |
 | Theme | `VIZEL_DEFAULT_THEME`, `resolveVizelTheme()` |
@@ -38,7 +38,7 @@ This package provides:
 | Plugin System | `VizelPluginManager`, `validateVizelPlugin()` |
 | Find & Replace | `createVizelFindReplaceExtension()`, `getVizelFindReplaceState()`, `vizelFindReplacePluginKey` |
 | i18n | `VizelLocale`, `vizelEnLocale`, `createVizelLocale()` |
-| Constants | `VIZEL_TEXT_COLORS`, `VIZEL_HIGHLIGHT_COLORS`, `vizelDefaultSlashCommands` |
+| Constants | `VIZEL_TEXT_COLORS`, `VIZEL_HIGHLIGHT_COLORS`, `vizelDefaultCommands` |
 
 ## CSS Entry Points
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,7 +8,7 @@ React 19 components and hooks for Vizel block-based Markdown editor.
 npm install @vizel/react
 ```
 
-`@vizel/core`, the required `@tiptap/*` packages, and ProseMirror are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` still appears in style imports because CSS cannot be re-exported across packages.
+The required `@tiptap/*` packages and ProseMirror are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` ships as a regular dependency, so installing `@vizel/react` is sufficient; it still appears in style imports because CSS cannot be re-exported across packages.
 
 Optional features require extra packages installed manually:
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -8,7 +8,7 @@ Svelte 5 components and runes for Vizel block-based Markdown editor.
 npm install @vizel/svelte
 ```
 
-`@vizel/core`, the required `@tiptap/*` packages, and ProseMirror are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` still appears in style imports because CSS cannot be re-exported across packages.
+The required `@tiptap/*` packages are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` ships as a regular dependency, so installing `@vizel/svelte` is sufficient; it still appears in style imports because CSS cannot be re-exported across packages.
 
 Optional features require extra packages installed manually:
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -8,7 +8,7 @@ Vue 3 components and composables for Vizel block-based Markdown editor.
 npm install @vizel/vue
 ```
 
-`@vizel/core`, the required `@tiptap/*` packages, and ProseMirror are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` still appears in style imports because CSS cannot be re-exported across packages.
+The required `@tiptap/*` packages and ProseMirror are declared as peer dependencies and are installed automatically by npm 7+, pnpm, and yarn. Add them to your own `package.json` only if you want to pin specific versions. `@vizel/core` ships as a regular dependency, so installing `@vizel/vue` is sufficient; it still appears in style imports because CSS cannot be re-exported across packages.
 
 Optional features require extra packages installed manually:
 


### PR DESCRIPTION
## Summary

- Correct the dependency model in the package READMEs. After WI-10 (ADR-0003), every adapter declares `@vizel/core` in `dependencies`, not `peerDependencies`; the `check:publishable` gate enforces this. The React, Vue, and Svelte READMEs no longer call `@vizel/core` a peer dependency, and the core README no longer says adapters declare it as a peer.
- Fix the broken shadcn/ui CSS import example in the root README. `@vizel/core/components.css` is not an exported subpath; the exported entry is `@vizel/core/styles/components.css`. Copy-pasting the old example threw `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Replace removed-export references in the core README. `VizelSlashCommandItem` is gone (replaced by `VizelCommand`) and `vizelDefaultSlashCommands` is gone (replaced by `vizelDefaultCommands`), both removed in the WI-6 slash-menu unification.
- Drop ProseMirror from the Svelte README peer list. The Svelte adapter declares no `@tiptap/pm` peer, unlike React and Vue.

## Test Plan

- [x] Run `pnpm lint`.
- [x] Run `pnpm typecheck`.
- [x] Confirm no bare `@vizel/core/components.css` import and no `@vizel/core`-as-peer wording remain in any README.
