### PR TITLE
fix(core): make list markers and block spacing survive host CSS resets

### DIFF
--- a/packages/core/src/styles/callout.scss
+++ b/packages/core/src/styles/callout.scss
@@ -28,6 +28,13 @@
     margin-bottom: 0;
   }
 
+  // Restore inter-block spacing inside multi-block callouts. Vizel sets no
+  // `p` / heading margin, so a host reset (Preflight `* { margin: 0 }`) would
+  // collapse the body. Unlayered CSS survives the reset. See #666.
+  > * + * {
+    margin-top: 0.75em;
+  }
+
   // Selection ring
   &.ProseMirror-selectednode {
     outline: 2px solid v("primary");

--- a/packages/core/src/styles/details.scss
+++ b/packages/core/src/styles/details.scss
@@ -140,6 +140,13 @@
       margin-bottom: 0;
     }
 
+    // Restore inter-block spacing inside the disclosure body. Vizel sets no
+    // `p` / heading margin, so a host reset (Preflight `* { margin: 0 }`) would
+    // collapse multi-block content. Unlayered CSS survives the reset. See #666.
+    > * + * {
+      margin-top: 0.75em;
+    }
+
     &.is-empty::before {
       content: "Add content here...";
       color: v("muted-foreground");

--- a/packages/core/src/styles/editor.scss
+++ b/packages/core/src/styles/editor.scss
@@ -79,6 +79,21 @@
     padding-inline-start: 1.5rem;
   }
 
+  // Set content-list markers explicitly so they survive a host CSS reset.
+  // Tailwind Preflight emits `ol, ul, menu { list-style: none }` in
+  // `@layer base`; with no Vizel `list-style-type`, the layered reset removes
+  // the User-Agent markers. Vizel ships unlayered CSS, so these declarations
+  // win. Exclude the marker-less opt-outs — task lists and the table-of-contents
+  // node both render a <ul> inside `.vizel-editor` — so the rule never overrides
+  // their `list-style: none` by specificity. See #666.
+  ul:not([data-type="taskList"]):not(.vizel-toc-list) {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
   li {
     margin: 0.25em 0;
   }
@@ -88,6 +103,22 @@
     padding-left: 1em;
     color: v("foreground-secondary");
     font-style: italic;
+
+    // Make inter-block spacing deterministic across hosts. Vizel sets no
+    // `p { margin }`, so multi-paragraph quotes relied on the UA default that a
+    // host reset (Preflight `* { margin: 0 }`) removes. Trim the outer edges and
+    // restore an explicit inter-sibling gap; unlayered CSS survives the reset.
+    > :first-child {
+      margin-top: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+
+    > * + * {
+      margin-top: 0.75em;
+    }
   }
 
   code {

--- a/packages/core/src/styles/link.scss
+++ b/packages/core/src/styles/link.scss
@@ -45,6 +45,10 @@
     padding: 0.25rem 0.5rem;
     border: 1px solid v("border");
     border-radius: v("radius-sm");
+    // Set an explicit surface so a host reset (Preflight makes inputs
+    // `background-color: transparent`) does not show the popover through the
+    // field. Matches the other Vizel inputs. See #666.
+    background: v("background");
     font-size: 0.875rem;
     width: 300px;
     outline: none;

--- a/packages/core/src/styles/table.scss
+++ b/packages/core/src/styles/table.scss
@@ -26,6 +26,14 @@
       text-align: inherit;
     }
 
+    // Space non-paragraph blocks (headings, lists) stacked in a cell.
+    // Paragraphs stay flush via the higher-specificity `p` rule above; other
+    // blocks relied on UA margins a host reset (Preflight `* { margin: 0 }`)
+    // removes. See #666.
+    > * + * {
+      margin-top: 0.5em;
+    }
+
     &.selectedCell {
       background: v("primary-bg-hover");
     }

--- a/tests/ct/react/specs/CssResetFixture.tsx
+++ b/tests/ct/react/specs/CssResetFixture.tsx
@@ -1,0 +1,40 @@
+import {
+  useVizelEditor,
+  useVizelState,
+  VizelBubbleMenu,
+  VizelEditor,
+  VizelProvider,
+  vizelDefaultFeatures,
+} from "@vizel/react";
+import { useEffect } from "react";
+
+/**
+ * Fixture for host-CSS-reset scenarios. Enables the curated feature set so a
+ * seeded document can contain callouts, details, tables, and task lists, and
+ * exposes the editor on `window.vizelTestEditor` so a scenario can set rich
+ * ProseMirror JSON content. The bubble menu is rendered so the link editor is
+ * reachable.
+ */
+export function CssResetFixture() {
+  const editor = useVizelEditor({
+    immediatelyRender: false,
+    features: vizelDefaultFeatures(),
+  });
+  useVizelState(editor);
+
+  useEffect(() => {
+    if (!editor) return;
+    const win = window as unknown as { vizelTestEditor?: unknown };
+    win.vizelTestEditor = editor;
+    return () => {
+      delete win.vizelTestEditor;
+    };
+  }, [editor]);
+
+  return (
+    <VizelProvider editor={editor}>
+      <VizelEditor />
+      <VizelBubbleMenu />
+    </VizelProvider>
+  );
+}

--- a/tests/ct/react/specs/Editor.spec.tsx
+++ b/tests/ct/react/specs/Editor.spec.tsx
@@ -1,5 +1,6 @@
 import { test } from "@playwright/experimental-ct-react";
 import {
+  testBlockSpacingSurvivesHostReset,
   testBoldShortcut,
   testBulletList,
   testEditorPlaceholder,
@@ -7,12 +8,14 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testLinkInputBackgroundSurvivesHostReset,
   testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
   testTaskListInputRule,
 } from "../../scenarios/editor.scenario";
+import { CssResetFixture } from "./CssResetFixture";
 import { EditorFixture } from "./EditorFixture";
 
 test.describe("Editor - React", () => {
@@ -74,5 +77,15 @@ test.describe("Editor - React", () => {
   test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
     const component = await mount(<EditorFixture />);
     await testListMarkersSurviveHostReset(component, page);
+  });
+
+  test("keeps block spacing under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(<CssResetFixture />);
+    await testBlockSpacingSurvivesHostReset(component, page);
+  });
+
+  test("keeps the link input opaque under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(<CssResetFixture />);
+    await testLinkInputBackgroundSurvivesHostReset(component, page);
   });
 });

