### PR TITLE
ci: auto-merge pnpm minor and patch updates in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -86,6 +86,16 @@
       automerge: true,
     },
 
+    // pnpm lives in the `packageManager` field, not devDependencies, so the
+    // generic "minor devDependency" rule below never matches it. Auto-merge its
+    // minor and patch bumps explicitly; major upgrades stay manual.
+    {
+      description: "Auto-merge pnpm minor and patch updates",
+      matchPackageNames: ["pnpm"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+
     // Default automerge rules
     {
       description: "Auto-merge patch updates",


### PR DESCRIPTION
## Summary

- pnpm is declared in the `packageManager` field, not `devDependencies`, so renovate's "Auto-merge minor devDependency updates" rule never matched it. Its minor bumps (e.g. #602, pnpm 11.7.0 → 11.8.0) never auto-merged and waited for a human.
- Add an explicit rule so renovate auto-merges pnpm **minor and patch** updates. Major pnpm upgrades stay manual.

## Verification

- [x] `renovate-config-validator` passes (`Config validated successfully`).

After this lands, renovate enables auto-merge on pnpm minor/patch PRs on its next run, including the open #602 once its CI is green.
