### PR TITLE
ci: convert npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,12 +201,11 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-          # Token auth (granular access token with publish rights to the
-          # @vizel scope). Required to create the new @vizel/headless package;
-          # OIDC trusted publishing cannot bootstrap a package that does not
-          # exist yet. `--provenance` still attaches an attestation via the
-          # workflow's id-token permission.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing: no token needed. setup-node v6.4.0 injects a
+          # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
+          # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
+          # On success npm uses the OIDC token from the id-token exchange.
+          NODE_AUTH_TOKEN: ''
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -219,12 +218,12 @@ jobs:
               PRERELEASE_TAG="next"
             fi
           fi
-          PUBLISH_OPTS="--provenance --access public --no-git-checks"
+          PUBLISH_OPTS="--provenance --access public"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing @vizel/headless with tag: $PRERELEASE_TAG"
           fi
-          cd packages/headless && pnpm publish $PUBLISH_OPTS
+          cd packages/headless && npm publish $PUBLISH_OPTS
           echo "✅ Published @vizel/headless@$VERSION"
 
   # Publish core next: it depends on @vizel/headless and is depended on by the adapters.
@@ -261,12 +260,11 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-          # Token auth (granular access token with publish rights to the
-          # @vizel scope). Required to create the new @vizel/headless package;
-          # OIDC trusted publishing cannot bootstrap a package that does not
-          # exist yet. `--provenance` still attaches an attestation via the
-          # workflow's id-token permission.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing: no token needed. setup-node v6.4.0 injects a
+          # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
+          # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
+          # On success npm uses the OIDC token from the id-token exchange.
+          NODE_AUTH_TOKEN: ''
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -279,12 +277,12 @@ jobs:
               PRERELEASE_TAG="next"
             fi
           fi
-          PUBLISH_OPTS="--provenance --access public --no-git-checks"
+          PUBLISH_OPTS="--provenance --access public"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing @vizel/core with tag: $PRERELEASE_TAG"
           fi
-          cd packages/core && pnpm publish $PUBLISH_OPTS
+          cd packages/core && npm publish $PUBLISH_OPTS
           echo "✅ Published @vizel/core@$VERSION"
 
   # Publish framework packages in parallel (each job has its own OIDC token)
@@ -329,12 +327,11 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-          # Token auth (granular access token with publish rights to the
-          # @vizel scope). Required to create the new @vizel/headless package;
-          # OIDC trusted publishing cannot bootstrap a package that does not
-          # exist yet. `--provenance` still attaches an attestation via the
-          # workflow's id-token permission.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing: no token needed. setup-node v6.4.0 injects a
+          # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
+          # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
+          # On success npm uses the OIDC token from the id-token exchange.
+          NODE_AUTH_TOKEN: ''
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -347,12 +344,12 @@ jobs:
               PRERELEASE_TAG="next"
             fi
           fi
-          PUBLISH_OPTS="--provenance --access public --no-git-checks"
+          PUBLISH_OPTS="--provenance --access public"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing @vizel/${{ matrix.package }} with tag: $PRERELEASE_TAG"
           fi
-          cd packages/${{ matrix.package }} && pnpm publish $PUBLISH_OPTS
+          cd packages/${{ matrix.package }} && npm publish $PUBLISH_OPTS
           echo "✅ Published @vizel/${{ matrix.package }}@$VERSION"
 
   # Finalize: commit version changes and create release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,7 +205,7 @@ jobs:
           # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
           # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
           # On success npm uses the OIDC token from the id-token exchange.
-          NODE_AUTH_TOKEN: ''
+          NODE_AUTH_TOKEN: ""
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -264,7 +264,7 @@ jobs:
           # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
           # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
           # On success npm uses the OIDC token from the id-token exchange.
-          NODE_AUTH_TOKEN: ''
+          NODE_AUTH_TOKEN: ""
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -331,7 +331,7 @@ jobs:
           # dummy NODE_AUTH_TOKEN when registry-url is set; force it empty so a
           # failed OIDC exchange surfaces as a clean ENEEDAUTH rather than E404.
           # On success npm uses the OIDC token from the id-token exchange.
-          NODE_AUTH_TOKEN: ''
+          NODE_AUTH_TOKEN: ""
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
## Summary

- Convert all three publish jobs (`@vizel/headless`, `@vizel/core`, and the `react`/`vue`/`svelte` matrix) from token auth to **npm OIDC trusted publishing**, matching the sibling toolchain repos where this is verified working end-to-end.
- `pnpm publish` → `npm publish` (workspace deps are already rewritten by `rewrite-workspace-deps.mjs` before publish, so `npm publish` handles the scoped packages).
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`; set `NODE_AUTH_TOKEN: ''` (setup-node@v6.4.0 injects a dummy token when `registry-url` is set — forcing it empty makes a failed OIDC exchange a clean `ENEEDAUTH` instead of an `E404`).\n- Drop the pnpm-only `--no-git-checks` flag. `--provenance` and `--access public` are retained.\n\n## Required npm-side setup (before the next release)\n\nConfigure a trusted publisher for **each** package at `https://www.npmjs.com/package/<pkg>/settings` → Trusted Publisher → GitHub Actions:\n\n| Field | Value |\n| --- | --- |\n| Organization or user | `seijikohara` |\n| Repository | `vizel` |\n| Workflow filename | `publish.yml` |\n| Environment | `npm` |\n\nFor all of: `@vizel/core`, `@vizel/headless`, `@vizel/react`, `@vizel/vue`, `@vizel/svelte`.\n\n## Notes\n\n- No pending release; this is exercised on the next `vizel` publish. CI-only change.\n- The stale comment claiming OIDC "cannot bootstrap a package that does not exist yet" is removed — all five packages now exist at 2.0.2.