--- a/tests/ct/react/specs/Editor.spec.tsx
+++ b/tests/ct/react/specs/Editor.spec.tsx
@@ -7,6 +7,7 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
@@ -68,5 +69,10 @@ test.describe("Editor - React", () => {
   test("creates checked task with [x] input rule", async ({ mount, page }) => {
     const component = await mount(<EditorFixture />);
     await testTaskListCheckedInputRule(component, page);
+  });
+
+  test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(<EditorFixture />);
+    await testListMarkersSurviveHostReset(component, page);
   });
 });

--- a/tests/ct/scenarios/editor.scenario.ts
+++ b/tests/ct/scenarios/editor.scenario.ts
@@ -229,3 +229,150 @@ export async function testListMarkersSurviveHostReset(
   expect(orderedMarker).toBe("decimal");
   expect(taskMarker).toBe("none");
 }
+
+/**
+ * A Tailwind v4 Preflight-like reset scoped to `@layer base`. It strips the
+ * User-Agent defaults Vizel must not depend on: margins, padding, borders, list
+ * markers, heading sizing, and the native input background.
+ */
+const VIZEL_PREFLIGHT_RESET = `@layer base {
+  *, ::before, ::after { margin: 0; padding: 0; border: 0 solid; }
+  ol, ul, menu { list-style: none; }
+  h1, h2, h3, h4, h5, h6 { font-size: inherit; font-weight: inherit; }
+  input, textarea, select, button { background-color: transparent; }
+}`;
+
+/**
+ * A document whose nested containers each hold two block siblings, so a missing
+ * inter-block margin is observable. The table cell pairs a paragraph with a
+ * heading because the cell paragraph reset keeps paragraphs flush; the heading
+ * is the block that must regain spacing.
+ */
+const VIZEL_RESET_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "blockquote",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Quote paragraph one." }] },
+        { type: "paragraph", content: [{ type: "text", text: "Quote paragraph two." }] },
+      ],
+    },
+    {
+      type: "callout",
+      attrs: { type: "info" },
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Callout paragraph one." }] },
+        { type: "paragraph", content: [{ type: "text", text: "Callout paragraph two." }] },
+      ],
+    },
+    {
+      type: "details",
+      attrs: { open: true },
+      content: [
+        { type: "detailsSummary", content: [{ type: "text", text: "Summary" }] },
+        {
+          type: "detailsContent",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "Details paragraph one." }] },
+            { type: "paragraph", content: [{ type: "text", text: "Details paragraph two." }] },
+          ],
+        },
+      ],
+    },
+    {
+      type: "table",
+      content: [
+        {
+          type: "tableRow",
+          content: [
+            {
+              type: "tableCell",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "Cell paragraph." }] },
+                {
+                  type: "heading",
+                  attrs: { level: 3 },
+                  content: [{ type: "text", text: "Cell heading" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/** Seed the editor with rich block content through the exposed test editor. */
+async function seedResetDoc(page: Page): Promise<void> {
+  await page.waitForFunction(() =>
+    Boolean((window as unknown as { vizelTestEditor?: unknown }).vizelTestEditor)
+  );
+  await page.evaluate((doc) => {
+    const win = window as unknown as {
+      vizelTestEditor: { commands: { setContent: (content: unknown) => void } };
+    };
+    // A JS object bypasses the markdown setContent override and loads as JSON.
+    win.vizelTestEditor.commands.setContent(doc);
+  }, VIZEL_RESET_DOC);
+}
+
+/**
+ * Verify inter-block spacing inside nested containers survives a host CSS reset.
+ *
+ * Callouts, details, blockquotes, and table cells set no paragraph or heading
+ * margin of their own, so they relied on the User-Agent default that a host
+ * reset removes. Each container now restores an explicit `> * + *` gap that, as
+ * unlayered CSS, wins over the layered reset. Regression guard for issue #666.
+ */
+export async function testBlockSpacingSurvivesHostReset(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  await page.addStyleTag({ content: VIZEL_PREFLIGHT_RESET });
+  await seedResetDoc(page);
+
+  const editor = component.locator(".vizel-editor");
+  const containers = [
+    "blockquote > * + *",
+    ".vizel-callout > * + *",
+    ".vizel-details-content > * + *",
+    ".vizel-table-cell > * + *",
+  ];
+  for (const selector of containers) {
+    const secondChild = editor.locator(selector).first();
+    await expect(secondChild).toBeVisible();
+    const marginTop = await secondChild.evaluate((node) => getComputedStyle(node).marginTop);
+    expect(marginTop, `${selector} keeps a top margin under a host reset`).not.toBe("0px");
+  }
+}
+
+/**
+ * Verify the link-editor input keeps an opaque surface under a host CSS reset.
+ *
+ * Preflight sets `input { background-color: transparent }`; the field now
+ * declares an explicit background so the popover does not show through it.
+ * Regression guard for issue #666.
+ */
+export async function testLinkInputBackgroundSurvivesHostReset(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  await page.addStyleTag({ content: VIZEL_PREFLIGHT_RESET });
+
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+  await page.keyboard.type("Linkable text");
+  await page.keyboard.press("ControlOrMeta+a");
+
+  const bubbleMenu = component.locator("[data-vizel-bubble-menu]");
+  await expect(bubbleMenu).toBeVisible();
+  await bubbleMenu.locator('[data-action="link"]').click();
+
+  const input = component.locator(".vizel-link-input");
+  await expect(input).toBeVisible();
+  const background = await input.evaluate((node) => getComputedStyle(node).backgroundColor);
+  expect(background).not.toBe("rgba(0, 0, 0, 0)");
+  expect(background).not.toBe("transparent");
+}

--- a/tests/ct/scenarios/editor.scenario.ts
+++ b/tests/ct/scenarios/editor.scenario.ts
@@ -184,3 +184,48 @@ export async function testTaskListCheckedInputRule(component: Locator, page: Pag
 
   await expect(taskItem).toHaveAttribute("data-checked", "true");
 }
+
+/**
+ * Verify content list markers survive a host CSS reset.
+ *
+ * Tailwind v4 Preflight emits `@layer base { ol, ul, menu { list-style: none } }`,
+ * which strips the User-Agent bullet and number markers. Vizel ships unlayered
+ * CSS, so its explicit `list-style-type` wins over the layered reset for content
+ * lists, while the task-list opt-out stays marker-less. Regression guard for
+ * issue #666.
+ */
+export async function testListMarkersSurviveHostReset(
+  component: Locator,
+  page: Page
+): Promise<void> {
+  // Reproduce Tailwind Preflight: a layered reset that removes the UA markers.
+  await page.addStyleTag({ content: "@layer base { ol, ul, menu { list-style: none; } }" });
+
+  const editor = component.locator(".vizel-editor");
+  await editor.click();
+
+  // Build a bullet list, an ordered list, and a task list as separate blocks.
+  await page.keyboard.type("- Bullet item");
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("1. Ordered item");
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("[ ] Task item");
+
+  const bulletList = editor.locator("ul:not([data-type='taskList'])").first();
+  const orderedList = editor.locator("ol").first();
+  const taskList = editor.locator("ul[data-type='taskList']").first();
+
+  await expect(bulletList).toBeVisible();
+  await expect(orderedList).toBeVisible();
+  await expect(taskList).toBeVisible({ timeout: 3000 });
+
+  const bulletMarker = await bulletList.evaluate((el) => getComputedStyle(el).listStyleType);
+  const orderedMarker = await orderedList.evaluate((el) => getComputedStyle(el).listStyleType);
+  const taskMarker = await taskList.evaluate((el) => getComputedStyle(el).listStyleType);
+
+  expect(bulletMarker).toBe("disc");
+  expect(orderedMarker).toBe("decimal");
+  expect(taskMarker).toBe("none");
+}

--- a/tests/ct/svelte/specs/CssResetFixture.svelte
+++ b/tests/ct/svelte/specs/CssResetFixture.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import {
+  createVizelEditor,
+  createVizelState,
+  VizelBubbleMenu,
+  VizelEditor,
+  VizelProvider,
+  vizelDefaultFeatures,
+} from "@vizel/svelte";
+
+// Fixture for host-CSS-reset scenarios. See the React CssResetFixture for the
+// rationale: curated features plus the editor exposed on window for rich seeding.
+interface TestWindow extends Window {
+  vizelTestEditor?: unknown;
+}
+
+const editor = createVizelEditor({
+  immediatelyRender: false,
+  features: vizelDefaultFeatures(),
+});
+createVizelState(() => editor.current);
+
+$effect(() => {
+  if (editor.current) {
+    (window as unknown as TestWindow).vizelTestEditor = editor.current;
+  }
+  return () => {
+    delete (window as unknown as TestWindow).vizelTestEditor;
+  };
+});
+</script>
+
+<VizelProvider editor={editor.current}>
+  <VizelEditor />
+  <VizelBubbleMenu />
+</VizelProvider>

--- a/tests/ct/svelte/specs/Editor.spec.ts
+++ b/tests/ct/svelte/specs/Editor.spec.ts
@@ -7,6 +7,7 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
@@ -70,5 +71,10 @@ test.describe("Editor - Svelte", () => {
   test("creates checked task with [x] input rule", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testTaskListCheckedInputRule(component, page);
+  });
+
+  test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testListMarkersSurviveHostReset(component, page);
   });
 });

--- a/tests/ct/svelte/specs/Editor.spec.ts
+++ b/tests/ct/svelte/specs/Editor.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "@playwright/experimental-ct-svelte";
 import {
+  testBlockSpacingSurvivesHostReset,
   testBoldShortcut,
   testBulletList,
   testEditorPlaceholder,
@@ -7,12 +8,14 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testLinkInputBackgroundSurvivesHostReset,
   testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
   testTaskListInputRule,
 } from "../../scenarios/editor.scenario";
+import CssResetFixture from "./CssResetFixture.svelte";
 import EditorFixture from "./EditorFixture.svelte";
 
 test.describe("Editor - Svelte", () => {
@@ -76,5 +79,15 @@ test.describe("Editor - Svelte", () => {
   test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testListMarkersSurviveHostReset(component, page);
+  });
+
+  test("keeps block spacing under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(CssResetFixture);
+    await testBlockSpacingSurvivesHostReset(component, page);
+  });
+
+  test("keeps the link input opaque under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(CssResetFixture);
+    await testLinkInputBackgroundSurvivesHostReset(component, page);
   });
 });

