### PR TITLE
feat(demo): add a Tailwind Preflight reset toggle

### DIFF
--- a/apps/demo/react/src/App.tsx
+++ b/apps/demo/react/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getFlavorContent } from "../../shared/content";
 import reactLogo from "../../shared/logos/react.svg";
+import { applyDemoPreflight } from "../../shared/preflight";
 import { mockMentionItems, mockUploadImage } from "../../shared/utils";
 
 const FLAVOR_BY_NAME: Record<string, VizelMarkdownFlavor> = {
@@ -116,6 +117,7 @@ interface DemoFeatures {
   comments: boolean;
   history: boolean;
   outline: boolean;
+  preflight: boolean;
 }
 
 type PanelTab = "markdown" | "json" | "history" | "comments";
@@ -155,6 +157,7 @@ function AppContent() {
     comments: true,
     history: true,
     outline: true,
+    preflight: false,
   });
 
   const [flavorName, setFlavorName] = useState<string>(vizelGfmFlavor.name);
@@ -200,6 +203,11 @@ function AppContent() {
       prevFlavorRef.current = flavor;
     }
   }, [flavor, editor]);
+
+  // Inject or remove a Tailwind Preflight-like host reset to exercise CSS robustness.
+  useEffect(() => {
+    applyDemoPreflight(features.preflight);
+  }, [features.preflight]);
 
   // Find & Replace extension (stable reference)
   const findReplaceExtensions = useMemo(() => [createVizelFindReplaceExtension()], []);
