### PR TITLE
chore: sync package versions to 2.0.2 and fix the ADR-0005 check

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/core",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/headless",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/react",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/svelte",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizel/vue",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/scripts/check-adr-compliance.ts
+++ b/scripts/check-adr-compliance.ts
@@ -85,32 +85,38 @@ function grepFiles(
 }
 
 /**
- * Verify every package under packages/ carries the expected version.
+ * Verify every package under packages/ carries one synchronized version on the
+ * v2 major line.
+ *
+ * ADR-0005 ships v2 as a single breaking release with all packages versioned in
+ * lockstep. The check asserts the lockstep (one shared version) and the major
+ * line (`2.x`) rather than a fixed `2.0.0`, so ongoing patch and minor releases
+ * (2.0.1, 2.0.2, …) stay compliant.
  */
 function checkPackageVersions(): CheckResult {
-  const expected = "2.0.0";
-  const violations: string[] = [];
-  for (const entry of readdirSync(resolve(REPO_ROOT, "packages"))) {
+  const versions = readdirSync(resolve(REPO_ROOT, "packages")).flatMap((entry) => {
     const manifest = readText(resolve(REPO_ROOT, "packages", entry, "package.json"));
-    if (manifest === null) continue;
+    if (manifest === null) return [];
     const match = manifest.match(/"version":\s*"([^"]+)"/);
-    if (match === null || match[1] !== expected) {
-      violations.push(`${entry}: ${match?.[1] ?? "unset"}`);
-    }
-  }
-  if (violations.length > 0) {
+    return [{ pkg: entry, version: match?.[1] ?? "unset" }];
+  });
+  const distinct = [...new Set(versions.map((entry) => entry.version))];
+  const allOnV2 = versions.every((entry) => /^2\.\d+\.\d+/.test(entry.version));
+  if (distinct.length !== 1 || !allOnV2) {
     return {
       adr: "ADR-0005",
       title: "v2.0.0 breaking release",
       status: "FAIL",
-      message: `Every package must declare version ${expected}: ${violations.join(", ")}`,
+      message: `Every package must share one synchronized 2.x version: ${versions
+        .map((entry) => `${entry.pkg}=${entry.version}`)
+        .join(", ")}`,
     };
   }
   return {
     adr: "ADR-0005",
     title: "v2.0.0 breaking release",
     status: "PASS",
-    message: `Every package declares ${expected}.`,
+    message: `Every package declares ${distinct[0]} (synchronized, 2.x line).`,
   };
 }
 


### PR DESCRIPTION
## Summary

- Fix the recurring failure of the `publish.yml` `Finalize` job and reconcile `main`'s package versions with the published release.
- The ADR-0005 compliance check (`scripts/check-adr-compliance.ts`) hardcoded the expected package version as `2.0.0`.
- The publish workflow's `Finalize` step bumps every package to the release version, then pushes the bump to `main`. The push runs the `lefthook` pre-push hook, which runs `pnpm check:adr-compliance`. For any release past `2.0.0` the check fails (it sees `2.0.x`, not `2.0.0`) and blocks the push, so the version-bump commit, the git tag, and the GitHub Release are never created.
- This silently affected the `2.0.1` and `2.0.2` releases: the packages on npm are at `2.0.2`, but `main`'s `package.json` files still declared `2.0.0`.

## Changes

- Rewrite the ADR-0005 check to assert that every package shares **one synchronized version on the `2.x` major line**, honoring ADR-0005's lockstep intent while allowing ongoing patch and minor releases (`2.0.1`, `2.0.2`, …).
- Bump all five packages (`@vizel/core`, `@vizel/headless`, `@vizel/react`, `@vizel/vue`, `@vizel/svelte`) from `2.0.0` to `2.0.2` to match the published release.

## Context

`2.0.2` is already published to npm (the disposer fix from the Vitest Browser Mode migration). The git tag `v2.0.2` and the GitHub Release were created manually after the `Finalize` job failed. This PR makes the next release's `Finalize` succeed automatically.

## Test Plan

- [x] `pnpm check:adr-compliance` — 14 PASS, 0 FAIL (ADR-0005 passes at `2.0.2`).
- [x] `pnpm lint`.
- [x] `pnpm check:nolet`.
- [x] Internal `@vizel/*` dependencies use `workspace:^`, so no version pins needed updating; `pnpm-lock.yaml` is unchanged.