--- a/tests/ct/vue/specs/CssResetFixture.vue
+++ b/tests/ct/vue/specs/CssResetFixture.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import {
+  useVizelEditor,
+  useVizelState,
+  VizelBubbleMenu,
+  VizelEditor,
+  VizelProvider,
+  vizelDefaultFeatures,
+} from "@vizel/vue";
+import { onBeforeUnmount, watch } from "vue";
+
+// Fixture for host-CSS-reset scenarios. See the React CssResetFixture for the
+// rationale: curated features plus the editor exposed on window for rich seeding.
+interface TestWindow extends Window {
+  vizelTestEditor?: unknown;
+}
+
+const editor = useVizelEditor({
+  immediatelyRender: false,
+  features: vizelDefaultFeatures(),
+});
+useVizelState(() => editor.value);
+
+watch(
+  () => editor.value,
+  (instance) => {
+    if (instance) {
+      (window as unknown as TestWindow).vizelTestEditor = instance;
+    }
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  delete (window as unknown as TestWindow).vizelTestEditor;
+});
+</script>
+
+<template>
+  <VizelProvider :editor="editor">
+    <VizelEditor />
+    <VizelBubbleMenu />
+  </VizelProvider>
+</template>

--- a/tests/ct/vue/specs/Editor.spec.ts
+++ b/tests/ct/vue/specs/Editor.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "@playwright/experimental-ct-vue";
 import {
+  testBlockSpacingSurvivesHostReset,
   testBoldShortcut,
   testBulletList,
   testEditorPlaceholder,
@@ -7,12 +8,14 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testLinkInputBackgroundSurvivesHostReset,
   testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
   testTaskListInputRule,
 } from "../../scenarios/editor.scenario";
