### PR TITLE
ci: publish via npm token to bootstrap the new headless package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,12 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          # Token auth (granular access token with publish rights to the
+          # @vizel scope). Required to create the new @vizel/headless package;
+          # OIDC trusted publishing cannot bootstrap a package that does not
+          # exist yet. `--provenance` still attaches an attestation via the
+          # workflow's id-token permission.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -219,6 +225,12 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          # Token auth (granular access token with publish rights to the
+          # @vizel scope). Required to create the new @vizel/headless package;
+          # OIDC trusted publishing cannot bootstrap a package that does not
+          # exist yet. `--provenance` still attaches an attestation via the
+          # workflow's id-token permission.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -271,6 +283,12 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          # Token auth (granular access token with publish rights to the
+          # @vizel scope). Required to create the new @vizel/headless package;
+          # OIDC trusted publishing cannot bootstrap a package that does not
+          # exist yet. `--provenance` still attaches an attestation via the
+          # workflow's id-token permission.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
The first publish of the new `@vizel/headless` package returns 404 under OIDC trusted publishing (OIDC cannot create a package that does not exist yet). Authenticate the publish steps with a granular npm token (`NODE_AUTH_TOKEN` from the `NPM_TOKEN` secret); `--provenance` is retained via the workflow's id-token permission. Requires the `NPM_TOKEN` repository secret (granular access token with read/write on the `@vizel` scope).