### PR TITLE
ci: fail publish on a version-mismatched build artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,6 +123,32 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Verify built artifacts match release version
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          # Guard against shipping a stale or mismatched build: every built
+          # package.json must report the release version, and core must carry a
+          # non-empty CSS catalogue. A mismatch here aborts the release before
+          # the artifact is uploaded, so a wrong-version tarball never reaches
+          # the registry. See issue #666.
+          fail=0
+          for pkg in core headless react vue svelte; do
+            built=$(node -p "require('./packages/$pkg/package.json').version")
+            if [ "$built" != "$VERSION" ]; then
+              echo "::error::@vizel/$pkg built version '$built' does not match release version '$VERSION'"
+              fail=1
+            fi
+          done
+          if [ ! -s packages/core/dist/styles.css ]; then
+            echo "::error::packages/core/dist/styles.css is missing or empty (stale or partial build)"
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ All built packages report version $VERSION"
+
       - name: Verify package contents
         run: |
           echo "## 📦 Package Contents" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- The publish workflow uploaded the built artifact without checking that its version matched the release, so a stale or mismatched build could ship a tarball whose bundled `package.json` reports the wrong version. This is the release-hygiene follow-up from the #666 investigation (the published 2.0.0 tarball was verified correct, but no gate prevents a future mismatch).
- The `build` job now asserts, before uploading the artifact, that every built `package.json` reports the release version and that `@vizel/core` ships a non-empty `dist/styles.css`. A mismatch fails the job, so a wrong-version tarball cannot reach the registry.

## Test Plan

- [x] Static review of `publish.yml`: the new step reads `VERSION` from `needs.validate.outputs.version` through `env:` (validated as semver upstream) and iterates a fixed package list, so no untrusted input reaches the `run:` script.
- [ ] Exercised on the next `workflow_dispatch` release run.

Refs #666