+import CssResetFixture from "./CssResetFixture.vue";
 import EditorFixture from "./EditorFixture.vue";
 
 test.describe("Editor - Vue", () => {
@@ -76,5 +79,15 @@ test.describe("Editor - Vue", () => {
   test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testListMarkersSurviveHostReset(component, page);
+  });
+
+  test("keeps block spacing under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(CssResetFixture);
+    await testBlockSpacingSurvivesHostReset(component, page);
+  });
+
+  test("keeps the link input opaque under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(CssResetFixture);
+    await testLinkInputBackgroundSurvivesHostReset(component, page);
   });
 });

--- a/tests/ct/vue/specs/Editor.spec.ts
+++ b/tests/ct/vue/specs/Editor.spec.ts
@@ -7,6 +7,7 @@ import {
   testEditorTyping,
   testHeadingShortcut,
   testItalicShortcut,
+  testListMarkersSurviveHostReset,
   testOrderedList,
   testTaskListCheckboxToggle,
   testTaskListCheckedInputRule,
@@ -70,5 +71,10 @@ test.describe("Editor - Vue", () => {
   test("creates checked task with [x] input rule", async ({ mount, page }) => {
     const component = await mount(EditorFixture);
     await testTaskListCheckedInputRule(component, page);
+  });
+
+  test("keeps list markers under a host CSS reset", async ({ mount, page }) => {
+    const component = await mount(EditorFixture);
+    await testListMarkersSurviveHostReset(component, page);
   });
 });


### PR DESCRIPTION
## Summary

- Content lists (`ul`/`ol`), callouts, `<details>`, blockquotes, table cells, and the link-editor input relied on User-Agent default styles that a host CSS reset removes, so list markers vanished and inter-block spacing collapsed inside reset hosts (e.g. Tailwind v4 Preflight). Reported in #666.
- Vizel ships unlayered CSS, so it now declares the at-risk properties explicitly; an unlayered declaration always wins over a layered reset (`@layer base`).
- The marker rule excludes the marker-less opt-outs — `ul[data-type="taskList"]` and `.vizel-toc-list` — via `:not()`, so task lists and the in-editor table of contents stay marker-less. The outline panel renders outside `.vizel-editor`, so it needs no exclusion.

### Changes

- `editor.scss`: explicit `list-style-type: disc/decimal` on content lists (opt-out-safe), plus blockquote inter-block spacing.
- `callout.scss`, `details.scss`, `table.scss`: restore inter-block spacing with a `> * + *` rule.
- `link.scss`: explicit `background` on `.vizel-link-input` (Preflight makes inputs transparent).
- New reset-resistant Playwright component test (`testListMarkersSurviveHostReset`) across React, Vue, and Svelte: it injects a Preflight-like `@layer base { ol, ul, menu { list-style: none } }` and asserts content lists keep `disc`/`decimal` markers while task lists stay `none`.

## Test Plan

- [x] `pnpm typecheck` — 0 errors across all packages.
- [x] `pnpm lint` — clean.
- [x] `pnpm check:scenarios`, `pnpm check:ct-parity`, `pnpm check:nolet`, `pnpm check:ssr` — pass.
- [x] Full CT suite on Chromium: 292 passed for each of React, Vue, Svelte (includes the new reset test). TDD RED to GREEN confirmed — markers resolve to `none` before the fix and `disc`/`decimal` after, while task lists stay `none`.
- [x] Rebuilt `@vizel/core` CSS and verified compiled `dist/styles.css` carries every new rule and the task-list / TOC opt-outs still resolve to `list-style: none`.
- [ ] CI: full matrix (React/Vue/Svelte x Chromium/Firefox/WebKit).

Refs #666
