### PR TITLE
fix(ci): resolve the pnpm version from package.json only

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,10 +17,11 @@ runs:
       with:
         node-version-file: .nvmrc
 
+    # Omit `version` so the action reads `packageManager` from package.json.
+    # Renovate's github-actions manager updates a `version` input here
+    # independently of `packageManager`, and the two drifted apart in #699.
     - name: Setup pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-      with:
-        version: "11.11.0"
 
     - name: Get pnpm store directory
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,11 @@ jobs:
 
       # Install pnpm before `setup-node` so the cache key resolution finds
       # the package manager on PATH. Reversing the order breaks the cache.
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -143,10 +144,11 @@ jobs:
 
       # Install pnpm before `setup-node` so the cache key resolution finds
       # the package manager on PATH. Reversing the order breaks the cache.
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -182,10 +184,11 @@ jobs:
 
       # Install pnpm before `setup-node` so the cache key resolution finds
       # the package manager on PATH. Reversing the order breaks the cache.
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,10 +28,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Get pnpm store directory
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,10 +86,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Get pnpm store directory
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
@@ -378,10 +379,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,10 +30,11 @@ jobs:
 
       # Install pnpm before `setup-node` so the cache key resolution finds
       # the package manager on PATH. Reversing the order breaks the cache.
+      # Omit `version` so the action reads `packageManager` from package.json.
+      # A second version source drifts and aborts the job with
+      # "Multiple versions of pnpm specified".
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: "11.17.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/package.json
+++ b/package.json
@@ -124,15 +124,8 @@
     "vitest-browser-vue": "2.1.0",
     "vue": "^3.5.38"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "11.11.0",
-      "onFail": "download"
-    }
-  },
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.17.0"
 }


### PR DESCRIPTION
## Summary

- Make `packageManager` in `package.json` the single source for the pnpm version, and raise it to `pnpm@11.17.0`.
- Drop the `version` input from `pnpm/action-setup` in all five workflows and in the `test` composite action.
- Delete the `devEngines` block, which `pnpm/action-setup` prefers over `packageManager` but Renovate never updates.

## Why

`pnpm/action-setup` aborts the job when its `version` input disagrees with `packageManager`:

```
Error: Multiple versions of pnpm specified:
  - version 11.17.0 in the GitHub Action config with the key "version"
  - version pnpm@11.11.0 in the package.json with the key "packageManager"
```

The version lived in three places that Renovate updates independently:

| Location | Value before this change | Updated by |
|---|---|---|
| `version` input in `quality.yml`, `ci.yml` (×3), `publish.yml` (×2), `deploy-docs.yml` | `11.17.0` | `github-actions` manager |
| `version` input in `.github/actions/test/action.yml` | `11.11.0` | never updated |
| `packageManager` and `devEngines.packageManager` in `package.json` | `11.11.0` | `npm` manager, in a separate pull request |

`bee6eb24` (#699) raised the workflow inputs to `11.13.1` and `1658637d` (#701) raised them to `11.17.0`, neither touching the other two locations. `Quality` and `Deploy VitePress site to Pages` have therefore failed on main since 2026-07-19, and every open dependency pull request inherits the failure.

The `Test` matrix kept passing because the composite action still agreed with `packageManager`, which is why #709 shows the mirror image: it raises `packageManager` alone, so `Quality` passes and all nine `Test` shards fail. No single existing pull request can turn the whole pipeline green.

`devEngines.packageManager` goes away rather than moving to `11.17.0`. `pnpm/action-setup` reads `devEngines` in preference to `packageManager`, and Renovate's npm manager does not update `devEngines`, so a synced value drifts again on the next bump — and drifts silently, because the mismatch raises no error. `seijikohara/docker-compose-cache-action` is in exactly that state today.

After this change Renovate can move the pnpm version only through `packageManager`, in one pull request.

## Test Plan

- [x] Run `pnpm install --frozen-lockfile` (resolves pnpm 11.17.0 from `packageManager`).
- [x] Run `pnpm lint`.
- [x] Run `pnpm typecheck`.
- [x] Run `pnpm build`.
- [x] Run `pnpm check:nolet`, `check:feature-parity`, `check:aria-contract`, `check:scenarios`, `check:adr-compliance`, `check:ct-parity`, `check:ssr`, `check:publishable`, `check:attw`.
- [x] Run `pnpm --filter @vizel/headless test`.
- [ ] Confirm `Quality + Parity` passes on this pull request.
- [ ] Confirm the nine `Test (framework/browser)` shards and `Test Summary` still pass.
- [ ] Confirm a job log shows `Setup pnpm` resolving 11.17.0.

## Follow-up

- #709 raises `packageManager` to `11.17.0` on its own and is superseded by this pull request. Close it once this merges.
