### PR TITLE
chore(deps): require katex 0.17 for the math peer and bump lucide

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,7 +102,7 @@
     "@tiptap/pm": "^3.23.4",
     "@tiptap/suggestion": "^3.23.4",
     "fuse.js": "^7.1.0",
-    "katex": "^0.16.0",
+    "katex": "^0.17.0",
     "linkedom": "^0.18.0",
     "lowlight": "^3.0.0",
     "mermaid": "^11.15.0",
@@ -142,7 +142,7 @@
     }
   },
   "devDependencies": {
-    "@iconify-json/lucide": "^1.2.112",
+    "@iconify-json/lucide": "^1.2.113",
     "@iconify/utils": "^3.1.3",
     "@tiptap/extension-mention": "^3.26.1",
     "@tiptap/extension-subscript": "^3.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,8 +475,8 @@ importers:
         specifier: workspace:^
         version: link:../headless
       katex:
-        specifier: ^0.16.0
-        version: 0.16.45
+        specifier: ^0.17.0
+        version: 0.17.0
       linkedom:
         specifier: ^0.18.0
         version: 0.18.12
@@ -515,7 +515,7 @@ importers:
         version: 13.6.30
     devDependencies:
       '@iconify-json/lucide':
-        specifier: ^1.2.112
+        specifier: ^1.2.113
         version: 1.2.113
       '@iconify/utils':
         specifier: ^3.1.3


### PR DESCRIPTION
## Summary

Final dependency tidy-up before the v2.0.0 release.

- Set the optional `katex` peer dependency to `^0.17.0`. The mathematics
  feature builds and is tested against katex 0.17 (the demos pin it), so
  the peer declares the current release rather than `^0.16.0`. Mermaid
  keeps its own transitive katex 0.16 for diagram math, unrelated to the
  Vizel peer.
- Bump `@iconify-json/lucide` to `^1.2.113`.

`taze` confirms nothing else is outdated except the Playwright family,
which stays pinned at 1.58.2 (no stable `@playwright/experimental-ct-svelte`
past it). The other optional-feature deps (mermaid, graphviz, lowlight,
fuse.js, linkedom) already carry broad peer ranges that allow their latest
releases.

## Test Plan

- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint`
- [x] `pnpm check:publishable`, `pnpm check:attw`