@@ -317,6 +325,11 @@ function AppContent() {
             label="Outline"
             checked={features.outline}
             onChange={(v) => updateFeature("outline", v)}
+          />
+          <FeatureToggle
+            label="Preflight reset"
+            checked={features.preflight}
+            onChange={(v) => updateFeature("preflight", v)}
           />
           <label className="feature-toggle">
             <span className="feature-toggle-label">Flavor</span>

--- a/apps/demo/shared/preflight.ts
+++ b/apps/demo/shared/preflight.ts
@@ -1,0 +1,55 @@
+/**
+ * Tailwind v4 Preflight excerpt for the demo's host-reset toggle.
+ *
+ * The demos otherwise run with no aggressive host reset, so a regression like
+ * issue #666 (editor styles relying on User-Agent defaults a reset strips) is
+ * invisible in them. Toggling this reset reproduces a Tailwind Preflight host:
+ * it lives in `@layer base`, mirroring Preflight, so Vizel's unlayered CSS must
+ * win for the editor to stay correct.
+ */
+export const DEMO_PREFLIGHT_CSS = `@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  hr { height: 0; color: inherit; border-top-width: 1px; }
+  h1, h2, h3, h4, h5, h6 { font-size: inherit; font-weight: inherit; }
+  a { color: inherit; text-decoration: inherit; }
+  ol, ul, menu { list-style: none; }
+  table { text-indent: 0; border-color: inherit; border-collapse: collapse; }
+  button, input, select, optgroup, textarea {
+    font: inherit;
+    color: inherit;
+    background-color: transparent;
+    border-radius: 0;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video { max-width: 100%; height: auto; }
+}`;
+
+const DEMO_PREFLIGHT_STYLE_ID = "vizel-demo-preflight";
+
+/**
+ * Inject or remove the Preflight reset stylesheet. The injected `<style>`
+ * element itself is the source of truth, so the helper stays idempotent without
+ * module-level mutable state.
+ */
+export function applyDemoPreflight(enabled: boolean): void {
+  if (typeof document === "undefined") return;
+  const existing = document.getElementById(DEMO_PREFLIGHT_STYLE_ID);
+  if (enabled && existing === null) {
+    const style = document.createElement("style");
+    style.id = DEMO_PREFLIGHT_STYLE_ID;
+    style.textContent = DEMO_PREFLIGHT_CSS;
+    document.head.appendChild(style);
+    return;
+  }
+  if (!enabled && existing !== null) {
+    existing.remove();
+  }
+}

--- a/apps/demo/svelte/src/App.svelte
+++ b/apps/demo/svelte/src/App.svelte
@@ -30,6 +30,7 @@ const FLAVOR_BY_NAME: Record<string, VizelMarkdownFlavor> = {
 
 import { getFlavorContent } from "../../shared/content";
 import svelteLogo from "../../shared/logos/svelte.svg";
+import { applyDemoPreflight } from "../../shared/preflight";
 import { mockMentionItems, mockUploadImage } from "../../shared/utils";
 import ThemeToggle from "./ThemeToggle.svelte";
 
@@ -43,6 +44,7 @@ let features = $state({
   comments: true,
   history: true,
   outline: true,
+  preflight: false,
 });
 
 let flavorName = $state<string>(vizelGfmFlavor.name);
@@ -105,6 +107,11 @@ $effect(() => {
     setVizelMarkdown(editorRef, getFlavorContent(flavor), { transformDiagrams: true });
   }
   prevFlavor = flavor;
+});
+
+// Inject or remove a Tailwind Preflight-like host reset to exercise CSS robustness.
+$effect(() => {
+  applyDemoPreflight(features.preflight);
 });
 
 const showPanel = $derived(features.syncPanel || features.history || features.comments);
@@ -220,6 +227,10 @@ function handleJsonChange(event: Event) {
       <label class="feature-toggle">
         <input type="checkbox" bind:checked={features.outline} />
         <span class="feature-toggle-label">Outline</span>
+      </label>
+      <label class="feature-toggle">
+        <input type="checkbox" bind:checked={features.preflight} />
+        <span class="feature-toggle-label">Preflight reset</span>
       </label>
       <label class="feature-toggle">
         <span class="feature-toggle-label">Flavor</span>

--- a/apps/demo/vue/src/App.vue
+++ b/apps/demo/vue/src/App.vue
@@ -22,6 +22,7 @@ import {
 import { computed, reactive, ref, shallowRef, watch } from "vue";
 import { getFlavorContent } from "../../shared/content";
 import vueLogo from "../../shared/logos/vue.svg";
+import { applyDemoPreflight } from "../../shared/preflight";
 import { mockMentionItems, mockUploadImage } from "../../shared/utils";
 import StatsBar from "./StatsBar.vue";
 import ThemeToggle from "./ThemeToggle.vue";
@@ -43,6 +44,7 @@ const features = reactive({
   comments: true,
   history: true,
   outline: true,
+  preflight: false,
 });
 
 const flavorName = ref<string>(vizelGfmFlavor.name);
@@ -92,6 +94,9 @@ watch(flavor, (newFlavor) => {
     setVizelMarkdown(editorRef.value, getFlavorContent(newFlavor), { transformDiagrams: true });
   }
 });
+
+// Inject or remove a Tailwind Preflight-like host reset to exercise CSS robustness.
+watch(() => features.preflight, applyDemoPreflight, { immediate: true });
 
 function handleCreate({ editor }: { editor: Editor }) {
   editorRef.value = editor;
@@ -206,6 +211,10 @@ const showPanel = computed(() => features.syncPanel || features.history || featu
           <label class="feature-toggle">
             <input type="checkbox" v-model="features.outline" />
             <span class="feature-toggle-label">Outline</span>
+          </label>
+          <label class="feature-toggle">
+            <input type="checkbox" v-model="features.preflight" />
+            <span class="feature-toggle-label">Preflight reset</span>
           </label>
           <label class="feature-toggle">
             <span class="feature-toggle-label">Flavor</span>


### PR DESCRIPTION
## Summary

- The demos run without an aggressive host CSS reset, so a regression like #666 (editor styles relying on User-Agent defaults a reset strips) is invisible in them. This PR adds a "Preflight reset" toggle so the host-reset behaviour is reproducible by hand.
- A shared `applyDemoPreflight(enabled)` helper (`apps/demo/shared/preflight.ts`) injects or removes a Tailwind v4 Preflight-like reset (in `@layer base`) on `document.head`. The React, Vue, and Svelte demos each gain a "Preflight reset" checkbox wired through their idiomatic effect hook (`useEffect` / `watch` / `$effect`).

## Test Plan

- [x] `biome check` clean on all changed demo files and the new shared helper.
- [x] `apps/demo/shared/preflight.ts` type-checks standalone (`tsc`, strict, DOM libs).
- [ ] Manual: run `pnpm dev:react` / `dev:vue` / `dev:svelte`, toggle "Preflight reset", and confirm list markers and block spacing stay correct (with #667 merged) — and visibly break against an unfixed core, demonstrating the toggle.

Note: a full demo build could not be run in the authoring worktree due to an unrelated rolldown build failure on `@vizel/core` (core builds in CI, as #667's green run shows). The demo apps are not built or type-checked by the PR CI matrix, so a quick local `pnpm dev:*` check is the intended verification.

Refs #666
