### PR TITLE
build: trust the committed lockfile during install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,14 @@ packages:
   - "packages/*"
   - "apps/demo/*"
 
+# Renovate resolves and pins every dependency itself, so CI does not re-apply
+# `minimumReleaseAge` to entries the lockfile already records. Without this
+# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
+# whenever a release is under a day old, which blocked #715 and #716.
+# Resolution-time cooldown and Renovate's own three-day hold still gate which
+# versions reach the lockfile.
+trustLockfile: true
+
 # Approve post-install build scripts for trusted tooling dependencies.
 # pnpm 10+ disables build scripts by default; these packages need their
 # build/install hooks to run for native binaries and git hook setup.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,15 @@ packages:
   - "packages/*"
   - "apps/demo/*"
 
-# Renovate resolves and pins every dependency itself, so CI does not re-apply
-# `minimumReleaseAge` to entries the lockfile already records. Without this
-# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
-# whenever a release is under a day old, which blocked #715 and #716.
-# Resolution-time cooldown and Renovate's own three-day hold still gate which
-# versions reach the lockfile.
+# Trust the resolutions the lockfile already records. The setting applies to
+# every install, local and CI alike, so none of them re-apply
+# `minimumReleaseAge` to lockfile entries. Renovate writes the lockfile and
+# opens the pull request within hours of a publish, so without this setting
+# `pnpm install --frozen-lockfile` rejects the lockfile Renovate just produced,
+# as it did on #715 and #716. The cooldown still applies when resolving a new
+# version, and Renovate's three-day hold still gates the merge. The accepted
+# trade-off is that a lockfile arriving through a pull request is no longer
+# re-audited.
 trustLockfile: true
 
 # Approve post-install build scripts for trusted tooling dependencies.


### PR DESCRIPTION
## Summary

- Set `trustLockfile: true` in `pnpm-workspace.yaml` so `pnpm install --frozen-lockfile` stops re-verifying the release age of every lockfile entry.

## Why

pnpm 11 turned supply-chain protection on by default: `minimumReleaseAge` defaults to `1440` (one day) and `trustLockfile` defaults to `false`. Every install therefore re-applies the age check to the whole lockfile and rejects entries published less than a day ago. #715 and #716 both failed that way:

```
✗ Lockfile failed supply-chain policy check (690 entries in 3.3s)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  markdown-it-deflist@4.0.0 was published at 2026-07-27T02:31:46.107Z,
    within the minimumReleaseAge cutoff (2026-07-26T22:40:59.694Z)
```

Renovate writes that lockfile, and it opens the pull request within hours of the publish — #715 about three hours after, #716 about seven. `minimumReleaseAge: "3 days"` in `renovate.json5` does not prevent it. When every candidate version fails the age check, `internalChecksFilter` (default `strict`) returns the newest one with `pendingChecks` set instead of withholding the update, so Renovate creates the branch and only marks `renovate/stability-days` pending. CI then fails on a lockfile Renovate produced one step earlier.

`trustLockfile: true` makes the install trust the resolutions the lockfile already records. The protection that matters stays in place:

- Resolution time — `pnpm update` and Renovate's own lockfile generation still honour `minimumReleaseAge`.
- Merge time — Renovate's three-day hold still blocks automerge through the pending `renovate/stability-days` check.

The trade-off is that CI no longer re-audits a lockfile supplied by a pull request.

## Test Plan

- [x] Run `pnpm install --frozen-lockfile`; pnpm accepts the setting and the install succeeds.
- [x] Run `pnpm lint` and `pnpm typecheck` via the `pre-push` hook.
- [ ] Confirm `Quality + Parity`, the nine `Test` shards, and `Test Summary` pass.
- [ ] Re-run CI on #715 and #716 and confirm `pnpm install --frozen-lockfile` no longer rejects the lockfile.
