### PR TITLE
docs(core): resolve TypeDoc reference and duplicate-comment warnings

### DIFF
--- a/packages/core/src/auto-save.ts
+++ b/packages/core/src/auto-save.ts
@@ -260,14 +260,14 @@ export function formatVizelRelativeTime(date: Date, locale?: VizelLocale): strin
 }
 
 /**
- * Resolved view-model for {@link VizelSaveIndicator}.
+ * Resolved view-model for the framework `VizelSaveIndicator` components.
  *
  * Captures the status → display mapping so each framework only has to
  * render the icon and text once, instead of hand-writing a `switch`
  * inside both `<script>` and template.
  */
 export interface VizelSaveIndicatorView {
-  /** Name of the {@link VizelIcon} to render. */
+  /** Name of the icon to render. */
   iconName: "check" | "loader" | "circle" | "warning";
   /** Whether the icon should be wrapped in the `vizel-save-indicator-spinner` element. */
   isSpinner: boolean;

--- a/packages/core/src/extensions/embed.ts
+++ b/packages/core/src/extensions/embed.ts
@@ -1154,7 +1154,7 @@ export function loadVizelEmbedScripts(container: HTMLElement, provider?: string)
 }
 
 /**
- * Discriminated view-model for {@link VizelEmbedView}.
+ * Discriminated view-model for the framework `VizelEmbedView` components.
  *
  * Each variant maps to one of the four render branches (oEmbed,
  * OGP, title-link, plain-link) plus the loading state. Framework

--- a/packages/core/src/feature-manifest.ts
+++ b/packages/core/src/feature-manifest.ts
@@ -80,7 +80,7 @@ export interface VizelAriaContract {
  * `scripts/check-aria-contract.ts` statically asserts that every key
  * belongs to the allow-list formed by the union of the `VizelCommand`
  * registry identifiers under `packages/core/src/commands/registry/` and
- * the navigation-verb vocabulary in {@link VIZEL_KEYBOARD_COMMANDS}, so a
+ * the navigation-verb vocabulary in `VIZEL_KEYBOARD_COMMANDS`, so a
  * binding name cannot rot into a string the editor never handles.
  *
  * Runtime enforcement (asserting each key actually triggers its command

--- a/packages/core/src/markdown/augment.ts
+++ b/packages/core/src/markdown/augment.ts
@@ -20,7 +20,10 @@ declare module "@tiptap/core" {
   interface Editor {
     /** Serialize the current document to a Markdown string. */
     getMarkdown(): string;
-    /** Markdown parser surface attached by the Vizel Markdown extension. */
+    // The `markdown` surface intentionally carries no doc comment here:
+    // `tiptap-markdown` already declares `Editor.markdown` with one, and a
+    // second comment makes TypeDoc warn and pick an arbitrary description.
+    // The module-level JSDoc above documents the surface instead.
     markdown: {
       /** Parse a Markdown string into a Tiptap JSON document. */
       parse(md: string): JSONContent;

--- a/packages/core/src/utils/keyboard.ts
+++ b/packages/core/src/utils/keyboard.ts
@@ -37,7 +37,7 @@ export function isVizelMacPlatform(): boolean {
 }
 
 /**
- * Type guard for the {@link VizelPlatformShortcut} object shape.
+ * Type guard for the `VizelPlatformShortcut` object shape.
  */
 const isVizelPlatformShortcut = (value: unknown): value is VizelPlatformShortcut =>
   typeof value === "object" && value !== null && "mac" in value && "other" in value;
@@ -45,7 +45,7 @@ const isVizelPlatformShortcut = (value: unknown): value is VizelPlatformShortcut
 /**
  * Format a keyboard shortcut for the current platform.
  *
- * Accepts either a plain shortcut string or a {@link VizelPlatformShortcut}
+ * Accepts either a plain shortcut string or a `VizelPlatformShortcut`
  * object. For the object form, the function selects the `mac` or `other`
  * string via {@link isVizelMacPlatform}. Both separators are recognized:
  * the `+` notation used by the legacy slash hints and the `-` notation used


### PR DESCRIPTION
## Summary

- Resolve all six TypeDoc warnings emitted by `pnpm docs:api`, at the root cause rather than by suppression. `pnpm exec typedoc` now reports 0 errors and 0 warnings.
- Convert five `{@link}` references that target non-documented symbols to inline code or descriptive prose:
  - `VizelSaveIndicator`, `VizelIcon`, and `VizelEmbedView` are framework components, not `@vizel/core` symbols, so TypeDoc cannot resolve them across packages.
  - `VizelPlatformShortcut` and `VIZEL_KEYBOARD_COMMANDS` are internal types that the public entry point does not export.
- Remove the redundant doc comment on the `Editor.markdown` augmentation. `tiptap-markdown` already declares `Editor.markdown` with a comment, so a second comment made TypeDoc warn and pick an arbitrary description. The module-level JSDoc continues to document the surface; an inline comment records the rationale.

## Test Plan

- [x] `pnpm exec typedoc` — 0 errors, 0 warnings (was 6 warnings).
- [x] Run `pnpm lint`.
- [x] Run `pnpm typecheck`.
